### PR TITLE
YALB-519 - adds Editoria11y module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "cweagans/composer-patches": "^1.7",
         "drupal/core-composer-scaffold": "^9.2",
         "drupal/core-recommended": "^9.2",
+        "drupal/editoria11y": "^1.0",
         "drush/drush": "^10",
         "pantheon-systems/drupal-integrations": "^9",
         "yalesites-org/yalesites_profile": "self.version"

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -24,6 +24,7 @@ module:
   dblog: 0
   dynamic_page_cache: 0
   editor: 0
+  editoria11y: 0
   emulsify_twig: 0
   entity_reference_revisions: 0
   field: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/editoria11y.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/editoria11y.settings.yml
@@ -1,0 +1,11 @@
+_core:
+  default_config_hash: NGxFi-xycxrzrGVZtCUl7MACi0jVRk130tNabvIN6ng
+content_root: ''
+no_load: ''
+ignore_containers: ''
+embedded_content_warning: ''
+allow_overflow: ''
+assertiveness: smart
+download_links: ''
+ignore_link_strings: ''
+hidden_handlers: ''


### PR DESCRIPTION
## [YALB-519: Title](https://yaleits.atlassian.net/browse/YALB-519)

### Description of work
- Adds and configs Editoria11y module.

### Functional testing steps:
- [x] Add some content that has obvious accessibility issues such as a skipped heading levels or a table with no header cells or a link with a url as the link text. 
- [x] Save the page.  See the editoria11y widget in the lower right.  Click on it to update it's feedback.
