### PR TITLE
YALB-570: Node help text

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.claro_help.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.claro_help.yml
@@ -1,0 +1,22 @@
+uuid: b2d6eb3b-6144-452f-8038-3951cd91018f
+langcode: en
+status: true
+dependencies:
+  module:
+    - help
+  theme:
+    - claro
+_core:
+  default_config_hash: jccFSSVqV0WCDb6NtML1VWAWTtDbZ-zn5YgTRMgMrIM
+id: claro_help
+theme: claro
+region: help
+weight: 0
+provider: null
+plugin: help_block
+settings:
+  id: help_block
+  label: Help
+  label_display: '0'
+  provider: help
+visibility: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.help.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.help.yml
@@ -1,0 +1,20 @@
+uuid: 61189169-4b66-429d-80e1-ed6f2e9b33a5
+langcode: en
+status: true
+dependencies:
+  module:
+    - help
+  theme:
+    - ys_admin_theme
+id: help
+theme: ys_admin_theme
+region: help
+weight: 0
+provider: null
+plugin: help_block
+settings:
+  id: help_block
+  label: Help
+  label_display: '0'
+  provider: help
+visibility: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -35,6 +35,7 @@ module:
   file: 0
   filter: 0
   gin_toolbar: 0
+  help: 0
   image: 0
   image_widget_crop: 0
   improve_line_breaks_filter: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/node.type.event.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/node.type.event.yml
@@ -19,7 +19,7 @@ third_party_settings:
 name: Event
 type: event
 description: 'Display the details of an individual event, such as time, date, and location. Can be displayed on a calendar of events.'
-help: ''
+help: "The Event content type allows you to create a page for your event. When creating an event page, remember to include important information relating to your events, such as speaker information, ticket pricing, parking, and building/room information.\_Event content pages can be dynamically listed in your other web pages using the Event Cards or Event List components.\_"
 new_revision: true
 preview_mode: 0
 display_submitted: false

--- a/web/profiles/custom/yalesites_profile/config/sync/node.type.news.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/node.type.news.yml
@@ -19,7 +19,7 @@ third_party_settings:
 name: News
 type: news
 description: 'Create a news article, blog post, or announcement, to share new and noteworthy information. Can be displayed in a news feed.'
-help: ''
+help: "The News content type allows you to create a page for your news article, blog posts, or announcements pages, to share new and noteworthy information to your community. News content pages can be dynamically listed in your other web pages using the News Cards or News List components. \_"
 new_revision: true
 preview_mode: 0
 display_submitted: false

--- a/web/profiles/custom/yalesites_profile/config/sync/node.type.page.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/node.type.page.yml
@@ -21,7 +21,7 @@ third_party_settings:
 name: Page
 type: page
 description: 'A multipurpose and flexible content type allowing free-form content entry. Used to build a variety of different page layouts, from simple to elaborate.'
-help: ''
+help: "The Page content type is your go-to multipurpose content type that allows free-form content entry. Any static web page that would be linked from your main navigation (but does not need to) would be considered a Page content type. \_"
 new_revision: true
 preview_mode: 0
 display_submitted: false


### PR DESCRIPTION
## [YALB-570: Node help text](https://yaleits.atlassian.net/browse/YALB-570)

### Description of work
- Enables the help module
- Place the help block on the admin theme
- Adds node instructions to each content type

### Functional testing steps:
- [x] Visit each content type and verify submission guidelines appear on the node add and edit forms. The text for these can be found the [site's data model](https://yaleedu.sharepoint.com/:x:/r/sites/YaleSitesUpgradeProgram/_layouts/15/Doc.aspx?sourcedoc=%7B2B574C06-BAC3-41E2-924A-F4562054F849%7D&file=Proposed%20Content%20Model.xlsx&action=default&mobileredirect=true&wdOrigin=TEAMS-ELECTRON.teams.files&wdExp=TEAMS-CONTROL&wdhostclicktime=1644421397192&cid=ebb5b8ed-9052-4995-9929-c2831aada5d4) on the content type tab.
