### PR TITLE
YALB-708: creates image grid and image grid item paragraphs type

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.media_grid.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.media_grid.default.yml
@@ -1,0 +1,45 @@
+uuid: bef987d2-6a6f-4926-b61f-561b0a66f0ff
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.media_grid.field_heading
+    - field.field.paragraph.media_grid.field_media_grid_items
+    - paragraphs.paragraphs_type.media_grid
+  module:
+    - paragraphs
+    - text
+id: paragraph.media_grid.default
+targetEntityType: paragraph
+bundle: media_grid
+mode: default
+content:
+  field_heading:
+    type: text_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_media_grid_items:
+    type: paragraphs
+    weight: 1
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.media_grid_item.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.media_grid_item.default.yml
@@ -1,0 +1,24 @@
+uuid: 4a8e07fa-a289-4d37-b640-4cd0b34c4612
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.media_grid_item.field_media
+    - paragraphs.paragraphs_type.media_grid_item
+  module:
+    - media_library
+id: paragraph.media_grid_item.default
+targetEntityType: paragraph
+bundle: media_grid_item
+mode: default
+content:
+  field_media:
+    type: media_library_widget
+    weight: 0
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.media_grid.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.media_grid.default.yml
@@ -1,0 +1,34 @@
+uuid: 597f7afe-5846-460c-b7df-d79031874d86
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.media_grid.field_heading
+    - field.field.paragraph.media_grid.field_media_grid_items
+    - paragraphs.paragraphs_type.media_grid
+  module:
+    - entity_reference_revisions
+    - text
+id: paragraph.media_grid.default
+targetEntityType: paragraph
+bundle: media_grid
+mode: default
+content:
+  field_heading:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_media_grid_items:
+    type: entity_reference_revisions_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.media_grid_item.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.media_grid_item.default.yml
@@ -1,0 +1,23 @@
+uuid: 551dc141-e816-4108-8d83-0417a7b3cce1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.media_grid_item.field_media
+    - paragraphs.paragraphs_type.media_grid_item
+id: paragraph.media_grid_item.default
+targetEntityType: paragraph
+bundle: media_grid_item
+mode: default
+content:
+  field_media:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_content.yml
@@ -10,6 +10,7 @@ dependencies:
     - paragraphs.paragraphs_type.divider
     - paragraphs.paragraphs_type.embed
     - paragraphs.paragraphs_type.image
+    - paragraphs.paragraphs_type.media_grid
     - paragraphs.paragraphs_type.pop_out_image
     - paragraphs.paragraphs_type.pull_quote
     - paragraphs.paragraphs_type.text
@@ -39,6 +40,7 @@ settings:
       pull_quote: pull_quote
       text: text
       text_with_image: text_with_image
+      media_grid: media_grid
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -56,23 +58,56 @@ settings:
       cta_banner:
         weight: 18
         enabled: false
+      custom_card:
+        weight: 31
+        enabled: false
+      custom_cards:
+        weight: 32
+        enabled: false
       divider:
         weight: 19
         enabled: true
       embed:
         weight: 20
         enabled: true
+      event_cards:
+        weight: 35
+        enabled: false
+      event_list:
+        weight: 36
+        enabled: false
       image:
         weight: 21
         enabled: true
+      media_grid:
+        weight: 38
+        enabled: true
+      media_grid_item:
+        weight: 39
+        enabled: false
+      news_cards:
+        weight: 40
+        enabled: false
+      news_list:
+        weight: 41
+        enabled: false
       pop_out_image:
         weight: 22
         enabled: true
       pull_quote:
         weight: 23
         enabled: true
+      quick_links:
+        weight: 44
+        enabled: false
       section:
         weight: 24
+        enabled: false
+      tab:
+        weight: 46
+        enabled: false
+      tabs:
+        weight: 47
         enabled: false
       text:
         weight: 25
@@ -80,4 +115,7 @@ settings:
       text_with_image:
         weight: 26
         enabled: true
+      video:
+        weight: 50
+        enabled: false
 field_type: entity_reference_revisions

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_content.yml
@@ -14,6 +14,7 @@ dependencies:
     - paragraphs.paragraphs_type.event_cards
     - paragraphs.paragraphs_type.event_list
     - paragraphs.paragraphs_type.image
+    - paragraphs.paragraphs_type.media_grid
     - paragraphs.paragraphs_type.news_cards
     - paragraphs.paragraphs_type.news_list
     - paragraphs.paragraphs_type.pop_out_image
@@ -58,6 +59,7 @@ settings:
       custom_cards: custom_cards
       quick_links: quick_links
       tabs: tabs
+      media_grid: media_grid
       video: video
     negate: 0
     target_bundles_drag_drop:
@@ -97,6 +99,12 @@ settings:
       image:
         weight: -31
         enabled: true
+      media_grid:
+        weight: 38
+        enabled: true
+      media_grid_item:
+        weight: 39
+        enabled: false
       news_cards:
         weight: -23
         enabled: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.media_grid.field_heading.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.media_grid.field_heading.yml
