### PR TITLE
YALB-729: Bug: Creating accordion items

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -24,7 +24,7 @@ function ys_themes_preprocess_paragraph(&$variables) {
 
   if (in_array($variables['paragraph']->getType(), $paragraphTypes)) {
     $parentParagraph = $variables['paragraph']->getParentEntity();
-    if ($parentParagraph->hasField($fieldHeading)) {
+    if ($parentParagraph && $parentParagraph->hasField($fieldHeading)) {
       $variables['has_outer_heading'] = $parentParagraph->get($fieldHeading)->getValue() ? TRUE : FALSE;
     }
   }


### PR DESCRIPTION
## [YALB-729: Bug: Creating accordion items](https://yaleits.atlassian.net/browse/YALB-729)

### Description of work
- Check if the parent paragraph exists before calling the `has` method. This currently fails when creating new accordion item paragraphs as the parent does not exist until the node is saved.

### Functional testing steps:
- [ ] Create a page with an accordion. Add multiple accordion items and save the node.
- [ ] If the node saves and there are no errors, they the bug is resolved.
