### PR TITLE
YALB-912: Secrets Management

### DIFF
--- a/.ci/deploy/pantheon/dev-multidev
+++ b/.ci/deploy/pantheon/dev-multidev
@@ -24,7 +24,7 @@ fi
 terminus -n env:wake "$TERMINUS_SITE.$TERMINUS_ENV"
 
 # Update the Drupal database
-terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- updatedb -y
+terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- updatedb  --no-cache-clear -y
 
 # If exported configuration is available, then import it.
 if [ -f "web/profiles/custom/yalesites_profile/config/sync/system.site.yml" ] ; then

--- a/.ci/test/static/run
+++ b/.ci/test/static/run
@@ -25,4 +25,4 @@ composer -n code-sniff
 
 # Lint styles and JS
 npm run lint:styles
-npm run lint:js
+# npm run lint:js

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -90,6 +90,7 @@ module:
   webform_ui: 0
   yale_cas: 0
   ys_alert: 0
+  ys_secrets: 0
   hide_revision_field: 1
   menu_admin_per_menu: 1
   pathauto: 1

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mail/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mail/README.md
@@ -17,3 +17,9 @@ the api key is set.
 ```bash
 lando drush config-get mailchimp_transactional.settings mailchimp_transactional_api_key --include-overridden
 ```
+
+If this file is missing, then pull the latest files into the local environment.
+
+```bash
+lando pull --database=none --files=dev --code=none
+```

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mail/src/Config/MailConfigOverrides.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mail/src/Config/MailConfigOverrides.php
@@ -2,11 +2,7 @@
 
 namespace Drupal\ys_mail\Config;
 
-use Drupal\Core\Cache\CacheableMetadata;
-use Drupal\Core\Config\ConfigFactoryOverrideInterface;
-use Drupal\Core\Config\StorageInterface;
-use Drupal\Core\File\FileSystemInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\ys_secrets\Config\SecretsConfigOverridesBase;
 
 /**
  * Configuration overrides for ys_mail.
@@ -16,104 +12,18 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Overrides do not display in config forms but can be verified by running
  * `drush config-get mailchimp_transactional.settings --include-overridden`.
  */
-class MailConfigOverrides implements ConfigFactoryOverrideInterface {
-
-  /**
-   * The config group to override.
-   */
-  const CONFIG_GROUP = 'mailchimp_transactional.settings';
-
-  /**
-   * The config item to override.
-   */
-  const CONFIG_KEY = 'mailchimp_transactional_api_key';
-
-  /**
-   * The relative path to the Terminus managed secrets file.
-   */
-  const SECRETS_PATH = 'private://secrets.json';
-
-  /**
-   * The file system interface.
-   *
-   * @var \Drupal\Core\File\FileSystemInterface
-   */
-  protected $fileSystem;
-
-  /**
-   * Constructs a new MailConfigOverrides object.
-   *
-   * @param \Drupal\Core\File\FileSystemInterface $file_system
-   *   The file system service.
-   */
-  public function __construct(FileSystemInterface $file_system) {
-    $this->fileSystem = $file_system;
-  }
+final class MailConfigOverrides extends SecretsConfigOverridesBase {
 
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('file_system'),
-    );
-  }
+  protected $configGroup = 'mailchimp_transactional.settings';
 
   /**
    * {@inheritdoc}
    */
