### PR TITLE
YALB-777: AX: Atomic theme paragraph previews

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -27,6 +27,7 @@
     "drupal/fast_404": "^2.0@alpha",
     "drupal/field_group": "^3.2",
     "drupal/gin": "^3.0@beta",
+    "drupal/gin_lp": "1.0.x-dev@dev",
     "drupal/hide_revision_field": "^2.2",
     "drupal/image_widget_crop": "^2.3",
     "drupal/improve_line_breaks_filter": "^1.3",

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
@@ -34,7 +34,7 @@ content:
     settings:
       view_mode: default
       link: ''
-      preview_view_mode: preview
+      preview_view_mode: default
       nesting_depth: 0
       require_layouts: 0
       empty_message: ''

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -36,6 +36,7 @@ module:
   field_ui: 0
   file: 0
   filter: 0
+  gin_lp: 0
   gin_toolbar: 0
   image: 0
   image_widget_crop: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/gin_lp.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/gin_lp.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: DVMt-oq2V5Xu-2KfZVufTJM5NfcbG-HUr4k1R71KDDg
+toastify_cdn: 1

--- a/web/profiles/custom/yalesites_profile/config/sync/system.performance.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.performance.yml
@@ -4,7 +4,7 @@ cache:
   page:
     max_age: 0
 css:
-  preprocess: true
+  preprocess: false
   gzip: true
 fast_404:
   enabled: true
@@ -12,6 +12,6 @@ fast_404:
   exclude_paths: '/\/(?:styles|imagecache)\//'
   html: '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>'
 js:
-  preprocess: true
+  preprocess: false
   gzip: true
 stale_file_threshold: 2592000

--- a/web/profiles/custom/yalesites_profile/config/sync/system.performance.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.performance.yml
@@ -4,7 +4,7 @@ cache:
   page:
     max_age: 0
 css:
-  preprocess: false
+  preprocess: true
   gzip: true
 fast_404:
   enabled: true
@@ -12,6 +12,6 @@ fast_404:
   exclude_paths: '/\/(?:styles|imagecache)\//'
   html: '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>'
 js:
-  preprocess: false
+  preprocess: true
   gzip: true
 stale_file_threshold: 2592000


### PR DESCRIPTION
## [YALB-777: AX: Atomic theme paragraph previews](https://yaleits.atlassian.net/browse/YALB-777)

### Description of work
- Correctly styles paragraphs after initial click of "Edit Content" button on the front-end.
- Note: If you then click on the edit button on a specific paragraph, this will open a side panel to edit the paragraph and the side panel still needs styling (like the modal was going to need anyways)
- Thank you to @vinmassaro for finding the gin_lp module which makes this work.

### Functional testing steps:
- [ ] Import config ```drush cim```
- [ ] Visit one of the prebuilt pages that has an "Text with Image" components 
- [ ] Hover over the content and click the blue "Edit content" button
- [ ] Verify that the paragraphs will not change styling (i.e. the text with image, the image is the same size and does not shrink) and/or that the CTA banner image doesn't get fuzzy.
