### PR TITLE
YALB-451: BE: Roles and Permissions

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/system.action.user_add_role_action.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.action.user_add_role_action.platform_admin.yml
@@ -1,0 +1,14 @@
+uuid: e6055e4c-ee05-43c4-9395-403314fb3445
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.platform_admin
+  module:
+    - user
+id: user_add_role_action.platform_admin
+label: 'Add the Platform administrator role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: platform_admin

--- a/web/profiles/custom/yalesites_profile/config/sync/system.action.user_add_role_action.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.action.user_add_role_action.site_admin.yml
@@ -1,0 +1,14 @@
+uuid: 4e2021c5-ea76-47f9-9ee4-dca19593b17f
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.site_admin
+  module:
+    - user
+id: user_add_role_action.site_admin
+label: 'Add the Site administrator role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: site_admin

--- a/web/profiles/custom/yalesites_profile/config/sync/system.action.user_remove_role_action.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.action.user_remove_role_action.platform_admin.yml
@@ -1,0 +1,14 @@
+uuid: 8362e6e5-32ae-4bd6-b00a-c3aad985943b
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.platform_admin
+  module:
+    - user
+id: user_remove_role_action.platform_admin
+label: 'Remove the Platform administrator role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: platform_admin

--- a/web/profiles/custom/yalesites_profile/config/sync/system.action.user_remove_role_action.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.action.user_remove_role_action.site_admin.yml
@@ -1,0 +1,14 @@
+uuid: 26a89d30-0ce4-4ee0-9fcb-accefe94894a
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.site_admin
+  module:
+    - user
+id: user_remove_role_action.site_admin
+label: 'Remove the Site administrator role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: site_admin

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -1,0 +1,61 @@
+uuid: 43a84569-622f-4e8e-abb5-7c048008d7c2
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+    - node.type.news
+    - node.type.page
+  module:
+    - media
+    - node
+    - paragraphs
+    - search
+    - system
+    - taxonomy
+    - toolbar
+id: platform_admin
+label: 'Platform administrator'
+weight: 2
+is_admin: null
+permissions:
+  - 'access content overview'
+  - 'access site in maintenance mode'
+  - 'access site reports'
+  - 'access taxonomy overview'
+  - 'access toolbar'
+  - 'access user profiles'
+  - 'administer taxonomy'
+  - 'administer users'
+  - 'create image media'
+  - 'create media'
+  - 'create news content'
+  - 'create page content'
+  - 'delete any image media'
+  - 'delete any media'
+  - 'delete any news content'
+  - 'delete any page content'
+  - 'delete media'
+  - 'delete own image media'
+  - 'delete own news content'
+  - 'delete own page content'
+  - 'edit any image media'
+  - 'edit any news content'
+  - 'edit any page content'
+  - 'edit own image media'
+  - 'edit own news content'
+  - 'edit own page content'
+  - 'revert news revisions'
+  - 'revert page revisions'
+  - 'search content'
+  - 'update any media'
+  - 'update media'
+  - 'use advanced search'
+  - 'view all media revisions'
+  - 'view all revisions'
+  - 'view news revisions'
+  - 'view own unpublished content'
+  - 'view own unpublished media'
+  - 'view page revisions'
+  - 'view the administration theme'
+  - 'view unpublished paragraphs'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -1,0 +1,60 @@
+uuid: 1cefeb42-bc40-4168-a483-238896f41bcd
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+    - node.type.news
+    - node.type.page
+  module:
+    - media
+    - node
+    - paragraphs
+    - search
+    - system
+    - taxonomy
+    - toolbar
+id: site_admin
+label: 'Site administrator'
+weight: 3
+is_admin: null
+permissions:
+  - 'access content overview'
+  - 'access site in maintenance mode'
+  - 'access taxonomy overview'
+  - 'access toolbar'
+  - 'access user profiles'
+  - 'administer taxonomy'
+  - 'administer users'
+  - 'create image media'
+  - 'create media'
+  - 'create news content'
+  - 'create page content'
+  - 'delete any image media'
+  - 'delete any media'
+  - 'delete any news content'
+  - 'delete any page content'
+  - 'delete media'
+  - 'delete own image media'
+  - 'delete own news content'
+  - 'delete own page content'
+  - 'edit any image media'
+  - 'edit any news content'
+  - 'edit any page content'
+  - 'edit own image media'
+  - 'edit own news content'
+  - 'edit own page content'
+  - 'revert news revisions'
+  - 'revert page revisions'
+  - 'search content'
+  - 'update any media'
+  - 'update media'
+  - 'use advanced search'
+  - 'view all media revisions'
+  - 'view all revisions'
+  - 'view news revisions'
+  - 'view own unpublished content'
+  - 'view own unpublished media'
+  - 'view page revisions'
+  - 'view the administration theme'
+  - 'view unpublished paragraphs'


### PR DESCRIPTION
## [YALB-451: BE: Roles and Permissions](https://yaleits.atlassian.net/browse/YALB-451)

### Description of work
- Adds site_admin and platform_admin user roles
- Adds default permissions for each role

### Functional testing steps:
- [ ] Visit `admin/people/roles` and see "Platform administrator" and "Site administrator" roles
- [ ] Visit `admin/people/permissions` and see new permissions set for both roles

