### PR TITLE
YALB 502: Dynamic heading levels

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -1,0 +1,77 @@
+callout:
+  field_style_color:
+    values:
+      blue-yale: Blue
+      gray-700: Gray
+      beige: Beige
+    default: blue-yale
+cta_banner:
+  field_style_color:
+    values:
+      gray-800: 'Dark Gray'
+      gray-700: Gray
+      gray-200: 'Light Gray (gray-200)'
+      gray-100: 'Light Gray (gray-100)'
+      white: White
+      blue-yale: Blue
+    default: gray-800
+  field_style_position:
+    values:
+      bottom: Bottom
+      left: Left
+      right: Right
+    default: bottom
+pull_quote:
+  field_style_variation:
+    values:
+      bar-left: 'Bar Left'
+      bar-right: 'Bar Right'
+      quote-left: 'Quote Left'
+    default: bar-left
+text_with_image:
+  field_style_position:
+    values:
+      image-left: 'Image Left'
+      image-right: 'Image Right'
+    default: image-left
+  field_style_width:
+    values:
+      feature: Feature
+      highlight: Highlight
+    default: feature
+  field_style_variation:
+    values:
+      equal: Equal
+      image: Image
+      content: Content
+    default: equal
+quick_links:
+  field_style_variation:
+    values:
+      promotional: Promotional
+      subtle: Subtle
+    default: promotional
+news_list:
+  field_style_variation:
+    values:
+      'true': Featured
+      'false': Secondary
+    default: 'true'
+news_cards:
+  field_style_variation:
+    values:
+      'true': Featured
+      'false': Secondary
+    default: 'true'
+event_list:
+  field_style_variation:
+    values:
+      'true': Featured
+      'false': Secondary
+    default: 'true'
+event_cards:
+  field_style_variation:
+    values:
+      'true': Featured
+      'false': Secondary
+    default: 'true'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Contains ys_themes.module functions.
+ */
+
+/**
+ * Preprocess paragraphs to determine child paragraph heading levels.
+ *
+ * Implements hook_preprocess_paragraph().
+ */
+function ys_themes_preprocess_paragraph(&$variables) {
+  $fieldHeading = 'field_heading';
+  $paragraphTypes = [
+    'accordion_item',
+  ];
+
+  if (in_array($variables['paragraph']->getType(), $paragraphTypes)) {
+    $parentParagraph = $variables['paragraph']->getParentEntity();
+    if ($parentParagraph->hasField($fieldHeading)) {
+      $variables['has_outer_heading'] = $parentParagraph->get($fieldHeading)->getValue() ? 3 : 2;
+    }
+  }
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -19,7 +19,7 @@ function ys_themes_preprocess_paragraph(&$variables) {
   if (in_array($variables['paragraph']->getType(), $paragraphTypes)) {
     $parentParagraph = $variables['paragraph']->getParentEntity();
     if ($parentParagraph->hasField($fieldHeading)) {
-      $variables['has_outer_heading'] = $parentParagraph->get($fieldHeading)->getValue() ? 3 : 2;
+      $variables['has_outer_heading'] = $parentParagraph->get($fieldHeading)->getValue() ? true : false;
     }
   }
 }


### PR DESCRIPTION
## [YALB-502: Feedback: Accordion item heading level](https://yaleits.atlassian.net/browse/YALB-502)

### Description of work
- Allows for accordion items to have a dynamic heading level based on the parent accordion heading
- Adds a variable available in ```paragraph--accordion-item.html.twig``` called ```has_outer_heading```
- Logic for what heading level it should be will be placed in ```paragraph--accordion-item.html.twig```

### Functional testing steps:
- [x] For this to work, merge in [Atomic PR-38](https://github.com/yalesites-org/atomic/pull/38) or edit ```web/themes/contrib/atomic/templates/paragraphs/paragraph--accordion-item.html.twig``` to add the logic for the ```has_outer_heading``` variable:

```
{% include "@molecules/accordion/_accordion-item.twig" with {
  accordion__item__heading: content.field_heading,
  accordion__item__content: content.field_content,
  accordion__item__heading__level: has_outer_heading ? 3 : 2
} %}
```

- [x] Flush Drupal cache
- [x] On the FAQ page (or create a new page with an accordion, accordion heading, and accordion items) - verify that the accordion item headings are h3 if the outside accordion heading exists.
- [x] Edit the FAQ or the page just created and remove the outside accordion heading and save the page
- [x] Verify that, without an outside accordion heading, the accordion internal headings have changed to h2.
