### PR TITLE
YALB-527: Image Cropping

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -45,7 +45,7 @@
         "drupal/redirect": "^1.7",
         "drupal/twig_tweak": "^3.1",
         "drupal/xmlsitemap": "^1.2",
-        "yalesites-org/atomic": "dev-YALB-430-layout-paragraphs-artifacts"
+        "yalesites-org/atomic": "^1.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.image.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.image.default.yml
@@ -6,7 +6,7 @@ dependencies:
     - field.field.media.image.field_media_image
     - media.type.image
   module:
-    - image
+    - image_widget_crop
     - path
 id: media.image.default
 targetEntityType: media
@@ -20,12 +20,19 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_media_image:
-    type: image_image
+    type: image_widget_crop
     weight: 0
     region: content
     settings:
       progress_indicator: throbber
       preview_image_style: ''
+      crop_preview_image_style: crop_thumbnail
+      crop_list:
+        - banner_16_5
+      crop_types_required: {  }
+      warn_multiple_usages: true
+      show_crop_area: false
+      show_default_crop: true
     third_party_settings: {  }
   path:
     type: path

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.banner_16_5.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.banner_16_5.yml
@@ -1,0 +1,30 @@
+uuid: 4816fe32-7fd6-4d68-90ff-206b8ae21bb5
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.banner_16_5
+    - field.field.media.image.field_media_image
+    - media.type.image
+    - responsive_image.styles.banner_16_5_
+  module:
+    - responsive_image
+id: media.image.banner_16_5
+targetEntityType: media
+bundle: image
+mode: banner_16_5
+content:
+  field_media_image:
+    type: responsive_image
+    label: hidden
+    settings:
+      responsive_image_style: banner_16_5_
+      image_link: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.cta_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.cta_banner.default.yml
@@ -19,7 +19,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: full
+      view_mode: banner_16_5
       link: false
     third_party_settings: {  }
     weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.cta_banner.preview.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.cta_banner.preview.yml
@@ -7,7 +7,7 @@ dependencies:
     - field.field.paragraph.cta_banner.field_image
     - field.field.paragraph.cta_banner.field_link
     - field.field.paragraph.cta_banner.field_text
-    - image.style.max_width_320
+    - image.style.16_5_320
     - paragraphs.paragraphs_type.cta_banner
   module:
     - link
@@ -23,7 +23,7 @@ content:
     label: hidden
     settings:
       image_link: ''
-      image_style: max_width_320
+      image_style: '16_5_320'
     third_party_settings: {  }
     weight: 0
     region: content

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.image.preview.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.image.preview.yml
@@ -6,8 +6,10 @@ dependencies:
     - core.entity_view_mode.paragraph.preview
     - field.field.paragraph.image.field_image
     - field.field.paragraph.image.field_text
+    - image.style.media_library
     - paragraphs.paragraphs_type.image
   module:
+    - media
     - text
 id: paragraph.image.preview
 targetEntityType: paragraph
@@ -15,11 +17,11 @@ bundle: image
 mode: preview
 content:
   field_image:
-    type: entity_reference_entity_view
+    type: media_thumbnail
     label: hidden
     settings:
-      view_mode: full
-      link: false
+      image_link: ''
+      image_style: media_library
     third_party_settings: {  }
     weight: 0
     region: content

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.pop_out_image.preview.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.pop_out_image.preview.yml
@@ -7,8 +7,10 @@ dependencies:
     - field.field.paragraph.pop_out_image.field_caption
     - field.field.paragraph.pop_out_image.field_image
     - field.field.paragraph.pop_out_image.field_text
+    - image.style.media_library
     - paragraphs.paragraphs_type.pop_out_image
   module:
+    - media
     - text
 id: paragraph.pop_out_image.preview
 targetEntityType: paragraph
@@ -16,25 +18,27 @@ bundle: pop_out_image
 mode: preview
 content:
   field_caption:
-    type: text_default
+    type: text_trimmed
     label: inline
-    settings: {  }
+    settings:
+      trim_length: 600
     third_party_settings: {  }
     weight: 1
     region: content
   field_image:
-    type: entity_reference_entity_view
+    type: media_thumbnail
     label: hidden
     settings:
-      view_mode: image_float
-      link: false
+      image_link: ''
+      image_style: media_library
     third_party_settings: {  }
     weight: 0
     region: content
   field_text:
-    type: text_default
+    type: text_trimmed
     label: above
-    settings: {  }
+    settings:
+      trim_length: 600
     third_party_settings: {  }
     weight: 2
     region: content

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.text.preview.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.text.preview.yml
@@ -15,7 +15,7 @@ mode: preview
 content:
   field_text:
     type: text_trimmed
