### PR TITLE
YALB-628: disables preview for content types

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/node.type.event.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/node.type.event.yml
@@ -16,5 +16,5 @@ type: event
 description: 'Display the details of an individual event, such as time, date, and location. Can be displayed on a calendar of events.'
 help: ''
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: false

--- a/web/profiles/custom/yalesites_profile/config/sync/node.type.news.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/node.type.news.yml
@@ -16,5 +16,5 @@ type: news
 description: 'Create a news article, blog post, or announcement, to share new and noteworthy information. Can be displayed in a news feed.'
 help: ''
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: false

--- a/web/profiles/custom/yalesites_profile/config/sync/node.type.page.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/node.type.page.yml
@@ -18,5 +18,5 @@ type: page
 description: 'A multipurpose and flexible content type allowing free-form content entry. Used to build a variety of different page layouts, from simple to elaborate.'
 help: ''
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: false


### PR DESCRIPTION
## [YALB-628: Node preview button error](https://yaleits.atlassian.net/browse/YALB-628)

### Description of work
- Disables preview option for content types.

### Functional testing steps:
- [ ] Navigate to site.
- [ ] Go to content/add content and make sure all content types (events, page, news) no longer have a preview button.
