### PR TITLE
YALB-551: update teaser media widget.

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
@@ -13,6 +13,7 @@ dependencies:
   module:
     - field_group
     - layout_paragraphs
+    - media_library
     - metatag
     - paragraphs
     - paragraphs_ee
@@ -145,14 +146,11 @@ content:
       use_details: true
     third_party_settings: {  }
   field_teaser_media:
-    type: entity_reference_autocomplete
+    type: media_library_widget
     weight: 11
     region: content
     settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+      media_types: {  }
     third_party_settings: {  }
   field_teaser_text:
     type: text_textarea


### PR DESCRIPTION
## [YALB-551: update teaser media widget ](https://yaleits.atlassian.net/browse/YALB-551)

### Description of work
- Adds teaser image on page
- Updates the teaser media field to use the media library widget

### Functional testing steps:
- [ ] login to local dev
- [ ] navigate to add page form https://yalesites-platform.lndo.site/node/add/page
- [ ] click the teaser tab
- [ ] verify the teaser media field exists
- [ ] very you can upload image to field 
