### PR TITLE
YALB-861: Alerts UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:js": "eslint --color --no-error-on-unmatched-pattern --format stylish {web/modules/custom,web/themes/custom,web/profiles/custom}/**/*.js",
     "lint:php": "composer lint:php",
     "lint:styles": "stylelint --color {web/modules/custom,web/themes/contrib/atomic,web/themes/custom,web/profiles/custom}/**/*.scss",
+    "fix:js": "eslint --fix {web/modules/custom,web/themes/custom,web/profiles/custom}/**/*.js",
     "local:review-with-atomic-and-cl-branch": "./scripts/local/local-review-with-atomic-and-cl-branch.sh",
     "local:review-with-atomic-branch": "./scripts/local/local-review-with-atomic-branch.sh",
     "local:review-with-cl-branch": "./scripts/local/local-review-with-cl-branch.sh",

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_alert.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_alert.settings.yml
@@ -1,3 +1,16 @@
+alert_types:
+  -
+    id: announcement
+    label: Announcement
+    description: "Announcement alerts are for sharing information relevant to the current site users' actions and goals they are seeking to accomplish. This includes planned outages, closures, important deadlines, and COVID-19 info and regulations."
+  -
+    id: marketing
+    label: Marketing
+    description: "Marketing alerts are more accurately classified as informational announcements and are meant to share information related to the site that may be of interest to the user. These may include event promotion, survey inquiry, fundraiser donation, and other elevated calls to action that are temporary and timely."
+  -
+    id: emergency
+    label: Emergency
+    description: "Emergency alerts are for sharing information vital to the average user's current situation. This includes lockdown/safety information, severe weather that requires people to take shelter, or other events with possible detrimental effects on ones safety. Only use this type of alert in the case of an extreme emergency."
 id: 1660263375
 headline: 'Optional banner for displaying an announcement or notice'
 message: 'Additional text goes here'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/js/confirm_type_modal.js
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/js/confirm_type_modal.js
@@ -1,0 +1,47 @@
+/**
+ * @file
+ * JavaScript for alert settings form confirmation modal.
+ */
+
+(function(Drupal) {
+
+  // Open a confimation modal window when trying to create an emergancy alert.
+  function confirm() {
+    var content = '<div>Please be aware that you have selected the Emergency Alert option. We strongly reccomend that you only use this alert option in the case of an emergency, such as lockdown/safety information, severe weather that requires people to take shelter, or other events with possible detrimental effects on one\'s safety.</div>';
+    var confirmationDialog = Drupal.dialog(content, {
+      dialogClass: 'confirm-dialog',
+      resizable: true,
+      closeOnEscape: false,
+      width: 600,
+      title: Drupal.t('Emergency Alert Confirmation'),
+      buttons: [
+        {
+          text: Drupal.t('Cancel'),
+          class: 'button--secondary button',
+          click: function() {
+            confirmationDialog.close();
+          }
+        },
+        {
+          text: Drupal.t('Confirm'),
+          class: 'button--primary button',
+          click: function() {
+            document.querySelector('form.ys-alert-settings').submit();
+          }
+        }
+      ],
+    });
+    confirmationDialog.showModal();
+  }
+
+  // Add click event to the submit button.
+  var submitButton = document.querySelector('#edit-submit');
+  submitButton.addEventListener('click', function (event) {
+    // Launch the modal if the user selected the 'emergancy' alert.
+    if (document.querySelector('#edit-type-emergency').checked) {
+      event.preventDefault();
+      confirm();
+    }
+  });
+
+})(Drupal);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/js/confirm_type_modal.js
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/js/confirm_type_modal.js
@@ -3,45 +3,44 @@
  * JavaScript for alert settings form confirmation modal.
  */
 
