### PR TITLE
YALB-281: Document: Create media type

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.default.yml
@@ -1,0 +1,34 @@
+uuid: 44e19741-66be-4ab4-94b5-20a85996b6ad
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.document.field_media_file
+    - media.type.document
+  module:
+    - file
+id: media.document.default
+targetEntityType: media
+bundle: document
+mode: default
+content:
+  field_media_file:
+    type: file_generic
+    weight: 1
+    region: content
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  path: true
+  status: true
+  uid: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.media_library.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.media_library.yml
@@ -1,0 +1,27 @@
+uuid: d451cc15-1506-4b17-9d58-237c156f874b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.document.field_media_file
+    - media.type.document
+id: media.document.media_library
+targetEntityType: media
+bundle: document
+mode: media_library
+content:
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  field_media_file: true
+  path: true
+  status: true
+  uid: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.default.yml
@@ -1,0 +1,28 @@
+uuid: 46a9d9e5-3a84-4146-82c9-faebe66d6159
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.document.field_media_file
+    - media.type.document
+  module:
+    - file
+id: media.document.default
+targetEntityType: media
+bundle: document
+mode: default
+content:
+  field_media_file:
+    type: file_default
+    label: visually_hidden
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.media_library.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.media_library.yml
@@ -1,0 +1,33 @@
+uuid: 919589de-4576-4a7a-b774-b8910013fadd
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.document.field_media_file
+    - image.style.media_library
+    - media.type.document
+  module:
+    - image
+id: media.document.media_library
+targetEntityType: media
+bundle: document
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: media_library
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_media_file: true
+  name: true
+  search_api_excerpt: true
+  uid: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.media.document.field_media_file.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.media.document.field_media_file.yml
@@ -1,0 +1,27 @@
+uuid: 15cb97f3-0fec-4e22-a185-33a23a73fe1b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_file
+    - media.type.document
+  module:
+    - file
+id: media.document.field_media_file
+field_name: field_media_file
+entity_type: media
+bundle: document
+label: File
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'txt doc docx pdf'
+  max_filesize: ''
+  description_field: false
+field_type: file

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.media.field_media_file.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.media.field_media_file.yml
@@ -1,0 +1,23 @@
+uuid: 0e3fd7e0-18ef-4233-a9fe-18f9d06c7183
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - media
+id: media.field_media_file
+field_name: field_media_file
+entity_type: media
+type: file
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/media.type.document.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/media.type.document.yml
@@ -1,7 +1,12 @@
 uuid: 219e9f46-5fec-478a-9f02-26248eedb605
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - crop
+third_party_settings:
+  crop:
+    image_field: _none
 id: document
 label: Document
 description: 'Used for local files such as Word documents and PDFs.'
@@ -10,4 +15,5 @@ queue_thumbnail_downloads: false
 new_revision: false
 source_configuration:
   source_field: field_media_file
-field_map: {  }
+field_map:
+  name: name

--- a/web/profiles/custom/yalesites_profile/config/sync/media.type.document.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/media.type.document.yml
@@ -1,0 +1,13 @@
+uuid: 219e9f46-5fec-478a-9f02-26248eedb605
+langcode: en
+status: true
+dependencies: {  }
+id: document
+label: Document
+description: 'Used for local files such as Word documents and PDFs.'
+source: file
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  source_field: field_media_file
+field_map: {  }


### PR DESCRIPTION
## [YALB-281: Document: Create media type](https://yaleits.atlassian.net/browse/YALB-281)

### Description of work
- Adds the 'document' media type according to the data model.
- Exports all related configuration
- Reference: [Data Model](https://yaleedu.sharepoint.com/:x:/r/sites/YaleSitesUpgradeProgram/_layouts/15/Doc.aspx?sourcedoc=%7B2B574C06-BAC3-41E2-924A-F4562054F849%7D&file=Proposed%20Content%20Model.xlsx&action=default&mobileredirect=true&wdOrigin=TEAMS-ELECTRON.teams.files&wdExp=TEAMS-CONTROL&wdhostclicktime=1644421397192&cid=d943a478-b42a-4c48-81f5-277a615700d1)

### Functional testing steps:
- [x] Login with drush `terminus drush yalesites-platform.pr-119 -- uli`
- [ ] Verify that the new [Document media entity](https://pr-119-yalesites-platform.pantheonsite.io/admin/structure/media/manage/document) exists and matches the description in the data model.