-    label: above
+    label: hidden
     settings:
       trim_length: 600
     third_party_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_mode.media.banner_16_5.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_mode.media.banner_16_5.yml
@@ -1,0 +1,10 @@
+uuid: 472c8ad5-25d9-43bc-8de6-a9892636b91e
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.banner_16_5
+label: 'Banner (16:5)'
+targetEntityType: media
+cache: true

--- a/web/profiles/custom/yalesites_profile/config/sync/crop.type.banner_16_5.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/crop.type.banner_16_5.yml
@@ -1,0 +1,12 @@
+uuid: a929ee7e-03bb-4f2d-9dc8-ab36b4efd9ce
+langcode: en
+status: true
+dependencies: {  }
+label: 'Banner (16:5)'
+id: banner_16_5
+description: ''
+aspect_ratio: '16:5'
+soft_limit_width: null
+soft_limit_height: null
+hard_limit_width: null
+hard_limit_height: null

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_1120.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_1120.yml
@@ -1,0 +1,26 @@
+uuid: 5c3406d8-a730-4ba5-bd60-d83491d9f093
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.banner_16_5
+  module:
+    - crop
+name: '16_5_1120'
+label: '16:5 (1120)'
+effects:
+  a3f6f93a-6e59-4ff0-97fe-4dfa901d7afb:
+    uuid: a3f6f93a-6e59-4ff0-97fe-4dfa901d7afb
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: banner_16_5
+      automatic_crop_provider: null
+  d3c08e35-74ed-47c5-ba44-cdd79a5826b9:
+    uuid: d3c08e35-74ed-47c5-ba44-cdd79a5826b9
+    id: image_scale
+    weight: 2
+    data:
+      width: 1120
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_1280.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_1280.yml
@@ -1,0 +1,26 @@
+uuid: c5e4cfb5-50bb-42eb-a08b-6e05fc328c77
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.banner_16_5
+  module:
+    - crop
+name: '16_5_1280'
+label: '16:5 (1280)'
+effects:
+  4494f16c-39ca-417d-9fee-4bd4e5a7a93a:
+    uuid: 4494f16c-39ca-417d-9fee-4bd4e5a7a93a
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: banner_16_5
+      automatic_crop_provider: null
+  82a60e78-2854-4454-b06d-43da7b6a2133:
+    uuid: 82a60e78-2854-4454-b06d-43da7b6a2133
+    id: image_scale
+    weight: 2
+    data:
+      width: 1280
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_1440.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_1440.yml
@@ -1,0 +1,26 @@
+uuid: 6a0aceba-426b-4c0e-b6e0-2ec0f809204c
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.banner_16_5
+  module:
+    - crop
+name: '16_5_1440'
+label: '16:5 (1440)'
+effects:
+  0d9e3344-94e1-4e67-96c9-5e18ecafaa0f:
+    uuid: 0d9e3344-94e1-4e67-96c9-5e18ecafaa0f
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: banner_16_5
+      automatic_crop_provider: null
+  80f73216-aac0-443d-a582-c9356271735b:
+    uuid: 80f73216-aac0-443d-a582-c9356271735b
+    id: image_scale
+    weight: 2
+    data:
+      width: 1440
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_1600.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_1600.yml
@@ -1,0 +1,26 @@
+uuid: 8a1334f3-818b-49b7-b06a-ab4931978099
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.banner_16_5
+  module:
+    - crop
+name: '16_5_1600'
+label: '16:5 (1600)'
+effects:
+  28fe5422-512f-451e-81e1-b43b97ecb038:
+    uuid: 28fe5422-512f-451e-81e1-b43b97ecb038
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: banner_16_5
+      automatic_crop_provider: null
+  a033acbe-817e-4aeb-8f32-7761ef2a6bc4:
+    uuid: a033acbe-817e-4aeb-8f32-7761ef2a6bc4
+    id: image_scale
+    weight: 2
+    data:
+      width: 1600
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_1760.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_1760.yml
@@ -1,0 +1,26 @@
+uuid: d7b468e9-e31b-4e8d-b6a8-42632f249c3d
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.banner_16_5
+  module:
+    - crop
+name: '16_5_1760'
+label: '16:5 (1760)'
+effects:
+  6ecf02e7-923b-46a4-9ac5-9c05a9958c98:
+    uuid: 6ecf02e7-923b-46a4-9ac5-9c05a9958c98
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: banner_16_5
+      automatic_crop_provider: null
+  569cc70b-52d4-453d-9869-7bf6d70b051d:
+    uuid: 569cc70b-52d4-453d-9869-7bf6d70b051d
+    id: image_scale
+    weight: 2
+    data:
+      width: 1760
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_1920.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_1920.yml
@@ -1,0 +1,26 @@
+uuid: 961fa128-7753-481c-905c-a92cc8f7bae3
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.banner_16_5
+  module:
+    - crop
+name: '16_5_1920'
+label: '16:5 (1920)'
+effects:
+  fece1c6b-0f42-458c-9d89-f5c7eda22db6:
+    uuid: fece1c6b-0f42-458c-9d89-f5c7eda22db6
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: banner_16_5
+      automatic_crop_provider: null
+  bf2b35d1-7243-4fc7-a3e2-9bd4a91ec426:
+    uuid: bf2b35d1-7243-4fc7-a3e2-9bd4a91ec426
+    id: image_scale
+    weight: 2
+    data:
+      width: 1920
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_2080.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_2080.yml
@@ -1,0 +1,26 @@
+uuid: 0f2d8725-4a60-4d73-b1f3-6456179c4914
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.banner_16_5
+  module:
+    - crop
+name: '16_5_2080'
+label: '16:5 (2080)'
+effects:
+  b7294c69-6971-48f4-9859-a1de8155be91:
+    uuid: b7294c69-6971-48f4-9859-a1de8155be91
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: banner_16_5
+      automatic_crop_provider: null
+  ebcb2d83-3d02-42b5-9c09-159cea7fdbdb:
+    uuid: ebcb2d83-3d02-42b5-9c09-159cea7fdbdb
+    id: image_scale
+    weight: 2
+    data:
+      width: 2080
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_2240.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_2240.yml
@@ -1,0 +1,26 @@
+uuid: 98367c5b-ef66-4ec2-b03c-fc5e24d5796c
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.banner_16_5
+  module:
+    - crop
+name: '16_5_2240'
+label: '16:5 (2240)'
+effects:
+  8569aa9c-38b7-4df9-8854-8e0499bda7f9:
+    uuid: 8569aa9c-38b7-4df9-8854-8e0499bda7f9
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: banner_16_5
+      automatic_crop_provider: null
+  5ed6910a-0431-4e02-9e04-582972281791:
+    uuid: 5ed6910a-0431-4e02-9e04-582972281791
+    id: image_scale
+    weight: 2
+    data:
+      width: 2240
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_2400.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_2400.yml
@@ -1,0 +1,26 @@
+uuid: d2a1bea4-0a12-4daa-ad9c-b4da77eb2457
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.banner_16_5
+  module:
+    - crop
+name: '16_5_2400'
+label: '16:5 (2400)'
+effects:
+  fdca5cb8-0cc2-4428-85f4-539f02dd6464:
+    uuid: fdca5cb8-0cc2-4428-85f4-539f02dd6464
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: banner_16_5
+      automatic_crop_provider: null
+  29b5e3f6-5798-4e37-96d7-948864c2d057:
+    uuid: 29b5e3f6-5798-4e37-96d7-948864c2d057
+    id: image_scale
+    weight: 2
+    data:
+      width: 2400
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_320.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_320.yml
@@ -1,0 +1,26 @@
+uuid: 8296566f-2005-42ca-9cf6-1df8d1f02f31
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.banner_16_5
+  module:
+    - crop
+name: '16_5_320'
+label: '16:5 (320)'
+effects:
+  0feb4b13-073a-4cb0-a9f3-8e00781e75ab:
+    uuid: 0feb4b13-073a-4cb0-a9f3-8e00781e75ab
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: banner_16_5
+      automatic_crop_provider: null
+  bb0227d9-61ec-495d-81d2-a3a00318b69e:
+    uuid: bb0227d9-61ec-495d-81d2-a3a00318b69e
+    id: image_scale
+    weight: 2
+    data:
+      width: 320
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_480.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_480.yml
@@ -1,0 +1,26 @@
+uuid: 09e3785d-f42c-4ef9-ae6a-1d30d00ed82a
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.banner_16_5
+  module:
+    - crop
+name: '16_5_480'
+label: '16:5 (480)'
+effects:
+  bada992f-b13e-42c2-b183-8e08361035b5:
+    uuid: bada992f-b13e-42c2-b183-8e08361035b5
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: banner_16_5
+      automatic_crop_provider: null
+  7fe86891-14d8-4c2c-9d1b-421de4c16bf1:
+    uuid: 7fe86891-14d8-4c2c-9d1b-421de4c16bf1
+    id: image_scale
+    weight: 2
+    data:
+      width: 480
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_640.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_640.yml
@@ -1,0 +1,26 @@
+uuid: 36769b56-0b3b-4b85-a842-1af1bef4c4cd
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.banner_16_5
+  module:
+    - crop
+name: '16_5_640'
+label: '16:5 (640)'
+effects:
+  21ec1a74-ca5e-4569-bc23-efdc7d3ef650:
+    uuid: 21ec1a74-ca5e-4569-bc23-efdc7d3ef650
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: banner_16_5
+      automatic_crop_provider: null
+  a47c26e5-9945-4897-8689-5210f7508685:
+    uuid: a47c26e5-9945-4897-8689-5210f7508685
+    id: image_scale
+    weight: 2
+    data:
+      width: 640
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_800.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_800.yml
@@ -1,0 +1,26 @@
+uuid: c2104bba-07e7-4a0c-8331-c6abd25969cd
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.banner_16_5
+  module:
+    - crop
+name: '16_5_800'
+label: '16:5 (800)'
+effects:
+  2f8b8182-8846-4f14-86f7-0e51c0952920:
+    uuid: 2f8b8182-8846-4f14-86f7-0e51c0952920
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: banner_16_5
+      automatic_crop_provider: null
+  caeb40a3-dcb4-4ee1-9dcf-056a1858d281:
+    uuid: caeb40a3-dcb4-4ee1-9dcf-056a1858d281
+    id: image_scale
+    weight: 2
+    data:
+      width: 800
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_960.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.16_5_960.yml
@@ -1,0 +1,26 @@
+uuid: 86c8438f-85c2-4d1d-a1ff-5ac505c37ebb
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.banner_16_5
+  module:
+    - crop
+name: '16_5_960'
+label: '16:5 (960)'
+effects:
+  ed3fe91d-a78e-4f45-8656-2d9b7435c901:
+    uuid: ed3fe91d-a78e-4f45-8656-2d9b7435c901
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: banner_16_5
+      automatic_crop_provider: null
+  91d87a1d-d8b4-4a25-b8ed-110ddc992632:
+    uuid: 91d87a1d-d8b4-4a25-b8ed-110ddc992632
+    id: image_scale
+    weight: 2
+    data:
+      width: 960
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.banner_16_5_.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.banner_16_5_.yml
@@ -1,0 +1,45 @@
+uuid: c2c26c15-4750-4299-a9df-5cabdc14b3c8
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.16_5_1120
+    - image.style.16_5_1280
+    - image.style.16_5_1440
+    - image.style.16_5_1600
+    - image.style.16_5_1760
+    - image.style.16_5_1920
+    - image.style.16_5_2080
+    - image.style.16_5_2240
+    - image.style.16_5_2400
+    - image.style.16_5_320
+    - image.style.16_5_480
+    - image.style.16_5_640
+    - image.style.16_5_800
+    - image.style.16_5_960
+id: banner_16_5_
+label: 'Banner (16:5)'
+image_style_mappings:
+  -
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - '16_5_2400'
+        - '16_5_1120'
+        - '16_5_1280'
+        - '16_5_1440'
+        - '16_5_1600'
+        - '16_5_1760'
+        - '16_5_1920'
+        - '16_5_2080'
+        - '16_5_2240'
+        - '16_5_320'
+        - '16_5_480'
+        - '16_5_640'
+        - '16_5_800'
+        - '16_5_960'
+    breakpoint_id: responsive_image.viewport_sizing
+    multiplier: 1x
+breakpoint_group: responsive_image
+fallback_image_style: '16_5_320'


