### PR TITLE
YALB-815: Add wrapped image overrides

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.wrapped_image.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.wrapped_image.default.yml
@@ -5,14 +5,69 @@ dependencies:
   config:
     - field.field.paragraph.wrapped_image.field_caption
     - field.field.paragraph.wrapped_image.field_image
+    - field.field.paragraph.wrapped_image.field_style_position
+    - field.field.paragraph.wrapped_image.field_style_variation
     - field.field.paragraph.wrapped_image.field_text
     - paragraphs.paragraphs_type.wrapped_image
   module:
     - allowed_formats
+    - field_group
     - maxlength
     - media_library
     - media_library_edit
     - text
+third_party_settings:
+  field_group:
+    group_tabs:
+      children:
+        - group_content
+        - group_styles
+      label: Tabs
+      region: content
+      parent_name: ''
+      weight: 3
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: horizontal
+        width_breakpoint: 640
+    group_content:
+      children:
+        - field_image
+        - field_caption
+        - field_text
+      label: Content
+      region: content
+      parent_name: group_tabs
+      weight: 20
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+        direction: vertical
+        width_breakpoint: 640
+    group_styles:
+      children:
+        - field_style_position
+        - field_style_variation
+      label: Styles
+      region: content
+      parent_name: group_tabs
+      weight: 21
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
 id: paragraph.wrapped_image.default
 targetEntityType: paragraph
 bundle: wrapped_image
@@ -42,6 +97,18 @@ content:
     third_party_settings:
       media_library_edit:
         show_edit: '1'
+  field_style_position:
+    type: options_select
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_style_variation:
+    type: options_select
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_text:
     type: text_textarea
     weight: 2

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.wrapped_image.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.wrapped_image.default.yml
@@ -5,9 +5,12 @@ dependencies:
   config:
     - field.field.paragraph.wrapped_image.field_caption
     - field.field.paragraph.wrapped_image.field_image
+    - field.field.paragraph.wrapped_image.field_style_position
+    - field.field.paragraph.wrapped_image.field_style_variation
     - field.field.paragraph.wrapped_image.field_text
     - paragraphs.paragraphs_type.wrapped_image
   module:
+    - options
     - text
 id: paragraph.wrapped_image.default
 targetEntityType: paragraph
@@ -29,6 +32,20 @@ content:
       link: false
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_style_position:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_style_variation:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
     region: content
   field_text:
     type: text_default

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.wrapped_image.preview.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.wrapped_image.preview.yml
@@ -6,6 +6,8 @@ dependencies:
     - core.entity_view_mode.paragraph.preview
     - field.field.paragraph.wrapped_image.field_caption
     - field.field.paragraph.wrapped_image.field_image
+    - field.field.paragraph.wrapped_image.field_style_position
+    - field.field.paragraph.wrapped_image.field_style_variation
     - field.field.paragraph.wrapped_image.field_text
     - image.style.media_library
     - paragraphs.paragraphs_type.wrapped_image
@@ -43,4 +45,6 @@ content:
     weight: 2
     region: content
 hidden:
+  field_style_position: true
+  field_style_variation: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.wrapped_image.field_style_position.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.wrapped_image.field_style_position.yml
@@ -1,0 +1,21 @@
+uuid: 19671ef4-4ba7-419c-94e8-bfbe35ecea96
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_style_position
+    - paragraphs.paragraphs_type.wrapped_image
+  module:
+    - options
+id: paragraph.wrapped_image.field_style_position
+field_name: field_style_position
+entity_type: paragraph
+bundle: wrapped_image
+label: Position
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.wrapped_image.field_style_variation.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.wrapped_image.field_style_variation.yml
@@ -1,0 +1,21 @@
+uuid: df5bd5f9-d71b-4dcb-9104-124dce0c2a22
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_style_variation
+    - paragraphs.paragraphs_type.wrapped_image
+  module:
+    - options
+id: paragraph.wrapped_image.field_style_variation
+field_name: field_style_variation
+entity_type: paragraph
+bundle: wrapped_image
+label: Style
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -41,8 +41,8 @@ text_with_image:
   field_style_variation:
     values:
       equal: 'Equal Focus'
-      image: Image
-      content: Content
+      image: 'Image Focus'
+      content: 'Content Focus'
     default: equal
 quick_links:
   field_style_variation:
@@ -74,3 +74,14 @@ event_cards:
       'true': Featured
       'false': Secondary
     default: 'true'
+wrapped_image:
+  field_style_position:
+    values:
+      left: 'Image Left'
+      right: 'Image Right'
+    default: left
+  field_style_variation:
+    values:
+      floated: Floated
+      offset: Offset
+    default: offset


### PR DESCRIPTION
## [YALB-815: Add wrapped image overrides](https://yaleits.atlassian.net/browse/YALB-815)

### Description of work
- Adds two new style overrides to the wrapped image component
- Organize style fields in a separate horizontal tab to match other paragraphs

### Functional testing steps:
- [ ] Add a 'Wrapped Image' paragraph to a page
- [ ] Verify it has fields organized in "Content" and "Styles" sections
- [ ] Confirm that the following fields exist for styling: Position (left or right) and Variation (offset or floated)
