### PR TITLE
fix: increase process-timeout for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,8 @@
             "composer/installers": true,
             "cweagans/composer-patches": true,
             "drupal/core-composer-scaffold": true
-        }
+        },
+        "process-timeout": 600
     },
     "scripts": {
         "unit-test": "echo 'No unit test step defined.'",


### PR DESCRIPTION
## Fix: increase process-timeout for composer

### Description of work
- Some users are running into an issue running `lando start` due to the default 300s composer timeout. I thought it might be an issue on older machines but I just experienced it on a 2018 Macbook Pro. This change increases composer process-timeout to to 600s.
```
 187/189 [===========================>]  98%    Install of drupal/core failed
    Install of yalesites-org/atomic failed
The following exception is caused by a process timeout
Check https://getcomposer.org/doc/06-config.md#process-timeout for details

  [Symfony\Component\Process\Exception\ProcessTimedOutException]
  The process "'/usr/bin/unzip' -qq '/app/vendor/composer/tmp-32ef6aef09a09ce508c461277acbe341' -d '/app/vendor/composer/e4758c8e'" exceeded the timeout of 300 seconds.
```

### Functional testing steps:
- [x] Run `lando start` without a process timeout error