### PR TITLE
fix: reverse condition on composer.lock check

### DIFF
--- a/scripts/local/setup.sh
+++ b/scripts/local/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Ignore the composer.lock file on local dev only.
-if grep -qxF 'composer.lock' .git/info/exclude; then
+if ! grep -qxF 'composer.lock' .git/info/exclude; then
   echo "Excluding composer.lock to keep it out of the repo."
   echo 'composer.lock' >> .git/info/exclude
 fi


### PR DESCRIPTION
## fix: reverse condition on composer.lock check

### Description of work
- `composer.lock` was not being written to `.git/info/excludes` when running `npm run setup`. It looks like we just need to reverse the condition.

### Functional testing steps:
- [ ] Run `npm run setup` on a fresh clone of this repo and branch and verify `composer.lock` gets written to `.git/info/excludes` and _Excluding composer.lock to keep it out of the repo_ is output to the screen.