### PR TITLE
YALB-684: Theme Settings: Generate CSS variables

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.theme_settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.theme_settings.yml
@@ -1,0 +1,7 @@
+action_color: blue-yale
+pull_quote_color: gray-500
+line_color: gray-500
+line_thickness: thick
+nav_position: right
+header_theme: white
+footer_theme: gray-700

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @file
+ * The ys_themes module.
+ */
+
+/**
+ * Implements hook_page_attachments_alter().
+ */
+function ys_themes_page_attachments_alter(array &$page) {
+  // Add CSS custom variables to the page to pass global overrides to the theme.
+  $page['#attached']['html_head'][] = [
+    [
+      '#tag' => 'style',
+      '#value' => ys_themes_build_css_variables(),
+    ],
+    'yalesites_theme_settings',
+  ];
+}
+
+/**
+ * Build a string of CSS variables to override theme settings.
+ *
+ * @todo: Refactor the backend management once frontend conventions are set.
+ * We will look for ways to introduce error handling and unit testing.
+ *
+ * @return string
+ *   CSS code.
+ */
+function ys_themes_build_css_variables() : string {
+  $settings = \Drupal::service('ys_themes.theme_settings_manager');
+  $css = [];
+  $css[] = ':root {';
+
+  $actionColor = $settings->getSetting('action_color');
+  $css[] = "--color-theme-button-primary: var(--color-{$actionColor});";
+
+  $pullQuoteColor = $settings->getSetting('pull_quote_color');
+  $css[] = "--color-theme-pull-quote-accent: var(--color-{$pullQuoteColor});";
+
+  $lineColor = $settings->getSetting('line_color');
+  $css[] = "--color-divider: var(--color-{$lineColor});";
+
+  $lineThickness = $settings->getSetting('line_thickness');
+  if ($lineThickness == 'thin') {
+    // Will punt this work to frontend.
+  }
+
+  $css[] = '}';
+  return implode(PHP_EOL, $css);
+}


### PR DESCRIPTION
## [YALB-684: Theme Settings: Generate CSS variables](https://yaleits.atlassian.net/browse/YALB-684)

### Description of work
- Adds cssvars to the page :root
- Updates cssvars based on the global theme settings stored in Drupal
- Exports a copy of the global theme settings configuration. While this is config ignored, we need a starter place for when new sites are installed.
- This work is procedural and does not include error handling, testing, or other backend goodness. A 'todo' was added to refactor this code once the frontend architecture/naming convention is established. A lot of decisions need to be made and keeping everything in one function makes for a more readable place to experiment.

### Functional testing steps:
- [x] Verify that three new css variables appear on the `:root` element. They look similar to the snippet below but may have different values based on your active configuration. 
```css
:root {
    --color-theme-button-primary: var(--color-blue-yale);
    --color-theme-pull-quote-accent: var(--color-gray-500);
    --color-divider: var(--color-gray-500);
}
```
- [x] Pull quote color can be changed based on settings in Drupal:
  - [x] Navigate to the theme settings form and set the pull quote color to 'Light Gray'. Save the configuration. [https://pr-100-yalesites-platform.pantheonsite.io/admin/yalesites/themes](https://pr-100-yalesites-platform.pantheonsite.io/admin/yalesites/themes)
  - [x] Create a page with a pull quote or visit node 1 if you are using the starterkit content [https://pr-100-yalesites-platform.pantheonsite.io/node/1](https://pr-100-yalesites-platform.pantheonsite.io/node/1).
  - [x] Change the theme setting so that pull quote color is now 'Blue'. Save the configuration.
  - [x] View the content again and verify that the color is now blue.

