### PR TITLE
YALB-717: Bug: Breadcrumbs for content without a menu link

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
@@ -93,11 +93,13 @@ class YaleSitesBreadcrumbBlock extends BlockBase implements ContainerFactoryPlug
     ];
 
     foreach ($breadcrumbs as $breadcrumb) {
-      array_push($links, [
-        'title' => $breadcrumb->getText(),
-        'url' => $breadcrumb->getUrl()->toString(),
-        'is_active' => empty($breadcrumb->getUrl()->toString()),
-      ]);
+      if ($breadcrumb->getText() !== '') {
+        array_push($links, [
+          'title' => $breadcrumb->getText(),
+          'url' => $breadcrumb->getUrl()->toString(),
+          'is_active' => empty($breadcrumb->getUrl()->toString()),
+        ]);
+      }
     }
 
     return [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesBreadcrumbBlock.php
@@ -83,7 +83,7 @@ class YaleSitesBreadcrumbBlock extends BlockBase implements ContainerFactoryPlug
    * {@inheritdoc}
    */
   public function build() {
-    $breadcrumbs = $this->breadcrumbManager->build($this->routeMatch)->getLinks();
+    $breadcrumbs = $this->removeEmptyLinks($this->getBreadcrumbs());
     $links = [
       [
         'title' => $this->t('Home'),
@@ -93,19 +93,42 @@ class YaleSitesBreadcrumbBlock extends BlockBase implements ContainerFactoryPlug
     ];
 
     foreach ($breadcrumbs as $breadcrumb) {
-      if ($breadcrumb->getText() !== '') {
-        array_push($links, [
-          'title' => $breadcrumb->getText(),
-          'url' => $breadcrumb->getUrl()->toString(),
-          'is_active' => empty($breadcrumb->getUrl()->toString()),
-        ]);
-      }
+      array_push($links, [
+        'title' => $breadcrumb->getText(),
+        'url' => $breadcrumb->getUrl()->toString(),
+        'is_active' => empty($breadcrumb->getUrl()->toString()),
+      ]);
     }
 
     return [
       '#theme' => 'ys_breadcrumb_block',
       '#items' => $links,
     ];
+  }
+
+  /**
+   * Get a list of breadcrumb links using the Drupal BreadcrumbBuilder.
+   *
+   * @return \Drupal\Core\Link[]
+   *   An array of Drupal links.
+   */
+  protected function getBreadcrumbs(): array {
+    return $this->breadcrumbManager->build($this->routeMatch)->getLinks();
+  }
+
+  /**
+   * Remove empty links from a list of links.
+   *
+   * @param \Drupal\Core\Link[] $links
+   *   An array of Drupal links.
+   *
+   * @return \Drupal\Core\Link[]
+   *   An array of Drupal links with empty ones removed.
+   */
+  protected function removeEmptyLinks(array $links): array {
+    return array_filter($links, function ($link) {
+      return $link->getText() !== '';
+    });
   }
 
   /**


### PR DESCRIPTION
## [YALB-717: Bug: Breadcrumbs for content without a menu link](https://yaleits.atlassian.net/browse/YALB-717)

### Description of work
- Fixes bug where content that was not in a menu was showing the breadcrumbs. No breadcrumbs should show for non-menu items

### Functional testing steps:
- [x] Create a new node (page, event, or news) and make sure it is not in the main menu
- [x] Save the page and view it
- [x] Verify that no breadcrumbs show
- [x] Edit the main menu and place one link as a child of another link and save
- [x] Verify that on the child link, the breadcrumbs still show fine
