### PR TITLE
refactor: move composer timeout to landofile from composer.json

### DIFF
--- a/.lando.local.example.yml
+++ b/.lando.local.example.yml
@@ -20,3 +20,8 @@ tooling:
     env:
       # Set base url based on above Lando project 'name'.
       DRUSH_OPTIONS_URI: "https://yalesites-platform.lndo.site/"
+services:
+  appserver:
+    overrides:
+      environment:
+        COMPOSER_PROCESS_TIMEOUT: 1800

--- a/composer.json
+++ b/composer.json
@@ -102,8 +102,7 @@
             "composer/installers": true,
             "cweagans/composer-patches": true,
             "drupal/core-composer-scaffold": true
-        },
-        "process-timeout": 600
+        }
     },
     "scripts": {
         "unit-test": "echo 'No unit test step defined.'",


### PR DESCRIPTION
## Increase and move composer timeout to landofile

### Description of work
- Moved the composer process-timeout override to `.lando.local.example.yml`
- Increased the value from 600s to 1800s

I was continuing to have issues building a local environment on an older Macbook Pro with the `composer install` step timing out. Increasing the timeout to 1800s fixed it but I also found that the config can be overridden in the landofile, so I moved it out of composer.json. Now, it won't get set on Pantheon.

### Functional testing steps:
- Run `npm run setup` and confirm there are no composer process timeout errors