### PR TITLE
YALB-521: Wire Pop-out Image

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.alert_block.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.alert_block.yml
@@ -1,0 +1,20 @@
+uuid: ebeb6fd8-d226-41aa-a5cd-f6c9c1f4fbf7
+langcode: en
+status: true
+dependencies:
+  module:
+    - ys_alert
+  theme:
+    - atomic
+id: alert_block
+theme: atomic
+region: header
+weight: 0
+provider: null
+plugin: alert_block
+settings:
+  id: alert_block
+  label: 'Alert block'
+  label_display: '0'
+  provider: ys_alert
+visibility: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.pop_out_image.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.pop_out_image.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.paragraph.pop_out_image.field_text
     - paragraphs.paragraphs_type.pop_out_image
   module:
+    - media_library
     - text
 id: paragraph.pop_out_image.default
 targetEntityType: paragraph
@@ -14,14 +15,11 @@ bundle: pop_out_image
 mode: default
 content:
   field_image:
-    type: entity_reference_autocomplete
+    type: media_library_widget
     weight: 0
     region: content
     settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+      media_types: {  }
     third_party_settings: {  }
   field_text:
     type: text_textarea

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.image_float.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.image_float.yml
@@ -1,23 +1,24 @@
-uuid: 7b2b7e9d-436d-45c9-b25f-6fb8985c701b
+uuid: 68285c19-46e4-4c0b-a441-b9ee2974e0f5
 langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.media.image_float
     - field.field.media.image.field_media_image
     - media.type.image
-    - responsive_image.styles.full_width
+    - responsive_image.styles.image_float
   module:
     - responsive_image
-id: media.image.default
+id: media.image.image_float
 targetEntityType: media
 bundle: image
-mode: default
+mode: image_float
 content:
   field_media_image:
     type: responsive_image
     label: hidden
     settings:
-      responsive_image_style: full_width
+      responsive_image_style: image_float
       image_link: ''
     third_party_settings: {  }
     weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.pop_out_image.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.pop_out_image.default.yml
@@ -14,16 +14,17 @@ bundle: pop_out_image
 mode: default
 content:
   field_image:
-    type: entity_reference_label
-    label: above
+    type: entity_reference_entity_view
+    label: hidden
     settings:
-      link: true
+      view_mode: image_float
+      link: false
     third_party_settings: {  }
     weight: 0
     region: content
   field_text:
     type: text_default
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     weight: 1

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_mode.media.image_float.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_mode.media.image_float.yml
@@ -1,0 +1,10 @@
+uuid: badbe192-58c1-455a-870b-a6a4a4de8737
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.image_float
+label: 'Image - Float'
+targetEntityType: media
+cache: true

--- a/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.full_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.full_width.yml
@@ -1,0 +1,45 @@
+uuid: 3e8949b7-f03c-4d65-afb6-bda9b7ef8a16
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.max_width_1120
+    - image.style.max_width_1280
+    - image.style.max_width_1440
+    - image.style.max_width_1600
+    - image.style.max_width_1760
+    - image.style.max_width_1920
+    - image.style.max_width_2080
+    - image.style.max_width_2240
+    - image.style.max_width_2400
+    - image.style.max_width_320
+    - image.style.max_width_480
+    - image.style.max_width_640
+    - image.style.max_width_800
+    - image.style.max_width_960
+id: full_width
+label: 'Full Width'
+image_style_mappings:
+  -
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: '(min-width: 2400px) 2400px, 100vw'
+      sizes_image_styles:
+        - max_width_1120
+        - max_width_1280
+        - max_width_1440
+        - max_width_1600
+        - max_width_1760
+        - max_width_1920
+        - max_width_2080
+        - max_width_2240
+        - max_width_2400
+        - max_width_320
+        - max_width_480
+        - max_width_640
+        - max_width_800
+        - max_width_960
+    breakpoint_id: responsive_image.viewport_sizing
+    multiplier: 1x
+breakpoint_group: responsive_image
+fallback_image_style: max_width_320

--- a/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.image_float.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.image_float.yml
@@ -1,0 +1,45 @@
+uuid: b62f69e8-2701-4e4e-8219-6235ac5eb3f0
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.max_width_1120
+    - image.style.max_width_1280
+    - image.style.max_width_1440
+    - image.style.max_width_1600
+    - image.style.max_width_1760
+    - image.style.max_width_1920
+    - image.style.max_width_2080
+    - image.style.max_width_2240
+    - image.style.max_width_2400
+    - image.style.max_width_320
+    - image.style.max_width_480
+    - image.style.max_width_640
+    - image.style.max_width_800
+    - image.style.max_width_960
+id: image_float
+label: 'Image - Float'
+image_style_mappings:
+  -
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: '(min-width: 992px) 395px, (min-width: 838px) 790px, 96vw'
+      sizes_image_styles:
+        - max_width_1120
+        - max_width_1280
+        - max_width_1440
+        - max_width_1600
+        - max_width_1760
+        - max_width_1920
+        - max_width_2080
+        - max_width_2240
+        - max_width_2400
+        - max_width_320
+        - max_width_480
+        - max_width_640
+        - max_width_800
+        - max_width_960
+    breakpoint_id: responsive_image.viewport_sizing
+    multiplier: 1x
+breakpoint_group: responsive_image
+fallback_image_style: max_width_320

--- a/web/sites/theming.services.yml
+++ b/web/sites/theming.services.yml
@@ -1,0 +1,13 @@
+# Local development services.
+#
+# To activate this feature, follow the instructions at the top of the
+# 'example.settings.local.php' file, which sits next to this file.
+parameters:
+  http.response.debug_cacheability_headers: true
+  twig.config:
+    debug: true
+    auto_reload: true
+    cache: false
+services:
+  cache.backend.null:
+    class: Drupal\Core\Cache\NullBackendFactory


### PR DESCRIPTION
## [YALB-521: Wire Pop-out Image](https://yaleits.atlassian.net/browse/YALB-521)

## Related to the following PRs:
- https://github.com/yalesites-org/component-library-twig/pull/80
- https://github.com/yalesites-org/atomic/pull/7

### Description of work
- Creates a`theming.services.yml` file that disables basically every cache so that theming is easier (must be opted in via `settings.local.php` - so it won't affect developers not actively working on the theme)
- Places the `alert_block` ... somehow that got missed before?
- Creates a "Full Width" responsive image style and applies it to the default view mode for the image media type
- Creates a "Image - Float" responsive image style and applies it to the "Image - Float" view mode for the image media type
- Configures the "Pop-out Image" to render its image using the "Image - Float" view mode

### Functional testing steps:
- [x] Create a page, and add a Pop-out Image component
- [x] Upload and image, and fill in some text. Save the page
- [x] Verify the image uses the following "sizes" attribute: `(min-width:992px) 395px, (min-width:838px) 790px, 96vw`