### PR TITLE
YALB-766: action banner button

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.cta_banner.field_link.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.cta_banner.field_link.yml
@@ -13,7 +13,7 @@ entity_type: paragraph
 bundle: cta_banner
 label: Link
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/paragraphs.json
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/paragraphs.json
@@ -205,7 +205,11 @@
             {
               "image_id": 3
             }
-          ]
+          ],
+          "field_link": {
+            "url": "http://www.example.com",
+            "title": "Action text"
+          }
         }
       },
       {


### PR DESCRIPTION
## [YALB-766: Require button on action banner](https://yaleits.atlassian.net/browse/YALB-766)

### Description of work
- Makes the link field for the action banner required.

### Functional testing steps:
- [x] Navigate to site
- [x] go to content/Standard Page one and verify that the link is now being displayed.
