### PR TITLE
YALB-757: all day events

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
@@ -50,11 +50,15 @@ content:
     weight: 2
     region: content
   field_event_date:
-    type: smartdate_plain
+    type: smartdate_default
     label: hidden
     settings:
       timezone_override: ''
-      separator: '-'
+      format_type: medium
+      format: html_datetime
+      force_chronological: false
+      add_classes: false
+      time_wrapper: true
     third_party_settings: {  }
     weight: 5
     region: content

--- a/web/profiles/custom/yalesites_profile/config/sync/smart_date.smart_date_format.html_datetime.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/smart_date.smart_date_format.html_datetime.yml
@@ -1,0 +1,15 @@
+uuid: 6410f42c-6c28-4ce8-ac76-153b39845c03
+langcode: en
+status: true
+dependencies: {  }
+id: html_datetime
+label: 'HTML Datetime'
+date_format: c
+time_format: 'g:i a'
+time_hour_format: 'g a'
+allday_label: 'All day'
+separator: ' - '
+join: ', '
+ampm_reduce: '1'
+date_first: '1'
+site_time_toggle: '1'


### PR DESCRIPTION
## [YALB-757: All Day Events](https://yaleits.atlassian.net/browse/YALB-757)

### Description of work
- Allows all day events to use the string "All Day" in place of the time.
- Display uses "smart date formatter"
- Requires PR: https://github.com/yalesites-org/atomic/pull/58
- Requires PR: https://github.com/yalesites-org/component-library-twig/pull/160

### Functional testing steps:
- [ ] navigate to site
- [ ] add content/event
- [ ] add title and go to logistics, scroll down and check all day box and add a date and save.
- [ ] verify that "All Day" is being shown under the selected date.