### PR TITLE
YALB-937: Views: Filter by tag

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -89,6 +89,9 @@
       },
       "drupal/core": {
         "plural results summary https://www.drupal.org/project/drupal/issues/2888320": "https://www.drupal.org/files/issues/2021-12-15/2888320-78.patch"
+      },
+      "drupal/hide_revision_field": {
+        "fix deprecated function unserialize https://www.drupal.org/project/hide_revision_field/issues/3260101": "https://www.drupal.org/files/issues/2022-01-24/3260101-2.patch"
       }
     }
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
@@ -11,7 +11,7 @@
   gap: 1rem;
 }
 
-.views-basic--group-user-selection .fieldset__wrapper {
+.views-basic--group-user-selection .grouped-items {
   display: flex;
   gap: 1rem;
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldFormatter/ViewsBasicPreviewFormatter.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldFormatter/ViewsBasicPreviewFormatter.php
@@ -102,6 +102,7 @@ class ViewsBasicPreviewFormatter extends FormatterBase implements ContainerFacto
       $paramsForRender = [
         'types' => [],
         'view_mode' => '',
+        'tags' => [],
       ];
       $paramsDecoded = json_decode($item->params, TRUE);
 
@@ -111,6 +112,14 @@ class ViewsBasicPreviewFormatter extends FormatterBase implements ContainerFacto
         array_push($paramsForRender['types'], $entityLabel);
         $viewModeLabel = $this->viewsBasicManager->getViewModeLabel($type, $paramsDecoded['view_mode']);
         $paramsForRender['view_mode'] = $viewModeLabel;
+      }
+
+      // Gets the tag labels.
+      if (!empty($paramsDecoded['filters']['tags'][0])) {
+        foreach ($paramsDecoded['filters']['tags'] as $tag) {
+          $tagLabel = $this->viewsBasicManager->getTagLabel($tag);
+          array_push($paramsForRender['tags'], $tagLabel);
+        }
       }
 
       $elements[$delta] = [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -112,6 +112,11 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       ],
     ];
 
+    $form['group_user_selection']['markup_pre_entity_types'] = [
+      '#type' => 'markup',
+      '#markup' => '<div class="grouped-items">',
+    ];
+
     $form['group_user_selection']['entity_types'] = [
       '#type' => 'select',
       '#options' => $this->viewsBasicManager->entityTypeList(),
@@ -156,6 +161,24 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       '#suffix' => '</div>',
     ];
 
+    $form['group_user_selection']['markup_post_entity_types'] = [
+      '#type' => 'markup',
+      '#markup' => '</div>',
+    ];
+
+    // @todo add validation for only one term.
+    // More info: https://www.drupal.org/project/drupal/issues/2951134
+    $form['group_user_selection']['tags'] = [
+      '#title' => $this->t('Filtered by tag'),
+      '#description' => $this->t('At this time, only one term is supported. If multiple terms are added, only the last one will be used.'),
+      '#type' => 'entity_autocomplete',
+      '#target_type' => 'taxonomy_term',
+      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('tags', $items[$delta]->params) : NULL,
+      '#selection_settings' => [
+        'target_bundles' => ['tags'],
+      ],
+    ];
+
     $element['group_params']['params'] = [
       '#type' => 'textarea',
       '#title' => $this->t('Params'),
@@ -183,6 +206,9 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
         "filters" => [
           "types" => [
             $form['group_user_selection']['entity_types']['#value'],
+          ],
+          "tags" => [
+            $form_state->getValue(['group_user_selection', 'tags']),
           ],
         ],
       ];

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/ViewsBasicFilter.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/ViewsBasicFilter.php
@@ -29,9 +29,11 @@ class ViewsBasicFilter extends FilterPluginBase {
     }
 
     // Parse tag filters.
