### PR TITLE
Install and enable devel and devel_kint_extras

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -22,6 +22,8 @@
         "drupal/config_ignore": "^2.3",
         "drupal/config_split": "^1.7",
         "drupal/ctools": "^3.7",
+        "drupal/devel": "^4.1",
+        "drupal/devel_kint_extras": "^1.0",
         "drupal/easy_breadcrumb": "^2.0",
         "drupal/editoria11y": "^1.0",
         "drupal/emulsify_twig": "^2.0",

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -24,6 +24,8 @@ module:
   datetime: 0
   datetime_range: 0
   dblog: 0
+  devel: 0
+  devel_kint_extras: 0
   dynamic_page_cache: 0
   editor: 0
   editoria11y: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/devel.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/devel.settings.yml
@@ -1,0 +1,12 @@
+_core:
+  default_config_hash: Aqx6J0yYT6mVqT0fbjeP4JkoL-700nmudVF5d6Pq2Yo
+page_alter: false
+raw_names: false
+error_handlers:
+  1: 1
+rebuild_theme: false
+debug_mail_file_format: '%to-%subject-%datetime.mail.txt'
+debug_mail_directory: 'temporary://devel-mails'
+devel_dumper: kint_extended
+debug_logfile: 'temporary://drupal_debug.txt'
+debug_pre: true

--- a/web/profiles/custom/yalesites_profile/config/sync/devel.toolbar.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/devel.toolbar.settings.yml
@@ -1,0 +1,10 @@
+_core:
+  default_config_hash: IQjf_ytthngZTAk_MU8-74VecArWD3G5g0oEH6PM6GA
+toolbar_items:
+  - devel.admin_settings_link
+  - devel.cache_clear
+  - devel.container_info.service
+  - devel.menu_rebuild
+  - devel.reinstall
+  - devel.route_info
+  - devel.run_cron

--- a/web/profiles/custom/yalesites_profile/config/sync/system.menu.devel.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.menu.devel.yml
@@ -1,0 +1,13 @@
+uuid: 57b17dde-6b4a-46d2-b8cd-cf43a450b7f8
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - devel
+_core:
+  default_config_hash: 3V-l1uuTcyirYOGLPZV5HWaDfr02uEbWZJIwc8Byz-c
+id: devel
+label: Development
+description: 'Links related to Devel module.'
+locked: true


### PR DESCRIPTION
### Description of work
- Install and configure Devel and Devel Kint Extras

### Functional testing steps:
- [ ] Do something with devel
- [ ] Throw a `{{ dsm() }}` into a Drupal template, and verify kint is used on the page - and that it shows available methods

You can also put this in your `settings.local.php` if kint takes too long/too much memory (you can adjust the depth to whatever works for you. 3-5 seems to be a pretty good range)
```
/*
 * Set Kint's max_depth to prevent memory issues.
 */
if (class_exists('Kint')) {
  Kint::$max_depth = 5;
}
```