### PR TITLE
chore(YALB-567): add news and page content type descriptions

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/node.type.news.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/node.type.news.yml
@@ -10,7 +10,7 @@ third_party_settings:
     parent: ''
 name: News
 type: news
-description: ''
+description: 'Create a news article, blog post, or announcement, to share new and noteworthy information. Can be displayed in a news feed.'
 help: ''
 new_revision: true
 preview_mode: 1

--- a/web/profiles/custom/yalesites_profile/config/sync/node.type.page.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/node.type.page.yml
@@ -11,7 +11,7 @@ third_party_settings:
     parent: 'main:'
 name: Page
 type: page
-description: ''
+description: 'A multipurpose and flexible content type allowing free-form content entry. Used to build a variety of different page layouts, from simple to elaborate.'
 help: ''
 new_revision: true
 preview_mode: 1


### PR DESCRIPTION
## [YALB-567: Add content type descriptions](https://yaleits.atlassian.net/browse/YALB-567)

### Description of work
- Adds content type descriptions for news and page

### Functional testing steps:
- [x] Visit the content type listing at `/admin/structure/types`
- [x] Verify that the news and page content types have a description matching the descriptions in the [Proposed Data Model](https://yaleedu.sharepoint.com/:x:/r/sites/YaleSitesUpgradeProgram/_layouts/15/Doc.aspx?sourcedoc=%7B2B574C06-BAC3-41E2-924A-F4562054F849%7D&file=Proposed%20Content%20Model.xlsx&action=default&mobileredirect=true&wdOrigin=TEAMS-ELECTRON.teams.files&wdExp=TEAMS-CONTROL&wdhostclicktime=1644421397192&cid=9306bd23-c280-4ca5-89f0-53241c4a1872)
