### PR TITLE
YALB-821: Hide teaser fields

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
@@ -15,7 +15,6 @@ dependencies:
   module:
     - entity_reference_revisions
     - link
-    - metatag
     - options
     - smart_date
     - user
@@ -31,7 +30,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 1
+    weight: 0
     region: content
   field_event_cta:
     type: link_separate
@@ -43,7 +42,7 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 2
+    weight: 1
     region: content
   field_event_date:
     type: smartdate_default
@@ -56,29 +55,19 @@ content:
       add_classes: false
       time_wrapper: true
     third_party_settings: {  }
-    weight: 5
+    weight: 3
     region: content
   field_event_format:
     type: list_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 3
-    region: content
-  field_metatags:
-    type: metatag_empty_formatter
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    weight: 4
-    region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 0
+    weight: 2
     region: content
 hidden:
+  field_metatags: true
   field_teaser_media: true
   field_teaser_text: true
   field_teaser_title: true
+  links: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.default.yml
@@ -12,8 +12,6 @@ dependencies:
     - node.type.news
   module:
     - entity_reference_revisions
-    - metatag
-    - text
     - user
 id: node.news.default
 targetEntityType: node
@@ -26,7 +24,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 105
+    weight: 0
     region: content
   field_content:
     type: entity_reference_revisions_entity_view
@@ -35,43 +33,12 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 106
-    region: content
-  field_metatags:
-    type: metatag_empty_formatter
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    weight: 103
-    region: content
-  field_teaser_media:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: default
-      link: false
-    third_party_settings: {  }
-    weight: 104
-    region: content
-  field_teaser_text:
-    type: text_default
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    weight: 102
-    region: content
-  field_teaser_title:
-    type: string
-    label: hidden
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    weight: 101
-    region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 100
+    weight: 1
     region: content
 hidden:
+  field_metatags: true
+  field_teaser_media: true
+  field_teaser_text: true
+  field_teaser_title: true
+  links: true
   search_api_excerpt: true


### PR DESCRIPTION
## [YALB-821: Hide teaser fields(https://yaleits.atlassian.net/browse/YALB-821)

### Description of work
-  Hide teaser and metadata fields from default node displays.

### Functional testing steps:
- [ ] Create an Event node and populate the teaser fields
- [ ] Save, publish, and view the node.
- [ ] Verify that the teaser fields do not appear on the node-view.
- [ ] Repeat the process for the news content type.
