### PR TITLE
YALB-952: Update CI Build Tools to PHP 8.1

### DIFF
--- a/.github/workflows/build_deploy_and_test.yml
+++ b/.github/workflows/build_deploy_and_test.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   configure_env_vars:
     container:
-      image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4
+      image: quay.io/pantheon-public/build-tools-ci:8.x-php8.1
       options: --user root
     runs-on: ubuntu-latest
     steps:
@@ -81,7 +81,7 @@ jobs:
 
   static_tests:
     container:
-      image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4
+      image: quay.io/pantheon-public/build-tools-ci:8.x-php8.1
       options: --user root
     runs-on: ubuntu-latest
     env:
@@ -122,7 +122,7 @@ jobs:
 
   deploy_to_pantheon:
     container:
-      image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4
+      image: quay.io/pantheon-public/build-tools-ci:8.x-php8.1
       options: --user root
     runs-on: ubuntu-latest
     needs: [configure_env_vars, static_tests]


### PR DESCRIPTION
## [YALB-952: Update CI Build Tools to PHP 8.1](https://yaleits.atlassian.net/browse/YALB-952)

### Description of work
- Tracking the [upstream version](https://github.com/pantheon-systems/tbt-ci-templates/blob/main/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml) of `.github/workflows/build_deploy_and_test.yml`, update to PHP 8.1 version of build tools project in CI.