### PR TITLE
YALB-857: Feedback: Section component content duplicates on the page

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - node.type.page
   module:
     - entity_reference_revisions
+    - layout_paragraphs
     - user
 id: node.page.default
 targetEntityType: node
@@ -28,7 +29,7 @@ content:
     weight: 0
     region: content
   field_content:
-    type: entity_reference_revisions_entity_view
+    type: layout_paragraphs
     label: hidden
     settings:
       view_mode: default


### PR DESCRIPTION
## [YALB-857: Feedback: Section component content duplicates on the page](https://yaleits.atlassian.net/browse/YALB-857)

### Description of work
- Removes duplicate content when using sections
- Internal notes: This changes the field formatter widget from "Referenced Entity" to "Layout Paragraphs" but does not use the "Layout Paragraphs Builder" as we had previously, so there are still no controls for editing content on the front-end. I have verified that the markup between "Referenced Entity" and "Layout Paragraphs" is the same but the duplicated content is removed with the latter.

### Functional testing steps:
- [x] If not done already, `drush cim` to import config
- [x] Create a page
- [x] Add a section to the page
- [x] Add a component into each of the sections, primary and secondary
- [x] Publish and save the page
- [x] View the page on the front-end and verify that only the section contains the content from the primary and secondary and that the content from those section areas does not appear below the section.
