### PR TITLE
YALB-112: overrides text with image paragraph fields

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -41,9 +41,9 @@ text_with_image:
     default: feature
   field_style_variation:
     values:
-      equal: Equal
-      image: Image
-      content: Content
+      equal: Focused
+      image: Focused
+      content: Focused
     default: equal
 quick_links:
   field_style_variation:

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -41,9 +41,9 @@ text_with_image:
     default: feature
   field_style_variation:
     values:
-      equal: Focused
-      image: Focused
-      content: Focused
+      equal: Equal Focused
+      image: Image Focused
+      content: Content Focused
     default: equal
 quick_links:
   field_style_variation:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
@@ -41,9 +41,9 @@ text_with_image:
     default: 'feature'
   field_style_variation:
     values:
-      equal: 'Focused'
-      image: 'Focused'
-      content: 'Focused'
+      equal: 'Equal Focused'
+      image: 'Image Focused'
+      content: 'Content Focused'
     default: 'equal'
 quick_links:
   field_style_variation:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
@@ -41,9 +41,9 @@ text_with_image:
     default: 'feature'
   field_style_variation:
     values:
-      equal: 'Equal'
-      image: 'Image'
-      content: 'Content'
+      equal: 'Focused'
+      image: 'Focused'
+      content: 'Focused'
     default: 'equal'
 quick_links:
   field_style_variation:


### PR DESCRIPTION
## [YALB-112: Update Text with Image overrides](https://yaleits.atlassian.net/browse/YALB-112)

### Description of work
- Updates Text with Image paragraph fields and overrides them.

### Functional testing steps:
- [x] navigate to site
- [ ] Go to content/add content/page, fill out title and click add content. Add text with image component.
- [ ] Go to styles and verify that the "focus" dropdown has the options "Equal Focused", "Image Focused", and "Content Focused".
