### PR TITLE
YALB-635: Add is_active to breadcrumb items to denote active page

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
@@ -75,7 +75,6 @@ class YaleSitesBreadcrumbBlock extends BlockBase implements ContainerFactoryPlug
     $links = [];
 
     foreach ($breadcrumbs as $breadcrumb) {
-
       array_push($links, [
         'title' => $breadcrumb->getText(),
         'url' => $breadcrumb->getUrl()->toString(),

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
@@ -75,9 +75,11 @@ class YaleSitesBreadcrumbBlock extends BlockBase implements ContainerFactoryPlug
     $links = [];
 
     foreach ($breadcrumbs as $breadcrumb) {
+
       array_push($links, [
         'title' => $breadcrumb->getText(),
         'url' => $breadcrumb->getUrl()->toString(),
+        'is_active' => empty($breadcrumb->getUrl()->toString()),
       ]);
     }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-breadcrumb-block.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-breadcrumb-block.html.twig
@@ -3,12 +3,13 @@
  # - items (array)
  #   - title: Link title
  #   - url: Link url
+ #   - is_active: (bool) is current page
  #}
 
 <ul>
   {% for item in items %}
     <li>
-      {% if item.url %}
+      {% if not item.is_active %}
           <a href="{{ item.url }}">{{ item.title }}</a>
         {% else %}
           {{ item.title }}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-breadcrumb-block.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-breadcrumb-block.html.twig
@@ -9,11 +9,11 @@
 <ul>
   {% for item in items %}
     <li>
-      {% if not item.is_active %}
-          <a href="{{ item.url }}">{{ item.title }}</a>
-        {% else %}
-          {{ item.title }}
-        {% endif %}
+      {% if item.is_active %}
+        {{ item.title }}
+      {% else %}
+        <a href="{{ item.url }}">{{ item.title }}</a>
+      {% endif %}
     </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
## [YALB-635: Breadcrumbs: Wiring components](https://yaleits.atlassian.net/browse/YALB-635?atlOrigin=eyJpIjoiODQ5N2MwMmY1YTY1NDM2Zjg5MTg5YTlhNDI2ODAzMDEiLCJwIjoiaiJ9)

### Description of work
- Adds ```is_active``` to each breadcrumb item to denote if it is the active page

### Functional testing steps:
- [ ] Nest some main menu items under each other
- [ ] If using the default module template, it is now using the ```is_active``` to not show a link for that breadcumb item on the current page
- [ ] If using another twig template, inside the for loop, you can use ```item.is_active``` that will denote the current page
