### PR TITLE
YALB-74: Add permissions for yalesites settings forms

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -21,6 +21,8 @@ dependencies:
     - system
     - taxonomy
     - toolbar
+    - ys_alert
+    - ys_core
 id: platform_admin
 label: 'Platform administrator'
 weight: 2
@@ -89,3 +91,5 @@ permissions:
   - 'view page revisions'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
+  - 'yalesites manage alerts'
+  - 'yalesites manage settings'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -21,6 +21,8 @@ dependencies:
     - system
     - taxonomy
     - toolbar
+    - ys_alert
+    - ys_core
 id: site_admin
 label: 'Site administrator'
 weight: 3
@@ -85,3 +87,5 @@ permissions:
   - 'view page revisions'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
+  - 'yalesites manage alerts'
+  - 'yalesites manage settings'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.permissions.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.permissions.yml
@@ -1,0 +1,4 @@
+# Permission to manage YaleSites alerts.
+yalesites manage alerts:
+  title: 'Manage YaleSite Alerts'
+  description: 'Set and change YaleSites alerts.'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.routing.yml
@@ -4,4 +4,4 @@ ys_alert.settings:
     _form: '\Drupal\ys_alert\Form\AlertSettings'
     _title: 'Alert Settings'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'yalesites manage alerts'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.permissions.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.permissions.yml
@@ -1,0 +1,4 @@
+# Permission to manage YaleSites settings forms.
+yalesites manage settings:
+  title: 'Manage YaleSite Settings'
+  description: 'Access the settings forms in the YaleSites section of the admin menu.'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.routing.yml
@@ -5,7 +5,7 @@ ys_core.admin_yalesites:
     _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
     _title: 'YaleSites'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'yalesites manage settings'
 # Sitewide settings form.
 ys_core.admin_site_settings:
   path: '/admin/yalesites/settings'
@@ -13,7 +13,7 @@ ys_core.admin_site_settings:
     _form: '\Drupal\ys_core\Form\SiteSettingsForm'
     _title: 'Site Settings'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'yalesites manage settings'
 # Footer settings form.
 ys_core.admin_footer_settings:
   path: '/admin/yalesites/footer'
@@ -21,4 +21,4 @@ ys_core.admin_footer_settings:
     _form: 'Drupal\ys_core\Form\FooterSettingsForm'
     _title: 'Footer Settings'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'yalesites manage settings'


### PR DESCRIPTION
## [YALB-74: Add permissions for yalesites settings forms](https://yaleits.atlassian.net/browse/YALB-74)

### Description of work
- Defines permissions in the ys_core and ys_alerts modules
- Apply this permission to the YaleSites settings forms
- Add the permission to site admins and platform admins

### Functional testing steps:
- [ ] Create an account with the 'Site Administrator' role
- [ ] Login as a site admin and verify the user can visit each of the YaleSites settings pages:
  - [ ] Top level menu link
  - [ ] Site settings
  - [ ] Theme settings
  - [ ] Alert settings
