### PR TITLE
YALB-283: AX: Remove confusing remove-button

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,6 +95,9 @@
     "patches": {
       "drupal/layout_paragraphs": {
         "save close tweaks": "https://git.drupalcode.org/project/layout_paragraphs/-/merge_requests/80.patch"
+      },
+      "drupal/paragraphs": {
+        "hide remove button": "https://www.drupal.org/files/issues/2020-05-13/hide_field_required_paragraphs_remove_button_1.patch"
       }
     }
   },


### PR DESCRIPTION
## [YALB-283: AX: Remove confusing remove-button](https://yaleits.atlassian.net/browse/YALB-283)

### Description of work
- Removes extra unnecessary "remove" button from paragraphs that have cardinality of 1 and the field is required.
- Note: The patch for this was added to the root composer file. If this needs to go into the profile composer file, let me know and I will move it.

### Functional testing steps:
- [ ] Create a page and add a paragraph of type accordion.
- [ ] Verify there is no longer a remove button for the "text" paragraph (internal paragraph)
- [ ] See screenshots for before/after

Before patch:
![Screen Shot 2022-10-06 at 3 35 20 PM](https://user-images.githubusercontent.com/107938318/194439663-a8564fb8-3552-4f48-a355-3bd708be643b.png)

After patch:
![Screen Shot 2022-10-06 at 3 35 27 PM](https://user-images.githubusercontent.com/107938318/194439699-ff5f0ad6-f06b-4d85-9041-ae7abb6ad812.png)

