### PR TITLE
YALB-295: Set accordion item cardinality

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.paragraph.field_content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.paragraph.field_content.yml
@@ -13,7 +13,7 @@ settings:
   target_type: paragraph
 module: entity_reference_revisions
 locked: false
-cardinality: -1
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false


### PR DESCRIPTION
## [YALB-295: Set accordion item cardinality](https://yaleits.atlassian.net/browse/YALB-295)

### Description of work
- Changes accordion item content cardinality to 1.
- Removes the ‘Add Text’ button that appears in the paragraph modal.

### Functional testing steps:
- [x] navigate to site
- [x] Add content/page and click content/accordion
- [x] Verify that "Add Text" no longer displays in the accordion modal.