### PR DESCRIPTION
## [YALB-527: Image Cropping](https://yaleits.atlassian.net/browse/YALB-527)

### Description of work
- Creates a "Banner (16:5)" crop type
- Creates "Banner (16:5)" image styles and responsive image style
- Creates "Banner (16:5)" media view mode, and configure it to use the above
- Updates the Banner component to use the above media view mode
- Tweaks some of the preview view modes of paragraphs

### Functional testing steps:
- [ ] [Log in](https://pr-29-yalesites-platform.pantheonsite.io/user/login) and then [create a page](https://pr-29-yalesites-platform.pantheonsite.io/node/add/page), and give it a title
- [ ] Go to the "Banner" tab
- [ ] Fill in the text fields
- [ ] Click "Add Media"
	- [ ] Upload a photo and give it some alt text
	- [ ] Right below the alt text field, expand the "Crop image" section
		- [ ] In here, move the crop indicator to wherever you want. Just note what's inside the indicator to validate it on the frontend.
	- [ ] Click "Save"
- [ ] Save the Banner, and save the page
- [ ] Verify the banner is shown, and that your cropped selection is used in the banner at all screen sizes
- [ ] Inspect the image, and verify the images in the `srcset` are using the `16_5_<width>` image styles.

### Notes
- [ ] Edit the page, and edit the banner
	- [ ] Note that you can't change anything about the image at the moment... I'd like to be able to adjust the crop here easily.
	- [ ] Currently, you have to go to /admin/content/media and edit the media item to be able to adjust the crop