### PR TITLE
YALB-809: Bug Feedback: limited permissions on fields for Platform Admins

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/FooterSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/FooterSettingsForm.php
@@ -60,7 +60,7 @@ class FooterSettingsForm extends ConfigFormBase {
     foreach ($this->socialLinks::SITES as $id => $name) {
       $form['social_links'][$id] = [
         '#type' => 'url',
-        '#title' => $this->t('@name URL', $name),
+        '#title' => $this->t('@name URL', ['@name' => $name]),
         '#default_value' => $config->get($id),
       ];
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/paragraphs.json
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/paragraphs.json
@@ -10,7 +10,7 @@
           },
           "field_text": {
             "value": "\"The homepage is the ideal place to tell your story. Paint a picture for the user and spark their interest.\"",
-            "format": "basic_html"
+            "format": "restricted_html"
           }
         }
       },
@@ -20,7 +20,7 @@
         "paragraph_fields": {
           "field_heading": {
             "value": "Short heading to introduce this item",
-            "format": "basic_html"
+            "format": "heading_html"
           },
           "field_images": [
             {
@@ -33,7 +33,7 @@
           },
           "field_subheading": {
             "value": "Optional subheading for extra content",
-            "format": "basic_html"
+            "format": "heading_html"
           },
           "field_text": {
             "value": "The feature width, equal focus text with image component is great for introducing linked content and/or drawing attention to free-standing pieces of content. It is meant to be short form content that is quick and to the point.",
@@ -61,7 +61,7 @@
         "paragraph_fields": {
           "field_heading": {
             "value": "Id consectetur purus ut faucibus nulla aliquet porttitor lacus",
-            "format": "basic_html"
+            "format": "heading_html"
           },
           "field_images": [
             {
@@ -120,7 +120,7 @@
         "paragraph_fields": {
           "field_text": {
             "value": "Nec ultrices dui sapien eget mi proin sed libero enim. Nisl pretium fusce id velit ut tortor pretium.",
-            "format": "basic_html"
+            "format": "restricted_html"
           }
         }
       },
@@ -258,7 +258,7 @@
           },
           "field_text": {
             "value": "Malesuada nunc vel risus commodo viverra maecenas accumsan. Aliquam eleifend mi in nulla posuere sollicitudin aliquam.",
-            "format": "basic_html"
+            "format": "restricted_html"
           }
         }
       },


### PR DESCRIPTION
## [YALB-809: Bug Feedback: limited permissions on fields for Platform Admins](https://yaleits.atlassian.net/browse/YALB-809)

### Description of work
- Allows platform admins to edit the pull quote text and the heading and subheading fields for the text with image on content generated from the starterkit
- Fixes the error when attempting to visit the Footer Settings page
- Note: Reimport of the starterkit migration is required, steps below

### Functional testing steps:
- [x] Remove existing migrated items: ```drush mr --all```
- [x] Perform migration: ```drush mim ys_menu_links --execute-dependencies```
- [x] Edit the "Top goal for the site" page
- [x] Edit the "Pull Quote" paragraph
- [x] Verify that the "Quote" field is editable
- [x] Click "Cancel"
- [x] Edit the "Text with Image" paragraph
- [x] Verify that the "Heading" and "Subheading" fields are editable
- [x] Click "Cancel"
- [x] Visit the "Footer Settings" page here: ```/admin/yalesites/footer```
- [x] Verify that the page loads without errors
