### PR TITLE
YALB-793: CI: check for module additions to root composer.json

### DIFF
--- a/.github/workflows/build_deploy_and_test.yml
+++ b/.github/workflows/build_deploy_and_test.yml
@@ -108,6 +108,14 @@ jobs:
       # https://github.com/pantheon-systems/docker-build-tools-ci/blob/6.x/scripts/set-environment
       - name: setup-environment-vars
         run: /build-tools-ci/scripts/set-environment
+
+      - name: Check for contrib dependencies in root composer.json
+        run: |
+          contrib_check=$(jq -r '.require | with_entries(select(.key | test("(drupal\/(?!core).*$)"))) | keys | join(", ")' ./composer.json)
+          if [ -n "$contrib_check" ]; then
+            echo "::error::contrib_check $contrib_check found in /composer.json and should be moved to /web/profiles/custom/yalesites_profile/composer.json" && exit 1
+          fi
+
       - name: run static tests
         run: |
           ./.ci/test/static/run

--- a/.github/workflows/build_deploy_and_test.yml
+++ b/.github/workflows/build_deploy_and_test.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           contrib_check=$(jq -r '.require | with_entries(select(.key | test("(drupal\/(?!core).*$)"))) | keys | join(", ")' ./composer.json)
           if [ -n "$contrib_check" ]; then
-            echo "::error::contrib_check $contrib_check found in /composer.json and should be moved to /web/profiles/custom/yalesites_profile/composer.json" && exit 1
+            echo "::error::$contrib_check found in /composer.json and should be moved to /web/profiles/custom/yalesites_profile/composer.json" && exit 1
           fi
 
       - name: run static tests

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "cweagans/composer-patches": "^1.7",
     "drupal/core-composer-scaffold": "^9.2",
     "drupal/core-recommended": "^9.2",
-    "drupal/redirect_after_login": "^2.7",
     "drush/drush": "^10",
     "pantheon-systems/drupal-integrations": "^9",
     "yalesites-org/yalesites_profile": "*"

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -52,6 +52,7 @@
     "drupal/publishcontent": "^1.5",
     "drupal/quick_node_clone": "^1.15",
     "drupal/redirect": "^1.7",
+    "drupal/redirect_after_login": "^2.7",
     "drupal/search_api": "^1.25",
     "drupal/search_api_exclude": "^2.0",
     "drupal/smart_date": "^3.5",


### PR DESCRIPTION
## [YALB-793: CI: check for module additions to root composer.json](https://yaleits.atlassian.net/browse/YALB-793)

### Description of work
Adds a CI check to make sure root composer.json require array only contains drupal/core*.

