### PR TITLE
YALB-536: configs layout_paragraphs modal

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/layout_paragraphs.modal_settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/layout_paragraphs.modal_settings.yml
@@ -1,0 +1,4 @@
+width: 90%
+height: 90%
+autoresize: true
+theme_display: null


### PR DESCRIPTION
## [YALB-536: Bug: Backend Editing - Modal doesn't size/resize properly](https://yaleits.atlassian.net/browse/YALB-536)

### Description of work
- Fixes modal resizing by configures modal settings

### Functional testing steps:
- [x] Add a Text With Image paragraph and edit from the frontend.  The modal should automatically resize.  
