### PR TITLE
YALB-41: Promoted news/events items

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
@@ -42,7 +42,6 @@ third_party_settings:
     group_content:
       children:
         - title
-        - field_subtitle
         - field_content
       label: Content
       region: content
@@ -97,7 +96,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 3
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -143,7 +142,7 @@ content:
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 2
+    weight: 1
     region: content
     settings:
       sidebar: true
@@ -174,11 +173,18 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 4
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
+    type: boolean_checkbox
+    weight: 5
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
     type: boolean_checkbox
     weight: 6
     region: content
@@ -194,11 +200,10 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 5
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   promote: true
-  sticky: true
   uid: true

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.event_cards.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.event_cards.yml
@@ -7,6 +7,7 @@ dependencies:
     - node.type.event
   module:
     - node
+    - smart_date
     - user
 id: event_cards
 label: 'Event Cards'
@@ -95,6 +96,21 @@ display:
         options: {  }
       empty: {  }
       sorts:
+        sticky:
+          id: sticky
+          table: node_field_data
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: sticky
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
         field_event_date_value:
           id: field_event_date_value
           table: node__field_event_date

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.event_list.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.event_list.yml
@@ -7,6 +7,7 @@ dependencies:
     - node.type.event
   module:
     - node
+    - smart_date
     - user
 id: event_list
 label: 'Event List'
@@ -111,6 +112,21 @@ display:
         options: {  }
       empty: {  }
       sorts:
+        sticky:
+          id: sticky
+          table: node_field_data
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: sticky
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
         field_event_date_value:
           id: field_event_date_value
           table: node__field_event_date

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.news_cards.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.news_cards.yml
@@ -95,6 +95,21 @@ display:
         options: {  }
       empty: {  }
       sorts:
+        sticky:
+          id: sticky
+          table: node_field_data
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: sticky
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
         created:
           id: created
           table: node_field_data

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.news_list.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.news_list.yml
@@ -111,6 +111,21 @@ display:
         options: {  }
       empty: {  }
       sorts:
+        sticky:
+          id: sticky
+          table: node_field_data
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: sticky
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
         created:
           id: created
           table: node_field_data

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -24,3 +24,9 @@ function ys_core_theme($existing, $type, $theme, $path): array {
     ],
   ];
 }
+
+function ys_core_form_alter(&$form, $form_state, $form_id) {
+  if ($form['sticky']) {
+    $form['sticky']['widget']['value']['#title'] = t('Pin to the beginning of list');
+  }
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -25,6 +25,11 @@ function ys_core_theme($existing, $type, $theme, $path): array {
   ];
 }
 
+/**
+ * Changes wording of sticky at top of lists.
+ *
+ * Implements hook_form_alter().
+ */
 function ys_core_form_alter(&$form, $form_state, $form_id) {
   if ($form['sticky']) {
     $form['sticky']['widget']['value']['#title'] = t('Pin to the beginning of list');


### PR DESCRIPTION
## [YALB-41: Promoted news/events items](https://yaleits.atlassian.net/browse/YALB-41)

### Description of work
- Changes wording of core "sticky" field from "Sticky at top of lists" to "Pin to the beginning of list" for node add forms.
- Note: This does not affect the back-end wording for use in views, etc. Those areas will still say "Sticky at top of lists".
- Adds checkbox for "Pin to beginning of list" to events edit page. The News edit page already had this field enabled.
- Changes views sort order for the four views (two each for news and events) to sort first by "sticky" and then by the previously enabled date field.

### Functional testing steps:
- [ ] Add a new news or event node.
- [ ] On the right sidebar, expand "Promotion options" and verify that there is a checkbox for "Pin to the beginning of list"
- [ ] Visit any one of the four view admin pages (```/admin/structure/views/view/event_cards```, ```/admin/structure/views/view/event_list```, ```/admin/structure/views/view/news_cards```, ```/admin/structure/views/view/news_list``` ) and verify that the sort order is set for "Sticky at top of lists" is first.
- [ ] Add some news/events nodes and add the "Pin to beginning of list" for some of the nodes.
- [ ] Revisit / update preview for the view admin page(s) visited above and notice the change in the sort order with "pinned" items at the top of the list.