### PR TITLE
YALB-702: Fix error message for show/hide search config

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -43,7 +43,7 @@ function ys_core_form_alter(&$form, $form_state, $form_id) {
  */
 function ys_core_preprocess_region(&$variables) {
   $config = \Drupal::config('ys_core.site');
-  if ($variables['elements']['#region'] == 'header') {
+  if ($variables['elements']['#region'] == 'header' && $config->get('search')) {
     $variables['utility_nav__search'] = $config->get('search')['enable_search_form'];
   }
 }


### PR DESCRIPTION
## [YALB-702: Search: Hide search form](https://yaleits.atlassian.net/browse/YALB-702)

### Description of work
- Fixes error message ```Notice: Trying to access array offset on value of type null in ys_core_preprocess_region() (line 47 of profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module).```

### Functional testing steps:
- [ ] Rebuild to get a clean copy: ```npm run rebuild```
- [ ] Load any page on the front end
- [ ] Verify that there are no more error messages like the one above