### PR TITLE
YALB-785: enables layout paragraphs for news

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.news.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.news.default.yml
@@ -12,9 +12,10 @@ dependencies:
     - node.type.news
   module:
     - field_group
+    - hide_revision_field
+    - layout_paragraphs
     - media_library
     - metatag
-    - paragraphs
     - path
     - text
 third_party_settings:
@@ -94,16 +95,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_content:
-    type: entity_reference_paragraphs
+    type: layout_paragraphs
     weight: 2
     region: content
     settings:
-      title: Paragraph
-      title_plural: Paragraphs
-      edit_mode: open
-      add_mode: dropdown
-      form_display_mode: default
-      default_paragraph_type: ''
+      preview_view_mode: default
+      nesting_depth: 0
+      require_layouts: 0
+      empty_message: ''
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.default.yml
@@ -11,7 +11,7 @@ dependencies:
     - field.field.node.news.field_teaser_title
     - node.type.news
   module:
-    - entity_reference_revisions
+    - layout_paragraphs
     - metatag
     - text
     - user
@@ -29,11 +29,15 @@ content:
     weight: 105
     region: content
   field_content:
-    type: entity_reference_revisions_entity_view
+    type: layout_paragraphs_builder
     label: hidden
     settings:
       view_mode: default
       link: ''
+      preview_view_mode: default
+      nesting_depth: 0
+      require_layouts: 0
+      empty_message: ''
     third_party_settings: {  }
     weight: 106
     region: content


### PR DESCRIPTION
## [YALB-785: enables layout paragraphs for news](https://yaleits.atlassian.net/browse/YALB-785)

### Description of work
- Updates the news content type to use ‘Layout Paragraph’ formatter/widget on the main content field.

### Functional testing steps:
- [ ] Go to site.
- [ ] Add content/news and fill out fields and add content and save.
- [ ] Verify that when hovering over the "content" of the news node the "edit content" button displays.
