### PR TITLE
Add local theme link script

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ _Notes:_
 
 - `confex` Exports your local drupal config.
 - `confim` Imports the current config files to your database.
-- `local:theme-link` Run this script once to establish `npm link`s to all three repositories. 
-- `local:cl-dev` Enables a frontend developer to work across all three repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance.
+- `local:theme-link` Run this script once to establish `npm links to all of the frontend-related repositories. 
+- `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory.

--- a/README.md
+++ b/README.md
@@ -44,4 +44,5 @@ _Notes:_
 
 - `confex` Exports your local drupal config.
 - `confim` Imports the current config files to your database.
-- `local:cl-dev` Enables a frontend developer to works across all three repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance.
+- `local:theme-link` Run this script once to establish `npm link`s to all three repositories. 
+- `local:cl-dev` Enables a frontend developer to work across all three repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance.

--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ _Notes:_
 
 - `confex` Exports your local drupal config.
 - `confim` Imports the current config files to your database.
-- `local:theme-link` Run this script once to establish `npm links to all of the frontend-related repositories. 
+- `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "local:review-with-atomic-branch": "./scripts/local/local-review-with-atomic-branch.sh",
     "local:review-with-cl-branch": "./scripts/local/local-review-with-cl-branch.sh",
     "local:cl-dev": "./scripts/local/local-cl-dev.sh",
+    "local:theme-link": "./scripts/local/local-theme-link.sh",
     "prettier": "prettier '{.github,docs,web/profiles/custom,web/modules/custom,web/themes/contrib/atomic,web/themes/custom}/**/*.{json,md,js,html,scss,html}' --ignore-unknown --list-different",
     "setup": "./scripts/local/setup.sh",
     "test": "./scripts/local/test.sh"

--- a/scripts/local/local-theme-link.sh
+++ b/scripts/local/local-theme-link.sh
@@ -16,19 +16,19 @@ ENDCOLOR='\033[0m'
 
 echo -e "${GREEN}Move into tokens repo and create a global link${ENDCOLOR}"
 cd web/themes/contrib/atomic
-[ ! -d "_node_modules/tokens" ] && git clone git@github.com:yalesites-org/tokens.git _node_modules/tokens
-cd _node_modules/tokens || exit
+[ ! -d "_yale-packages/tokens" ] && git clone git@github.com:yalesites-org/tokens.git _yale-packages/tokens
+cd _yale-packages/tokens || exit
 npm link
 cd ../..
 echo -e "${GREEN}Move into component library, use the tokens link, and create a global link${ENDCOLOR}"
-[ ! -d "_node_modules/component-library-twig" ] && git clone git@github.com:yalesites-org/component-library-twig.git _node_modules/component-library-twig
-cd _node_modules/component-library-twig || exit
+[ ! -d "_yale-packages/component-library-twig" ] && git clone git@github.com:yalesites-org/component-library-twig.git _yale-packages/component-library-twig
+cd _yale-packages/component-library-twig || exit
 npm link
 echo -e "${GREEN}Move into Atomic and use the component-library global link${ENDCOLOR}"
 cd ../..
 npm link @yalesites-org/component-library-twig
 echo -e "${GREEN}Move into the component-library and use the tokens global link${ENDCOLOR}"
-cd _node_modules/component-library-twig || exit
+cd _yale-packages/component-library-twig || exit
 # Run npm ci. This is required to patch our version of Twig.js.
 npm ci
 npm link @yalesites-org/tokens

--- a/scripts/local/local-theme-link.sh
+++ b/scripts/local/local-theme-link.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# This script will use npm link under-the-hood (inside the Docker container) to
+# enable frontend developers to work inside Storybook as they normally would,
+# but also make those changes imediately available to the local Drupal instance.
+# This is particularly useful when a wiring ticket surfaces required component
+# library updates.
+
+# Note: Changes to the component library are still tracked ONLY in the component
+# library's repository, so in order for the changes to be seen on a remotely
+# built environment (multidev, or any live site) the changes will have to go
+# through the regular component library release process, and be included in an
+# official release of Atomic.
+
+GREEN='\033[1;32m'
+ENDCOLOR='\033[0m'
+
+echo -e "${GREEN}Move into tokens repo and create a global link${ENDCOLOR}"
+cd web/themes/contrib/atomic
+[ ! -d "_node_modules/tokens" ] && git clone git@github.com:yalesites-org/tokens.git _node_modules/tokens
+cd _node_modules/tokens || exit
+npm link
+cd ../..
+echo -e "${GREEN}Move into component library, use the tokens link, and create a global link${ENDCOLOR}"
+[ ! -d "_node_modules/component-library-twig" ] && git clone git@github.com:yalesites-org/component-library-twig.git _node_modules/component-library-twig
+cd _node_modules/component-library-twig || exit
+npm link
+echo -e "${GREEN}Move into Atomic and use the component-library global link${ENDCOLOR}"
+cd ../..
+npm link @yalesites-org/component-library-twig
+echo -e "${GREEN}Move into the component-library and use the tokens global link${ENDCOLOR}"
+cd _node_modules/component-library-twig || exit
+# Run npm ci. This is required to patch our version of Twig.js.
+npm ci
+npm link @yalesites-org/tokens
+echo -e "${GREEN}Run the develop script in the component library${ENDCOLOR}"


### PR DESCRIPTION
### Description of work
- Adds `local-theme-link` script to run all the same set up commands as the `local-cl-dev` but meant to only be run once and _does not_ include `npm run develop` at the end. 
- After running `npm run local:theme-link` once, you can use npm run local:cl-dev` for developement

### Functional testing steps:
- [ ] Pull down branch and run `npm run local:theme-link`
- [ ] Verify it completes without error
- [ ] Verify Drupal still loads properly (with theme styles in place)
- [ ] Verify you can run `npm run local:cl-dev` 
- [ ] Review the changes I made to README and verify it reads well.

### Question: 
- Should we simplify the `local-cl-dev` script to only run the following?: 
```
cd _yale-packages/component-library-twig || exit
echo -e "${GREEN}Run the develop script in the component library${ENDCOLOR}"
npm run develop
```

Or would that require adjusting other scripts and/or is there a reason not to simplify?