### PR TITLE
YALB-255: creates dashboard interface

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Controller/DashboardController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Controller/DashboardController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\ys_core\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * Give me a description.
+ */
+class DashboardController extends ControllerBase {
+
+  /**
+   * Returns a render-able array for a test page.
+   */
+  public function content() {
+
+    // Do something with your variables here.
+    $myText = 'This is not just a default text!';
+    $myNumber = 1;
+    $myArray = [1, 2, 3];
+
+    return [
+      // Your theme hook name.
+      '#theme' => 'ys_dashboard_theme_hook',
+      // Your variables.
+      '#variable1' => $myText,
+      '#variable2' => $myNumber,
+      '#variable3' => $myArray,
+    ];
+  }
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-dashboard-theme-hook.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-dashboard-theme-hook.html.twig
@@ -1,0 +1,14 @@
+<h1>My lovely twig template.</h1>
+<p>You passed this text: <b>{{ variable1 }}</b></p>
+<p>You passed this number value: {{ variable2 }}</p>
+<p>And you passed this array:</p>
+
+<ul>
+  {% for item in variable3 %}
+    <li>
+       {{ item }}
+    </li>
+  {% endfor %}
+</ul>
+
+<p>Ciao!</p>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
@@ -19,3 +19,9 @@ ys_core.admin_footer_settings:
   route_name: ys_core.admin_footer_settings
   title: 'Footer Settings'
   weight: 20
+# Dashboard
+ys_core.admin_dashboard:
+  description: 'Dashboard settings'
+  parent: ys_core.admin_yalesites
+  route_name: ys_core.admin_dashboard
+  title: 'Dashboard'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -22,6 +22,14 @@ function ys_core_theme($existing, $type, $theme, $path): array {
         'items' => [],
       ],
     ],
+    'ys_dashboard_theme_hook' => [
+      'render element' => 'children',
+      'variables' => [
+        'variable1' => 'Yet another default text.',
+        'variable2' => 0,
+        'variable3' => [0, 0, 0],
+      ],
+    ],
   ];
 }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.routing.yml
@@ -22,3 +22,11 @@ ys_core.admin_footer_settings:
     _title: 'Footer Settings'
   requirements:
     _permission: 'yalesites manage settings'
+# Dashboard
+ys_core.admin_dashboard:
+  path: '/admin/yalesites/dashboard'
+  defaults:
+    _controller: '\Drupal\ys_core\Controller\DashboardController::content'
+    _title: 'Dashboard'
+  requirements:
+    _permission: 'yalesites manage settings'


### PR DESCRIPTION
## [YALB-255: creates dashboard interface](https://yaleits.atlassian.net/browse/YALB-255)

### Description of work
- Creates a new space to act as the dashboard.

### Functional testing steps:
- [ ] Navigate to site
- [ ] Go to admin/yalesites and verify "Dashboard" is showing in the list.
- [ ] Go to Dashoard and verify placeholder text is being shown.
