### PR TITLE
YALB-656: Adds CKEditor plugins to handle email, phone, and new window

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,30 @@
     "drupal": {
       "type": "composer",
       "url": "https://packages.drupal.org/8"
+    },
+    "ckeditor-plugin/link": {
+      "type": "package",
+      "package": {
+        "name": "ckeditor-plugin/link",
+        "version": "4.19.3",
+        "type": "drupal-library",
+        "dist": {
+          "url": "https://github.com/yalesites-org/ckeditor-advanced-link-plugin/archive/refs/heads/main.zip",
+          "type": "zip"
+        }
+      }
+    },
+    "ckeditor-plugin/fakeobjects": {
+      "type": "package",
+      "package": {
+        "name": "ckeditor-plugin/fakeobjects",
+        "version": "4.19.1",
+        "type": "drupal-library",
+        "dist": {
+          "url": "https://download.ckeditor.com/fakeobjects/releases/fakeobjects_4.19.1.zip",
+          "type": "zip"
+        }
+      }
     }
   },
   "require": {
@@ -55,6 +79,9 @@
         "[project-root]/.gitattributes": false
       }
     },
+    "installer-types": [
+      "ckeditor-plugin"
+    ],
     "installer-paths": {
       "web/core": [
         "type:drupal-core"
@@ -85,6 +112,9 @@
       ],
       "web/private/scripts/quicksilver/{$name}/": [
         "type:quicksilver-script"
+      ],
+      "web/libraries/ckeditor/plugins/{$name}": [
+        "type:ckeditor-plugin"
       ]
     },
     "composer-exit-on-patch-failure": true,

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -11,6 +11,7 @@
         "drupal/admin_toolbar": "^3.1",
         "drupal/address": "^1.10",
         "drupal/allowed_formats": "^1.4",
+        "drupal/anchor_link": "^2.5",
         "drupal/autosave_form": "^1.3",
         "drupal/cas": "^2.0",
         "drupal/chosen": "^3.0",
@@ -22,6 +23,7 @@
         "drupal/devel": "^4.1",
         "drupal/devel_kint_extras": "^1.0",
         "drupal/easy_breadcrumb": "^2.0",
+        "drupal/editor_advanced_link": "^2.0",
         "drupal/editoria11y": "^1.0",
         "drupal/emulsify_twig": "^2.0",
         "drupal/fast_404": "^2.0@alpha",
@@ -51,7 +53,9 @@
         "drupal/twig_tweak": "^3.1",
         "drupal/xmlsitemap": "^1.2",
         "yalesites-org/atomic": "^1.0",
-        "yalesites-org/yale_cas": "^1.0"
+        "yalesites-org/yale_cas": "^1.0",
+        "ckeditor-plugin/link": "4.19.3",
+        "ckeditor-plugin/fakeobjects": "4.19.1"
     },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -5,6 +5,7 @@ module:
   admin_toolbar: 0
   admin_toolbar_tools: 0
   allowed_formats: 0
+  anchor_link: 0
   block: 0
   breakpoint: 0
   cas: 0
@@ -28,9 +29,11 @@ module:
   devel_kint_extras: 0
   dynamic_page_cache: 0
   editor: 0
+  editor_advanced_link: 0
   editoria11y: 0
   emulsify_twig: 0
   entity_reference_revisions: 0
+  fakeobjects: 0
   field: 0
   field_group: 0
   field_ui: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/editor.editor.basic_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/editor.editor.basic_html.yml
@@ -28,6 +28,7 @@ settings:
           name: Links
           items:
             - DrupalLink
+            - Link
             - DrupalUnlink
         -
           name: Lists
@@ -47,13 +48,13 @@ settings:
             - Maximize
             - '-'
   plugins:
+    drupallink:
+      linkit_enabled: true
+      linkit_profile: default
     language:
       language_list: un
     stylescombo:
       styles: ''
-    drupallink:
-      linkit_enabled: true
-      linkit_profile: default
 image_upload:
   status: false
   scheme: public

--- a/web/profiles/custom/yalesites_profile/config/sync/editor.editor.basic_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/editor.editor.basic_html.yml
@@ -51,10 +51,6 @@ settings:
     drupallink:
       linkit_enabled: true
       linkit_profile: default
-    language:
-      language_list: un
-    stylescombo:
-      styles: ''
 image_upload:
   status: false
   scheme: public

--- a/web/profiles/custom/yalesites_profile/config/sync/filter.format.basic_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/filter.format.basic_html.yml
@@ -16,7 +16,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol type start> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <sup> <sub> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title target !href>'
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol type start> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <sup> <sub> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title target>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_align:
@@ -51,17 +51,17 @@ filters:
     weight: 50
     settings:
       remove_empty_paragraphs: '1'
-  filter_autop:
-    id: filter_autop
-    provider: filter
-    status: true
-    weight: 0
-    settings: {  }
   filter_htmlcorrector:
     id: filter_htmlcorrector
     provider: filter
     status: true
     weight: 10
+    settings: {  }
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: 0
     settings: {  }
   linkit:
     id: linkit

--- a/web/profiles/custom/yalesites_profile/config/sync/filter.format.basic_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/filter.format.basic_html.yml
@@ -16,7 +16,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <sup> <sub>'
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol type start> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <sup> <sub> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title target !href>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_align:


### PR DESCRIPTION
## [YALB-656: Links: Authoring tools](https://yaleits.atlassian.net/browse/YALB-656?atlOrigin=eyJpIjoiY2ZmNGMzNzZkODkyNGMwNDg5YTVlN2JjYTYzMWEzNTEiLCJwIjoiaiJ9)

### Description of work
- This adds several CKEditor plugins to handle easily handle adding email and phone links and also adds the ability to open links in a new window.
- One of the plugins is a custom plugin forked from the original [CKEditor Link plugin](https://ckeditor.com/cke4/addon/link) and is stored in a [public repo attached to yalesites-org](https://github.com/yalesites-org/ckeditor-advanced-link-plugin). This gives us the ability to change the title text of the button and change the icon to distinguish the plugin from the default Drupal link plugin.
- Note: Currently there is a known bug with the modal within modal where this second link button will not allow you to enter text inside the modal.

### Functional testing steps:
- [x] Add a new page
- [x] Add a paragraph of type "Text"
- [x] Verify there are 2 link buttons on the toolbar - the first is the Drupal link that uses Linkit, the second is the new "Email/Phone/Regular" link to allow for email and phone links
- [x] Once we get the bug fixed (as noted above), to change the type of link, select the "Link Type" select list and choose either "Email" or "Phone"
- [x] To open links in a new window for the first link button, expand the "Advanced" accordion and turn on the "Open in new window/tab"
- [x] To open links in a new window for the new link button, click on the "Target" tab at the top of the modal and select "New Window (_blank).

