### PR TITLE
YALB-585: Allow banner in page content

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_banner.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_banner.yml
@@ -13,7 +13,7 @@ field_name: field_banner
 entity_type: node
 bundle: page
 label: Banner
-description: ''
+description: 'Display a banner at the top of the page.'
 required: false
 translatable: false
 default_value: {  }
@@ -46,11 +46,29 @@ settings:
       embed:
         weight: 18
         enabled: false
+      event_cards:
+        weight: 25
+        enabled: false
+      event_list:
+        weight: 26
+        enabled: false
+      image:
+        weight: 27
+        enabled: false
+      news_cards:
+        weight: 28
+        enabled: false
+      news_list:
+        weight: 29
+        enabled: false
       pop_out_image:
         weight: 19
         enabled: false
       pull_quote:
         weight: 20
+        enabled: false
+      section:
+        weight: 32
         enabled: false
       text:
         weight: 21

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_content.yml
@@ -7,6 +7,7 @@ dependencies:
     - node.type.page
     - paragraphs.paragraphs_type.accordion
     - paragraphs.paragraphs_type.callout
+    - paragraphs.paragraphs_type.cta_banner
     - paragraphs.paragraphs_type.divider
     - paragraphs.paragraphs_type.embed
     - paragraphs.paragraphs_type.event_cards
@@ -49,6 +50,7 @@ settings:
       event_list: event_list
       news_cards: news_cards
       news_list: news_list
+      cta_banner: cta_banner
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -65,7 +67,7 @@ settings:
         enabled: false
       cta_banner:
         weight: -20
-        enabled: false
+        enabled: true
       divider:
         weight: -27
         enabled: true


### PR DESCRIPTION
## [YALB-XX: Title](https://yaleits.atlassian.net/browse/YALB-XX)

### Description of work
- Enables the CTA banner as a valid paragraph in the page content
- Adds help text to the banner field.

### Functional testing steps:
- [ ] Create a page and verify that a 'CTA Banner' is valid option for the content field.