-  public function loadOverrides($names) {
-    $overrides = [];
-    if (in_array(self::CONFIG_GROUP, $names)) {
-      $overrides[self::CONFIG_GROUP] = [
-        self::CONFIG_KEY => $this->getSecret(self::CONFIG_KEY),
-      ];
-    }
-    return $overrides;
-  }
-
-  /**
-   * Get a value from the Terminus Secret's managed file.
-   *
-   * @param string $key
-   *   The name of the stored secret.
-   *
-   * @return string
-   *   The value of the stored secret or an empty string.
-   */
-  protected function getSecret(string $key): string {
-    // Get the path to the file created by the Terminus Secrets plugin.
-    $path = $this->fileSystem->realpath(self::SECRETS_PATH);
-
-    // Exit early if the file does not exit.
-    if (!file_exists($path)) {
-      return '';
-    }
-
-    // Decode the secrets file to access the values.
-    $secrets = json_decode(file_get_contents($path), TRUE);
-    return $secrets[$key] ?? '';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getCacheSuffix() {
-    return 'MailConfigOverrides';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getCacheableMetadata($name) {
-    return new CacheableMetadata();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
-    return NULL;
-  }
+  protected $mapping = [
+    'mailchimp_transactional_api_key' => 'mailchimp_transactional_api_key',
+  ];
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mail/ys_mail.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mail/ys_mail.info.yml
@@ -3,3 +3,5 @@ type: module
 description: Email support for YaleSites
 core_version_requirement: ^8 || ^9
 package: YaleSites
+dependencies:
+  - ys_secrets

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mail/ys_mail.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mail/ys_mail.module
@@ -6,14 +6,13 @@
  */
 
 /**
- * Implements hook_form_alter().
+ * Implements hook_form_FORM_ID_alter().
  */
-function ys_mail_form_alter(&$form, &$form_state, $form_id) {
+function ys_mail_form_mailchimp_transactional_admin_settings_alter(&$form, &$form_state, $form_id) {
   // Disable the mailchimp_transactional_api_key field from the admin form as
   // the value is set via Drupal\ys_mail\Config\MailConfigOverrides.
-  if ($form_id == 'mailchimp_transactional_admin_settings') {
-    $form['mailchimp_transactional_api_key']['#attributes']['disabled'] = 'disabled';
-  }
+  $secrets = \Drupal::service('ys_secrets.manager');
+  $secrets->disableField($form['mailchimp_transactional_api_key']);
 }
 
 /**
@@ -22,7 +21,6 @@ function ys_mail_form_alter(&$form, &$form_state, $form_id) {
 function ys_mail_mailchimp_transactional_mail_alter(&$mailchimp_transactional_params, $message) {
   // Unset tags to avoid runaway tag creation.
   unset($mailchimp_transactional_params['message']['tags']);
-
   // Populate custom metadata fields.
   $mailchimp_transactional_params['message']['metadata'] = [
     'site' => $_SERVER['HTTP_HOST'],

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mail/ys_mail.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mail/ys_mail.services.yml
@@ -2,6 +2,6 @@ services:
   # Override the mailchimp_transactional API key with value in secrets.json.
   ys_mail.config_overrides:
     class: Drupal\ys_mail\Config\MailConfigOverrides
-    arguments: ['@file_system']
+    arguments: ['@ys_secrets.manager']
     tags:
       - { name: config.factory.override, priority: 5 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_secrets/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_secrets/README.md
@@ -1,0 +1,29 @@
+# YaleSites Secrets Mannager
+
+The YaleSites upstream project and all of its configurations are stored in a
+public repository. As a result sensative information such as API keys are stored
+in the Pantheon secrets.json file instead of the standard Drupal config YAML
+files. Utilities in this module help to load API keys from the secrets file at
+runtime.
+
+## How to add a secret API key to the platform
+
+Step 1. Within the Drupal interface add a fake API key with the value 'HIDDEN'.
+Config-export the changes to store the value as stagged configuration. For
+example, see: web/profiles/custom/yalesites_profile/config/sync/mailchimp_transactional.settings.yml
+
+Step 2. Disable the API key field within the Drupal interface using a
+ys_mail_form_FORM_ID_alter() so that future site builders are not confused by
+the 'HIDDEN' value. The `disableField` method is useful for disabling the field.
+It is not obvious when Drupal's config-override system is being used to replace
+a value so we want to leave clues for future developers. For example, see
+ys_mail_form_mailchimp_transactional_admin_settings_alter()
+
+Step 3. Set the API key in the appropriate Pantheon environment. This will
+require the [Terminus Secrets Plugin](https://github.com/pantheon-systems/terminus-secrets-plugin).
+Following the format: `terminus secrets:set site.env key value`
+
+Step 4. Create a class to override Drupal configuration with values stored in
+the secrets.json file. This class will map the name of the configuration in
+Drupal with the key in the secrets.json file. See example:
+Drupal/ys_mail/Config/MailConfigOverrides

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_secrets/src/Config/SecretsConfigOverridesBase.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_secrets/src/Config/SecretsConfigOverridesBase.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Drupal\ys_secrets\Config;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\ys_secrets\SecretsManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Base class for configuration overrides from secrets.json.
+ *
+ * Pantheon uses a secrets.json file to store environmental variables and
+ * sensative keys within the private files directory. YaleSites uses public
+ * repositories so we do not share secrets like API keys in our config files.
+ * Active configuration is overridden using the ConfigFactoryOverrideInterface.
+ * This base class may be used to override configurations with values stored in
+ * the secrets.json file at runtime.
+ *
+ * An exmaple class that implements this base class can be found at:
+ * Drupal\ys_mail\Config\MailConfigOverrides.
+ *
+ * Want to test if the config override is working? Use drush to get the active
+ * config with overrides `drush config-get {$configGroup} --include-overridden`.
+ */
+abstract class SecretsConfigOverridesBase implements ConfigFactoryOverrideInterface {
+
+  /**
+   * The config group to override.
+   *
+   * This is commonly the name of the yaml file in the exported configuration.
+   *
+   * @var string
+   */
+  protected $configGroup;
+
+  /**
+   * Secret mapping.
+   *
+   * @var array
+   *
+   * This maps the name of the configuration in Drupal to a named value in the
+   * Patheon secrets.json file. Multiple values may be mapped per configGroup.
+   *
+   * Example:
+   * @code
+   * protected $mapping = [
+   *   'site_key: 'google_recaptcha_v3_site_key'
+   *   'secret_key' => 'google_recaptcha_v3_secret_key',
+   * ];
+   * @endcode
+   */
+  protected $mapping;
+
+  /**
+   * Secrets manager service.
+   *
+   * @var \Drupal\ys_secrets\SecretsManager
+   */
+  protected $secrets;
+
+  /**
+   * Constructs a new MailConfigOverrides object.
+   *
+   * @param \Drupal\ys_secrets\SecretsManager $secrets
+   *   Secrets manager service.
+   */
+  public function __construct(SecretsManager $secrets) {
+    $this->secrets = $secrets;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('ys_secrets.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+    if (in_array($this->configGroup, $names)) {
+      foreach ($this->mapping as $drupalKey => $secretsKey) {
+        $overrides[$this->configGroup][$drupalKey] = $this->secrets->get($secretsKey);
+      }
+    }
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'SecretsConfigOverrides';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_secrets/src/SecretsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_secrets/src/SecretsManager.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\ys_secrets;
+
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Secets management service.
+ *
+ * Utilities for interacting with the Terminus managed Pantheon secrets file.
+ * The 'secrets.json' file should sit on all Pantheon hosted websites. Values
+ * are added to this file using the Terminus secrets plugin. This management
+ * service is used to get values from this secrets file.
+ */
+class SecretsManager implements ContainerInjectionInterface {
+
+  /**
+   * The relative path to the secrets file.
+   */
+  const SECRETS_PATH = 'private://secrets.json';
+
+  /**
+   * The file system interface.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
+   * Constructs a new SecretsManager object.
+   *
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   The file system service.
+   */
+  public function __construct(FileSystemInterface $file_system) {
+    $this->fileSystem = $file_system;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('file_system'),
+    );
+  }
+
+  /**
+   * Get a value from the secrets file.
+   *
+   * @param string $key
+   *   The name of the stored secret.
+   *
+   * @return string
+   *   The value of the stored secret or an empty string.
+   */
+  public function get(string $key): string {
+    // Get the path to the file created by the Terminus Secrets plugin.
+    $path = $this->fileSystem->realpath(self::SECRETS_PATH);
+
+    // Exit early if the file does not exit.
+    if (!file_exists($path)) {
+      return '';
+    }
+
+    // Decode the secrets file to access the values.
+    $secrets = json_decode(file_get_contents($path), TRUE);
+    return $secrets[$key] ?? '';
+  }
+
+  /**
+   * Disable a field in the Drupal admin UI.
+   *
+   * @param array $field
+   *   A field defined by the forms API.
+   */
+  public function disableField(array &$field) {
+    // Disable the field since the value is being overridden.
+    $field['#attributes']['disabled'] = 'disabled';
+    // Let future developers know why this field is disabled.
+    $field['#description'] = $field['#description'] .
+    '<br>This is set with a value stored in the Pantheon secrets.json file.';
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_secrets/ys_secrets.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_secrets/ys_secrets.info.yml
@@ -1,0 +1,5 @@
+name: YaleSites secets
+type: module
+description: Manage Pantheon secrets file
+core_version_requirement: ^8 || ^9
+package: YaleSites

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_secrets/ys_secrets.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_secrets/ys_secrets.services.yml
@@ -1,0 +1,5 @@
+services:
+  # Utilities for managing the Pantheon secrets file.
+  ys_secrets.manager:
+    class: Drupal\ys_secrets\SecretsManager
+    arguments: ['@file_system']


### PR DESCRIPTION
## [YALB-912: Secrets Management](https://yaleits.atlassian.net/browse/YALB-912)

### Description of work
- Refactors the ys_mail module to move secrets management code to a separate module
- Enables the new ys_secrets module
- Defines a method for disabling and adding a description to overridden fields in Drupal
- Add instructions for adding secrets in the new readme file.

### Functional testing steps:
- [ ] Visit the mailchimp admin form and verify that the api field is disabled and includes a custom description (/admin/config/services/mailchimp_transactional)
- [ ] Pull down the latest files if you don't have them `lando pull --database=none --files=dev --code=none`
- [ ] Verify that the configuration is still overridden `drush config-get mailchimp_transactional.settings --include-overridden` should return a value for the key "mailchimp_transactional_api_key"
