### PR TITLE
YALB-681: News/Events: Base path setting and token

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/config_ignore.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/config_ignore.settings.yml
@@ -4,3 +4,4 @@ ignored_config_entities:
   - system.site.name
   - system.site.mail
   - 'system.site.page.*'
+  - 'ys_core.*'

--- a/web/profiles/custom/yalesites_profile/config/sync/config_split.config_split.site_specific_ignored_config.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/config_split.config_split.site_specific_ignored_config.yml
@@ -12,6 +12,6 @@ theme: {  }
 blacklist: {  }
 graylist:
   - 'ys_core.*'
-  - 'ys_themes.*'
+  - 'ys_themes.theme_settings'
 graylist_dependents: true
 graylist_skip_equal: true

--- a/web/profiles/custom/yalesites_profile/config/sync/config_split.config_split.site_specific_ignored_config.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/config_split.config_split.site_specific_ignored_config.yml
@@ -12,6 +12,6 @@ theme: {  }
 blacklist: {  }
 graylist:
   - 'ys_core.*'
-  - ys_themes.theme_settings
+  - 'ys_themes.*'
 graylist_dependents: true
 graylist_skip_equal: true

--- a/web/profiles/custom/yalesites_profile/config/sync/config_split.config_split.site_specific_ignored_config.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/config_split.config_split.site_specific_ignored_config.yml
@@ -12,6 +12,6 @@ theme: {  }
 blacklist: {  }
 graylist:
   - 'ys_core.*'
-  - 'ys_themes.theme_settings'
+  - ys_themes.theme_settings
 graylist_dependents: true
 graylist_skip_equal: true

--- a/web/profiles/custom/yalesites_profile/config/sync/pathauto.pattern.events.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/pathauto.pattern.events.yml
@@ -7,12 +7,12 @@ dependencies:
 id: events
 label: Events
 type: 'canonical_entities:node'
-pattern: '[yale:news_landing_page_path]/[node:field_event_date:value-custom:Y-m-d]-[node:title]'
+pattern: '[yale:event_landing_page_path]/[node:field_event_date:value-custom:Y-m-d]-[node:title]'
 selection_criteria:
-  b493d2cc-e2b6-4d94-b858-f548d2bac7a4:
+  8ce66998-9056-4157-8d0f-2e7061015616:
     id: 'entity_bundle:node'
     negate: false
-    uuid: b493d2cc-e2b6-4d94-b858-f548d2bac7a4
+    uuid: 8ce66998-9056-4157-8d0f-2e7061015616
     context_mapping:
       node: node
     bundles:

--- a/web/profiles/custom/yalesites_profile/config/sync/pathauto.pattern.events.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/pathauto.pattern.events.yml
@@ -1,0 +1,22 @@
+uuid: 0c920237-c4b6-4f4c-921e-d5876c08b0ae
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: events
+label: Events
+type: 'canonical_entities:node'
+pattern: '[yale:news_landing_page_path]/[node:field_event_date:value-custom:Y-m-d]-[node:title]'
+selection_criteria:
+  b493d2cc-e2b6-4d94-b858-f548d2bac7a4:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: b493d2cc-e2b6-4d94-b858-f548d2bac7a4
+    context_mapping:
+      node: node
+    bundles:
+      event: event
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/pathauto.pattern.news.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/pathauto.pattern.news.yml
@@ -1,0 +1,22 @@
+uuid: f1bf29f5-f7d7-47d7-9129-3b52b3846e5b
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: news
+label: News
+type: 'canonical_entities:node'
+pattern: '[yale:news_landing_page_path]/[node:created:custom:Y-m-d]-[node:title]'
+selection_criteria:
+  8a744808-8c9b-41fd-bb78-ada30c5622e8:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 8a744808-8c9b-41fd-bb78-ada30c5622e8
+    context_mapping:
+      node: node
+    bundles:
+      news: news
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_core.site.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_core.site.yml
@@ -1,0 +1,3 @@
+page:
+  news: /news
+  events: /events

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/install/ys_core.site.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/install/ys_core.site.yml
@@ -1,0 +1,3 @@
+page:
+  news: /news
+  events: /events

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -13,6 +13,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Form for managing sitewide settings.
  *
