### PR TITLE
YALB-752: set max lengths in drupal

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.media_library.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.media_library.yml
@@ -19,6 +19,18 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  revision_log_message:
+    type: hide_revision_field_log_widget
+    weight: 80
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+      show: true
+      default: ''
+      permission_based: false
+      allow_user_settings: true
+    third_party_settings: {  }
 hidden:
   created: true
   field_media_file: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.video.media_library.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.video.media_library.yml
@@ -19,6 +19,18 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  revision_log_message:
+    type: hide_revision_field_log_widget
+    weight: 80
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+      show: true
+      default: ''
+      permission_based: false
+      allow_user_settings: true
+    third_party_settings: {  }
 hidden:
   created: true
   field_media_oembed_video: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
@@ -177,6 +177,18 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  revision_log:
+    type: hide_revision_field_log_widget
+    weight: 80
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+      show: true
+      default: ''
+      permission_based: false
+      allow_user_settings: true
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 5

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.news.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.news.default.yml
@@ -142,6 +142,18 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  revision_log:
+    type: hide_revision_field_log_widget
+    weight: 80
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+      show: true
+      default: ''
+      permission_based: false
+      allow_user_settings: true
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 7

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
@@ -168,6 +168,18 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  revision_log:
+    type: hide_revision_field_log_widget
+    weight: 80
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+      show: true
+      default: ''
+      permission_based: false
+      allow_user_settings: true
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 3

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.accordion_item.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.accordion_item.default.yml
@@ -40,7 +40,7 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 80
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
 hidden:
   created: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.callout_item.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.callout_item.default.yml
@@ -29,7 +29,7 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 80
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
   field_link:
     type: link_default
@@ -51,10 +51,9 @@ content:
         hide_help: '1'
         hide_guidelines: '0'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 150
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: false
-        maxlength_js_truncate_html: false
+        maxlength_js_enforce: true
 hidden:
   created: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.cta_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.cta_banner.default.yml
@@ -11,8 +11,10 @@ dependencies:
     - field.field.paragraph.cta_banner.field_text
     - paragraphs.paragraphs_type.cta_banner
   module:
+    - allowed_formats
     - field_group
     - link
+    - maxlength
     - media_library
     - media_library_edit
     - text
@@ -79,7 +81,13 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 50
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
   field_image:
     type: media_library_widget
     weight: 1
@@ -116,7 +124,14 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 90
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
 hidden:
   created: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.custom_card.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.custom_card.default.yml
@@ -9,7 +9,9 @@ dependencies:
     - field.field.paragraph.custom_card.field_text
     - paragraphs.paragraphs_type.custom_card
   module:
+    - allowed_formats
     - link
+    - maxlength
     - media_library
     - media_library_edit
     - text
@@ -25,7 +27,13 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 80
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
   field_image:
     type: media_library_widget
     weight: 0
@@ -50,7 +58,14 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 175
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
 hidden:
   created: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.custom_cards.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.custom_cards.default.yml
@@ -7,6 +7,8 @@ dependencies:
     - field.field.paragraph.custom_cards.field_heading
     - paragraphs.paragraphs_type.custom_cards
   module:
+    - allowed_formats
+    - maxlength
     - paragraphs
     - text
 id: paragraph.custom_cards.default
@@ -33,7 +35,13 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 50
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
 hidden:
   created: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.embed.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.embed.default.yml
@@ -36,7 +36,7 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 80
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
 hidden:
   created: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.event_cards.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.event_cards.default.yml
@@ -6,6 +6,8 @@ dependencies:
     - field.field.paragraph.event_cards.field_heading
     - paragraphs.paragraphs_type.event_cards
   module:
+    - allowed_formats
+    - maxlength
     - text
 id: paragraph.event_cards.default
 targetEntityType: paragraph
@@ -19,7 +21,13 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 125
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
 hidden:
   created: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.event_list.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.event_list.default.yml
@@ -6,6 +6,8 @@ dependencies:
     - field.field.paragraph.event_list.field_heading
     - paragraphs.paragraphs_type.event_list
   module:
+    - allowed_formats
+    - maxlength
     - text
 id: paragraph.event_list.default
 targetEntityType: paragraph
@@ -19,7 +21,13 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 50
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
 hidden:
   created: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.gallery.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.gallery.default.yml
@@ -46,7 +46,7 @@ content:
         hide_help: '1'
         hide_guidelines: '0'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 50
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
 hidden:
   created: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.gallery_item.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.gallery_item.default.yml
