### PR TITLE
YALB-254: Allows pages to utility nav

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_banner.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_banner.yml
@@ -13,13 +13,13 @@ field_name: field_banner
 entity_type: node
 bundle: page
 label: Banner
-description: ''
+description: "Display a banner at the top of the page."
 required: false
 translatable: false
-default_value: {  }
-default_value_callback: ''
+default_value: {}
+default_value_callback: ""
 settings:
-  handler: 'default:paragraph'
+  handler: "default:paragraph"
   handler_settings:
     target_bundles:
       cta_banner: cta_banner
@@ -46,11 +46,29 @@ settings:
       embed:
         weight: 18
         enabled: false
+      event_cards:
+        weight: 25
+        enabled: false
+      event_list:
+        weight: 26
+        enabled: false
+      image:
+        weight: 27
+        enabled: false
+      news_cards:
+        weight: 28
+        enabled: false
+      news_list:
+        weight: 29
+        enabled: false
       pop_out_image:
         weight: 19
         enabled: false
       pull_quote:
         weight: 20
+        enabled: false
+      section:
+        weight: 32
         enabled: false
       text:
         weight: 21

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_content.yml
@@ -7,6 +7,7 @@ dependencies:
     - node.type.page
     - paragraphs.paragraphs_type.accordion
     - paragraphs.paragraphs_type.callout
+    - paragraphs.paragraphs_type.cta_banner
     - paragraphs.paragraphs_type.divider
     - paragraphs.paragraphs_type.embed
     - paragraphs.paragraphs_type.event_cards
@@ -26,13 +27,13 @@ field_name: field_content
 entity_type: node
 bundle: page
 label: Content
-description: ''
+description: ""
 required: false
 translatable: false
-default_value: {  }
-default_value_callback: ''
+default_value: {}
+default_value_callback: ""
 settings:
-  handler: 'default:paragraph'
+  handler: "default:paragraph"
   handler_settings:
     target_bundles:
       section: section
@@ -49,6 +50,7 @@ settings:
       event_list: event_list
       news_cards: news_cards
       news_list: news_list
+      cta_banner: cta_banner
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -65,7 +67,7 @@ settings:
         enabled: false
       cta_banner:
         weight: -20
-        enabled: false
+        enabled: true
       divider:
         weight: -27
         enabled: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.cta_banner.field_heading.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.cta_banner.field_heading.yml
@@ -17,10 +17,10 @@ field_name: field_heading
 entity_type: paragraph
 bundle: cta_banner
 label: Heading
-description: ''
-required: false
+description: ""
+required: true
 translatable: true
-default_value: {  }
-default_value_callback: ''
-settings: {  }
+default_value: {}
+default_value_callback: ""
+settings: {}
 field_type: text

--- a/web/profiles/custom/yalesites_profile/config/sync/node.type.page.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/node.type.page.yml
@@ -8,6 +8,7 @@ third_party_settings:
   menu_ui:
     available_menus:
       - main
+      - utility-navigation
     parent: 'main:'
 name: Page
 type: page


### PR DESCRIPTION
## [YALB-254: Utility Nav](https://yaleits.atlassian.net/browse/YALB-254)

### Description of work
- Allows pages to be added to the utility navigation.

### Functional testing steps:
- [ ] log in
- [ ] navigate to content/add content/page
- [ ] on the right side click menu settings/provide menu link
- [ ] add menu link
- [ ] under parent link choose utility navigation 
- [ ] save changes/view page
