### PR TITLE
YALB-700: Search Form and Settings

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_local_actions.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_local_actions.yml
@@ -9,7 +9,7 @@ _core:
 id: atomic_local_actions
 theme: atomic
 region: content
-weight: -2
+weight: -3
 provider: null
 plugin: local_actions_block
 settings:

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_local_tasks.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_local_tasks.yml
@@ -9,7 +9,7 @@ _core:
 id: atomic_local_tasks
 theme: atomic
 region: content
-weight: -3
+weight: -4
 provider: null
 plugin: local_tasks_block
 settings:

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_messages.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_messages.yml
@@ -11,7 +11,7 @@ _core:
 id: atomic_messages
 theme: atomic
 region: content
-weight: -4
+weight: -5
 provider: null
 plugin: system_messages_block
 settings:

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.exposedformsearchpage_1.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.exposedformsearchpage_1.yml
@@ -1,0 +1,28 @@
+uuid: 1b7b4838-20f1-42ab-adda-3a9d3bb0a68b
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.search
+  module:
+    - system
+    - views
+  theme:
+    - atomic
+id: exposedformsearchpage_1
+theme: atomic
+region: content
+weight: 0
+provider: null
+plugin: 'views_exposed_filter_block:search-page_1'
+settings:
+  id: 'views_exposed_filter_block:search-page_1'
+  label: ''
+  label_display: '0'
+  provider: views
+  views_label: ''
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: /search

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.main_page_content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.main_page_content.yml
@@ -9,7 +9,7 @@ dependencies:
 id: main_page_content
 theme: atomic
 region: content
-weight: 0
+weight: 1
 provider: null
 plugin: system_main_block
 settings:

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.pagetitle.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.pagetitle.yml
@@ -1,0 +1,24 @@
+uuid: cccf566f-09f2-4b6f-8002-a355a6a5a734
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - atomic
+id: pagetitle
+theme: atomic
+region: content
+weight: -1
+provider: null
+plugin: page_title_block
+settings:
+  id: page_title_block
+  label: 'Page title'
+  label_display: '0'
+  provider: core
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: /search

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.yalesitesbreadcrumbs.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.yalesitesbreadcrumbs.yml
@@ -9,7 +9,7 @@ dependencies:
 id: yalesitesbreadcrumbs
 theme: atomic
 region: content
-weight: -1
+weight: -2
 provider: null
 plugin: ys_breadcrumb_block
 settings:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -55,6 +55,7 @@ module:
   menu_link_content: 0
   menu_ui: 0
   metatag: 0
+  metatag_views: 0
   migrate: 0
   migrate_plus: 0
   migrate_tools: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -55,7 +55,6 @@ module:
   menu_link_content: 0
   menu_ui: 0
   metatag: 0
-  metatag_views: 0
   migrate: 0
   migrate_plus: 0
   migrate_tools: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/search_api.index.node_index.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/search_api.index.node_index.yml
@@ -108,11 +108,19 @@ processor_settings:
     exceptions:
       mexican: mexic
       texan: texa
+  transliteration:
+    weights:
+      preprocess_index: -20
+      preprocess_query: -20
+    all_fields: true
+    fields:
+      - field_teaser_text
+      - rendered_item
 tracker_settings:
   default:
     indexing_order: fifo
 options:
   cron_limit: 50
-  index_directly: false
+  index_directly: true
   track_changes_in_references: true
 server: database_server

--- a/web/profiles/custom/yalesites_profile/config/sync/search_api.server.database_server.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/search_api.server.database_server.yml
@@ -10,5 +10,5 @@ description: ''
 backend: search_api_db
 backend_config:
   database: 'default:default'
-  min_chars: 1
+  min_chars: 3
   matching: partial

--- a/web/profiles/custom/yalesites_profile/config/sync/views.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.settings.yml
@@ -1,6 +1,7 @@
 _core:
   default_config_hash: uZHsLrDp1ThO0RvupHKcPzLOyVvWexm58JTTHNDo7yc
-display_extenders: {  }
+display_extenders:
+  - metatag_display_extender
 skip_cache: false
 sql_signature: false
 ui:

--- a/web/profiles/custom/yalesites_profile/config/sync/views.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.settings.yml
@@ -1,7 +1,6 @@
 _core:
   default_config_hash: uZHsLrDp1ThO0RvupHKcPzLOyVvWexm58JTTHNDo7yc
