### PR TITLE
YALB-667 - Prepend home to breadcrumb list

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
@@ -72,7 +72,13 @@ class YaleSitesBreadcrumbBlock extends BlockBase implements ContainerFactoryPlug
    */
   public function build() {
     $breadcrumbs = $this->breadcrumbManager->build($this->routeMatch)->getLinks();
-    $links = [];
+    $links = [
+      [
+        'title' => $this->t('Home'),
+        'url' => '/',
+        'is_active' => FALSE,
+      ],
+    ];
 
     foreach ($breadcrumbs as $breadcrumb) {
       array_push($links, [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
@@ -8,6 +8,7 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Routing\UrlGeneratorInterface;
 
 /**
  * Provides a block to display the breadcrumbs.
@@ -35,6 +36,13 @@ class YaleSitesBreadcrumbBlock extends BlockBase implements ContainerFactoryPlug
   protected $routeMatch;
 
   /**
+   * UrlGenerator.
+   *
+   * @var \Drupal\Core\Routing\UrlGenerator
+   */
+  protected $urlGenerator;
+
+  /**
    * Constructs a new YaleSitesBreadcrumbBlock object.
    *
    * @param array $configuration
@@ -47,11 +55,14 @@ class YaleSitesBreadcrumbBlock extends BlockBase implements ContainerFactoryPlug
    *   The breadcrumb manager.
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The current route match.
+   * @param \Drupal\Core\Routing\UrlGeneratorInterface $url_generator
+   *   The URL Generator class.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, BreadcrumbBuilderInterface $breadcrumb_manager, RouteMatchInterface $route_match) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, BreadcrumbBuilderInterface $breadcrumb_manager, RouteMatchInterface $route_match, UrlGeneratorInterface $url_generator) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->breadcrumbManager = $breadcrumb_manager;
     $this->routeMatch = $route_match;
+    $this->urlGenerator = $url_generator;
   }
 
   /**
@@ -63,7 +74,8 @@ class YaleSitesBreadcrumbBlock extends BlockBase implements ContainerFactoryPlug
       $plugin_id,
       $plugin_definition,
       $container->get('breadcrumb'),
-      $container->get('current_route_match')
+      $container->get('current_route_match'),
+      $container->get('url_generator')
     );
   }
 
@@ -75,7 +87,7 @@ class YaleSitesBreadcrumbBlock extends BlockBase implements ContainerFactoryPlug
     $links = [
       [
         'title' => $this->t('Home'),
-        'url' => '/',
+        'url' => $this->urlGenerator->generateFromRoute('<front>', []),
         'is_active' => FALSE,
       ],
     ];


### PR DESCRIPTION
## [YALB-667: Prepend "Home" to breadcrumbs](https://yaleits.atlassian.net/browse/YALB-667?atlOrigin=eyJpIjoiZDUxNzY5NDFlM2JhNGE4YTg3NzVlYTE3ZDU3ZTY4MWIiLCJwIjoiaiJ9)

### Description of work
- Prepend home link to the breadcrumb list

### Functional testing steps:
- [ ] Visit a page that has more than 2 links deep in a menu (so the breadcrumbs are visible)
- [ ] Verify that you can see a home link and that it goes to the home page