+ * This form recreates some of the logic from the Drupal Site Information form
+ * and may need to be updated if the core form changes. See:
+ * \Drupal\system\Form\SiteInformationForm.
+ *
  * @package Drupal\ys_core\Form
  */
 class SiteSettingsForm extends ConfigFormBase {
@@ -80,18 +84,20 @@ class SiteSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   protected function getEditableConfigNames() {
-    return ['system.site'];
+    return ['system.site', 'ys_core.site'];
   }
 
   /**
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $config = $this->config('system.site');
+    $siteConfig = $this->config('system.site');
+    $yaleConfig = $this->config('ys_core.site');
+
     $form['site_name'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Site name'),
-      '#default_value' => $config->get('name'),
+      '#default_value' => $siteConfig->get('name'),
       '#required' => TRUE,
     ];
 
@@ -99,7 +105,7 @@ class SiteSettingsForm extends ConfigFormBase {
       '#type' => 'textfield',
       '#description' => $this->t("The From address in automated emails sent during registration and new password requests, and other notifications. (Use an address ending in your site's domain to help prevent this email being flagged as spam.)"),
       '#title' => $this->t('Site email'),
-      '#default_value' => $config->get('mail'),
+      '#default_value' => $siteConfig->get('mail'),
       '#required' => TRUE,
     ];
 
@@ -107,22 +113,38 @@ class SiteSettingsForm extends ConfigFormBase {
       '#type' => 'textfield',
       '#description' => $this->t("Specify a relative URL to display as the front page."),
       '#title' => $this->t('Front page'),
-      '#default_value' => $config->get('page')['front'],
+      '#default_value' => $siteConfig->get('page')['front'],
       '#required' => TRUE,
+    ];
+
+    $form['site_page_news'] = [
+      '#type' => 'textfield',
+      '#description' => $this->t("Specify a relative URL to display as the news landing page."),
+      '#title' => $this->t('News landing page'),
+      '#default_value' => $yaleConfig->get('page')['news'],
+      '#required' => FALSE,
+    ];
+
+    $form['site_page_events'] = [
+      '#type' => 'textfield',
+      '#description' => $this->t("Specify a relative URL to display as the events calenndar page."),
+      '#title' => $this->t('Events calendar page'),
+      '#default_value' => $yaleConfig->get('page')['events'],
+      '#required' => FALSE,
     ];
 
     $form['site_page_403'] = [
       '#type' => 'textfield',
       '#description' => $this->t('This page is displayed when the requested document is denied to the current user. Leave blank to display a generic "access denied" page.'),
       '#title' => $this->t('403 page'),
-      '#default_value' => $config->get('page')['403'],
+      '#default_value' => $siteConfig->get('page')['403'],
     ];
 
     $form['site_page_404'] = [
       '#type' => 'textfield',
       '#description' => $this->t('This page is displayed when no other content matches the requested document. Leave blank to display a generic "page not found" page.'),
       '#title' => $this->t('404 page'),
-      '#default_value' => $config->get('page')['404'],
+      '#default_value' => $siteConfig->get('page')['404'],
     ];
 
     return parent::buildForm($form, $form_state);
@@ -132,45 +154,28 @@ class SiteSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
-    // Validate front page path.
-    if (($value = $form_state->getValue('site_page_front')) && $value[0] !== '/') {
-      $form_state->setErrorByName('site_page_front', $this->t("The path '%path' has to start with a slash.", ['%path' => $form_state->getValue('site_page_front')]));
-    }
-    if (!$this->pathValidator->isValid($form_state->getValue('site_page_front'))) {
-      $form_state->setErrorByName('site_page_front', $this->t("Either the path '%path' is invalid or you do not have access to it.", ['%path' => $form_state->getValue('site_page_front')]));
-    }
-    // Get the normal paths of both error pages.
+    // Validate front, news, and event page paths.
+    $this->validateStartWithSlash($form_state, 'site_page_front');
+    $this->validateStartWithSlash($form_state, 'site_page_news');
+    $this->validateStartWithSlash($form_state, 'site_page_events');
+    $this->validatePath($form_state, 'site_page_front');
+
+    // Get the normal paths of error pages.
     if (!$form_state->isValueEmpty('site_page_403')) {
       $form_state->setValueForElement($form['site_page_403'], $this->aliasManager->getPathByAlias($form_state->getValue('site_page_403')));
     }
     if (!$form_state->isValueEmpty('site_page_404')) {
       $form_state->setValueForElement($form['site_page_404'], $this->aliasManager->getPathByAlias($form_state->getValue('site_page_404')));
     }
-    if (($value = $form_state->getValue('site_page_403')) && $value[0] !== '/') {
-      $form_state->setErrorByName('site_page_403', $this->t("The path '%path' has to start with a slash.", ['%path' => $form_state->getValue('site_page_403')]));
-    }
-    if (($value = $form_state->getValue('site_page_404')) && $value[0] !== '/') {
-      $form_state->setErrorByName('site_page_404', $this->t("The path '%path' has to start with a slash.", ['%path' => $form_state->getValue('site_page_404')]));
-    }
-    // Validate 403 error path.
-    if (!$form_state->isValueEmpty('site_page_403') && !$this->pathValidator->isValid($form_state->getValue('site_page_403'))) {
-      $form_state->setErrorByName('site_page_403', $this->t("Either the path '%path' is invalid or you do not have access to it.", ['%path' => $form_state->getValue('site_page_403')]));
-    }
-    // Validate 404 error path.
-    if (!$form_state->isValueEmpty('site_page_404') && !$this->pathValidator->isValid($form_state->getValue('site_page_404'))) {
-      $form_state->setErrorByName('site_page_404', $this->t("Either the path '%path' is invalid or you do not have access to it.", ['%path' => $form_state->getValue('site_page_404')]));
-    }
+
+    // Validate error page paths.
+    $this->validateStartWithSlash($form_state, 'site_page_404');
+    $this->validateStartWithSlash($form_state, 'site_page_403');
+    $this->validatePath($form_state, 'site_page_404');
+    $this->validatePath($form_state, 'site_page_403');
+
     // Email validations.
-    if (($value = $form_state->getValue('site_mail'))) {
-      // Validate email format.
-      if (!filter_var($value, FILTER_VALIDATE_EMAIL)) {
-        $form_state->setErrorByName('site_mail', $this->t('Email format for "%email" is not valid. Expected format is "user@yale.edu".', ['%email' => $form_state->getValue('site_mail')]));
-      }
-      // Validate yale email.
-      if (strpos($value, '@yale.edu') === FALSE) {
-        $form_state->setErrorByName('site_mail', $this->t('Email domain has to be @yale.edu.'));
-      }
-    }
+    $this->validateEmail($form_state, 'site_mail');
 
     parent::validateForm($form, $form_state);
   }
@@ -179,17 +184,91 @@ class SiteSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    // Retrieve the configuration.
     $this->configFactory->getEditable('system.site')
-      // Set the submitted configuration setting.
       ->set('name', $form_state->getValue('site_name'))
       ->set('mail', $form_state->getValue('site_mail'))
       ->set('page.front', $form_state->getValue('site_page_front'))
       ->set('page.403', $form_state->getValue('site_page_403'))
       ->set('page.404', $form_state->getValue('site_page_404'))
       ->save();
+    $this->configFactory->getEditable('ys_core.site')
+      ->set('page.news', $form_state->getValue('site_page_news'))
+      ->set('page.events', $form_state->getValue('site_page_events'))
+      ->save();
 
     parent::submitForm($form, $form_state);
   }
 
+  /**
+   * Check that a submitted value starts with a slash.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state passed by reference.
+   * @param string $fieldId
+   *   The id of a field on the connfig form.
+   *
+   * @return void
+   */
+  protected function validateStartWithSlash(&$form_state, $fieldId) {
+    if (($value = $form_state->getValue($fieldId)) && $value[0] !== '/') {
+      $form_state->setErrorByName(
+        $fieldId,
+        $this->t(
+          "The path '%path' has to start with a slash.",
+         ['%path' => $form_state->getValue($fieldId)]
+        )
+      );
+    }
+  }
+
+  /**
+   * Check that a submitted value represents a valid Drupal path.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state passed by reference.
+   * @param string $fieldId
+   *   The id of a field on the connfig form.
+   *
+   * @return void
+   */
+  protected function validatePath(&$form_state, $fieldId) {
+    if (!$this->pathValidator->isValid($form_state->getValue($fieldId))) {
+      $form_state->setErrorByName(
+        $fieldId,
+        $this->t(
+          "Either the path '%path' is invalid or you do not have access to it.",
+          ['%path' => $form_state->getValue($fieldId)]
+        )
+      );
+    }
+  }
+
+  /**
+   * Check that a submitted value matches the format of a valid Yale email.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state passed by reference.
+   * @param string $fieldId
+   *   The id of a field on the connfig form.
+   *
+   * @return void
+   */
+  protected function validateEmail(&$form_state, $fieldId) {
+    if (($value = $form_state->getValue($fieldId))) {
+      if (!filter_var($value, FILTER_VALIDATE_EMAIL)) {
+        $form_state->setErrorByName(
+          $fieldId,
+          $this->t(
+            'Email format for "%email" is not valid. Expected format is "user@yale.edu".',
+            ['%email' => $form_state->getValue('site_mail')]
+          )
+        );
+      }
+      if (strpos($value, '@yale.edu') === FALSE) {
+        $form_state->setErrorByName(
+          $fieldId, $this->t('Email domain has to be @yale.edu.')
+        );
+      }
+    }
+  }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -162,6 +162,8 @@ class SiteSettingsForm extends ConfigFormBase {
     $this->validatePath($form_state, 'site_page_front');
     $this->validateStartWithSlash($form_state, 'site_page_news');
     $this->validateStartWithSlash($form_state, 'site_page_events');
+    $this->validateIsNotRootPath($form_state, 'site_page_news');
+    $this->validateIsNotRootPath($form_state, 'site_page_events');
     if ($form_state->getValue('site_page_news') !== self::DEFAULT_NEWS_PATH) {
       $this->validatePath($form_state, 'site_page_news');
     }
@@ -224,6 +226,28 @@ class SiteSettingsForm extends ConfigFormBase {
         $fieldId,
         $this->t(
           "The path '%path' has to start with a slash.",
+         ['%path' => $form_state->getValue($fieldId)]
+        )
+      );
+    }
+  }
+
+  /**
+   * Check that a submitted value is not the root path.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state passed by reference.
+   * @param string $fieldId
+   *   The id of a field on the connfig form.
+   *
+   * @return void
+   */
+  protected function validateIsNotRootPath(&$form_state, $fieldId) {
+    if (($value = $form_state->getValue($fieldId)) && $value == '/') {
+      $form_state->setErrorByName(
+        $fieldId,
+        $this->t(
+          "The path '%path' can not be the site root.",
          ['%path' => $form_state->getValue($fieldId)]
         )
       );

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -21,6 +21,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class SiteSettingsForm extends ConfigFormBase {
 
+  const DEFAULT_NEWS_PATH = '/news';
+  const DEFAULT_EVENTS_PATH = '/events';
+
   /**
    * The path alias manager.
    *
@@ -119,7 +122,7 @@ class SiteSettingsForm extends ConfigFormBase {
 
     $form['site_page_news'] = [
       '#type' => 'textfield',
-      '#description' => $this->t("Specify a relative URL to display as the news landing page."),
+      '#description' => $this->t("Specify a relative URL to display as the news landing page. This can be set to an existing page URL or use the default value '/news'."),
       '#title' => $this->t('News landing page'),
       '#default_value' => $yaleConfig->get('page')['news'],
       '#required' => FALSE,
@@ -127,7 +130,7 @@ class SiteSettingsForm extends ConfigFormBase {
 
     $form['site_page_events'] = [
       '#type' => 'textfield',
-      '#description' => $this->t("Specify a relative URL to display as the events calenndar page."),
+      '#description' => $this->t("Specify a relative URL to display as the events calenndar page. This can be set to an existing page URL or use the default value '/events'."),
       '#title' => $this->t('Events calendar page'),
       '#default_value' => $yaleConfig->get('page')['events'],
       '#required' => FALSE,
@@ -156,9 +159,15 @@ class SiteSettingsForm extends ConfigFormBase {
   public function validateForm(array &$form, FormStateInterface $form_state) {
     // Validate front, news, and event page paths.
     $this->validateStartWithSlash($form_state, 'site_page_front');
+    $this->validatePath($form_state, 'site_page_front');
     $this->validateStartWithSlash($form_state, 'site_page_news');
     $this->validateStartWithSlash($form_state, 'site_page_events');
-    $this->validatePath($form_state, 'site_page_front');
+    if ($form_state->getValue('site_page_news') !== self::DEFAULT_NEWS_PATH) {
+      $this->validatePath($form_state, 'site_page_news');
+    }
+    if ($form_state->getValue('site_page_events') !== self::DEFAULT_EVENTS_PATH) {
+      $this->validatePath($form_state, 'site_page_events');
+    }
 
     // Get the normal paths of error pages.
     if (!$form_state->isValueEmpty('site_page_403')) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.tokens.inc
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.tokens.inc
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @file
+ * Builds custom tokens for YaleSites.
+ */
+
+use Drupal\Core\Render\BubbleableMetadata;
+
+/**
+ * Implements hook_token_info().
+ */
+function ys_core_token_info() {
+  $info = [];
+  $info['types']['yale'] = [
+    'name' => t('Yale Tokens'),
+    'description' => t('Custom tokens for YaleSites.'),
+  ];
+  $info['tokens']['yale']['news_landing_page_path'] = [
+    'name' => t('News landing page'),
+    'description' => t('The path alias for the news landing page.'),
+  ];
+  $info['tokens']['yale']['event_landing_page_path'] = [
+    'name' => t('Events landing page'),
+    'description' => t('The path alias for the events landing page.'),
+  ];
+  return $info;
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function ys_core_tokens($type, array $tokens, array $data, array $options, BubbleableMetadata $bubbleable_metadata) {
+  $replacements = [];
+  if ($type == 'yale' && !empty($data['node'])) {
+    foreach ($tokens as $name => $original) {
+      switch ($name) {
+        case 'news_landing_page_path':
+          $config = \Drupal::config('ys_core.site');
+          $replacements[$original] = $config->get('page.news');
+          break;
+        case 'event_landing_page_path':
+          $config = \Drupal::config('ys_core.site');
+          $replacements[$original] = $config->get('page.events');
+          break;
+      }
+    }
+  }
+  return $replacements;
+}


### PR DESCRIPTION
## [YALB-681: News/Events: Base path setting and token](https://yaleits.atlassian.net/browse/YALB-681)
## [YALB-682: News/Events: URL alias](https://yaleits.atlassian.net/browse/YALB-682)

### Description of work
- Defines a new config for for ys_core settings.
- Adds settings for news and events landing page paths.
- Reorganizes validation the site settings form.
- Creates custom tokens for the new landing page paths.
- Sets up path auto patterns for news and events leveraging these paths.
- Enables the config split as it was disabled.

### Functional testing steps:
- [x] Navigate to the (site settings form)[admin/yalesites/settings] and verify that the new fields exist for news landing page and event landing page paths.
- [x] Try changing the fields. Verify that a starting slash is required.
- [x] Create and publish a new news node. Verify that the URL alias leverages the new landing page path and follows the pattern `	[yale:news_landing_page_path]/[node:created:custom:Y-m-d]-[node:title]` 
- [x] Create and publish a new event node. Verify that the URL alias leverages the new landing page path and follows the pattern `	[yale:event_landing_page_path]/[node:field_event_date:value-custom:Y-m-d]-[node:title]` 
