### PR TITLE
YALB-476: Wire Image Paragraph

### DIFF
--- a/scripts/local/rebuild.sh
+++ b/scripts/local/rebuild.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-composer install
+lando composer install
 npm run import-local-db
 npm run confim
 lando drush uli

--- a/scripts/local/setup.sh
+++ b/scripts/local/setup.sh
@@ -2,7 +2,7 @@
 
 # Ignore the composer.lock file on local dev only.
 if grep -qxF 'composer.lock' .git/info/exclude; then
-  echo "Excluding composer.log to keep it out of the repo."
+  echo "Excluding composer.lock to keep it out of the repo."
   echo 'composer.lock' >> .git/info/exclude
 fi
 

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -45,7 +45,7 @@
         "drupal/redirect": "^1.7",
         "drupal/twig_tweak": "^3.1",
         "drupal/xmlsitemap": "^1.2",
-        "yalesites-org/atomic": "dev-YALB-253-theming-support-artifacts"
+        "yalesites-org/atomic": "dev-YALB-476-wire-image-paragraph-artifact"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.image.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.image.default.yml
@@ -14,16 +14,17 @@ bundle: image
 mode: default
 content:
   field_image:
-    type: entity_reference_label
-    label: above
+    type: entity_reference_entity_view
+    label: hidden
     settings:
-      link: true
+      view_mode: full
+      link: false
     third_party_settings: {  }
     weight: 0
     region: content
   field_text:
     type: text_default
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     weight: 1

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_content.yml
@@ -7,7 +7,6 @@ dependencies:
     - node.type.page
     - paragraphs.paragraphs_type.accordion_item
     - paragraphs.paragraphs_type.callout_item
-    - paragraphs.paragraphs_type.image
   module:
     - entity_reference_revisions
 id: node.page.field_content
@@ -25,7 +24,6 @@ settings:
   handler_settings:
     target_bundles:
       accordion_item: accordion_item
-      image: image
       callout_item: callout_item
     negate: 1
     target_bundles_drag_drop:
@@ -49,7 +47,7 @@ settings:
         enabled: false
       image:
         weight: 12
-        enabled: true
+        enabled: false
       pop_out_image:
         weight: 15
         enabled: false


### PR DESCRIPTION
## [YALB-476: Wire Image Paragraph](https://yaleits.atlassian.net/browse/YALB-476)

### Description of work
- Wires the Image paragraph type

### Functional testing steps:
- [ ] Log in to the site https://pr-20-yalesites-platform.pantheonsite.io/user/login
- [ ] [Create a page](https://pr-20-yalesites-platform.pantheonsite.io/node/add). Fill in the title and add an "Image" component (with caption).
- [ ] Save the page, and verify the image and caption render on the page as expected ("content-width" wrapped in a `<figure>` tag)
- [ ] Edit the page, and remove the caption
- [ ] Save the page, and verify the image is just an `<img>` tag now, without the figure markup. But that it's still "content-width".