### PR TITLE
YALB-635: Add custom breadcrumb block to change link item key from text to title

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @Block(
  *   id = "ys_breadcrumb_block",
- *   admin_label = @Translation("Breadcrumbs"),
+ *   admin_label = @Translation("YaleSites Breadcrumbs"),
  *   category = @Translation("YaleSites Core"),
  * )
  */

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\ys_core\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a block to display the breadcrumbs.
+ *
+ * @Block(
+ *   id = "ys_breadcrumb_block",
+ *   admin_label = @Translation("Breadcrumbs"),
+ *   category = @Translation("YaleSites Core"),
+ * )
+ */
+class YaleSitesBreadcrumbBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The breadcrumb manager.
+   *
+   * @var \Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface
+   */
+  protected $breadcrumbManager;
+
+  /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * Constructs a new SystemBreadcrumbBlock object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface $breadcrumb_manager
+   *   The breadcrumb manager.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, BreadcrumbBuilderInterface $breadcrumb_manager, RouteMatchInterface $route_match) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->breadcrumbManager = $breadcrumb_manager;
+    $this->routeMatch = $route_match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('breadcrumb'),
+      $container->get('current_route_match')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $breadcrumbs = $this->breadcrumbManager->build($this->routeMatch)->getLinks();
+    $links = [];
+
+    foreach ($breadcrumbs as $breadcrumb) {
+      array_push($links, [
+        'title' => $breadcrumb->getText(),
+        'url' => $breadcrumb->getUrl()->toString(),
+      ]);
+    }
+
+    return [
+      '#theme' => 'ys_breadcrumb_block',
+      '#items' => $links,
+    ];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-breadcrumb-block.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-breadcrumb-block.html.twig
@@ -1,0 +1,18 @@
+{#
+ # Available Variables:
+ # - items (array)
+ #   - title: Link title
+ #   - url: Link url
+ #}
+
+<ul>
+  {% for item in items %}
+    <li>
+      {% if item.url %}
+          <a href="{{ item.url }}">{{ item.title }}</a>
+        {% else %}
+          {{ item.title }}
+        {% endif %}
+    </li>
+  {% endfor %}
+</ul>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -17,5 +17,10 @@ function ys_core_theme($existing, $type, $theme, $path): array {
         'icons' => []
       ],
     ],
+    'ys_breadcrumb_block' => [
+      'variables' => [
+        'items' => []
+      ],
+    ],
   ];
 }


### PR DESCRIPTION
## [YALB-635: Breadcrumbs: Wiring components](https://yaleits.atlassian.net/browse/YALB-XX](https://yaleits.atlassian.net/browse/YALB-635?atlOrigin=eyJpIjoiZWQyYjg5YzU3MzZhNGY0ZjgyYjU1N2NjMmVmNWY0MTkiLCJwIjoiaiJ9))

### Description of work
- Adds a custom breadcrumb block called "YaleSites Breadcrumbs"
- The ```items``` array now contains links that have a ```title``` key instead of the ```text``` key

### Functional testing steps:
- [ ] Enable YS Core module (if not already enabled)
- [ ] Add the YaleSites Breadcrumbs block to a region
- [ ] Use twig template from ```ys_core/templates/ys-breadcrumb-block.html.twig``` in your theme
- [ ] Verify that ```item.title``` exists and works as expected