### PR TITLE
YALB-525: Two Column Layout Builder Layout

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -36,7 +36,6 @@ module:
   image_widget_crop: 0
   improve_line_breaks_filter: 0
   inline_entity_form: 0
-  layout_builder: 0
   layout_discovery: 0
   layout_paragraphs: 0
   libraries: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -16,6 +16,7 @@ module:
   config_ignore: 0
   config_split: 0
   content_moderation: 0
+  contextual: 0
   crop: 0
   ctools: 0
   datetime: 0
@@ -35,6 +36,7 @@ module:
   image_widget_crop: 0
   improve_line_breaks_filter: 0
   inline_entity_form: 0
+  layout_builder: 0
   layout_discovery: 0
   layout_paragraphs: 0
   libraries: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -69,6 +69,7 @@ module:
   workflows: 0
   ys_admin: 0
   ys_alert: 0
+  ys_layouts: 0
   ys_mail: 0
   pathauto: 1
   xmlsitemap: 1

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/README.md
@@ -1,3 +1,3 @@
 # YaleSites Layouts
 
-This module defines layouts used on the YaleSites platform. These layouts are used within other site building tools such as the Layout Paragraphs. Instances of these layouts are exported as configuration within the YaleSites installation profile.
+This module defines layouts used on the YaleSites platform. These layouts are used within other site building tools such as the Layout Paragraphs module. Instances of these layouts are exported as configuration within the YaleSites installation profile.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/README.md
@@ -1,0 +1,3 @@
+# YaleSites Layouts
+
+This module defines layouts used on the YaleSites platform. These layouts are used within other site building tools such as the Layout Paragraphs. Instances of these layouts are exported as configuration within the YaleSites installation profile.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/layouts/two-column/ys-layouts--yds-twocol.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/layouts/two-column/ys-layouts--yds-twocol.html.twig
@@ -1,21 +1,11 @@
-{#
-# In this file, we're checking `if directory` in order to determine if the
-# active environment is a Drupal site. We need to do this because Drupal's
-# drag-and-drop interface needs specific attributes on the wrapper elements
-# that would not make sense, or even cause errors in environments like
-# Storybook.
-#}
-
-{% set two_column__base_class = 'yds-two-column' %}
-
-<div {{ attributes.addClass(two_column__base_class) }} data-component-width='max' data-embedded-components>
-    <div {{ attributes.addClass("#{two_column__base_class}__inner") }}>
-        <div {{ region_attributes.primary.addClass("#{two_column__base_class}__primary") }}>
+<div class='yds-two-column' data-component-width='max' data-embedded-components>
+    <div class='yds-two-column__inner'>
+        <div class='yds-two-column__primary'>
             {% block two_column__primary %}
                 {{ content.primary }}
             {% endblock %}
         </div>
-        <div {{ region_attributes.secondary.addClass("#{two_column__base_class}__secondary") }}>
+        <div  class='yds-two-column__secondary'>
             {% block two_column__secondary %}
                 {{ content.secondary }}
             {% endblock %}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/layouts/two-column/ys-layouts--yds-twocol.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/layouts/two-column/ys-layouts--yds-twocol.html.twig
@@ -8,12 +8,12 @@
 
 {% set two_column__base_class = 'yds-two-column' %}
 
-<div {{ bem(two_column__base_class) }} data-component-width='max' data-embedded-components>
-    <div {{ bem('inner', [], two_column__base_class) }}>
+<div {{ attributes.addClass(two_column__base_class) }} data-component-width='max' data-embedded-components>
+    <div {{ attributes.addClass("#{two_column__base_class}__inner") }}>
         {% if directory %}
         <div {{ region_attributes.primary.addClass('yds-two-column__primary') }}>
             {% else %}
-            <div {{ bem('primary', [], two_column__base_class) }}>
+            <div {{ attributes.addClass("#{two_column__base_class}__primary") }}>
                 {% endif %}
                 {% block two_column__primary %}
                     {{ content.primary }}
@@ -22,7 +22,7 @@
             {% if directory %}
             <div {{ region_attributes.secondary.addClass('yds-two-column__secondary') }}>
                 {% else %}
-                <div {{ bem('secondary', [], two_column__base_class) }}>
+                <div {{ attributes.addClass("#{two_column__base_class}__secondary") }}>
                     {% endif %}
                     {% block two_column__secondary %}
                         {{ content.secondary }}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/layouts/two-column/ys-layouts--yds-twocol.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/layouts/two-column/ys-layouts--yds-twocol.html.twig
@@ -10,25 +10,15 @@
 
 <div {{ attributes.addClass(two_column__base_class) }} data-component-width='max' data-embedded-components>
     <div {{ attributes.addClass("#{two_column__base_class}__inner") }}>
-        {% if directory %}
-        <div {{ region_attributes.primary.addClass('yds-two-column__primary') }}>
-            {% else %}
-            <div {{ attributes.addClass("#{two_column__base_class}__primary") }}>
-                {% endif %}
-                {% block two_column__primary %}
-                    {{ content.primary }}
-                {% endblock %}
-            </div>
-            {% if directory %}
-            <div {{ region_attributes.secondary.addClass('yds-two-column__secondary') }}>
-                {% else %}
-                <div {{ attributes.addClass("#{two_column__base_class}__secondary") }}>
-                    {% endif %}
-                    {% block two_column__secondary %}
-                        {{ content.secondary }}
-                    {% endblock %}
-                </div>
-            </div>
+        <div {{ attributes.addClass("#{two_column__base_class}__primary") }}>
+            {% block two_column__primary %}
+                {{ content.primary }}
+            {% endblock %}
+        </div>
+        <div {{ attributes.addClass("#{two_column__base_class}__secondary") }}>
+            {% block two_column__secondary %}
+                {{ content.secondary }}
+            {% endblock %}
         </div>
     </div>
 </div>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/layouts/two-column/ys-layouts--yds-twocol.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/layouts/two-column/ys-layouts--yds-twocol.html.twig
@@ -10,12 +10,12 @@
 
 <div {{ attributes.addClass(two_column__base_class) }} data-component-width='max' data-embedded-components>
     <div {{ attributes.addClass("#{two_column__base_class}__inner") }}>
-        <div {{ attributes.addClass("#{two_column__base_class}__primary") }}>
+        <div {{ region_attributes.primary.addClass("#{two_column__base_class}__primary") }}>
             {% block two_column__primary %}
                 {{ content.primary }}
             {% endblock %}
         </div>
-        <div {{ attributes.addClass("#{two_column__base_class}__secondary") }}>
+        <div {{ region_attributes.secondary.addClass("#{two_column__base_class}__secondary") }}>
             {% block two_column__secondary %}
                 {{ content.secondary }}
             {% endblock %}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/layouts/two-column/ys-layouts--yds-twocol.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/layouts/two-column/ys-layouts--yds-twocol.html.twig
@@ -1,12 +1,21 @@
+{#
+ # For each region, we need to check whether it either has content to render
+ # (used by the frontend) or has attributes (used by the backend) to know if we
+ # should render the region in a given circumstance. The 'has_primary' and
+ # 'has_secondary' checks below account for both cases.
+ #}
+{% set has_primary = content.primary|render is not empty or content.primary['#attributes'] %}
+{% set has_secondary = content.secondary|render is not empty or content.secondary['#attributes'] %}
+
 {% if content %}
   <div {{ attributes.addClass('yds-two-column').setAttribute('data-component-width', 'max').setAttribute('data-embedded-components', '') }}>
     <div class='yds-two-column__inner'>
-      {% if content.primary %}
+      {% if has_primary %}
         <div {{ region_attributes.primary.addClass('yds-two-column__primary') }}>
           {{ content.primary }}
         </div>
       {% endif %}
-      {% if content.secondary %}
+      {% if has_secondary %}
         <div {{ region_attributes.secondary.addClass('yds-two-column__secondary') }}>
           {{ content.secondary }}
         </div>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/layouts/two-column/ys-layouts--yds-twocol.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/layouts/two-column/ys-layouts--yds-twocol.html.twig
@@ -1,14 +1,16 @@
-<div class='yds-two-column' data-component-width='max' data-embedded-components>
+{% if content %}
+  <div {{ attributes.addClass('yds-two-column').setAttribute('data-component-width', 'max').setAttribute('data-embedded-components', '') }}>
     <div class='yds-two-column__inner'>
-        <div class='yds-two-column__primary'>
-            {% block two_column__primary %}
-                {{ content.primary }}
-            {% endblock %}
+      {% if content.primary %}
+        <div {{ region_attributes.primary.addClass('yds-two-column__primary') }}>
+          {{ content.primary }}
         </div>
-        <div  class='yds-two-column__secondary'>
-            {% block two_column__secondary %}
-                {{ content.secondary }}
-            {% endblock %}
+      {% endif %}
+      {% if content.secondary %}
+        <div {{ region_attributes.secondary.addClass('yds-two-column__secondary') }}>
+          {{ content.secondary }}
         </div>
+      {% endif %}
     </div>
-</div>
+  </div>
+{% endif %}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/layouts/two-column/ys-layouts--yds-twocol.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/layouts/two-column/ys-layouts--yds-twocol.html.twig
@@ -1,0 +1,34 @@
+{#
+# In this file, we're checking `if directory` in order to determine if the
+# active environment is a Drupal site. We need to do this because Drupal's
+# drag-and-drop interface needs specific attributes on the wrapper elements
+# that would not make sense, or even cause errors in environments like
+# Storybook.
+#}
+
+{% set two_column__base_class = 'yds-two-column' %}
+
+<div {{ bem(two_column__base_class) }} data-component-width='max' data-embedded-components>
+    <div {{ bem('inner', [], two_column__base_class) }}>
+        {% if directory %}
+        <div {{ region_attributes.primary.addClass('yds-two-column__primary') }}>
+            {% else %}
+            <div {{ bem('primary', [], two_column__base_class) }}>
+                {% endif %}
+                {% block two_column__primary %}
+                    {{ content.primary }}
+                {% endblock %}
+            </div>
+            {% if directory %}
+            <div {{ region_attributes.secondary.addClass('yds-two-column__secondary') }}>
+                {% else %}
+                <div {{ bem('secondary', [], two_column__base_class) }}>
+                    {% endif %}
+                    {% block two_column__secondary %}
+                        {{ content.secondary }}
+                    {% endblock %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.info.yml
@@ -1,0 +1,7 @@
+name: YaleSites Layouts
+type: module
+description: Layouts shared across YaleSites
+core_version_requirement: ^8 || ^9
+package: YaleSites
+dependencies:
+  - drupal:layout_builder

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.info.yml
@@ -4,4 +4,4 @@ description: Layouts shared across YaleSites
 core_version_requirement: ^8 || ^9
 package: YaleSites
 dependencies:
-  - drupal:layout_builder
+  - drupal:layout_discovery

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.layouts.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.layouts.yml
@@ -1,0 +1,11 @@
+two_column:
+  label: 'YDS Two column'
+  category: 'YDS Layouts'
+  path: templates/layouts/two-column
+  template: ys-layouts--yds-twocol
+  default_region: primary
+  regions:
+    primary:
+      label: Primary content
+    secondary:
+      label: Secondary content

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.layouts.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.layouts.yml
@@ -1,6 +1,7 @@
+# YaleSites two column layout used by layout paragraphs.
 two_column:
-  label: 'YDS Two column'
-  category: 'YDS Layouts'
+  label: 'Two column'
+  category: 'YaleSites Layouts'
   path: templates/layouts/two-column
   template: ys-layouts--yds-twocol
   default_region: primary

--- a/web/profiles/custom/yalesites_profile/yalesites_profile.info.yml
+++ b/web/profiles/custom/yalesites_profile/yalesites_profile.info.yml
@@ -42,6 +42,7 @@ install:
   - file
   - filter
   - image
+  - layout_builder
   - link
   - media
   - media_library

--- a/web/profiles/custom/yalesites_profile/yalesites_profile.info.yml
+++ b/web/profiles/custom/yalesites_profile/yalesites_profile.info.yml
@@ -64,6 +64,7 @@ install:
   - ys_admin
   - ys_alert
   - ys_mail
+  - ys_layouts
 
 # Required modules
 # Note that any dependencies of the modules listed here will be installed automatically.

--- a/web/profiles/custom/yalesites_profile/yalesites_profile.info.yml
+++ b/web/profiles/custom/yalesites_profile/yalesites_profile.info.yml
@@ -42,7 +42,6 @@ install:
   - file
   - filter
   - image
-  - layout_builder
   - link
   - media
   - media_library
@@ -64,8 +63,8 @@ install:
   - workflows
   - ys_admin
   - ys_alert
-  - ys_mail
   - ys_layouts
+  - ys_mail
 
 # Required modules
 # Note that any dependencies of the modules listed here will be installed automatically.


### PR DESCRIPTION
## [YALB-525: Two Column Layout Builder Layout](https://yaleits.atlassian.net/browse/YALB-525)

### Description of work
- Defines a new ys_layouts module to contain custom layouts for the platform.
- Creates a new layout for a two column layout and provides a template for this layout.
- Enables the ys_layout module. Also enables contextual links. Not important for this PR, be we will leave it in there for now unless there are any objections.

### Functional testing steps:
- [x] [Login to the multidev](https://pr-22-yalesites-platform.pantheonsite.io/user) (password in JIRA ticket.)
- [x] Navigate to the [Layout Paragraph Sections](https://pr-22-yalesites-platform.pantheonsite.io/admin/config/content/layout_paragraphs/sections) settings page.
- [x] Click the 'Use as a Layout Section' for one of the paragraphs (any of them.) 
- [x] Verify that 'YaleSites Layouts' appears as an optgroup in this list of layouts and a 'Two column' layout exists in this group.
