### PR TITLE
YALB-612: Refactor social links

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,16 @@
 # Getting started as a developer
 
+## PR Workflow
+
+When you're working on a new ticket, you'll want to start with the latest `develop` branch, and rebuild that before you do your new work. Assuming you're followed the setup steps (specifically having run the `npm run setup` script) here's the recommended workflow for regular development:
+
+- `git checkout develop`
+- `git pull`
+- `git checkout -b YALB-XXX-ticket-description`
+- `npm run rebuild`
+
+After running those commands, you should have a clean environment to make your changes.
+
 ## Updating Drupal configuration
 
 Drupal's configuration management system organizes information about the structure and settings of the application into a consistent collection of structured data. Active configurations are typically stored in the site's database while staged configurations are stored in a series of YAML files. DevOps and version control tools will track changes to the YAML files to deploy configuration changes across different websites and environments. Changes made in a local development environment can be tested and released to the production website predictably.

--- a/scripts/local/rebuild.sh
+++ b/scripts/local/rebuild.sh
@@ -4,4 +4,5 @@ lando composer update
 npm run get-db
 npm run get-files
 npm run confim
+lando drush cr
 lando drush uli

--- a/scripts/local/setup.sh
+++ b/scripts/local/setup.sh
@@ -16,7 +16,7 @@ fi
 lando start
 
 # Install packages and pull down latest database and files.
-lando composer install
+lando composer update
 lando pull --database=dev --files=dev --code=none
 
 # Ensure everything is up to date.

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.social_links_block.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.social_links_block.yml
@@ -1,0 +1,20 @@
+uuid: a349192a-9081-41c1-8662-83b576fbf15c
+langcode: en
+status: true
+dependencies:
+  module:
+    - ys_core
+  theme:
+    - atomic
+id: social_links_block
+theme: atomic
+region: footer
+weight: 0
+provider: null
+plugin: social_links_block
+settings:
+  id: social_links_block
+  label: 'Social Links Block'
+  label_display: '0'
+  provider: ys_core
+visibility: {  }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/YSCoreFooterSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/YSCoreFooterSettingsForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\ys_core\Form;
 
+use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -21,6 +22,13 @@ class YSCoreFooterSettingsForm extends ConfigFormBase {
   public function getFormId() {
     return 'ys_core_footer_settings_form';
   }
+
+  /**
+   * THe Drupal backend cache renderer service.
+   *
+   * @var \Drupal\Core\Path\CacheBackendInterface
+   */
+  protected $cacheRender;
 
   /**
    * Social Links Manager.
@@ -73,6 +81,7 @@ class YSCoreFooterSettingsForm extends ConfigFormBase {
       $config->set($id, $form_state->getValue($id));
     }
     $config->save();
+    $this->cacheRender->invalidateAll();
     return parent::submitForm($form, $form_state);
   }
 
@@ -91,15 +100,24 @@ class YSCoreFooterSettingsForm extends ConfigFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
+      $container->get('cache.render'),
       $container->get('ys_core.social_links_manager')
     );
   }
 
   /**
-   * {@inheritdoc}
+   * Constructs the object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Path\CacheBackendInterface $cache_render
+   *   The Cache backend interface.
+   * @param \Drupal\ys_core\SocialLinksManager $social_links_manager
+   *   The Yale social media links management service.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, SocialLinksManager $social_links_manager) {
+  public function __construct(ConfigFactoryInterface $config_factory, CacheBackendInterface $cache_render, SocialLinksManager $social_links_manager) {
     parent::__construct($config_factory);
+    $this->cacheRender = $cache_render;
     $this->socialLinks = $social_links_manager;
   }
 


### PR DESCRIPTION
## [YALB-612: Refactor social links](https://yaleits.atlassian.net/browse/YALB-612)

### Description of work
- Updates the template to follow the shape defined in the component library (icon, name, url)
- Moves common work to a custom service
- Renames social links config to make it easier to use this namespace for other projects
- Invalidates the cache on form submit

## Code Review Diff
I messed up and committed most of this work directly to develop. I forgot this was not a protected branch for this project and this caused most of my commits to go right to dev. For code review please use the following compare:
- [What changed in this work](https://github.com/yalesites-org/yalesites-project/compare/25ee0ed46ff92525c8fca993c124d913269c16af..5c933325da7b596135f791353334289eb7237ecd)

### Functional testing steps:
- [ ] Login to the multidev `terminus drush yalesites-platform.pr-73 -- uli`
- [ ] (I already did this step) Add the 'Social Links Block' [block the the layout](https://pr-73-yalesites-platform.pantheonsite.io/admin/structure/block) somewhere/anywhere for testing
- [ ] Add some social links on the [footer config form](https://pr-73-yalesites-platform.pantheonsite.io/admin/yalesites/footer)
- [ ] Verify they [display on any content page](https://pr-73-yalesites-platform.pantheonsite.io/node/5) in the newly placed block as text links with a name and URL.
