### PR TITLE
YALB-518: AX: Ability to clone nodes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "cweagans/composer-patches": "^1.7",
     "drupal/core-composer-scaffold": "^9.2",
     "drupal/core-recommended": "^9.2",
+    "drupal/quick_node_clone": "^1.15",
     "drush/drush": "^10",
     "pantheon-systems/drupal-integrations": "^9",
     "yalesites-org/yalesites_profile": "*"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "cweagans/composer-patches": "^1.7",
     "drupal/core-composer-scaffold": "^9.2",
     "drupal/core-recommended": "^9.2",
-    "drupal/quick_node_clone": "^1.15",
     "drush/drush": "^10",
     "pantheon-systems/drupal-integrations": "^9",
     "yalesites-org/yalesites_profile": "*"

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -48,6 +48,7 @@
     "drupal/paragraphs_features": "^1.15",
     "drupal/pathauto": "^1.8",
     "drupal/publishcontent": "^1.5",
+    "drupal/quick_node_clone": "^1.15",
     "drupal/redirect": "^1.7",
     "drupal/search_api": "^1.25",
     "drupal/search_api_exclude": "^2.0",

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -69,6 +69,7 @@ module:
   path: 0
   path_alias: 0
   publishcontent: 0
+  quick_node_clone: 0
   redirect: 0
   responsive_image: 0
   search_api: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/quick_node_clone.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/quick_node_clone.settings.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: 6XRelHPjACQVOo9yRQMmbXt-ysCA2Pt6l762bxQQbdw
+exclude:
+  node: {  }
+  paragraph: {  }
+text_to_prepend_to_title: 'Clone of'
+clone_status: false

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -17,6 +17,7 @@ dependencies:
     - paragraphs
     - path
     - publishcontent
+    - quick_node_clone
     - system
     - taxonomy
     - toolbar
@@ -36,6 +37,9 @@ permissions:
   - 'administer main menu items'
   - 'administer users'
   - 'administer utility-navigation menu items'
+  - 'clone event content'
+  - 'clone news content'
+  - 'clone page content'
   - 'create event content'
   - 'create image media'
   - 'create media'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -17,6 +17,7 @@ dependencies:
     - paragraphs
     - path
     - publishcontent
+    - quick_node_clone
     - system
     - taxonomy
     - toolbar
@@ -35,6 +36,9 @@ permissions:
   - 'administer main menu items'
   - 'administer users'
   - 'administer utility-navigation menu items'
+  - 'clone event content'
+  - 'clone news content'
+  - 'clone page content'
   - 'create event content'
   - 'create image media'
   - 'create media'


### PR DESCRIPTION
## [YALB-518: AX: Ability to clone nodes](https://yaleits.atlassian.net/browse/YALB-518)

### Description of work
Story: As a content owner, I do not want to manually recreate content. I want to avoid the chore of copying and pasting. Examples: a series of events that have closely related content. I want to recreate a layout and will use the clone module as a starting place.

### Acceptance Criteria
- The Quick Node Clone module is required via composer and install via Drupal Config management.  
- Site Admins can clone any node (page, event, or news).

### Functional testing steps:
- [x] Log in as a site administrator or platform administrator
- [x] Visit an existing node
- [x] You should see a "Clone" link in the admin links at the top of a node
