### PR TITLE
YALB-691: Update machine color names to match component library

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.theme_settings.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.theme_settings.yml
@@ -1,4 +1,4 @@
-action_color: 'blue'
+action_color: 'blue-yale'
 pull_quote_color: 'gray-500'
 line_color: 'gray-500'
 line_thickness: 'thin'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
@@ -19,16 +19,16 @@ class ThemeSettingsManager {
     'action_color' => [
       'name' => 'Action Color',
       'values' => [
-        'blue' => 'Blue',
+        'blue-yale' => 'Blue',
       ],
-      'default' => 'blue',
+      'default' => 'blue-yale',
     ],
     'pull_quote_color' => [
       'name' => 'Pull Quote Color',
       'values' => [
         'gray-200' => 'Light Gray',
         'gray-500' => 'Gray',
-        'blue' => 'Blue',
+        'blue-yale' => 'Blue',
         'accent' => 'Accent',
       ],
       'default' => 'gray-500',
@@ -37,7 +37,7 @@ class ThemeSettingsManager {
       'name' => 'Line Color',
       'values' => [
         'gray-500' => 'Gray',
-        'blue' => 'Blue',
+        'blue-yale' => 'Blue',
         'accent' => 'Accent',
       ],
       'default' => 'gray-500',
@@ -64,7 +64,7 @@ class ThemeSettingsManager {
       'values' => [
         'white' => 'White',
         'gray-100' => 'Light Gray',
-        'blue' => 'Blue',
+        'blue-yale' => 'Blue',
       ],
       'default' => 'white',
     ],
@@ -75,7 +75,7 @@ class ThemeSettingsManager {
         'gray-100' => 'Light Gray',
         'gray-700' => 'Gray',
         'gray-800' => 'Dark Gray',
-        'blue' => 'Blue',
+        'blue-yale' => 'Blue',
       ],
       'default' => 'gray-700',
     ],


### PR DESCRIPTION
## [YALB-691: Update machine names of theme settings to match component library](https://yaleits.atlassian.net/browse/YALB-691)

### Description of work
- Updates machine color names to match component library

### Functional testing steps:
- [ ] Since there isn't yet anything to test in the UI for this, we can inspect one of the radio buttons for "Blue" on the form at ```/admin/yalesites/themes``` and verify that the value in the DOM is set to ```blue-yale``` instead of simply ```blue```