### PR TITLE
YALB-288: Demo Content Updates

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/system.site.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.site.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: l58O_yEXSo-SeJi19LXdzTU1tNJG3lmnIhCitRkM1tk
 langcode: en
 uuid: 3be7d457-cc13-4e03-bde2-d004a9e0f46e
-name: 'YaleSites Platform'
+name: 'Your Site Title'
 mail: noreply@yale.edu
 slogan: ''
 page:

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_alert.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_alert.settings.yml
@@ -1,6 +1,6 @@
-id: 1648762055
-headline: 'Headline example'
-message: 'Message example'
+id: 1660263375
+headline: 'Optional banner for displaying an announcement or notice'
+message: 'Additional text goes here'
 status: 1
 type: announcement
 link_title: ''

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/paragraph_callout.json
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/paragraph_callout.json
@@ -6,16 +6,16 @@
         "paragraph_type": "callout_item",
         "paragraph_fields": {
           "field_heading": {
-            "value": "Callouts help you accomplish goals",
+            "value": "This is a text callout",
             "format": "basic_html"
           },
           "field_text": {
-            "value": "They're handy for directing attention to actions that aren't the page's main goal but are important to the user.",
+            "value": "Use callouts for actions you want users to take or to direct them to related, useful information.",
             "format": "basic_html"
           },
           "field_link": {
             "url": "https://www.example.com",
-            "title": "Direct your user"
+            "title": "Action text"
           }
         }
       }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/paragraphs.json
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/paragraphs.json
@@ -175,7 +175,7 @@
         "paragraph_type": "cta_banner",
         "paragraph_fields": {
           "field_heading": {
-            "value": "Top goal for the site",
+            "value": "Title of promotional feature",
             "format": "heading_html"
           },
           "field_images": [
@@ -184,7 +184,7 @@
             }
           ],
           "field_text": {
-            "value": "Use this space to promote your site's primary goal. Keep the text concise.",
+            "value": "Use this space to communicate your site's purpose or to showcase content that support your goals. Keep text concise.",
             "format": "basic_html"
           },
           "field_link": {


### PR DESCRIPTION
## [YALB-288: Feedback: Demo content updates](https://yaleits.atlassian.net/browse/YALB-288?atlOrigin=eyJpIjoiZDJiMTNmZjE4NDFlNDA4OTgzZTk5MmQ4NDBiNzEzMjIiLCJwIjoiaiJ9)

### Description of work
- Changes demo content with feedback from tickets: YALB-641, YALB-643, YALB-644, and YALB-645

### Functional testing steps:
- [x] If demo content hasn't changed on a dev site, the migration needs to be rolled back and re-run
- [x] To rollback: ```drush mr --all```
- [x] To reimport: ```drush mim ys_menu_links --execute-dependencies```
- [x] Verify that the demo content has changed as per the above tickets
- [ ] Navigate to the multidev. All changes can be seen [on this demo page](https://pr-80-yalesites-platform.pantheonsite.io/node/11)...
  - [ ] Update “Top goal for the site” within the banner heading to now read “Title of promotional feature”
  - [ ] Update the banner description text to say “Use this space to communicate your site’s purpose or to showcase content that support your goals. Keep text concise.”
  - [ ] Change the site's default title to  “Your Site Title”
  - [ ] Change the default alert content, Update “Headline example” to say “Optional banner for displaying an announcement or notice” and update “Message example” to say “Additional text goes here”.
  - [ ] For the callout... Change title to say “This is a text callout”; Change description text to say “Use callouts for actions you want users to take or to direct them to related, useful information.” Change button label to say “Action text”