@@ -1,0 +1,26 @@
+uuid: 96f01da8-58ff-4a7e-a8bd-73abf916402a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_heading
+    - paragraphs.paragraphs_type.media_grid
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - heading_html
+id: paragraph.media_grid.field_heading
+field_name: field_heading
+entity_type: paragraph
+bundle: media_grid
+label: Heading
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.media_grid.field_media_grid_items.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.media_grid.field_media_grid_items.yml
@@ -1,51 +1,41 @@
-uuid: c08e81c8-164b-4a1c-a8c5-4099b6197c46
+uuid: 51de7829-bed4-49e5-90fc-3a480cf014b4
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_content
-    - node.type.news
-    - paragraphs.paragraphs_type.divider
-    - paragraphs.paragraphs_type.image
+    - field.storage.paragraph.field_media_grid_items
     - paragraphs.paragraphs_type.media_grid
-    - paragraphs.paragraphs_type.pop_out_image
-    - paragraphs.paragraphs_type.pull_quote
-    - paragraphs.paragraphs_type.text
+    - paragraphs.paragraphs_type.media_grid_item
   module:
     - entity_reference_revisions
-id: node.news.field_content
-field_name: field_content
-entity_type: node
-bundle: news
-label: Content
+id: paragraph.media_grid.field_media_grid_items
+field_name: field_media_grid_items
+entity_type: paragraph
+bundle: media_grid
+label: Images
 description: ''
-required: false
-translatable: true
+required: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      image: image
-      divider: divider
-      pop_out_image: pop_out_image
-      pull_quote: pull_quote
-      text: text
-      media_grid: media_grid
+      media_grid_item: media_grid_item
     negate: 0
     target_bundles_drag_drop:
       accordion:
-        weight: 10
+        weight: 26
         enabled: false
       accordion_item:
-        weight: 11
+        weight: 27
         enabled: false
       callout:
-        weight: 12
+        weight: 28
         enabled: false
       callout_item:
-        weight: 13
+        weight: 29
         enabled: false
       cta_banner:
         weight: 30
@@ -57,10 +47,10 @@ settings:
         weight: 32
         enabled: false
       divider:
-        weight: 14
-        enabled: true
+        weight: 33
+        enabled: false
       embed:
-        weight: 18
+        weight: 34
         enabled: false
       event_cards:
         weight: 35
@@ -69,14 +59,14 @@ settings:
         weight: 36
         enabled: false
       image:
-        weight: 12
-        enabled: true
+        weight: 37
+        enabled: false
       media_grid:
         weight: 38
-        enabled: true
+        enabled: false
       media_grid_item:
         weight: 39
-        enabled: false
+        enabled: true
       news_cards:
         weight: 40
         enabled: false
@@ -84,11 +74,11 @@ settings:
         weight: 41
         enabled: false
       pop_out_image:
-        weight: 15
-        enabled: true
+        weight: 42
+        enabled: false
       pull_quote:
-        weight: 16
-        enabled: true
+        weight: 43
+        enabled: false
       quick_links:
         weight: 44
         enabled: false
@@ -102,10 +92,10 @@ settings:
         weight: 47
         enabled: false
       text:
-        weight: 17
-        enabled: true
+        weight: 48
+        enabled: false
       text_with_image:
-        weight: 18
+        weight: 49
         enabled: false
       video:
         weight: 50

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.media_grid_item.field_media.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.media_grid_item.field_media.yml
@@ -1,0 +1,29 @@
+uuid: 5da838e3-0f54-4afc-b55c-50769159de68
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_media
+    - media.type.image
+    - paragraphs.paragraphs_type.media_grid_item
+id: paragraph.media_grid_item.field_media
+field_name: field_media
+entity_type: paragraph
+bundle: media_grid_item
+label: Image
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.paragraph.field_media.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.paragraph.field_media.yml
@@ -1,0 +1,20 @@
+uuid: fee56ed8-aa97-40ba-93a9-f2894f3fe21f
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - paragraphs
+id: paragraph.field_media
+field_name: field_media
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.paragraph.field_media_grid_items.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.paragraph.field_media_grid_items.yml
@@ -1,0 +1,20 @@
+uuid: 861ef644-ac1c-4c58-b52f-ba95d24410a2
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_media_grid_items
+field_name: field_media_grid_items
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/paragraphs.paragraphs_type.media_grid.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/paragraphs.paragraphs_type.media_grid.yml
@@ -1,0 +1,10 @@
+uuid: 927eb60e-15f9-4009-a55e-534b912cb180
+langcode: en
+status: true
+dependencies: {  }
+id: media_grid
+label: 'Image Grid'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/paragraphs.paragraphs_type.media_grid_item.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/paragraphs.paragraphs_type.media_grid_item.yml
@@ -1,0 +1,10 @@
+uuid: 10ec3d46-c6b2-4f96-8982-246ec5acf5a7
+langcode: en
+status: true
+dependencies: {  }
+id: media_grid_item
+label: 'Image Grid Item'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }


### PR DESCRIPTION
## [YALB-708: creates image grid and image grid item paragraph type](https://yaleits.atlassian.net/browse/YALB-708)

### Description of work
- creates image grid and image grid item paragraph type for news/events/pages.

### Functional testing steps:
- [ ] Navigate to site and add content/page.
- [ ] Click content/Image Grid and fill out fields and save.
- [ ] Verify Image Grid is also displaying on news/event pages.
