### PR TITLE
YALB-286: Add ability to get all theme settings in twig

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
@@ -134,6 +134,13 @@ class ThemeSettingsManager {
   }
 
   /**
+   * Gets all theme settings from config.
+   */
+  public function getAllSettings() {
+    return($this->yaleThemeSettings->get(''));
+  }
+
+  /**
    * Sets theme setting to config.
    *
    * @param string $setting_name

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemesTwigExtension.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemesTwigExtension.php
@@ -25,6 +25,7 @@ class ThemesTwigExtension extends AbstractExtension {
   public function getFunctions() {
     return [
       new TwigFunction('getThemeSetting', [$this, 'getThemeSetting']),
+      new TwigFunction('getAllThemeSettings', [$this, 'getAllThemeSettings']),
     ];
   }
 
@@ -36,6 +37,13 @@ class ThemesTwigExtension extends AbstractExtension {
    */
   public function getThemeSetting($setting_name) {
     return $this->themeSettingsManager->getSetting($setting_name);
+  }
+
+  /**
+   * Function that returns all theme settings.
+   */
+  public function getAllThemeSettings() {
+    return $this->themeSettingsManager->getAllSettings();
   }
 
   /**


### PR DESCRIPTION
## [YALB-286: Theme Settings: Twig function](https://yaleits.atlassian.net/browse/YALB-286)

### Description of work
- Adds an additional twig function to get all theme settings in an array

### Functional testing steps:
- [x] In a twig template, add either ```{{ dump(getAllThemeSettings()) }}``` or ```{{ kint(getAllThemeSettings()) }}```
- [x] Verify that the output is an array of setting keys and values