### PR TITLE
YALB-936: Views: Tagging content

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
     - field.field.node.event.field_metatags
+    - field.field.node.event.field_tags
     - field.field.node.event.field_teaser_media
     - field.field.node.event.field_teaser_text
     - field.field.node.event.field_teaser_title
@@ -45,6 +46,7 @@ third_party_settings:
     group_content:
       children:
         - title
+        - field_tags
         - field_content
       label: Content
       region: content
@@ -105,7 +107,7 @@ content:
     third_party_settings: {  }
   field_content:
     type: layout_paragraphs
-    weight: 7
+    weight: 3
     region: content
     settings:
       preview_view_mode: preview
@@ -152,6 +154,16 @@ content:
     settings:
       sidebar: true
       use_details: true
+    third_party_settings: {  }
+  field_tags:
+    type: entity_reference_autocomplete_tags
+    weight: 2
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_teaser_media:
     type: media_library_widget

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.news.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.news.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.news.field_content
     - field.field.node.news.field_metatags
     - field.field.node.news.field_publish_date
+    - field.field.node.news.field_tags
     - field.field.node.news.field_teaser_media
     - field.field.node.news.field_teaser_text
     - field.field.node.news.field_teaser_title
@@ -27,6 +28,7 @@ third_party_settings:
     group_content:
       children:
         - title
+        - field_tags
         - field_author
         - field_content
       label: Content
@@ -102,7 +104,7 @@ mode: default
 content:
   field_author:
     type: string_textfield
-    weight: 1
+    weight: 2
     region: content
     settings:
       size: 60
@@ -110,7 +112,7 @@ content:
     third_party_settings: {  }
   field_content:
     type: layout_paragraphs
-    weight: 2
+    weight: 3
     region: content
     settings:
       preview_view_mode: default
@@ -131,6 +133,16 @@ content:
     weight: 9
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_tags:
+    type: entity_reference_autocomplete_tags
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_teaser_media:
     type: media_library_widget

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.page.field_banner
     - field.field.node.page.field_content
     - field.field.node.page.field_metatags
+    - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_media
     - field.field.node.page.field_teaser_text
     - field.field.node.page.field_teaser_title
@@ -41,6 +42,7 @@ third_party_settings:
     group_content:
       children:
         - title
+        - field_tags
         - field_content
         - field_metatags
       label: Content
@@ -114,7 +116,7 @@ content:
           dialog_style: tiles
   field_content:
     type: layout_paragraphs
-    weight: 1
+    weight: 2
     region: content
     settings:
       preview_view_mode: preview
@@ -124,11 +126,21 @@ content:
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 2
+    weight: 3
     region: content
     settings:
       sidebar: true
       use_details: true
+    third_party_settings: {  }
+  field_tags:
+    type: entity_reference_autocomplete_tags
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_teaser_media:
     type: media_library_widget

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.card.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.card.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
     - field.field.node.event.field_metatags
+    - field.field.node.event.field_tags
     - field.field.node.event.field_teaser_media
     - field.field.node.event.field_teaser_text
     - field.field.node.event.field_teaser_title
@@ -76,5 +77,6 @@ content:
 hidden:
   field_event_cta: true
   field_metatags: true
+  field_tags: true
   links: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
     - field.field.node.event.field_metatags
+    - field.field.node.event.field_tags
     - field.field.node.event.field_teaser_media
     - field.field.node.event.field_teaser_text
     - field.field.node.event.field_teaser_title
@@ -66,6 +67,7 @@ content:
     region: content
 hidden:
   field_metatags: true
+  field_tags: true
   field_teaser_media: true
   field_teaser_text: true
   field_teaser_title: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.list_item.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.list_item.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
     - field.field.node.event.field_metatags
+    - field.field.node.event.field_tags
     - field.field.node.event.field_teaser_media
     - field.field.node.event.field_teaser_text
     - field.field.node.event.field_teaser_title
@@ -76,5 +77,6 @@ content:
 hidden:
   field_event_cta: true
   field_metatags: true
+  field_tags: true
   links: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.search_result.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
     - field.field.node.event.field_metatags
+    - field.field.node.event.field_tags
     - field.field.node.event.field_teaser_media
     - field.field.node.event.field_teaser_text
     - field.field.node.event.field_teaser_title
@@ -39,6 +40,7 @@ hidden:
   field_event_date: true
   field_event_format: true
   field_metatags: true
+  field_tags: true
   field_teaser_media: true
   field_teaser_title: true
   links: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
     - field.field.node.event.field_metatags
+    - field.field.node.event.field_tags
     - field.field.node.event.field_teaser_media
     - field.field.node.event.field_teaser_text
     - field.field.node.event.field_teaser_title
@@ -31,6 +32,7 @@ hidden:
   field_event_date: true
   field_event_format: true
   field_metatags: true
+  field_tags: true
   field_teaser_media: true
   field_teaser_text: true
   field_teaser_title: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.card.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.card.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.news.field_content
     - field.field.node.news.field_metatags
     - field.field.node.news.field_publish_date
+    - field.field.node.news.field_tags
     - field.field.node.news.field_teaser_media
     - field.field.node.news.field_teaser_text
     - field.field.node.news.field_teaser_title
@@ -49,5 +50,6 @@ hidden:
   field_content: true
   field_metatags: true
   field_publish_date: true
+  field_tags: true
   links: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.news.field_content
     - field.field.node.news.field_metatags
     - field.field.node.news.field_publish_date
+    - field.field.node.news.field_tags
     - field.field.node.news.field_teaser_media
     - field.field.node.news.field_teaser_text
     - field.field.node.news.field_teaser_title
