### PR TITLE
YALB-841: Remove color from callout

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -3,7 +3,6 @@ callout:
     values:
       blue-yale: Blue
       gray-700: Gray
-      beige: Beige
     default: blue-yale
 cta_banner:
   field_style_color:
@@ -41,7 +40,7 @@ text_with_image:
     default: feature
   field_style_variation:
     values:
-      equal: Equal
+      equal: 'Equal Focus'
       image: Image
       content: Content
     default: equal


### PR DESCRIPTION
## [YALB-841: Remove color from callout](https://yaleits.atlassian.net/browse/YALB-841)

### Description of work
- Remove beige as a color option from the callout styles

### Functional testing steps:
- [ ] Create a new callout paragraph and edit the styles. Verify that beige is not an option.
