### PR TITLE
YALB-932: Node edit form title

### DIFF
--- a/web/themes/custom/ys_admin_theme/ys_admin_theme.theme
+++ b/web/themes/custom/ys_admin_theme/ys_admin_theme.theme
@@ -4,3 +4,38 @@
  * @file
  * Functions to support the YaleSites admin theme.
  */
+
+use Drupal\node\Entity\Node;
+
+/**
+ * Implements hook_preprocess_HOOK() for page title templates.
+ */
+function ys_admin_theme_preprocess_page_title(&$variables) {
+  if (\Drupal::routeMatch()->getRouteName() == 'entity.node.edit_form') {
+    ys_admin_theme_set_title_on_node_edit_page($variables);
+  }
+}
+
+/**
+ * Set the page title on node edit forms.
+ *
+ * Override page title defined in gin/includes/page.theme. The name of the node
+ * bundle is prefixed to the title to improve the authoring experience.
+ *
+ * @param array $variables
+ *   The variables array.
+ *
+ * @todo Move <em> to a styled class in admin theme CSS.
+ */
+function ys_admin_theme_set_title_on_node_edit_page(array &$variables) {
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if ($node instanceof Node) {
+    $bundle_label = \Drupal::entityTypeManager()
+      ->getStorage('node_type')
+      ->load($node->bundle())
+      ->label();
+    $variables['title'] = [
+      '#markup' => "<em>" . $bundle_label . ":</em> " . $node->getTitle(),
+    ];
+  }
+}


### PR DESCRIPTION
## [YALB-932: Node edit form title](https://yaleits.atlassian.net/browse/YALB-932)

### Description of work
- Changes the node edit form title to have the format: `<em>{{content type}}:</em> {{node title}}`

### Functional testing steps:
- [ ] Login to the multidev environment
- [ ] Add a new page and verify the node-add form continues to read "Add a new Page". This is not a change.
- [ ] Save and publish the page. Verify that the title of the page displays correctly.
- [ ] Edit the page and verify that the node-edit form displays in the new format with the content type prefixing the title of the page.
![Screen Shot 2023-02-01 at 1 29 14 PM](https://user-images.githubusercontent.com/9594124/216130928-c6bf3933-c387-486d-ac21-7c22da3f1b69.png)
