### PR TITLE
YALB-969: Add media permissions

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -3,7 +3,11 @@ langcode: en
 status: true
 dependencies:
   config:
+    - media.type.background_video
+    - media.type.document
+    - media.type.embed
     - media.type.image
+    - media.type.video
     - node.type.event
     - node.type.news
     - node.type.page
@@ -44,32 +48,52 @@ permissions:
   - 'clone event content'
   - 'clone news content'
   - 'clone page content'
+  - 'create background_video media'
+  - 'create document media'
+  - 'create embed media'
   - 'create event content'
   - 'create image media'
   - 'create media'
   - 'create news content'
   - 'create page content'
   - 'create url aliases'
+  - 'create video media'
+  - 'delete any background_video media'
+  - 'delete any document media'
+  - 'delete any embed media'
   - 'delete any event content'
   - 'delete any image media'
   - 'delete any media'
   - 'delete any news content'
   - 'delete any page content'
+  - 'delete any video media'
   - 'delete any webform submission'
   - 'delete media'
+  - 'delete own background_video media'
+  - 'delete own document media'
+  - 'delete own embed media'
   - 'delete own event content'
   - 'delete own image media'
   - 'delete own news content'
   - 'delete own page content'
+  - 'delete own video media'
+  - 'edit any background_video media'
+  - 'edit any document media'
+  - 'edit any embed media'
   - 'edit any event content'
   - 'edit any image media'
   - 'edit any news content'
   - 'edit any page content'
+  - 'edit any video media'
   - 'edit any webform submission'
+  - 'edit own background_video media'
+  - 'edit own document media'
+  - 'edit own embed media'
   - 'edit own event content'
   - 'edit own image media'
   - 'edit own news content'
   - 'edit own page content'
+  - 'edit own video media'
   - 'edit own webform submission'
   - 'override all authored by option'
   - 'override all authored on option'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -3,7 +3,11 @@ langcode: en
 status: true
 dependencies:
   config:
+    - media.type.background_video
+    - media.type.document
+    - media.type.embed
     - media.type.image
+    - media.type.video
     - node.type.event
     - node.type.news
     - node.type.page
@@ -43,32 +47,52 @@ permissions:
   - 'clone event content'
   - 'clone news content'
   - 'clone page content'
+  - 'create background_video media'
+  - 'create document media'
+  - 'create embed media'
   - 'create event content'
   - 'create image media'
   - 'create media'
   - 'create news content'
   - 'create page content'
   - 'create url aliases'
+  - 'create video media'
+  - 'delete any background_video media'
+  - 'delete any document media'
+  - 'delete any embed media'
   - 'delete any event content'
   - 'delete any image media'
   - 'delete any media'
   - 'delete any news content'
   - 'delete any page content'
+  - 'delete any video media'
   - 'delete any webform submission'
   - 'delete media'
+  - 'delete own background_video media'
+  - 'delete own document media'
+  - 'delete own embed media'
   - 'delete own event content'
   - 'delete own image media'
   - 'delete own news content'
   - 'delete own page content'
+  - 'delete own video media'
+  - 'edit any background_video media'
+  - 'edit any document media'
+  - 'edit any embed media'
   - 'edit any event content'
   - 'edit any image media'
   - 'edit any news content'
   - 'edit any page content'
+  - 'edit any video media'
   - 'edit any webform submission'
+  - 'edit own background_video media'
+  - 'edit own document media'
+  - 'edit own embed media'
   - 'edit own event content'
   - 'edit own image media'
   - 'edit own news content'
   - 'edit own page content'
+  - 'edit own video media'
   - 'edit own webform submission'
   - 'override all sticky option'
   - 'override news authored on option'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/ys_embed.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/ys_embed.routing.yml
@@ -5,6 +5,6 @@ ys_embed.instructions:
     _title: 'Adding Embeded Media'
     _controller: '\Drupal\ys_embed\Controller\EmbedInstructionsController::openDialog'
   requirements:
-    _permission: 'create embed media'
+    _permission: 'access media overview'
   options:
     _admin_route: TRUE


### PR DESCRIPTION
## [YALB-969: Add media permissions](https://yaleits.atlassian.net/browse/YALB-969)

### Description of work
- Adds permissions for each user type (no functional change here, just feels good to check the boxes)
- Updates the callback for the embed entity modal to grant authors permission to view the content

### Functional testing steps:
- [ ] [Login to the multidev](https://pr-203-yalesites-platform.pantheonsite.io/)
- [ ] [Create a new page](https://pr-203-yalesites-platform.pantheonsite.io/node/add/page)
- [ ] Add an 'Embed' paragraph
- [ ] Click 'Add Media' to launch Drupal's media library
- [ ] Click the 'Learn about supported formats and options' links
- [ ] Verify that the modal window opens
