### PR TITLE
YALB-830: Disable layout paragraphs FE experience

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_local_actions.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_local_actions.yml
@@ -8,7 +8,7 @@ _core:
   default_config_hash: ABoKnlk20KHqZRw_2Qr4EvaFvH4lnQ2nuhunHeE1JIU
 id: atomic_local_actions
 theme: atomic
-region: content
+region: system
 weight: -3
 provider: null
 plugin: local_actions_block

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_local_tasks.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_local_tasks.yml
@@ -8,7 +8,7 @@ _core:
   default_config_hash: T0wbI6qVdThbbIqXDZFg_1VZ3_ittXBdEoUH7d7ux_E
 id: atomic_local_tasks
 theme: atomic
-region: content
+region: system
 weight: -4
 provider: null
 plugin: local_tasks_block

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_messages.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.atomic_messages.yml
@@ -10,7 +10,7 @@ _core:
   default_config_hash: aeqlWs7HwctZeZC7ADcbxfqehJzBRfZKmuZz3DsH3_4
 id: atomic_messages
 theme: atomic
-region: content
+region: system
 weight: -5
 provider: null
 plugin: system_messages_block

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.exposedformsearchpage_1.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.exposedformsearchpage_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: exposedformsearchpage_1
 theme: atomic
 region: content
-weight: 0
+weight: -4
 provider: null
 plugin: 'views_exposed_filter_block:search-page_1'
 settings:

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.main_page_content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.main_page_content.yml
@@ -9,7 +9,7 @@ dependencies:
 id: main_page_content
 theme: atomic
 region: content
-weight: 1
+weight: -3
 provider: null
 plugin: system_main_block
 settings:

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.pagetitle.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.pagetitle.yml
@@ -9,7 +9,7 @@ dependencies:
 id: pagetitle
 theme: atomic
 region: content
-weight: -1
+weight: -5
 provider: null
 plugin: page_title_block
 settings:

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.yalesitesbreadcrumbs.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.yalesitesbreadcrumbs.yml
@@ -9,7 +9,7 @@ dependencies:
 id: yalesitesbreadcrumbs
 theme: atomic
 region: content
-weight: -4
+weight: -2
 provider: null
 plugin: ys_breadcrumb_block
 settings:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
@@ -13,7 +13,7 @@ dependencies:
     - field.field.node.event.field_teaser_title
     - node.type.event
   module:
-    - layout_paragraphs
+    - entity_reference_revisions
     - link
     - metatag
     - options
@@ -25,15 +25,11 @@ bundle: event
 mode: default
 content:
   field_content:
-    type: layout_paragraphs_builder
+    type: entity_reference_revisions_entity_view
     label: hidden
     settings:
       view_mode: default
       link: ''
-      preview_view_mode: default
-      nesting_depth: 0
-      require_layouts: 0
-      empty_message: ''
     third_party_settings: {  }
     weight: 1
     region: content

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.default.yml
@@ -11,7 +11,7 @@ dependencies:
     - field.field.node.news.field_teaser_title
     - node.type.news
   module:
-    - layout_paragraphs
+    - entity_reference_revisions
     - metatag
     - text
     - user
@@ -29,15 +29,11 @@ content:
     weight: 105
     region: content
   field_content:
-    type: layout_paragraphs_builder
+    type: entity_reference_revisions_entity_view
     label: hidden
     settings:
       view_mode: default
       link: ''
-      preview_view_mode: default
-      nesting_depth: 0
-      require_layouts: 0
-      empty_message: ''
     third_party_settings: {  }
     weight: 106
     region: content

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
@@ -12,7 +12,6 @@ dependencies:
     - node.type.page
   module:
     - entity_reference_revisions
-    - layout_paragraphs
     - user
 id: node.page.default
 targetEntityType: node
@@ -29,15 +28,11 @@ content:
     weight: 0
     region: content
   field_content:
-    type: layout_paragraphs_builder
+    type: entity_reference_revisions_entity_view
     label: hidden
     settings:
       view_mode: default
       link: ''
-      preview_view_mode: preview
-      nesting_depth: 0
-      require_layouts: 0
-      empty_message: ''
     third_party_settings: {  }
     weight: 1
     region: content


### PR DESCRIPTION
## [YALB-830: Disable layout paragraphs FE experience](https://yaleits.atlassian.net/browse/YALB-830)

**Depends on https://github.com/yalesites-org/atomic/pull/65**

### Description of work
- Disables LPB on the frontend
- Moves system blocks into the "system" region

### Functional testing steps:
- [ ] Checkout this branch, and run `npm run local:review-with-atomic-branch` and pass in `YALB-830-lp-fe-experience` when asked.
- [ ] Create a page, and add a bunch of content. Verify everything is spaced appropriately
- [ ] Add a Banner in the banner tab/field. Verify it is flush with the header
- [ ] Add a Banner as the last item in the content, and verify it is flush with the footer
- [ ] Add a Callout as the last item in the content, and verify it is flush with the footer
- [ ] Put anything else as the last item in the content, and verify there is a large gap before the footer