@@ -29,7 +29,7 @@ content:
         hide_help: '1'
         hide_guidelines: '0'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 80
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
   field_media:
     type: media_library_widget
@@ -50,9 +50,9 @@ content:
         hide_help: '1'
         hide_guidelines: '0'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 120
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: false
+        maxlength_js_enforce: true
 hidden:
   created: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.image.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.image.default.yml
@@ -38,10 +38,9 @@ content:
         hide_help: '1'
         hide_guidelines: '0'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 120
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: false
-        maxlength_js_truncate_html: false
+        maxlength_js_enforce: true
 hidden:
   created: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.media_grid.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.media_grid.default.yml
@@ -7,6 +7,8 @@ dependencies:
     - field.field.paragraph.media_grid.field_media_grid_items
     - paragraphs.paragraphs_type.media_grid
   module:
+    - allowed_formats
+    - maxlength
     - paragraphs
     - text
 id: paragraph.media_grid.default
@@ -21,7 +23,13 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 50
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
   field_media_grid_items:
     type: paragraphs
     weight: 1

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.news_cards.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.news_cards.default.yml
@@ -6,6 +6,8 @@ dependencies:
     - field.field.paragraph.news_cards.field_heading
     - paragraphs.paragraphs_type.news_cards
   module:
+    - allowed_formats
+    - maxlength
     - text
 id: paragraph.news_cards.default
 targetEntityType: paragraph
@@ -19,7 +21,13 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 125
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
 hidden:
   created: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.news_list.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.news_list.default.yml
@@ -6,6 +6,8 @@ dependencies:
     - field.field.paragraph.news_list.field_heading
     - paragraphs.paragraphs_type.news_list
   module:
+    - allowed_formats
+    - maxlength
     - text
 id: paragraph.news_list.default
 targetEntityType: paragraph
@@ -19,7 +21,13 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 125
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
 hidden:
   created: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.pull_quote.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.pull_quote.default.yml
@@ -74,7 +74,7 @@ content:
       placeholder: ''
     third_party_settings:
       maxlength:
-        maxlength_js: null
+        maxlength_js: 90
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
   field_style_variation:
     type: options_select
@@ -94,10 +94,9 @@ content:
         hide_help: '1'
         hide_guidelines: '0'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 425
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: false
-        maxlength_js_truncate_html: false
+        maxlength_js_enforce: true
 hidden:
   created: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.quick_links.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.quick_links.default.yml
@@ -10,8 +10,10 @@ dependencies:
     - field.field.paragraph.quick_links.field_text
     - paragraphs.paragraphs_type.quick_links
   module:
+    - allowed_formats
     - field_group
     - link
+    - maxlength
     - media_library
     - media_library_edit
     - text
@@ -77,7 +79,13 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 50
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
   field_image:
     type: media_library_widget
     weight: 3
@@ -94,7 +102,10 @@ content:
     settings:
       placeholder_url: ''
       placeholder_title: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 50
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
   field_style_variation:
     type: options_select
     weight: 5
@@ -108,7 +119,14 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 100
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
 hidden:
   created: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.tab.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.tab.default.yml
@@ -7,6 +7,8 @@ dependencies:
     - field.field.paragraph.tab.field_heading
     - paragraphs.paragraphs_type.tab
   module:
+    - allowed_formats
+    - maxlength
     - paragraphs
     - paragraphs_ee
     - paragraphs_features
@@ -52,7 +54,13 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 40
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
 hidden:
   created: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.text_with_image.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.text_with_image.default.yml
@@ -90,7 +90,7 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 80
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
   field_image:
     type: media_library_widget
@@ -139,7 +139,7 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 50
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
   field_text:
     type: text_textarea
@@ -153,10 +153,9 @@ content:
         hide_help: '1'
         hide_guidelines: '0'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 500
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: false
-        maxlength_js_truncate_html: false
+        maxlength_js_enforce: true
 hidden:
   created: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.video.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.video.default.yml
@@ -44,9 +44,9 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 120
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: false
+        maxlength_js_enforce: true
   field_video:
     type: media_library_widget
     weight: 3


### PR DESCRIPTION
## [YALB-752: set max lengths in drupal](https://yaleits.atlassian.net/browse/YALB-752)

### Description of work
- Updates the set max length text fields for paragraphs in drupal.

### Functional testing steps:
- [x] Go to site
- [x] Go to structure/paragraph types/manage fields/manage form display.
- [x] verify that all text fields for paragraphs are updated to the correct character limit according to the data model.