-(function(Drupal) {
-
+(function (Drupal) {
   // Open a confimation modal window when trying to create an emergancy alert.
   function confirm() {
-    var content = '<div>Please be aware that you have selected the Emergency Alert option. We strongly reccomend that you only use this alert option in the case of an emergency, such as lockdown/safety information, severe weather that requires people to take shelter, or other events with possible detrimental effects on one\'s safety.</div>';
+    const content =
+      "<div>Please be aware that you have selected the Emergency Alert option. We strongly reccomend that you only use this alert option in the case of an emergency, such as lockdown/safety information, severe weather that requires people to take shelter, or other events with possible detrimental effects on one's safety.</div>";
     var confirmationDialog = Drupal.dialog(content, {
-      dialogClass: 'confirm-dialog',
+      dialogClass: "confirm-dialog",
       resizable: true,
       closeOnEscape: false,
       width: 600,
-      title: Drupal.t('Emergency Alert Confirmation'),
+      title: Drupal.t("Emergency Alert Confirmation"),
       buttons: [
         {
-          text: Drupal.t('Cancel'),
-          class: 'button--secondary button',
-          click: function() {
+          text: Drupal.t("Cancel"),
+          class: "button--secondary button",
+          click() {
             confirmationDialog.close();
-          }
+          },
         },
         {
-          text: Drupal.t('Confirm'),
-          class: 'button--primary button',
-          click: function() {
-            document.querySelector('form.ys-alert-settings').submit();
-          }
-        }
+          text: Drupal.t("Confirm"),
+          class: "button--primary button",
+          click() {
+            document.querySelector("form.ys-alert-settings").submit();
+          },
+        },
       ],
     });
     confirmationDialog.showModal();
   }
 
   // Add click event to the submit button.
-  var submitButton = document.querySelector('#edit-submit');
-  submitButton.addEventListener('click', function (event) {
+  const submitButton = document.querySelector("#edit-submit");
+  submitButton.addEventListener("click", function (event) {
     // Launch the modal if the user selected the 'emergancy' alert.
-    if (document.querySelector('#edit-type-emergency').checked) {
+    if (document.querySelector("#edit-type-emergency").checked) {
       event.preventDefault();
       confirm();
     }
   });
-
 })(Drupal);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/src/AlertManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/src/AlertManager.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\ys_alert;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Service for interacting with YaleSites alerts and their configuration.
+ */
+class AlertManager implements ContainerInjectionInterface {
+
+  /**
+   * Configuration Factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $alertConfig;
+
+  /**
+   * Constructs a new AlertManager object.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->alertConfig = $config_factory->getEditable('ys_alert.settings');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+    );
+  }
+
+  /**
+   * Get alert type data from ys_alert.settings config file.
+   *
+   * @return array
+   *   An array of alert type definitions.
+   */
+  public function getAlertTypes() {
+    return (array) $this->alertConfig->get('alert_types');
+  }
+
+  public function getTypeOptions() {
+    $types = $this->getAlertTypes();
+    return array_combine(
+      array_column($types, 'id'),
+      array_column($types, 'label')
+    );
+  }
+
+  public function getTypeById($id) {
+    return current(
+      array_filter(
+        $this->getAlertTypes(),
+        function ($type) use ($id) {
+          return $type['id'] == $id;
+        }
+      )
+    );
+  }
+
+  public function getTypeDescription($id) {
+    $type = $this->getTypeById($id);
+    return !empty($type['description']) ? $type['description'] : '';
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/src/AlertManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/src/AlertManager.php
@@ -40,19 +40,39 @@ class AlertManager implements ContainerInjectionInterface {
    * @return array
    *   An array of alert type definitions.
    */
-  public function getAlertTypes() {
-    return (array) $this->alertConfig->get('alert_types');
+  public function getAlertTypes(): array {
+    $config = (array) $this->alertConfig->get('alert_types');
+    return !empty($config) ? $config : [];
   }
 
-  public function getTypeOptions() {
+  /**
+   * Get array of options for alert-types form.
+   *
+   * This is used by the AlertSettings form to display a list of alert types.
+   * Options are keyed by alert id and have the value of alert label.
+   *
+   * @return array
+   *   An array of alert types to display as form options.
+   */
+  public function getTypeOptions(): array {
     $types = $this->getAlertTypes();
-    return array_combine(
+    $options = array_combine(
       array_column($types, 'id'),
       array_column($types, 'label')
     );
+    return !empty($options) ? $options : [];
   }
 
-  public function getTypeById($id) {
+  /**
+   * Get the alert type definition from its id.
+   *
+   * @param string $id
+   *   The id for a given alert type defined in the config file.
+   *
+   * @return array
+   *   The alert definition matching the given id.
+   */
+  public function getTypeById($id): array {
     return current(
       array_filter(
         $this->getAlertTypes(),
@@ -63,7 +83,16 @@ class AlertManager implements ContainerInjectionInterface {
     );
   }
 
-  public function getTypeDescription($id) {
+  /**
+   * Get the alert type description from its id.
+   *
+   * @param string $id
+   *   The id for a given alert type defined in the config file.
+   *
+   * @return string
+   *   The description for a given alert or an empty string.
+   */
+  public function getTypeDescription(string $id): string {
     $type = $this->getTypeById($id);
     return !empty($type['description']) ? $type['description'] : '';
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/src/Form/AlertSettings.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/src/Form/AlertSettings.php
@@ -119,8 +119,8 @@ class AlertSettings extends ConfigFormBase {
         'callback' => '::updateAlertDescriptionCallback',
         'wrapper' => 'alert-description',
         'progress' => [
-          'type' => 'none'
-        ]
+          'type' => 'none',
+        ],
       ],
     ];
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.libraries.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.libraries.yml
@@ -1,0 +1,6 @@
+confirm_type_modal:
+  js:
+    js/confirm_type_modal.js : {}
+  dependencies:
+    - core/drupal.ajax
+    - core/drupal.dialog

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.services.yml
@@ -1,0 +1,5 @@
+services:
+  # Service for interacting with YaleSites alerts and their configuration.
+  ys_alert.manager:
+    class: Drupal\ys_alert\AlertManager
+    arguments: ['@config.factory']


### PR DESCRIPTION
## [YALB-861: Alerts UI](https://yaleits.atlassian.net/browse/YALB-861)

### Description of work
- Adds alert types to the config yaml files
- Creates a management service for retrieving content from the config files
- Refactors the 'Alerts Settings' form type field to use a radio button and to pull text from the configuration yaml files.
- Adds a Drupal dialog in JS to provide a confirmation message before creating an emergency alert.

### Functional testing steps:
- [ ] Login to the multidev via [CAS login](https://pr-201-yalesites-platform.pantheonsite.io/cas) or `terminus drush yalesites-platform.pr-201 -- uli`
- [ ] Navigate to the [Alerts Settings interface](https://pr-201-yalesites-platform.pantheonsite.io/admin/yalesites/alert)
- [ ] Verify that 3 alert types are displayed (Announcement, Marketing, Emergency). These definitions are now stored in a new location.
- [ ] Change the alert type and confirm that the description below each one updates accordingly.
- [ ] Make changes to this form and select a 'Marketing' alert. Save the configuration. Verify that your changes were saved (the values should still be in the form.)
- [ ] Make some more changes and select an 'Emergency' alert.
  - [ ] When saving configuration, a confirmation modal appears.
  - [ ] Cancelling the model results in no change to the settings.
  - [ ] Confirming the modal will save the settings.
![Screen Shot 2023-01-24 at 10 58 08 AM](https://user-images.githubusercontent.com/9594124/214343261-090ab739-c237-4f92-b523-20a219f036ac.png)
