### PR TITLE
YALB-790: DevOps: Run cim on multidevs

### DIFF
--- a/.ci/deploy/pantheon/dev-multidev
+++ b/.ci/deploy/pantheon/dev-multidev
@@ -27,7 +27,7 @@ terminus -n env:wake "$TERMINUS_SITE.$TERMINUS_ENV"
 terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- updatedb -y
 
 # If exported configuration is available, then import it.
-if [ -f "config/system.site.yml" ] ; then
+if [ -f "web/profiles/custom/config/sync/system.site.yml" ] ; then
   terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- config-import --yes
 fi
 

--- a/.ci/deploy/pantheon/dev-multidev
+++ b/.ci/deploy/pantheon/dev-multidev
@@ -27,7 +27,7 @@ terminus -n env:wake "$TERMINUS_SITE.$TERMINUS_ENV"
 terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- updatedb -y
 
 # If exported configuration is available, then import it.
-if [ -f "web/profiles/custom/config/sync/system.site.yml" ] ; then
+if [ -f "web/profiles/custom/yalesites_profile/config/sync/system.site.yml" ] ; then
   terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- config-import --yes
 fi
 

--- a/web/profiles/custom/yalesites_profile/config/sync/system.site.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.site.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: l58O_yEXSo-SeJi19LXdzTU1tNJG3lmnIhCitRkM1tk
 langcode: en
 uuid: 3be7d457-cc13-4e03-bde2-d004a9e0f46e
-name: 'Your Site Title'
+name: 'Test Config Change'
 mail: noreply@yale.edu
 slogan: ''
 page:

--- a/web/profiles/custom/yalesites_profile/config/sync/system.site.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.site.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: l58O_yEXSo-SeJi19LXdzTU1tNJG3lmnIhCitRkM1tk
 langcode: en
 uuid: 3be7d457-cc13-4e03-bde2-d004a9e0f46e
-name: 'Test Config Change'
+name: 'Your Site Title'
 mail: noreply@yale.edu
 slogan: ''
 page:


### PR DESCRIPTION
## [YALB-790: DevOps: Run cim on multidevs](https://yaleits.atlassian.net/browse/YALB-790)

### Description of work
- Runs config import on multidev creation

### Functional testing steps:
- [ ] Make a config change locally
- [ ] Export config locally ```drush cex```
- [ ] Commit this change and push to a new branch
- [ ] Create a PR to create a multidev
- [ ] Verify that the config was automatically imported into this new multidev