### PR TITLE
YALB-590: News: Change publication date

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -8,8 +8,8 @@
         }
     ],
     "require": {
-        "drupal/admin_toolbar": "^3.1",
         "drupal/address": "^1.10",
+        "drupal/admin_toolbar": "^3.1",
         "drupal/allowed_formats": "^1.4",
         "drupal/autosave_form": "^1.3",
         "drupal/cas": "^2.0",
@@ -37,10 +37,11 @@
         "drupal/mailsystem": "^4.3",
         "drupal/maxlength": "^2.0@RC",
         "drupal/menu_admin_per_menu": "^1.4",
-        "drupal/menu_breadcrumb" : "^1.16",
+        "drupal/menu_breadcrumb": "^1.16",
         "drupal/metatag": "^1.19",
         "drupal/migrate_plus": "^6.0",
         "drupal/migrate_tools": "^6.0",
+        "drupal/override_node_options": "^2.6",
         "drupal/pantheon_advanced_page_cache": "^1.2",
         "drupal/paragraphs": "^1.12",
         "drupal/paragraphs_ee": "^2.0",

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.news.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.news.default.yml
@@ -138,27 +138,20 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
-  promote:
-    type: boolean_checkbox
-    weight: 4
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 8
+    weight: 7
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 5
+    weight: 4
     region: content
     settings:
       display_label: true
@@ -182,8 +175,9 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 7
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  promote: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -61,6 +61,7 @@ module:
   mysql: 0
   node: 0
   options: 0
+  override_node_options: 0
   page_cache: 0
   pantheon_advanced_page_cache: 0
   paragraphs_features: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/override_node_options.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/override_node_options.settings.yml
@@ -1,0 +1,4 @@
+_core:
+  default_config_hash: Y0Jxf-pLD0BpNVMs5eY2YL6Ctcxc-sKfAi5IJa_bwQk
+general_permissions: true
+specific_permissions: true

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -13,6 +13,7 @@ dependencies:
     - media
     - menu_admin_per_menu
     - node
+    - override_node_options
     - paragraphs
     - path
     - publishcontent
@@ -60,6 +61,11 @@ permissions:
   - 'edit own image media'
   - 'edit own news content'
   - 'edit own page content'
+  - 'override all authored by option'
+  - 'override all authored on option'
+  - 'override all promote to front page option'
+  - 'override all published option'
+  - 'override all sticky option'
   - 'publish any content'
   - 'publish editable content'
   - 'revert all revisions'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -13,6 +13,7 @@ dependencies:
     - media
     - menu_admin_per_menu
     - node
+    - override_node_options
     - paragraphs
     - path
     - publishcontent
@@ -59,6 +60,8 @@ permissions:
   - 'edit own image media'
   - 'edit own news content'
   - 'edit own page content'
+  - 'override all sticky option'
+  - 'override news authored on option'
   - 'publish any content'
   - 'publish editable content'
   - 'revert all revisions'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -31,7 +31,7 @@ function ys_core_theme($existing, $type, $theme, $path): array {
  * Implements hook_form_alter().
  */
 function ys_core_form_alter(&$form, $form_state, $form_id) {
-  if ($form['sticky']) {
+  if (isset($form['sticky'])) {
     $form['sticky']['widget']['value']['#title'] = t('Pin to the beginning of list');
   }
 }


### PR DESCRIPTION
## [YALB-590: News: Change publication date](https://yaleits.atlassian.net/browse/YALB-590)

### Description of work
- Requires and enables the override_node_options module
- Sets permissions for site admins to edit news node 'authored on' date
- Removes the 'promote' option from the manage news form (as we do not need it).
- Fixes warning by checking if sticky form element isset.

### Functional testing steps:
- [x] Create a user with the 'Site Administrator' role. Note: A bug within the CAS module may cause this to fail. Edit `web/modules/custom/yale_cas/yale_cas.module` and comment out the `yale_cas_form_user_form_alter` function as a temporary workaround.
- [x] Login as the site admin. Visit the node add forms for each content type.
- [x] Verify the user can edit the "authored on" date for news but not pages or events.
