### PR TITLE
YALB-271: hides media form fields

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -27,6 +27,7 @@
     "drupal/fast_404": "^2.0@alpha",
     "drupal/field_group": "^3.2",
     "drupal/gin": "^3.0@beta",
+    "drupal/hide_revision_field": "^2.2",
     "drupal/image_widget_crop": "^2.3",
     "drupal/improve_line_breaks_filter": "^1.3",
     "drupal/inline_entity_form": "^1.0@RC",

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - media.type.document
   module:
     - file
+    - hide_revision_field
 id: media.document.default
 targetEntityType: media
 bundle: document
@@ -26,6 +27,18 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  revision_log_message:
+    type: hide_revision_field_log_widget
+    weight: 80
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+      show: false
+      default: ''
+      permission_based: false
+      allow_user_settings: true
     third_party_settings: {  }
 hidden:
   created: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.image.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.image.default.yml
@@ -6,19 +6,13 @@ dependencies:
     - field.field.media.image.field_media_image
     - media.type.image
   module:
+    - hide_revision_field
     - image_widget_crop
-    - path
 id: media.image.default
 targetEntityType: media
 bundle: image
 mode: default
 content:
-  created:
-    type: datetime_timestamp
-    weight: 10
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_media_image:
     type: image_widget_crop
     weight: 0
@@ -35,28 +29,21 @@ content:
       show_crop_area: false
       show_default_crop: true
     third_party_settings: {  }
-  path:
-    type: path
-    weight: 30
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 100
+  revision_log_message:
+    type: hide_revision_field_log_widget
+    weight: 80
     region: content
     settings:
-      display_label: true
-    third_party_settings: {  }
-  uid:
-    type: entity_reference_autocomplete
-    weight: 5
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
+      rows: 5
       placeholder: ''
+      show: false
+      default: ''
+      permission_based: false
+      allow_user_settings: true
     third_party_settings: {  }
 hidden:
+  created: true
   name: true
+  path: true
+  status: true
+  uid: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.video.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.video.default.yml
@@ -6,19 +6,13 @@ dependencies:
     - field.field.media.video.field_media_oembed_video
     - media.type.video
   module:
+    - hide_revision_field
     - media
-    - path
 id: media.video.default
 targetEntityType: media
 bundle: video
 mode: default
 content:
-  created:
-    type: datetime_timestamp
-    weight: 10
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_media_oembed_video:
     type: oembed_textfield
     weight: 0
@@ -27,28 +21,21 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  path:
-    type: path
-    weight: 30
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 100
+  revision_log_message:
+    type: hide_revision_field_log_widget
+    weight: 80
     region: content
     settings:
-      display_label: true
-    third_party_settings: {  }
-  uid:
-    type: entity_reference_autocomplete
-    weight: 5
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
+      rows: 5
       placeholder: ''
+      show: false
+      default: ''
+      permission_based: false
+      allow_user_settings: true
     third_party_settings: {  }
 hidden:
+  created: true
   name: true
+  path: true
+  status: true
+  uid: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -89,6 +89,7 @@ module:
   ys_mail: 0
   ys_starterkit: 0
   ys_themes: 0
+  hide_revision_field: 1
   menu_admin_per_menu: 1
   pathauto: 1
   xmlsitemap: 1


### PR DESCRIPTION
## [YALB-271: hides media form fields](https://yaleits.atlassian.net/browse/YALB-271)

### Description of work
- Hides unhelpful media form fields.
- Adds "Hide revision field" module

### Functional testing steps:
- [x] navigate to site
- [x] Go to content/media/add media verify all add media fields only show relevant fields.
- [x] Revision information, publishing (default to published), url alias, authoring information fields should all be hidden.
