### PR TITLE
Fix local cl dev script

### DIFF
--- a/scripts/local/local-cl-dev.sh
+++ b/scripts/local/local-cl-dev.sh
@@ -18,12 +18,12 @@ echo -e "${GREEN}Move into component library and create a global link${ENDCOLOR}
 cd web/themes/contrib/atomic
 [ ! -d "component-library-twig" ] && git clone git@github.com:yalesites-org/component-library-twig.git
 cd component-library-twig || exit
-# Run npm install, only if node_modules doesn't exist
-[ ! -d "node_modules" ] && npm install
 npm link
 echo -e "${GREEN}Move into Atomic and use the newly created global link${ENDCOLOR}"
 cd ..
 npm link @yalesites-org/component-library-twig
 echo -e "${GREEN}Run the develop script in the component library${ENDCOLOR}"
 cd component-library-twig || exit
+# Run npm ci. This is required to patch our version of Twig.js.
+npm ci
 npm run develop


### PR DESCRIPTION
### Description of work
- Updates the local cl dev script to patch Twig.js

### Functional testing steps:
- [x] Checkout this branch, run `npm run local:cl-dev` and visit a page example. (`http://localhost:6006/?path=/story/page-examples-standard-pages--basic`)
- [x] Verify the page displays correctly (and doesn't show the `file.includes` error in the main window)