-    $tag_table = $query->addTable('node__field_tags');
-    foreach ($this->value['filters']['tags'] as $tid) {
-      $query->addWhere(0, "$tag_table.field_tags_target_id", $tid);
+    if (($this->value['filters']['tags'][0])) {
+      $tag_table = $query->addTable('node__field_tags');
+      foreach ($this->value['filters']['tags'] as $tid) {
+        $query->addWhere(0, "$tag_table.field_tags_target_id", $tid);
+      }
     }
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/ViewsBasicFilter.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/ViewsBasicFilter.php
@@ -24,9 +24,14 @@ class ViewsBasicFilter extends FilterPluginBase {
     $query = $this->query;
 
     // Parse content type filters.
-    // @todo Add taxonomy term as a filter. Code here: https://gist.github.com/marcb4k/fd4716eb133aa846f90a9e42c80def8c.
     foreach ($this->value['filters']['types'] as $content_type) {
       $query->addWhere($this->options['group'], 'type', $content_type);
+    }
+
+    // Parse tag filters.
+    $tag_table = $query->addTable('node__field_tags');
+    foreach ($this->value['filters']['tags'] as $tid) {
+      $query->addWhere(0, "$tag_table.field_tags_target_id", $tid);
     }
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -109,6 +109,26 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
   }
 
   /**
+   * Returns an array of taxonomy tags.
+   */
+  public function tagsList() {
+    $vid = 'tags';
+    /** @var Drupal\Core\Entity\EntityTypeManagerInterface $vocab */
+    $vocab = $this->entityTypeManager()->getStorage('taxonomy_term');
+    $terms = $vocab->loadTree($vid);
+
+    if (empty($terms)) {
+      return NULL;
+    }
+
+    foreach ($terms as $term) {
+      $tagsList[$term->tid] = $term->name;
+    }
+
+    return $tagsList;
+  }
+
+  /**
    * Returns an entity label given an entity type and machine name.
    */
   public function getEntityLabel($type) {
@@ -123,10 +143,19 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
   }
 
   /**
+   * Returns a tag label given a term ID.
+   */
+  public function getTagLabel($tag) {
+    $term = $this->entityTypeManager()->getStorage('taxonomy_term')->load($tag);
+    return $term->name->value;
+  }
+
+  /**
    * Returns a default value for a parameter to auto-select one in the list.
    */
   public function getDefaultParamValue($type, $params) {
     $paramsDecoded = json_decode($params, TRUE);
+
     switch ($type) {
       /* @todo Currently, this only selects the first entity type which is
        * okay since there is only a simple dropdown for now. We should change
@@ -134,6 +163,11 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
        */
       case 'types':
         $defaultParam = $paramsDecoded['filters']['types'][0];
+        break;
+
+      case 'tags':
+        $tid = (int) $paramsDecoded['filters']['tags'][0];
+        $defaultParam = $this->entityTypeManager()->getStorage('taxonomy_term')->load($tid);
         break;
 
       default:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/templates/views-basic-formatter-preview.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/templates/views-basic-formatter-preview.html.twig
@@ -1,1 +1,8 @@
-Display {{ params.types|join(', ') }} as {{ params.view_mode }}
+<div>
+  Display {{ params.types|join(', ') }} as {{ params.view_mode }}
+</div>
+<div>
+  {% if params.tags %}
+    Filtered by tag "{{ params.tags|join(', ') }}"
+  {% endif %}
+</div>


### PR DESCRIPTION
## [YALB-937: Views: Filter by tag](https://yaleits.atlassian.net/browse/YALB-937)

### Description of work
- Adds the ability to filter views basic lists by a taxonomy term in the tags vocabulary
- At the moment only one term is supported and help text is added to inform the content editor
- There is some work in Drupal core over single value autocomplete widgets not warning about cardinality: https://www.drupal.org/project/drupal/issues/2951134 so for the moment, if there are multiple values, the last value is used.

### Functional testing steps:
- [ ] Create a few News nodes and tag them with some tags. Make sure to reuse a tag or two for testing the view.
- [ ] Create a page and add a Views Basic paragraph to it
- [ ] Select "Display News articles as News cards"
- [ ] Start typing the name of one of the tags used above for autocomplete and select that tag
- [ ] Save the paragraph and verify that the preview adds the "Filtered by tag "{tagname}"
- [ ] Save the page
- [ ] Verify that the view displays only the news nodes tagged with the tag selected.