### PR TITLE
feat(YALB-328): Ignore site specific config settings

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/config_ignore.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/config_ignore.settings.yml
@@ -4,4 +4,3 @@ ignored_config_entities:
   - system.site.name
   - system.site.mail
   - 'system.site.page.*'
-  - 'ys_core.*'

--- a/web/profiles/custom/yalesites_profile/config/sync/config_split.config_split.site_specific_ignored_config.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/config_split.config_split.site_specific_ignored_config.yml
@@ -1,0 +1,16 @@
+uuid: 818fba60-67dc-4398-9d5f-989b8300c731
+langcode: en
+status: true
+dependencies: {  }
+id: site_specific_ignored_config
+label: 'Site Specific Ignored Config'
+description: 'Ignores site specific config such as YS Core settings.'
+weight: -10
+folder: ''
+module: {  }
+theme: {  }
+blacklist: {  }
+graylist:
+  - 'ys_core.*'
+graylist_dependents: true
+graylist_skip_equal: true

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_core.social_links.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_core.social_links.yml
@@ -1,5 +1,0 @@
-facebook: ''
-instagram: ''
-twitter: ''
-youtube: ''
-weibo: ''


### PR DESCRIPTION
## [YALB-328: LocalDev: Ignore select config in export](https://yaleits.atlassian.net/browse/YALB-328?atlOrigin=eyJpIjoiYWQ3ZGNiZGY0ZGM2NGQ1NWJjOWVkMGY0ZTFmOWY2YjIiLCJwIjoiaiJ9)

### Description of work
- Removed ```ys_core.*``` from config ignore settings
- Creates a new config split for site specific config and adds ```ys_core.*``` so all ys_core settings are ignored when performing drush cex/cim

### Functional testing steps:
- [x] Make a change to the YaleSites Footer Settings - ex: add a URL for one of the social networks and save the configuration.
- [x] Perform a ```drush cex```
- [x] Verify that no config from ys_core should appear in the repo
