### PR TITLE
YALB-307: redirects on login to frontpage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "cweagans/composer-patches": "^1.7",
     "drupal/core-composer-scaffold": "^9.2",
     "drupal/core-recommended": "^9.2",
+    "drupal/redirect_after_login": "^2.7",
     "drush/drush": "^10",
     "pantheon-systems/drupal-integrations": "^9",
     "yalesites-org/yalesites_profile": "*"

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -72,6 +72,7 @@ module:
   publishcontent: 0
   quick_node_clone: 0
   redirect: 0
+  redirect_after_login: 0
   responsive_image: 0
   search_api: 0
   search_api_db: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/redirect_after_login.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/redirect_after_login.settings.yml
@@ -1,0 +1,6 @@
+login_redirection:
+  anonymous: null
+  authenticated: /<front>
+  platform_admin: /<front>
+  site_admin: /<front>
+exclude_urls: ''


### PR DESCRIPTION
## [YALB-307: Redirect on login](https://yaleits.atlassian.net/browse/YALB-307)

### Description of work
- Installs the Redirect After Login module. 
- Redirects all roles to the front page.

### Functional testing steps:
- [ ] Navigate to site
- [ ] Go to configuration/System/Set Log In Destination. 
- [ ] Make sure all roles are redirected to <front>.
