### PR TITLE
Bug: roles are removed from users if not part of Grouper group

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/cas_attributes.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/cas_attributes.settings.yml
@@ -1,6 +1,7 @@
 _core:
   default_config_hash: 3Qy8Ap9CL1suaCnYTcFq1kziOQux44inp7Ew7EMxS2Q
 sitewide_token_support: true
+token_allowed_attributes: {  }
 field:
   sync_frequency: 2
   overwrite: true
@@ -18,4 +19,4 @@ role:
       attribute: memberOf
       value: 'CN=yale:apps:Yalesites:Yalesites_Team:Yalesites_Team,OU=Prod,OU=YaleGroups,DC=yu,DC=yale,DC=edu'
       negate: false
-      remove_without_match: true
+      remove_without_match: false


### PR DESCRIPTION
## [YALB-946: Bug: roles are removed from users if not part of Grouper group](https://yaleits.atlassian.net/browse/YALB-946)

### Description of work
CAS users who have been given a role but are not in the Yalesites Grouper group are stripped of that role on their next login because of the CAS Attributes setting "Remove role from user if match fails?". This changes the value to false to stop this from happening.