### PR TITLE
YALB-703: Search: Opt out of index

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -50,6 +50,7 @@
     "drupal/publishcontent": "^1.5",
     "drupal/redirect": "^1.7",
     "drupal/search_api": "^1.25",
+    "drupal/search_api_exclude": "^2.0",
     "drupal/smart_date": "^3.5",
     "drupal/twig_tweak": "^3.1",
     "drupal/xmlsitemap": "^1.2",

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -72,6 +72,7 @@ module:
   responsive_image: 0
   search_api: 0
   search_api_db: 0
+  search_api_exclude: 0
   smart_date: 0
   smart_date_recur: 0
   system: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/node.type.event.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/node.type.event.yml
@@ -4,10 +4,13 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - search_api_exclude
 third_party_settings:
   menu_ui:
     available_menus: {  }
     parent: ''
+  search_api_exclude:
+    enabled: 1
 name: Event
 type: event
 description: 'Display the details of an individual event, such as time, date, and location. Can be displayed on a calendar of events.'

--- a/web/profiles/custom/yalesites_profile/config/sync/node.type.news.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/node.type.news.yml
@@ -4,10 +4,13 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - search_api_exclude
 third_party_settings:
   menu_ui:
     available_menus: {  }
     parent: ''
+  search_api_exclude:
+    enabled: 1
 name: News
 type: news
 description: 'Create a news article, blog post, or announcement, to share new and noteworthy information. Can be displayed in a news feed.'

--- a/web/profiles/custom/yalesites_profile/config/sync/node.type.page.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/node.type.page.yml
@@ -4,12 +4,15 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - search_api_exclude
 third_party_settings:
   menu_ui:
     available_menus:
       - main
       - utility-navigation
     parent: 'main:'
+  search_api_exclude:
+    enabled: 1
 name: Page
 type: page
 description: 'A multipurpose and flexible content type allowing free-form content entry. Used to build a variety of different page layouts, from simple to elaborate.'

--- a/web/profiles/custom/yalesites_profile/config/sync/search_api.index.node_index.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/search_api.index.node_index.yml
@@ -8,6 +8,7 @@ dependencies:
   module:
     - node
     - search_api
+    - search_api_exclude
 id: node_index
 name: 'Node Index'
 description: ''
@@ -96,6 +97,7 @@ processor_settings:
       - field_teaser_text
       - rendered_item
   language_with_fallback: {  }
+  node_exclude: {  }
   rendered_item: {  }
   stemmer:
     weights:


### PR DESCRIPTION
## [YALB-703: Search: Opt out of index](https://yaleits.atlassian.net/browse/YALB-703)

### Description of work
- Allows content authors to exclude specific nodes from search

### Functional testing steps:
- [x] Reindex search ```lando drush search-api:clear && lando drush search-api:index```
- [x] Go to ```/search``` and search for "longform"
- [x] Verify that there are 2 nodes in the results: "Longform article" and "News"
- [x] Edit the "Longform article" and on the right sidebar under "Search API Exclude", toggle the slider to "Prevent this node from being indexed" and save the node
- [x] Reindex search ```lando drush search-api:clear && lando drush search-api:index```
- [x] Revisit the ```/search``` page and preform the same search for "longform"
- [x] Verify that the results will not include the actual "Longform article", but will still include the "News" page.
