### PR TITLE
fix(YALB-606): adds heading field to cta banner.

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.cta_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.cta_banner.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.cta_banner.field_heading
     - field.field.paragraph.cta_banner.field_image
     - field.field.paragraph.cta_banner.field_link
     - field.field.paragraph.cta_banner.field_text
@@ -16,6 +17,14 @@ targetEntityType: paragraph
 bundle: cta_banner
 mode: default
 content:
+  field_heading:
+    type: text_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_image:
     type: media_library_widget
     weight: 0
@@ -25,7 +34,7 @@ content:
     third_party_settings: {  }
   field_link:
     type: link_default
-    weight: 2
+    weight: 3
     region: content
     settings:
       placeholder_url: ''
@@ -33,7 +42,7 @@ content:
     third_party_settings: {  }
   field_text:
     type: text_textarea
-    weight: 1
+    weight: 2
     region: content
     settings:
       rows: 5

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.cta_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.cta_banner.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.cta_banner.field_heading
     - field.field.paragraph.cta_banner.field_image
     - field.field.paragraph.cta_banner.field_link
     - field.field.paragraph.cta_banner.field_text
@@ -15,6 +16,13 @@ targetEntityType: paragraph
 bundle: cta_banner
 mode: default
 content:
+  field_heading:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
   field_image:
     type: entity_reference_entity_view
     label: hidden

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.cta_banner.preview.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.cta_banner.preview.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.cta_banner.field_heading
     - field.field.paragraph.cta_banner.field_image
     - field.field.paragraph.cta_banner.field_link
     - field.field.paragraph.cta_banner.field_text
@@ -47,4 +48,5 @@ content:
     third_party_settings: {  }
     weight: 1
     region: content
-hidden: {  }
+hidden:
+  field_heading: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.cta_banner.field_heading.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.cta_banner.field_heading.yml
@@ -1,0 +1,26 @@
+uuid: 335fcc00-da84-43bb-a7c7-8d10e7a47eee
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_heading
+    - paragraphs.paragraphs_type.cta_banner
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - heading_html
+id: paragraph.cta_banner.field_heading
+field_name: field_heading
+entity_type: paragraph
+bundle: cta_banner
+label: Heading
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text


### PR DESCRIPTION
## [YALB-606: adds heading field to cta banner](https://yaleits.atlassian.net/browse/YALB-606)

### Description of work
- Adds heading field to cta banner
- updates the cta banner paragraph field so the page <title> is no longer used as the CTA banner heading.

### Functional testing steps:
- [x] log in
- [x] Navigate to content/page/banner
- [x] add cta banner to banner
