### PR TITLE
YALB-743: Nav: Basic Menu Drupal settings

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/ys_core.site.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_core.site.yml
@@ -1,5 +1,7 @@
 page:
   news: ''
   events: ''
+menu:
+  primary_menu_type: 'mega'
 search:
   enable_search_form: 1

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/install/ys_core.site.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/install/ys_core.site.yml
@@ -1,5 +1,7 @@
 page:
   news: ''
   events: ''
+menu:
+  primary_menu_type: 'mega'
 search:
   enable_search_form: 1

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -147,6 +147,16 @@ class SiteSettingsForm extends ConfigFormBase {
       '#default_value' => $siteConfig->get('page')['404'],
     ];
 
+    $form['primary_menu_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Primary Menu Type'),
+      '#default_value' => $yaleConfig->get('menu')['primary_menu_type'],
+      '#options' => [
+        'mega' => 'Mega Menu',
+        'basic' => 'Basic Menu',
+      ]
+    ];
+
     $form['enable_search_form'] = [
       '#type' => 'checkbox',
       '#description' => $this->t('Enable the search form located in the utility navigation area.'),
@@ -209,6 +219,7 @@ class SiteSettingsForm extends ConfigFormBase {
     $this->configFactory->getEditable('ys_core.site')
       ->set('page.news', $form_state->getValue('site_page_news'))
       ->set('page.events', $form_state->getValue('site_page_events'))
+      ->set('menu.primary_menu_type', $form_state->getValue('primary_menu_type'))
       ->set('search.enable_search_form', $form_state->getValue('enable_search_form'))
       ->save();
 


### PR DESCRIPTION
## [YALB-743: Nav: Basic Menu Drupal settings](https://yaleits.atlassian.net/browse/YALB-743)

### Description of work
- Adds a setting to the YaleSites Site Setting form to change the primary menu type.
- This is only the backend work. So changing the menu to "Basic" will not impact the front end in this ticket.

### Functional testing steps:
- [ ] Visit the site setting form `/admin/yalesites/settings`
- [ ] Verify that the "Primary Menu Type" setting exists, defaults to "Mega Menu" but also contains "Basic Menu" as a second option.
- [ ] Change this field to "Basic Menu" and save the form. Verify that the value saves.