-display_extenders:
-  - metatag_display_extender
+display_extenders: {  }
 skip_cache: false
 sql_signature: false
 ui:

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
@@ -296,7 +296,11 @@ display:
     position: 1
     display_options:
       exposed_block: true
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender:
+          metatags:
+            title: 'Search for {{ arguments.search_api_fulltext }} | [site:name]'
+          tokenize: true
       path: search
     cache_metadata:
       max-age: -1

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
@@ -161,7 +161,43 @@ display:
             label: ''
             field_identifier: ''
           exposed: false
-      arguments: {  }
+      arguments:
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_node_index
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_fulltext
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: true
+          title: 'Search for: {{ raw_arguments.search_api_fulltext }}'
+          default_argument_type: query_parameter
+          default_argument_options:
+            query_param: terms
+            fallback: ''
+            multiple: and
+          default_argument_skip_url: true
+          summary_options: {  }
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: none
+            fail: empty
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          parse_mode: terms
+          conjunction: AND
+          fields: {  }
       filters:
         search_api_fulltext:
           id: search_api_fulltext
@@ -249,6 +285,7 @@ display:
     display_plugin: page
     position: 1
     display_options:
+      exposed_block: true
       display_extenders: {  }
       path: search
     cache_metadata:

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
@@ -299,7 +299,7 @@ display:
       display_extenders:
         metatag_display_extender:
           metatags:
-            title: 'Search for {{ arguments.search_api_fulltext }} | [site:name]'
+            title: '[view:title] | [site:name]'
           tokenize: true
       path: search
     cache_metadata:

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
@@ -176,7 +176,7 @@ display:
             title_enable: false
             title: All
           title_enable: true
-          title: 'Search for: {{ raw_arguments.search_api_fulltext }}'
+          title: 'Search for: {{ arguments.search_api_fulltext }}'
           default_argument_type: query_parameter
           default_argument_options:
             query_param: terms
@@ -264,7 +264,17 @@ display:
           preserve_facet_query_args: false
           query_tags: {  }
       relationships: {  }
-      header: {  }
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
       footer: {  }
       display_extenders: {  }
     cache_metadata:
@@ -286,7 +296,11 @@ display:
     position: 1
     display_options:
       exposed_block: true
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender:
+          metatags:
+            title: 'Search for: {{ arguments.search_api_fulltext }} | [site:name]'
+          tokenize: true
       path: search
     cache_metadata:
       max-age: -1

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
@@ -219,7 +219,7 @@ display:
             operator: search_api_fulltext_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: terms
+            identifier: keywords
             required: true
             remember: true
             multiple: false

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
@@ -176,10 +176,10 @@ display:
             title_enable: false
             title: All
           title_enable: true
-          title: 'Search for: {{ arguments.search_api_fulltext }}'
+          title: 'Search for {{ arguments.search_api_fulltext }}'
           default_argument_type: query_parameter
           default_argument_options:
-            query_param: terms
+            query_param: keywords
             fallback: ''
             multiple: and
           default_argument_skip_url: true
@@ -296,11 +296,7 @@ display:
     position: 1
     display_options:
       exposed_block: true
-      display_extenders:
-        metatag_display_extender:
-          metatags:
-            title: 'Search for: {{ arguments.search_api_fulltext }} | [site:name]'
-          tokenize: true
+      display_extenders: {  }
       path: search
     cache_metadata:
       max-age: -1

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -181,3 +181,16 @@ function ys_themes_theme_suggestions_form_element_label_alter(array &$suggestion
     $suggestions[] = $hook . '__search_form';
   }
 }
