### PR TITLE
YALB-719: Quick links style variation for link field

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -25,7 +25,29 @@ function ys_themes_preprocess_paragraph(&$variables) {
   if (in_array($variables['paragraph']->getType(), $paragraphTypes)) {
     $parentParagraph = $variables['paragraph']->getParentEntity();
     if ($parentParagraph->hasField($fieldHeading)) {
-      $variables['has_outer_heading'] = $parentParagraph->get($fieldHeading)->getValue() ? true : false;
+      $variables['has_outer_heading'] = $parentParagraph->get($fieldHeading)->getValue() ? TRUE : FALSE;
+    }
+  }
+}
+
+/**
+ * Preprocess field to add style variation twig variable to child fields.
+ *
+ * Implements hook_preprocess_field().
+ */
+function ys_themes_preprocess_field(&$variables) {
+
+  /* Key value pair of paragraph machine name and twig variable name. */
+  $paragraphTypes = [
+    'quick_links' => 'quick_links__variation',
+  ];
+
+  if ($variables['field_name'] == 'field_links') {
+    $parentParagraph = $variables['element']['#items']->getEntity();
+    foreach ($paragraphTypes as $paragraph => $twigVariable) {
+      if ($parentParagraph->getType() == $paragraph) {
+        $variables[$twigVariable] = $parentParagraph->get('field_style_variation')->getValue() ? $parentParagraph->get('field_style_variation')->getString() : NULL;
+      }
     }
   }
 }


### PR DESCRIPTION
## [YALB-719: Quick Links Subtle - Variation](https://yaleits.atlassian.net/browse/YALB-719)

### Description of work
- Adds quick links style variation to links field to correctly style links

### Functional testing steps:
- [x] This also requires [PR-42](https://github.com/yalesites-org/atomic/pull/42) from atomic to be merged in
- [x] Create a new page and add a quick links paragraph to the page
- [x] Under the "Styles" tab, select "subtle" as the Style
- [x] Save and view the page on the front-end
- [x] Verify that the quick links style is the subtle variation
- [x] The paragraph itself will be styled correctly if PR-42 is merged in
