### PR TITLE
YALB-762: Bug: Fix CI build - multidev not created

### DIFF
--- a/.ci/build/build_frontend
+++ b/.ci/build/build_frontend
@@ -37,6 +37,9 @@ if [ -n "$(git ls-remote --heads https://github.com/yalesites-org/component-libr
   npm ci --omit=dev --ignore-scripts
   npm install webpack-cli
   npm run build
+  rm -rf node_modules
+
+  # Copy built component library into atomic theme.
   mv /tmp/component-library-twig "$GITHUB_WORKSPACE"/"$ATOMIC_PATH"/node_modules/@yalesites-org
 
   # Clean up atomic's node_modules and remove gitignores so the changes can be staged.
@@ -46,13 +49,19 @@ if [ -n "$(git ls-remote --heads https://github.com/yalesites-org/component-libr
     fi
   done
 
+  # Copy atomic theme to tmp for safe keeping.
+  cp -pr "$GITHUB_WORKSPACE"/"$ATOMIC_PATH" /tmp
+
+  # Remove atomic as a composer dependency. so Integred Composer doesn't fail.
+  cd "$GITHUB_WORKSPACE"/web/profiles/custom/yalesites_profile
+  composer remove yalesites-org/atomic
+
+  # Copy atomic back into the themes directory and remove its gitignore so node_modules can be committed.
+  cp -pr /tmp/atomic "$GITHUB_WORKSPACE"/web/themes/contrib
+  rm "$GITHUB_WORKSPACE"/"$ATOMIC_PATH"/.gitignore
+
   cd "$GITHUB_WORKSPACE"
 
-  # Remove atomic and root gitignore so we can commit theme changes.
-  rm "$ATOMIC_PATH"/.gitignore
-  rm .gitignore
-
-  # Stage theme changes and restore root gitignore to clean up staging area.
-  git add "$GITHUB_WORKSPACE"/"$ATOMIC_PATH"
-  git checkout "$GITHUB_WORKSPACE"/.gitignore
+  # Cut the gitignore file so themes can be committed.
+  terminus build:gitignore:cut
 fi

--- a/.ci/deploy/pantheon/dev-multidev
+++ b/.ci/deploy/pantheon/dev-multidev
@@ -14,8 +14,6 @@ terminus build:gitignore:cut
 # Authenticate with Terminus
 terminus -n auth:login --machine-token="$TERMINUS_TOKEN"
 
-git status
-
 if [[ $CI_BRANCH != $DEFAULT_BRANCH ]]
 then
   # Create a new multidev environment (or push to an existing one)

--- a/.ci/deploy/pantheon/dev-multidev
+++ b/.ci/deploy/pantheon/dev-multidev
@@ -8,13 +8,10 @@ set -eo pipefail
 # Otherwise a multidev environment is used.
 #
 
-# Cut gitignore at the cut mark.
-terminus build:gitignore:cut
-
 # Authenticate with Terminus
 terminus -n auth:login --machine-token="$TERMINUS_TOKEN"
 
-if [[ $CI_BRANCH != $DEFAULT_BRANCH ]]
+if [[ "$CI_BRANCH" != "$DEFAULT_BRANCH" ]]
 then
   # Create a new multidev environment (or push to an existing one)
   terminus -n build:env:create "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --pr-id="$PR_NUMBER" --yes
@@ -38,10 +35,10 @@ fi
 terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- cr
 
 # Clear the environment cache
-terminus -n env:clear-cache $TERMINUS_SITE.$TERMINUS_ENV
+terminus -n env:clear-cache "$TERMINUS_SITE.$TERMINUS_ENV"
 
 # Ensure secrets are set
 terminus -n secrets:set "$TERMINUS_SITE.$TERMINUS_ENV" token "${GH_TOKEN:-$GITHUB_TOKEN}" --file='.build-secrets/tokens.json' --clear --skip-if-empty
 # Delete old multidev environments associated
 # with a PR that has been merged or closed.
-terminus -n build:env:delete:pr $TERMINUS_SITE --yes
+terminus -n build:env:delete:pr "$TERMINUS_SITE" --yes

--- a/.ci/deploy/pantheon/dev-multidev
+++ b/.ci/deploy/pantheon/dev-multidev
@@ -14,6 +14,8 @@ terminus build:gitignore:cut
 # Authenticate with Terminus
 terminus -n auth:login --machine-token="$TERMINUS_TOKEN"
 
+git status
+
 if [[ $CI_BRANCH != $DEFAULT_BRANCH ]]
 then
   # Create a new multidev environment (or push to an existing one)

--- a/.github/workflows/build_deploy_and_test.yml
+++ b/.github/workflows/build_deploy_and_test.yml
@@ -184,10 +184,15 @@ jobs:
       - name: setup-environment-vars
         run: /build-tools-ci/scripts/set-environment
 
-      - name: Setup tmate session
+      - name: build frontend components
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
           YALESITES_BUILD_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
+        run: |
+          ./.ci/build/build_frontend
+
+      - name: Setup tmate session
+        if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
 
       # Deploy to Pantheon

--- a/.github/workflows/build_deploy_and_test.yml
+++ b/.github/workflows/build_deploy_and_test.yml
@@ -179,15 +179,10 @@ jobs:
       - name: setup-environment-vars
         run: /build-tools-ci/scripts/set-environment
 
-      - name: build frontend components
+      - name: Setup tmate session
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
           YALESITES_BUILD_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
-        run: |
-          ./.ci/build/build_frontend
-
-      - name: Setup tmate session
-        if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
 
       # Deploy to Pantheon

--- a/.github/workflows/build_deploy_and_test.yml
+++ b/.github/workflows/build_deploy_and_test.yml
@@ -123,6 +123,11 @@ jobs:
           ref: ${{ github.head_ref || github.ref_name }}
           fetch-depth: 0
 
+      # Workaround for https://github.com/actions/runner/issues/2033
+      - name: Set git safe.directory
+        run: |
+           git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Set bash_env env var
         run: echo BASH_ENV=${RUNNER_TEMP}/bash_env.txt >> $GITHUB_ENV
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+/web/themes/contrib/
+# :::::::::::::::::::::: cut ::::::::::::::::::::::
+
+# Put ignore patterns for build artifacts above the cut line
+# so they are ignored in the source repo and committed
+# to Pantheon.
 # This file contains .gitignore rules that are often used with Drupal projects.
 # Because .gitignore is specific to your site and its deployment processes, you
 # may need to uncomment, add, or remove rules.
@@ -58,7 +64,6 @@
 /drush/Commands/contrib/
 /web/core/
 /web/modules/contrib/
-/web/themes/contrib/
 /web/profiles/contrib/
 /web/libraries/
 /web/private/scripts/quicksilver
@@ -110,3 +115,8 @@
 
 # Database references
 reference
+
+# Ignore contrib themes except atomic.
+# `terminus build:gitignore:cut` allows these lines to work in CI.
+/web/themes/contrib/*
+!/web/themes/contrib/atomic/

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,7 @@ reference
 # `terminus build:gitignore:cut` allows these lines to work in CI.
 /web/themes/contrib/*
 !/web/themes/contrib/atomic/
+
+# Yalesites profile assets
+web/profiles/custom/yalesites_profile/composer.lock
+web/profiles/custom/yalesites_profile/vendor/


### PR DESCRIPTION
## [YALB-762: Bug: Fix CI build - multidev not created](https://yaleits.atlassian.net/browse/YALB-762)

### Description of work
Builds are currently failing on the build_frontend step when files being modified are managed by Composer.

This PR updates the build_frontend script to build out the atomic theme dependencies and remove the dependency from composer so that Integrated Composer running on Pantheon does not conflict. This is accomplished by introducing the cut line to `.gitignore`, modifying some of the ignored theme paths, and running `terminus build:gitignore:cut` so that `/web/themes/contrib/atomic/` can be committed when running in CI.

This also fixes an a second issue issue that caused builds to fail around the same time, for another reason: https://github.com/actions/runner/issues/2033