### PR TITLE
YALB-732: Pages: Url Alias defaults

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/pathauto.pattern.page.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/pathauto.pattern.page.yml
@@ -1,0 +1,22 @@
+uuid: 668fb0b3-4af7-4cf9-90f6-225e6613e30f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: page
+label: Page
+type: 'canonical_entities:node'
+pattern: '[node:menu-link:parent:url:relative]/[node:title]'
+selection_criteria:
+  5171710c-0766-4ea2-8585-2d27a3518a94:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 5171710c-0766-4ea2-8585-2d27a3518a94
+    context_mapping:
+      node: node
+    bundles:
+      page: page
+selection_logic: and
+weight: -10
+relationships: {  }


### PR DESCRIPTION
## [YALB-732: Pages: Url Alias defaults](https://yaleits.atlassian.net/browse/YALB-732)

### Description of work
- Defines a pathauto pattern for all pages based on menu hierarchy.

### Functional testing steps:
- [x] Login via terminus `terminus drush yalesites-platform.pr-118 -- uli`
- [x] Create a page and add it to the main menu at the top level using the menu settings on the node-add form. Verify that a top-level page in the main menu will have a URL alias that matches the node title. [Example page here](https://pr-118-yalesites-platform.pantheonsite.io/parent)
- [x] Create another node and add it to the main menu as a child of the first page. This is a child page. Verify that this new page has a URL alias that matches the format parent-url/node-title. [Example page here](https://pr-118-yalesites-platform.pantheonsite.io/parent/child)
- [x] Create another node and add it to the main menu as a child of the second page. This is a grandchild page. Verify that this new page has a URL alias that matches the format parent-url/child-url/node-title. [Example page here](https://pr-118-yalesites-platform.pantheonsite.io/parent/child/grandchild)
- [x] Create another node that is not in the main menu. Verify that the url alias matches the title of the node.
