### PR TITLE
YALB-774: TechDebt: Move patch to the profile

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,17 +91,6 @@
     "composer-exit-on-patch-failure": true,
     "patchLevel": {
       "drupal/core": "-p2"
-    },
-    "patches": {
-      "drupal/layout_paragraphs": {
-        "save close tweaks": "https://git.drupalcode.org/project/layout_paragraphs/-/merge_requests/80.patch"
-      },
-      "drupal/paragraphs": {
-        "hide remove button": "https://www.drupal.org/files/issues/2020-05-13/hide_field_required_paragraphs_remove_button_1.patch"
-      },
-      "drupal/linkit": {
-        "add linkit widget to link fields": "https://www.drupal.org/files/issues/2022-07-22/2712951-293.patch"
-      }
     }
   },
   "config": {

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -65,5 +65,23 @@
   "prefer-stable": true,
   "config": {
     "sort-packages": true
+  },
+  "extra": {
+    "enable-patching": true,
+    "composer-exit-on-patch-failure": true,
+    "patchLevel": {
+      "drupal/core": "-p2"
+    },
+    "patches": {
+      "drupal/layout_paragraphs": {
+        "save close tweaks": "https://git.drupalcode.org/project/layout_paragraphs/-/merge_requests/80.patch"
+      },
+      "drupal/paragraphs": {
+        "hide remove button": "https://www.drupal.org/files/issues/2020-05-13/hide_field_required_paragraphs_remove_button_1.patch"
+      },
+      "drupal/linkit": {
+        "add linkit widget to link fields": "https://www.drupal.org/files/issues/2022-07-22/2712951-293.patch"
+      }
+    }
   }
 }


### PR DESCRIPTION
## [YALB-774: TechDebt: Move patch to the profile](https://yaleits.atlassian.net/browse/YALB-774)

### Description of work
- Moves patches from the root composer.json file to the yalesites_profile composer.json

### Functional testing steps:
- [ ] Not necessary, but if any patches have been added/removed/changed, run ```composer update```
- [ ] Verify that the patches that are currently there still work:
- [ ] Layout paragraphs - on the front-end, click the "Edit Content" above the paragraphs and the save/close button should be on top (where the Edit button used to be)
- [ ] Paragraphs - Edit an accordion on the back-end and there should only be one "remove" button per accordion item, not two.
- [ ] Linkit - Edit a paragraph that has a link field (such as a callout item) and the autocomplete for the link field should include the author and the date/time stamp.