### PR TITLE
YALB-665: Add responsive image style for content width

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.default.yml
@@ -5,7 +5,7 @@ dependencies:
   config:
     - field.field.media.image.field_media_image
     - media.type.image
-    - responsive_image.styles.full_width
+    - responsive_image.styles.image_max_width
   module:
     - responsive_image
 id: media.image.default
@@ -17,7 +17,7 @@ content:
     type: responsive_image
     label: hidden
     settings:
-      responsive_image_style: full_width
+      responsive_image_style: image_max_width
       image_link: ''
     third_party_settings: {  }
     weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.image_content_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.image_content_width.yml
@@ -1,0 +1,30 @@
+uuid: 1daa98fc-9522-4544-a602-5c12950e37da
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.image_content_width
+    - field.field.media.image.field_media_image
+    - media.type.image
+    - responsive_image.styles.image_content_width
+  module:
+    - responsive_image
+id: media.image.image_content_width
+targetEntityType: media
+bundle: image
+mode: image_content_width
+content:
+  field_media_image:
+    type: responsive_image
+    label: hidden
+    settings:
+      responsive_image_style: image_content_width
+      image_link: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.image.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.image.default.yml
@@ -17,7 +17,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: full
+      view_mode: image_content_width
       link: false
     third_party_settings: {  }
     weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_mode.media.image_content_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_mode.media.image_content_width.yml
@@ -1,0 +1,10 @@
+uuid: 5b43d191-184a-4040-ad6c-6afc0e44950a
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.image_content_width
+label: 'Image - Content Width'
+targetEntityType: media
+cache: true

--- a/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.full_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.full_width.yml
@@ -18,7 +18,7 @@ dependencies:
     - image.style.max_width_800
     - image.style.max_width_960
 id: full_width
-label: 'Full Width'
+label: 'Image - Max Width'
 image_style_mappings:
   -
     image_mapping_type: sizes

--- a/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.image_content_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.image_content_width.yml
@@ -1,0 +1,45 @@
+uuid: b960773d-0a57-42b5-9597-79fefe948b93
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.3_2_1120
+    - image.style.3_2_1280
+    - image.style.3_2_1440
+    - image.style.3_2_1600
+    - image.style.3_2_1760
+    - image.style.3_2_1920
+    - image.style.3_2_2080
+    - image.style.3_2_2240
+    - image.style.3_2_2400
+    - image.style.3_2_320
+    - image.style.3_2_480
+    - image.style.3_2_640
+    - image.style.3_2_800
+    - image.style.3_2_960
+id: image_content_width
+label: 'Image - Content Width'
+image_style_mappings:
+  -
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: '(min-width: 790px) 790px, 100vw'
+      sizes_image_styles:
+        - '3_2_1120'
+        - '3_2_1280'
+        - '3_2_1440'
+        - '3_2_1600'
+        - '3_2_1760'
+        - '3_2_1920'
+        - '3_2_2080'
+        - '3_2_2240'
+        - '3_2_2400'
+        - '3_2_320'
+        - '3_2_480'
+        - '3_2_640'
+        - '3_2_800'
+        - '3_2_960'
+    breakpoint_id: responsive_image.viewport_sizing
+    multiplier: 1x
+breakpoint_group: responsive_image
+fallback_image_style: '3_2_320'

--- a/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.image_content_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.image_content_width.yml
@@ -3,20 +3,20 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.3_2_1120
-    - image.style.3_2_1280
-    - image.style.3_2_1440
-    - image.style.3_2_1600
-    - image.style.3_2_1760
-    - image.style.3_2_1920
-    - image.style.3_2_2080
-    - image.style.3_2_2240
-    - image.style.3_2_2400
-    - image.style.3_2_320
-    - image.style.3_2_480
-    - image.style.3_2_640
-    - image.style.3_2_800
-    - image.style.3_2_960
+    - image.style.max_width_1120
+    - image.style.max_width_1280
+    - image.style.max_width_1440
+    - image.style.max_width_1600
+    - image.style.max_width_1760
+    - image.style.max_width_1920
+    - image.style.max_width_2080
+    - image.style.max_width_2240
+    - image.style.max_width_2400
+    - image.style.max_width_320
+    - image.style.max_width_480
+    - image.style.max_width_640
+    - image.style.max_width_800
+    - image.style.max_width_960
 id: image_content_width
 label: 'Image - Content Width'
 image_style_mappings:
@@ -25,21 +25,21 @@ image_style_mappings:
     image_mapping:
       sizes: '(min-width: 790px) 790px, 100vw'
       sizes_image_styles:
-        - '3_2_1120'
-        - '3_2_1280'
-        - '3_2_1440'
-        - '3_2_1600'
-        - '3_2_1760'
-        - '3_2_1920'
-        - '3_2_2080'
-        - '3_2_2240'
-        - '3_2_2400'
-        - '3_2_320'
-        - '3_2_480'
-        - '3_2_640'
-        - '3_2_800'
-        - '3_2_960'
+        - max_width_1120
+        - max_width_1280
+        - max_width_1440
+        - max_width_1600
+        - max_width_1760
+        - max_width_1920
+        - max_width_2080
+        - max_width_2240
+        - max_width_2400
+        - max_width_320
+        - max_width_480
+        - max_width_640
+        - max_width_800
+        - max_width_960
     breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
 breakpoint_group: responsive_image
-fallback_image_style: '3_2_320'
+fallback_image_style: max_width_320

--- a/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.image_max_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.image_max_width.yml
@@ -1,4 +1,4 @@
-uuid: 3e8949b7-f03c-4d65-afb6-bda9b7ef8a16
+uuid: 7bb715ae-a9c0-450c-9865-ddf6dba40950
 langcode: en
 status: true
 dependencies:
@@ -17,7 +17,7 @@ dependencies:
     - image.style.max_width_640
     - image.style.max_width_800
     - image.style.max_width_960
-id: full_width
+id: image_max_width
 label: 'Image - Max Width'
 image_style_mappings:
   -


### PR DESCRIPTION
## [YALB-665: Create Responsive Image Styles for Image Component](https://yaleits.atlassian.net/browse/YALB-665?atlOrigin=eyJpIjoiMjEzNjM1YTVlMzJlNGIwZmJhZTRiYjhjMDMwY2YyZDUiLCJwIjoiaiJ9)

### Description of work
- Add responsive image style for content width image
- Change title of Full Width image style to Image - Max Width to match Storybook
- Change default image style for image paragraph to use new content width image

### Functional testing steps:
- [ ] Import config (if not already done)
- [ ] Add an image paragraph to a page
- [ ] Inspect image and make sure the secret is using the new 3x2 image responsive image style
