### PR TITLE
YALB-736: Feedback: Remove starterkit install hooks

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/ys_starterkit.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/ys_starterkit.install
@@ -5,34 +5,6 @@
  * Install, update and uninstall functions for the module.
  */
 
-use Drupal\migrate\MigrateExecutable;
-use Drupal\migrate\MigrateMessage;
-
-/**
- * Implements hook_install().
- */
-function ys_starterkit_install() {
-  if (!\Drupal::service('config.installer')->isSyncing()) {
-    $migrations = [
-      "ys_images_files",
-      "ys_images_media",
-      "ys_paragraph_callout",
-      "ys_paragraph_accordion_text",
-      "ys_paragraph_accordion_item",
-      "ys_paragraph_accordion",
-      "ys_paragraphs",
-      "ys_pages",
-      "ys_news"
-    ];
-
-    foreach ($migrations as $migrationToImport) {
-      $migration = \Drupal::service('plugin.manager.migration')->createInstance($migrationToImport);
-      $executable = new MigrateExecutable($migration, new MigrateMessage());
-      $executable->import();
-    }
-  }
-}
-
 /**
  * Implements hook_uninstall().
  */


### PR DESCRIPTION
## [YALB-XX: Feedback: Remove starterkit install hooks](https://yaleits.atlassian.net/browse/YALB-736)

### Description of work
- Removes install hook that won't do anything for this project. This works to initiate migrations on module install, but not profile install
- Keeps the uninstall hook so if the module is uninstalled, the correct configs are removed

### Functional testing steps:
- [ ] None, this is just maintenance work