@@ -39,6 +40,7 @@ content:
 hidden:
   field_metatags: true
   field_publish_date: true
+  field_tags: true
   field_teaser_media: true
   field_teaser_text: true
   field_teaser_title: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.list_item.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.list_item.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.news.field_content
     - field.field.node.news.field_metatags
     - field.field.node.news.field_publish_date
+    - field.field.node.news.field_tags
     - field.field.node.news.field_teaser_media
     - field.field.node.news.field_teaser_text
     - field.field.node.news.field_teaser_title
@@ -49,5 +50,6 @@ hidden:
   field_content: true
   field_metatags: true
   field_publish_date: true
+  field_tags: true
   links: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.search_result.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.news.field_content
     - field.field.node.news.field_metatags
     - field.field.node.news.field_publish_date
+    - field.field.node.news.field_tags
     - field.field.node.news.field_teaser_media
     - field.field.node.news.field_teaser_text
     - field.field.node.news.field_teaser_title
@@ -37,6 +38,7 @@ hidden:
   field_content: true
   field_metatags: true
   field_publish_date: true
+  field_tags: true
   field_teaser_media: true
   field_teaser_title: true
   links: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.teaser.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.teaser.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.news.field_content
     - field.field.node.news.field_metatags
     - field.field.node.news.field_publish_date
+    - field.field.node.news.field_tags
     - field.field.node.news.field_teaser_media
     - field.field.node.news.field_teaser_text
     - field.field.node.news.field_teaser_title
@@ -29,6 +30,7 @@ hidden:
   field_content: true
   field_metatags: true
   field_publish_date: true
+  field_tags: true
   field_teaser_media: true
   field_teaser_text: true
   field_teaser_title: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.page.field_banner
     - field.field.node.page.field_content
     - field.field.node.page.field_metatags
+    - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_media
     - field.field.node.page.field_teaser_text
     - field.field.node.page.field_teaser_title
@@ -39,6 +40,7 @@ content:
     region: content
 hidden:
   field_metatags: true
+  field_tags: true
   field_teaser_media: true
   field_teaser_text: true
   field_teaser_title: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.search_result.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.page.field_banner
     - field.field.node.page.field_content
     - field.field.node.page.field_metatags
+    - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_media
     - field.field.node.page.field_teaser_text
     - field.field.node.page.field_teaser_title
@@ -35,6 +36,7 @@ hidden:
   field_banner: true
   field_content: true
   field_metatags: true
+  field_tags: true
   field_teaser_media: true
   field_teaser_title: true
   links: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.page.field_banner
     - field.field.node.page.field_content
     - field.field.node.page.field_metatags
+    - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_media
     - field.field.node.page.field_teaser_text
     - field.field.node.page.field_teaser_title
@@ -27,6 +28,7 @@ hidden:
   field_banner: true
   field_content: true
   field_metatags: true
+  field_tags: true
   field_teaser_media: true
   field_teaser_text: true
   field_teaser_title: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_tags.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_tags.yml
@@ -1,0 +1,29 @@
+uuid: 803d94f3-8a36-4115-ad0c-070b3af5845a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_tags
+    - node.type.event
+    - taxonomy.vocabulary.tags
+id: node.event.field_tags
+field_name: field_tags
+entity_type: node
+bundle: event
+label: Tags
+description: 'Separate tags with commas. Tags will autocomplete if one exists.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.news.field_tags.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.news.field_tags.yml
@@ -1,0 +1,29 @@
+uuid: 1ff1f237-3c4e-437d-8570-c884f627bc93
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_tags
+    - node.type.news
+    - taxonomy.vocabulary.tags
+id: node.news.field_tags
+field_name: field_tags
+entity_type: node
+bundle: news
+label: Tags
+description: 'Separate tags with commas. Tags will autocomplete if one exists.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_tags.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_tags.yml
@@ -1,0 +1,29 @@
+uuid: 9cd8a07c-a7bb-4018-adab-aac8a6960b45
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_tags
+    - node.type.page
+    - taxonomy.vocabulary.tags
+id: node.page.field_tags
+field_name: field_tags
+entity_type: node
+bundle: page
+label: Tags
+description: 'Separate tags with commas. Tags will autocomplete if one exists.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_tags.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_tags.yml
@@ -1,0 +1,20 @@
+uuid: d6e696ad-4b15-4113-a9e3-a1c713f56d8e
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_tags
+field_name: field_tags
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.tags.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.tags.yml
@@ -1,0 +1,8 @@
+uuid: 2e4d620d-2f88-43fe-8490-42095ca9c77a
+langcode: en
+status: true
+dependencies: {  }
+name: Tags
+vid: tags
+description: ''
+weight: 0


### PR DESCRIPTION
## [YALB-936: Views: Tagging content](https://yaleits.atlassian.net/browse/YALB-936)

### Description of work
- Adds tags vocabulary
- Adds taxonomy term reference field to Page, News, and Event content types
- Sets the widget settings and placement of the fields for the form
- Removes the tag field from the display

### Functional testing steps:
- [ ] Import config `drush cim`
- [ ] Add or edit a page, news, and/or event
- [ ] Verify the tags field is below the title field (this location can be changed if Yale wishes)
- [ ] Enter in some tags. Tags separated by commas.
- [ ] Save the node
- [ ] Verify that the tags do not show up on the front-end
- [ ] Verify the tags were created at `/admin/structure/taxonomy/manage/tags/overview`
- [ ] Add/edit a different page, news, and/or event
- [ ] Start typing an existing tag name and verify that it shows up in the autocomplete list