+
+/**
+ * Implements hook_metatags_alter().
+ *
+ * If there is a search term, change the title to reflect what was searched for.
+ */
+function ys_themes_metatags_alter(array &$metatags, array &$context) {
+  if (\Drupal::service('path.current')->getPath() == "/search") {
+    if (isset($_GET['keywords']) && $_GET['keywords'] != '') {
+      $metatags['title'] = t("Search for {$_GET['keywords']} | [site:name]");
+    }
+  }
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -177,7 +177,7 @@ function ys_themes_form_alter(&$form, &$form_state, $form_id) {
  * Add a template to visually hide the search form label and add custom icon.
  */
 function ys_themes_theme_suggestions_form_element_label_alter(array &$suggestions, array $variables, $hook) {
-  if (strpos($variables['element']['#id'], "edit-terms") === 0) {
+  if (strpos($variables['element']['#id'], "edit-keywords") === 0) {
     $suggestions[] = $hook . '__search_form';
   }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -181,16 +181,3 @@ function ys_themes_theme_suggestions_form_element_label_alter(array &$suggestion
     $suggestions[] = $hook . '__search_form';
   }
 }
-
-/**
- * Implements hook_metatags_alter().
- *
- * If there is a search term, change the title to reflect what was searched for.
- */
-function ys_themes_metatags_alter(array &$metatags, array &$context) {
-  if (\Drupal::service('path.current')->getPath() == "/search") {
-    if (isset($_GET['keywords']) && $_GET['keywords'] != '') {
-      $metatags['title'] = t("Search for {$_GET['keywords']} | [site:name]");
-    }
-  }
-}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -166,7 +166,7 @@ function ys_themes_build_css_variables() : string {
  */
 function ys_themes_form_alter(&$form, &$form_state, $form_id) {
   if ($form_id == "views_exposed_form" && $form['#id'] == "views-exposed-form-search-page-1") {
-    $form['terms']['#attributes'] = ['placeholder' => [t("Search this site")]];
+    $form['keywords']['#attributes'] = ['placeholder' => [t("Search this site")]];
     $form['actions']['submit']['#attributes']['class'][] = "visually-hidden";
   }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -158,3 +158,26 @@ function ys_themes_build_css_variables() : string {
   $css[] = '}';
   return implode(PHP_EOL, $css);
 }
+
+/**
+ * Implements hook_form_alter().
+ *
+ * Adds a placeholder to the search form and visually hides the submit button.
+ */
+function ys_themes_form_alter(&$form, &$form_state, $form_id) {
+  if ($form_id == "views_exposed_form" && $form['#id'] == "views-exposed-form-search-page-1") {
+    $form['terms']['#attributes'] = ['placeholder' => [t("Search this site")]];
+    $form['actions']['submit']['#attributes']['class'][] = "visually-hidden";
+  }
+}
+
+/**
+ * Implements hook_theme_suggestions_form_element_label_alter().
+ *
+ * Add a template to visually hide the search form label and add custom icon.
+ */
+function ys_themes_theme_suggestions_form_element_label_alter(array &$suggestions, array $variables, $hook) {
+  if (strpos($variables['element']['#id'], "edit-terms") === 0) {
+    $suggestions[] = $hook . '__search_form';
+  }
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -177,7 +177,7 @@ function ys_themes_form_alter(&$form, &$form_state, $form_id) {
  * Add a template to visually hide the search form label and add custom icon.
  */
 function ys_themes_theme_suggestions_form_element_label_alter(array &$suggestions, array $variables, $hook) {
-  if (strpos($variables['element']['#id'], "edit-keywords") === 0) {
+  if (isset($variables['element']['#id']) && strpos($variables['element']['#id'], "edit-keywords") === 0) {
     $suggestions[] = $hook . '__search_form';
   }
 }


### PR DESCRIPTION
## [YALB-700: Search: Form component](https://yaleits.atlassian.net/browse/YALB-700)

### Description of work
- Adds a search form to the utility navigation area
- Adds a search form to the search view
- Enables additional search processors
- Adds a dynamic meta title to the search page if there are search terms
- Adds number of results to the search view
- NOTE: This requires [PR-46](https://github.com/yalesites-org/atomic/pull/46) from atomic and [PR-147](https://github.com/yalesites-org/component-library-twig/pull/147) from component-library-twig

### Functional testing steps:
- [x] Import config: ```drush cim```
- [x] Reindex search: ```drush search-api-index```
- [x] Visit any page and verify that the search box is located in the utility menu area and is styled appropriately (See screenshot)
- [x] Search for something. Examples: "longform" or "interest".
- [x] Verify that the search page has a results counter on top.
- [x] Verify that the meta title (in the tab of the browser) is dynamic and only changes to "Search for [search term]" if there is a search term.

![Screen Shot 2022-09-22 at 10 56 36 AM](https://user-images.githubusercontent.com/107938318/191818158-f6bcd047-dba7-494b-9554-e18050e7dc08.png)
