### PR TITLE
YALB-845: Add Drupal Console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
   "require": {
     "composer/installers": "^1.9",
     "cweagans/composer-patches": "^1.7",
+    "drupal/console": "~1.0",
     "drupal/core-composer-scaffold": "^9.2",
     "drupal/core-recommended": "^9.2",
     "drush/drush": "^10",
@@ -103,7 +104,8 @@
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "composer/installers": true,
       "cweagans/composer-patches": true,
-      "drupal/core-composer-scaffold": true
+      "drupal/core-composer-scaffold": true,
+      "drupal/console-extend-plugin": true
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
   "require": {
     "composer/installers": "^1.9",
     "cweagans/composer-patches": "^1.7",
-    "drupal/console": "~1.0",
     "drupal/core-composer-scaffold": "^9.2",
     "drupal/core-recommended": "^9.2",
     "drush/drush": "^10",
@@ -25,6 +24,7 @@
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
     "drupal/coder": "^8.3",
+    "drupal/console": "~1.0",
     "drupal/core-dev": "^9.2",
     "drupal/drupal-driver": "^2.1",
     "drupal/drupal-extension": "^4.1",


### PR DESCRIPTION
## [YALB-845: Add Drupal Console](https://yaleits.atlassian.net/browse/YALB-845)

### Description of work
- Adds drupal console to the project as a composer dependency. 

### Functional testing steps:
- [ ] Run `lando drupal` to verify the tool is running.