### PR TITLE
YALB-278 - Event content type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,10 @@
   "require": {
     "composer/installers": "^1.9",
     "cweagans/composer-patches": "^1.7",
+    "drupal/address": "^1.10",
     "drupal/core-composer-scaffold": "^9.2",
     "drupal/core-recommended": "^9.2",
+    "drupal/smart_date": "^3.5",
     "drush/drush": "^10",
     "pantheon-systems/drupal-integrations": "^9",
     "yalesites-org/yalesites_profile": "self.version"

--- a/web/profiles/custom/yalesites_profile/config/sync/core.base_field_override.node.event.promote.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.base_field_override.node.event.promote.yml
@@ -1,0 +1,22 @@
+uuid: a98ae9e9-9bc8-4b5c-a667-1aa22c938cf5
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.event
+id: node.event.promote
+field_name: promote
+entity_type: node
+bundle: event
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/web/profiles/custom/yalesites_profile/config/sync/core.base_field_override.node.event.status.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.base_field_override.node.event.status.yml
@@ -1,0 +1,22 @@
+uuid: fff84acf-2433-4e7c-91ca-593f11f30acb
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.event
+id: node.event.status
+field_name: status
+entity_type: node
+bundle: event
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
@@ -1,0 +1,176 @@
+uuid: ad0ddbf1-9c1e-4328-a6e3-d2162193263e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.event.field_content
+    - field.field.node.event.field_event_cta
+    - field.field.node.event.field_event_date
+    - field.field.node.event.field_event_format
+    - field.field.node.event.field_event_location
+    - field.field.node.event.field_metatags
+    - field.field.node.event.field_subtitle
+    - field.field.node.event.field_teaser_media
+    - field.field.node.event.field_teaser_text
+    - field.field.node.event.field_teaser_title
+    - node.type.event
+  module:
+    - address
+    - link
+    - metatag
+    - paragraphs
+    - path
+    - smart_date
+    - text
+id: node.event.default
+targetEntityType: node
+bundle: event
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_content:
+    type: entity_reference_paragraphs
+    weight: 2
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+  field_event_cta:
+    type: link_default
+    weight: 8
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_event_date:
+    type: smartdate_inline
+    weight: 6
+    region: content
+    settings:
+      modal: false
+      default_duration: 60
+      default_duration_increments: |-
+        30
+        60|1 hour
+        90
+        120|2 hours
+        custom
+      show_extra: false
+      hide_date: true
+    third_party_settings: {  }
+  field_event_format:
+    type: options_select
+    weight: 9
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_event_location:
+    type: address_default
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_metatags:
+    type: metatag_firehose
+    weight: 10
+    region: content
+    settings:
+      sidebar: true
+      use_details: true
+    third_party_settings: {  }
+  field_subtitle:
+    type: text_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_teaser_media:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_teaser_text:
+    type: text_textarea
+    weight: 4
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_teaser_title:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 15
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 13
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 17
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 14
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 11
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 16
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
@@ -1,0 +1,121 @@
+uuid: 11493ede-578f-4b77-9014-2d21dc8a045a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.event.field_content
+    - field.field.node.event.field_event_cta
+    - field.field.node.event.field_event_date
+    - field.field.node.event.field_event_format
+    - field.field.node.event.field_event_location
+    - field.field.node.event.field_metatags
+    - field.field.node.event.field_subtitle
+    - field.field.node.event.field_teaser_media
+    - field.field.node.event.field_teaser_text
+    - field.field.node.event.field_teaser_title
+    - node.type.event
+  module:
+    - address
+    - entity_reference_revisions
+    - link
+    - metatag
+    - options
+    - smart_date
+    - text
+    - user
+id: node.event.default
+targetEntityType: node
+bundle: event
+mode: default
+content:
+  field_content:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_event_cta:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 8
+    region: content
+  field_event_date:
+    type: smartdate_default
+    label: above
+    settings:
+      timezone_override: ''
+      format_type: medium
+      format: default
+      force_chronological: false
+      add_classes: false
+      time_wrapper: true
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_event_format:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 9
+    region: content
+  field_event_location:
+    type: address_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_metatags:
+    type: metatag_empty_formatter
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  field_subtitle:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_teaser_media:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_teaser_text:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_teaser_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -1,0 +1,40 @@
+uuid: a84ab5cf-20aa-4e4e-b31f-3b3d8ba896f6
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.event.field_content
+    - field.field.node.event.field_event_cta
+    - field.field.node.event.field_event_date
+    - field.field.node.event.field_event_format
+    - field.field.node.event.field_event_location
+    - field.field.node.event.field_metatags
+    - field.field.node.event.field_subtitle
+    - field.field.node.event.field_teaser_media
+    - field.field.node.event.field_teaser_text
+    - field.field.node.event.field_teaser_title
+    - node.type.event
+  module:
+    - user
+id: node.event.teaser
+targetEntityType: node
+bundle: event
+mode: teaser
+content:
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_content: true
+  field_event_cta: true
+  field_event_date: true
+  field_event_format: true
+  field_event_location: true
+  field_metatags: true
+  field_subtitle: true
+  field_teaser_media: true
+  field_teaser_text: true
+  field_teaser_title: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -1,6 +1,7 @@
 _core:
   default_config_hash: R4IF-ClDHXxblLcG0L7MgsLvfBIMAvi_skumNFQwkDc
 module:
+  address: 0
   admin_toolbar: 0
   allowed_formats: 0
   block: 0
@@ -61,6 +62,7 @@ module:
   redirect: 0
   responsive_image: 0
   search: 0
+  smart_date: 0
   system: 0
   taxonomy: 0
   text: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_content.yml
@@ -1,0 +1,83 @@
+uuid: b5cbd83a-8f31-417e-b6f7-7855be05dd84
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content
+    - node.type.event
+    - paragraphs.paragraphs_type.accordion
+    - paragraphs.paragraphs_type.callout
+    - paragraphs.paragraphs_type.divider
+    - paragraphs.paragraphs_type.embed
+    - paragraphs.paragraphs_type.image
+    - paragraphs.paragraphs_type.pop_out_image
+    - paragraphs.paragraphs_type.pull_quote
+    - paragraphs.paragraphs_type.text
+    - paragraphs.paragraphs_type.text_with_image
+  module:
+    - entity_reference_revisions
+id: node.event.field_content
+field_name: field_content
+entity_type: node
+bundle: event
+label: Content
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      accordion: accordion
+      callout: callout
+      divider: divider
+      embed: embed
+      image: image
+      pop_out_image: pop_out_image
+      pull_quote: pull_quote
+      text: text
+      text_with_image: text_with_image
+    negate: 0
+    target_bundles_drag_drop:
+      accordion:
+        weight: 14
+        enabled: true
+      accordion_item:
+        weight: 15
+        enabled: false
+      callout:
+        weight: 16
+        enabled: true
+      callout_item:
+        weight: 17
+        enabled: false
+      cta_banner:
+        weight: 18
+        enabled: false
+      divider:
+        weight: 19
+        enabled: true
+      embed:
+        weight: 20
+        enabled: true
+      image:
+        weight: 21
+        enabled: true
+      pop_out_image:
+        weight: 22
+        enabled: true
+      pull_quote:
+        weight: 23
+        enabled: true
+      section:
+        weight: 24
+        enabled: false
+      text:
+        weight: 25
+        enabled: true
+      text_with_image:
+        weight: 26
+        enabled: true
+field_type: entity_reference_revisions

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_event_cta.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_event_cta.yml
@@ -1,0 +1,23 @@
+uuid: 6429518c-83de-4f8a-9467-629097217b0a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_cta
+    - node.type.event
+  module:
+    - link
+id: node.event.field_event_cta
+field_name: field_event_cta
+entity_type: node
+bundle: event
+label: 'Call to Action'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 1
+  link_type: 17
+field_type: link

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_event_date.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_event_date.yml
@@ -1,0 +1,26 @@
+uuid: 831b95dc-6d1c-41a2-b7e1-294ee1003bc1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_date
+    - node.type.event
+  module:
+    - smart_date
+id: node.event.field_event_date
+field_name: field_event_date
+entity_type: node
+bundle: event
+label: Date
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    default_duration: 60
+    default_duration_increments: "30\r\n60|1 hour\r\n90\r\n120|2 hours\r\ncustom"
+    default_date_type: ''
+    default_date: ''
+default_value_callback: ''
+settings: {  }
+field_type: smartdate

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_event_format.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_event_format.yml
@@ -1,0 +1,21 @@
+uuid: a5d45087-36aa-4fe7-bf51-6bc7694a7503
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_format
+    - node.type.event
+  module:
+    - options
+id: node.event.field_event_format
+field_name: field_event_format
+entity_type: node
+bundle: event
+label: Format
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_event_location.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_event_location.yml
@@ -1,0 +1,43 @@
+uuid: 59cdc215-61e7-4806-8116-7a32468c5e77
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_location
+    - node.type.event
+  module:
+    - address
+id: node.event.field_event_location
+field_name: field_event_location
+entity_type: node
+bundle: event
+label: Location
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    langcode: null
+    country_code: US
+    administrative_area: ''
+    locality: ''
+    dependent_locality: null
+    postal_code: ''
+    sorting_code: null
+    address_line1: ''
+    address_line2: ''
+    organization: ''
+    given_name: ''
+    additional_name: null
+    family_name: ''
+default_value_callback: ''
+settings:
+  available_countries: {  }
+  langcode_override: ''
+  field_overrides:
+    sortingCode:
+      override: hidden
+    dependentLocality:
+      override: hidden
+  fields: {  }
+field_type: address

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_metatags.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_metatags.yml
@@ -1,0 +1,21 @@
+uuid: 8917ec6b-6231-4954-bffc-1bb1a4764d11
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_metatags
+    - node.type.event
+  module:
+    - metatag
+id: node.event.field_metatags
+field_name: field_metatags
+entity_type: node
+bundle: event
+label: Metadata
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_subtitle.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_subtitle.yml
@@ -1,0 +1,26 @@
+uuid: 976ec16f-3e5b-468e-9452-e3c607db16f6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_subtitle
+    - node.type.event
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - heading_html
+id: node.event.field_subtitle
+field_name: field_subtitle
+entity_type: node
+bundle: event
+label: Subtitle
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_teaser_media.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_teaser_media.yml
@@ -1,0 +1,29 @@
+uuid: 8be0edcf-b365-4950-9765-5dd115c2aacf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_teaser_media
+    - media.type.image
+    - node.type.event
+id: node.event.field_teaser_media
+field_name: field_teaser_media
+entity_type: node
+bundle: event
+label: 'Teaser Media'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_teaser_text.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_teaser_text.yml
@@ -1,0 +1,26 @@
+uuid: b85a201f-73ae-4be6-a421-2db7ee64655b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_teaser_text
+    - node.type.event
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - basic_html
+id: node.event.field_teaser_text
+field_name: field_teaser_text
+entity_type: node
+bundle: event
+label: 'Teaser Text'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_teaser_title.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_teaser_title.yml
@@ -1,0 +1,19 @@
+uuid: 9105ca61-a61c-4964-90a1-b3373ad44377
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_teaser_title
+    - node.type.event
+id: node.event.field_teaser_title
+field_name: field_teaser_title
+entity_type: node
+bundle: event
+label: 'Teaser Title'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_event_cta.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_event_cta.yml
@@ -1,0 +1,19 @@
+uuid: c91bddf9-c515-4a97-9b6e-085ac02d430d
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_event_cta
+field_name: field_event_cta
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_event_date.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_event_date.yml
@@ -1,0 +1,19 @@
+uuid: 9073ab07-feff-4c3b-8d90-42f59b143e9c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - smart_date
+id: node.field_event_date
+field_name: field_event_date
+entity_type: node
+type: smartdate
+settings: {  }
+module: smart_date
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_event_format.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_event_format.yml
@@ -1,0 +1,27 @@
+uuid: 28701bd0-6136-42b9-b8f5-03e3a4703e1a
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_event_format
+field_name: field_event_format
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: inperson
+      label: In-person
+    -
+      value: online
+      label: Online
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_event_location.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_event_location.yml
@@ -1,0 +1,19 @@
+uuid: 9e1c530b-2ea5-4b01-ab9b-c934518a7ffd
+langcode: en
+status: true
+dependencies:
+  module:
+    - address
+    - node
+id: node.field_event_location
+field_name: field_event_location
+entity_type: node
+type: address
+settings: {  }
+module: address
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_subtitle.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_subtitle.yml
@@ -1,0 +1,20 @@
+uuid: e08d425e-ef23-46c6-9541-16be3c6e56c2
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_subtitle
+field_name: field_subtitle
+entity_type: node
+type: text
+settings:
+  max_length: 255
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/node.type.event.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/node.type.event.yml
@@ -1,0 +1,17 @@
+uuid: c19e042c-ed72-4eac-a5c7-aec52bb5ec69
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: Event
+type: event
+description: 'Display the details of an individual event, such as time, date, and location. Can be displayed on a calendar of events.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/web/profiles/custom/yalesites_profile/config/sync/smart_date.smart_date_format.compact.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/smart_date.smart_date_format.compact.yml
@@ -1,0 +1,17 @@
+uuid: b38c8b1c-4dc2-44ae-9ea2-994db32de33b
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: 3k0ojgMLZae-f358WLWxfKYddQPSaQSnIdAKiYw2wnY
+id: compact
+label: Compact
+date_format: 'M j Y'
+time_format: 'g:ia'
+time_hour_format: ga
+allday_label: ''
+separator: ' - '
+join: ' | '
+ampm_reduce: '1'
+date_first: '1'
+site_time_toggle: '1'

--- a/web/profiles/custom/yalesites_profile/config/sync/smart_date.smart_date_format.date_only.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/smart_date.smart_date_format.date_only.yml
@@ -1,0 +1,17 @@
+uuid: 50060425-747e-4a90-b688-c43c7641a719
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: 7nuRA2AaypQtPD_xr-tJAwYM67JCE408LQngMZ9rKWw
+id: date_only
+label: 'Date Only'
+date_format: 'D, M j Y'
+time_format: ''
+time_hour_format: ''
+allday_label: ''
+separator: ' - '
+join: ', '
+ampm_reduce: '1'
+date_first: '1'
+site_time_toggle: '1'

--- a/web/profiles/custom/yalesites_profile/config/sync/smart_date.smart_date_format.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/smart_date.smart_date_format.default.yml
@@ -1,0 +1,17 @@
+uuid: 01f2f1c6-f3ee-40ff-8fe7-641e3f2e3ecf
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: QOzaA8j2871_aWBJyVZm_LqREilQnXZqRuk3HNANrEo
+id: default
+label: default
+date_format: 'D, M j Y'
+time_format: 'g:ia'
+time_hour_format: ga
+allday_label: 'All day'
+separator: ' - '
+join: ', '
+ampm_reduce: '1'
+date_first: '1'
+site_time_toggle: '1'

--- a/web/profiles/custom/yalesites_profile/config/sync/smart_date.smart_date_format.time_only.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/smart_date.smart_date_format.time_only.yml
@@ -1,0 +1,17 @@
+uuid: 68143b57-f813-436b-8fe3-b714f0cb42cc
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: xEhkfUyGlu4kn_4FEWINXB7DujMZQzmQdhJofrbE7Ck
+id: time_only
+label: 'Time Only'
+date_format: ''
+time_format: 'g:ia'
+time_hour_format: 'g:ia'
+allday_label: 'All day'
+separator: ' - '
+join: ', '
+ampm_reduce: '1'
+date_first: '1'
+site_time_toggle: '1'


### PR DESCRIPTION
## [YALB-278: Create event content type](https://yaleits.atlassian.net/browse/YALB-278)

### Description of work
- Creates the event content type per the [data model](https://yaleedu.sharepoint.com/:x:/r/sites/YaleSitesUpgradeProgram/_layouts/15/doc2.aspx?sourcedoc=%7B2B574C06-BAC3-41E2-924A-F4562054F849%7D&file=Proposed%20Content%20Model.xlsx&action=default&mobileredirect=true&wdOrigin=TEAMS-ELECTRON.teams.files&wdExp=TEAMS-CONTROL&wdhostclicktime=1644421397192&cid=4fef4513-b4eb-4438-bd07-5338facb887d).

### Functional testing steps:
- [ ] Import config - `lando drush cim` and `lando drush cr`
- [ ] Behold the Event content type at /admin/structure/types/manage/event

### Notes:
- Took my best guess at the Address field setup. 
