### PR TITLE
YALB-614: Follow menu trail

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -37,6 +37,7 @@
         "drupal/mailsystem": "^4.3",
         "drupal/maxlength": "^2.0@RC",
         "drupal/menu_admin_per_menu": "^1.4",
+        "drupal/menu_breadcrumb" : "^1.16",
         "drupal/metatag": "^1.19",
         "drupal/migrate_plus": "^6.0",
         "drupal/migrate_tools": "^6.0",

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_local_actions.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_local_actions.yml
@@ -9,7 +9,7 @@ _core:
 id: atomic_local_actions
 theme: atomic
 region: content
-weight: 0
+weight: -2
 provider: null
 plugin: local_actions_block
 settings:

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_local_tasks.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_local_tasks.yml
@@ -9,7 +9,7 @@ _core:
 id: atomic_local_tasks
 theme: atomic
 region: content
-weight: -1
+weight: -3
 provider: null
 plugin: local_tasks_block
 settings:

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.breadcrumbs_2.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.breadcrumbs_2.yml
@@ -1,4 +1,4 @@
-uuid: 3d0dfc63-a8ad-4d22-b47d-70c9c45fe272
+uuid: 5cde02bd-9862-4934-be00-89ef171ef8a2
 langcode: en
 status: true
 dependencies:
@@ -6,15 +6,15 @@ dependencies:
     - system
   theme:
     - atomic
-id: main_page_content
+id: breadcrumbs_2
 theme: atomic
 region: content
-weight: 0
+weight: -1
 provider: null
-plugin: system_main_block
+plugin: system_breadcrumb_block
 settings:
-  id: system_main_block
-  label: 'Main page content'
+  id: system_breadcrumb_block
+  label: Breadcrumbs
   label_display: '0'
   provider: system
 visibility: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -51,6 +51,7 @@ module:
   maxlength: 0
   media: 0
   media_library: 0
+  menu_breadcrumb: 0
   menu_link_content: 0
   menu_ui: 0
   metatag: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/filter.format.basic_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/filter.format.basic_html.yml
@@ -37,18 +37,6 @@ filters:
     status: false
     weight: 11
     settings: {  }
-  filter_autop:
-    id: filter_autop
-    provider: filter
-    status: true
-    weight: 0
-    settings: {  }
-  filter_htmlcorrector:
-    id: filter_htmlcorrector
-    provider: filter
-    status: true
-    weight: 10
-    settings: {  }
   filter_url:
     id: filter_url
     provider: filter
@@ -63,6 +51,18 @@ filters:
     weight: 50
     settings:
       remove_empty_paragraphs: '1'
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: 0
+    settings: {  }
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: 10
+    settings: {  }
   linkit:
     id: linkit
     provider: linkit

--- a/web/profiles/custom/yalesites_profile/config/sync/menu_breadcrumb.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/menu_breadcrumb.settings.yml
@@ -1,0 +1,19 @@
+_core:
+  default_config_hash: B_6w2RYqF6vEA_QZ8-0LRUI0AqnS4NZuQqlO9rXwfJs
+determine_menu: true
+disable_admin_page: true
+append_current_page: true
+current_page_as_link: false
+stop_on_first_match: false
+append_member_page: false
+member_page_as_link: false
+remove_home: false
+add_home: false
+front_title: 0
+exclude_empty_url: false
+exclude_disabled_menu_items: false
+derived_active_trail: false
+menu_breadcrumb_menus:
+  main:
+    enabled: 1
+    weight: -10


### PR DESCRIPTION
## [YALB-614: Breadcrumbs: Follow menu trail](https://yaleits.atlassian.net/browse/YALB-614?atlOrigin=eyJpIjoiZWE3ZjhkNjY5MjhiNDhkNGI0NDc4NDRkODk3MGUyZWMiLCJwIjoiaiJ9)

### Description of work
- Adds menu breadcrumb module
- Breadcrumbs will follow menu structure, not path structure

### Functional testing steps:
- [x] Add the breadcrumb block to a region
- [x] Add some menu items and make some of those items subs of other menu items
- [x] Verify that the breadcrumb for these pages matches the menu structure
