### PR TITLE
YALB-687: DevOps: fix intermittent failed CI builds

### DIFF
--- a/.ci/deploy/pantheon/dev-multidev
+++ b/.ci/deploy/pantheon/dev-multidev
@@ -23,6 +23,9 @@ else
   terminus -n build:env:push "$TERMINUS_SITE.dev" --yes
 fi
 
+# Wake the environment to make sure the database is reachable.
+terminus -n env:wake "$TERMINUS_SITE.$TERMINUS_ENV"
+
 # Update the Drupal database
 terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- updatedb -y
 


### PR DESCRIPTION
## [YALB-687: DevOps: fix intermittent failed CI builds](https://yaleits.atlassian.net/browse/YALB-687)

### Description of work
Sometimes during CI deployments, the build fails on the `drush updatedb` step because the environment has not finished spinning up, and the database is not yet reachable.

```
Notice: ] Command: ***.pr-71 -- drush updatedb [Exit: 137]
Error: ]  SQLSTATE[HY000] [2002] Connection refused 
SQLSTATE[HY000] [2002] Connection refused
Error: Process completed with exit code 1.
```

This started from a Slack thread: https://pantheon-community.slack.com/archives/C57J1MUEM/p1660148365952049

It appears to be an intermittent issue with others using Pantheon Build Tools, so I have proposed this change to the templates project as well: https://github.com/pantheon-systems/tbt-ci-templates/pull/17
