### PR TITLE
YALB-444: Remove github token step for setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,6 @@
       "type": "path",
       "url": "web/profiles/custom/yalesites_profile"
     },
-    "cas": {
-      "type": "vcs",
-      "url": "https://github.com/yalesites-org/yale_cas.git"
-    },
     "drupal": {
       "type": "composer",
       "url": "https://packages.drupal.org/8"

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -3,10 +3,6 @@
     "type": "drupal-custom-profile",
     "repositories": [
         {
-            "type": "vcs",
-            "url": "https://github.com/yalesites-org/yale_cas.git"
-        },
-        {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }
@@ -51,7 +47,7 @@
         "drupal/twig_tweak": "^3.1",
         "drupal/xmlsitemap": "^1.2",
         "yalesites-org/atomic": "^1.0",
-        "yalesites-org/yale_cas": "dev-main"
+        "yalesites-org/yale_cas": "^1.0"
     },
   "minimum-stability": "dev",
   "prefer-stable": true,


### PR DESCRIPTION
## [YALB-444: Remove github token step for setup](https://yaleits.atlassian.net/browse/YALB-444)

### Description of work
- Moves the ys_cas module to packagist to avoid unnecessary github token. This is already a public repo.

### Functional testing steps:
- [x] Remove your local composer log file `rm composer.lock`
- [x] Clear your local composer cache `lando composer clearcache`
- [x] Checkout this branch `git fetch` and `git checkout YALB-444`
- [x] Run composer install `lando composer install`
- [x] Verify that the ys_cas module downloaded and exists at `web/modules/custom/yale_cas`