### PR TITLE
YALB-553: remove unused fields from page form display

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
@@ -30,7 +30,7 @@ third_party_settings:
       label: Wrapper
       region: content
       parent_name: ''
-      weight: 1
+      weight: 0
       format_type: tabs
       format_settings:
         classes: ''
@@ -92,12 +92,6 @@ targetEntityType: node
 bundle: page
 mode: default
 content:
-  created:
-    type: datetime_timestamp
-    weight: 3
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_banner:
     type: paragraphs
     weight: 26
@@ -170,27 +164,13 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  promote:
-    type: boolean_checkbox
-    weight: 4
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 8
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    weight: 5
+    weight: 3
     region: content
     settings:
       display_label: true
@@ -203,19 +183,13 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  uid:
-    type: entity_reference_autocomplete
-    weight: 2
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
   url_redirects:
-    weight: 7
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  created: true
+  promote: true
+  sticky: true
+  uid: true


### PR DESCRIPTION
## [YALB-553: Disable unused node metadata](https://yaleits.atlassian.net/browse/YALB-553)

### Description of work
- Disables unused fields on page form display
  + Authored by
  + Authored on
  + Promoted to front page
  + Sticky at top of lists

### Functional testing steps:
- [ ] Add/edit the page content type
- [ ] There should be none of the fields listed above on the sidebar anymore
