### PR TITLE
YALB-852: AX: Build follow up to fieldgroups work

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -37,6 +37,7 @@
     "drupal/linkit": "^6.0@beta",
     "drupal/mailchimp_transactional": "^1.0",
     "drupal/mailsystem": "^4.3",
+    "drupal/markup": "^1.0@beta",
     "drupal/maxlength": "^2.0@RC",
     "drupal/media_library_edit": "^3.0",
     "drupal/menu_admin_per_menu": "^1.4",

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.event.field_content
+    - field.field.node.event.field_content_title
     - field.field.node.event.field_event_cta
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
@@ -19,6 +20,7 @@ dependencies:
     - hide_revision_field
     - layout_paragraphs
     - linkit
+    - markup
     - maxlength
     - media_library
     - metatag
@@ -45,6 +47,7 @@ third_party_settings:
         width_breakpoint: 640
     group_content:
       children:
+        - field_content_title
         - title
         - field_tags
         - field_content
@@ -69,14 +72,15 @@ third_party_settings:
       region: content
       parent_name: group_wrapper
       weight: 21
-      format_type: tab
+      format_type: details_sidebar
       format_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        formatter: closed
+        open: true
         description: ''
         required_fields: true
+        weight: -10
     group_logistics:
       children:
         - field_event_format
@@ -107,13 +111,19 @@ content:
     third_party_settings: {  }
   field_content:
     type: layout_paragraphs
-    weight: 3
+    weight: 84
     region: content
     settings:
       preview_view_mode: preview
       nesting_depth: 0
       require_layouts: 0
       empty_message: ''
+    third_party_settings: {  }
+  field_content_title:
+    type: markup
+    weight: 81
+    region: content
+    settings: {  }
     third_party_settings: {  }
   field_event_cta:
     type: linkit
@@ -157,7 +167,7 @@ content:
     third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete_tags
-    weight: 2
+    weight: 83
     region: content
     settings:
       match_operator: CONTAINS
@@ -229,7 +239,7 @@ content:
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 1
+    weight: 82
     region: content
     settings:
       size: 60

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.news.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.news.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.news.field_author
     - field.field.node.news.field_content
+    - field.field.node.news.field_content_title
     - field.field.node.news.field_metatags
     - field.field.node.news.field_publish_date
     - field.field.node.news.field_tags
@@ -18,6 +19,7 @@ dependencies:
     - field_group
     - hide_revision_field
     - layout_paragraphs
+    - markup
     - maxlength
     - media_library
     - metatag
@@ -27,6 +29,7 @@ third_party_settings:
   field_group:
     group_content:
       children:
+        - field_content_title
         - title
         - field_tags
         - field_author
@@ -55,17 +58,15 @@ third_party_settings:
       region: content
       parent_name: group_wrapper
       weight: 4
-      format_type: tab
+      format_type: details_sidebar
       format_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        formatter: closed
+        open: true
         description: ''
         required_fields: true
-        direction: vertical
-        width_breakpoint: 640
-        effect: none
+        weight: -10
     group_wrapper:
       children:
         - group_content
@@ -104,7 +105,7 @@ mode: default
 content:
   field_author:
     type: string_textfield
-    weight: 2
+    weight: 15
     region: content
     settings:
       size: 60
@@ -112,13 +113,19 @@ content:
     third_party_settings: {  }
   field_content:
     type: layout_paragraphs
-    weight: 3
+    weight: 16
     region: content
     settings:
       preview_view_mode: default
       nesting_depth: 0
       require_layouts: 0
       empty_message: ''
+    third_party_settings: {  }
+  field_content_title:
+    type: markup
+    weight: 12
+    region: content
+    settings: {  }
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
@@ -136,7 +143,7 @@ content:
     third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete_tags
-    weight: 1
+    weight: 14
     region: content
     settings:
       match_operator: CONTAINS
@@ -208,7 +215,7 @@ content:
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 0
+    weight: 13
     region: content
     settings:
       size: 60

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.news.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.news.default.yml
@@ -116,7 +116,7 @@ content:
     weight: 16
     region: content
     settings:
-      preview_view_mode: default
+      preview_view_mode: preview
       nesting_depth: 0
       require_layouts: 0
       empty_message: ''

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.page.field_banner
     - field.field.node.page.field_content
+    - field.field.node.page.field_content_title
     - field.field.node.page.field_metatags
     - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_media
@@ -16,6 +17,7 @@ dependencies:
     - field_group
     - hide_revision_field
     - layout_paragraphs
+    - markup
     - maxlength
     - media_library
     - metatag
@@ -41,6 +43,7 @@ third_party_settings:
         width_breakpoint: 640
     group_content:
       children:
+        - field_content_title
         - title
         - field_tags
         - field_content
@@ -55,7 +58,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         formatter: open
-        description: ''
+        description: 'Test description here'
         required_fields: true
     group_teaser:
       children:
@@ -66,18 +69,19 @@ third_party_settings:
       region: content
       parent_name: group_wrapper
       weight: 15
-      format_type: tab
+      format_type: details_sidebar
       format_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        formatter: closed
+        open: true
         description: ''
         required_fields: true
+        weight: -10
     group_hero:
       children:
         - field_banner
-      label: Banner
+      label: 'Intro Banner'
       region: content
       parent_name: group_wrapper
       weight: 16
@@ -116,7 +120,7 @@ content:
           dialog_style: tiles
   field_content:
     type: layout_paragraphs
-    weight: 2
+    weight: 84
     region: content
     settings:
       preview_view_mode: preview
@@ -124,9 +128,15 @@ content:
       require_layouts: 0
       empty_message: ''
     third_party_settings: {  }
+  field_content_title:
+    type: markup
+    weight: 81
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 3
+    weight: 85
     region: content
     settings:
       sidebar: true
@@ -134,7 +144,7 @@ content:
     third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete_tags
-    weight: 1
+    weight: 83
     region: content
     settings:
       match_operator: CONTAINS
@@ -199,7 +209,7 @@ content:
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 0
+    weight: 82
     region: content
     settings:
       size: 60

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
@@ -58,7 +58,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         formatter: open
-        description: 'Test description here'
+        description: ''
         required_fields: true
     group_teaser:
       children:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.card.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.card.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.card
     - field.field.node.event.field_content
+    - field.field.node.event.field_content_title
     - field.field.node.event.field_event_cta
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
@@ -75,6 +76,7 @@ content:
     weight: 1
     region: content
 hidden:
+  field_content_title: true
   field_event_cta: true
   field_metatags: true
   field_tags: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.event.field_content
+    - field.field.node.event.field_content_title
     - field.field.node.event.field_event_cta
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
@@ -66,6 +67,7 @@ content:
     weight: 2
     region: content
 hidden:
+  field_content_title: true
   field_metatags: true
   field_tags: true
   field_teaser_media: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.list_item.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.list_item.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.list_item
     - field.field.node.event.field_content
+    - field.field.node.event.field_content_title
     - field.field.node.event.field_event_cta
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
@@ -75,6 +76,7 @@ content:
     weight: 1
     region: content
 hidden:
+  field_content_title: true
   field_event_cta: true
   field_metatags: true
   field_tags: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.search_result.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.event.field_content
+    - field.field.node.event.field_content_title
     - field.field.node.event.field_event_cta
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
@@ -36,6 +37,7 @@ content:
     region: content
 hidden:
   field_content: true
+  field_content_title: true
   field_event_cta: true
   field_event_date: true
   field_event_format: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.event.field_content
+    - field.field.node.event.field_content_title
     - field.field.node.event.field_event_cta
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
@@ -28,6 +29,7 @@ content:
     region: content
 hidden:
   field_content: true
+  field_content_title: true
   field_event_cta: true
   field_event_date: true
   field_event_format: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.card.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.card.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.card
     - field.field.node.news.field_author
     - field.field.node.news.field_content
+    - field.field.node.news.field_content_title
     - field.field.node.news.field_metatags
     - field.field.node.news.field_publish_date
     - field.field.node.news.field_tags
@@ -48,6 +49,7 @@ content:
 hidden:
   field_author: true
   field_content: true
+  field_content_title: true
   field_metatags: true
   field_publish_date: true
   field_tags: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.news.field_author
     - field.field.node.news.field_content
+    - field.field.node.news.field_content_title
     - field.field.node.news.field_metatags
     - field.field.node.news.field_publish_date
     - field.field.node.news.field_tags
@@ -38,6 +39,7 @@ content:
     weight: 1
     region: content
 hidden:
+  field_content_title: true
   field_metatags: true
   field_publish_date: true
   field_tags: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.list_item.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.list_item.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.list_item
     - field.field.node.news.field_author
     - field.field.node.news.field_content
+    - field.field.node.news.field_content_title
     - field.field.node.news.field_metatags
     - field.field.node.news.field_publish_date
     - field.field.node.news.field_tags
@@ -48,6 +49,7 @@ content:
 hidden:
   field_author: true
   field_content: true
+  field_content_title: true
   field_metatags: true
   field_publish_date: true
   field_tags: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.search_result.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.search_result
     - field.field.node.news.field_author
     - field.field.node.news.field_content
+    - field.field.node.news.field_content_title
     - field.field.node.news.field_metatags
     - field.field.node.news.field_publish_date
     - field.field.node.news.field_tags
@@ -36,6 +37,7 @@ content:
 hidden:
   field_author: true
   field_content: true
+  field_content_title: true
   field_metatags: true
   field_publish_date: true
   field_tags: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.teaser.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.news.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.news.field_author
     - field.field.node.news.field_content
+    - field.field.node.news.field_content_title
     - field.field.node.news.field_metatags
     - field.field.node.news.field_publish_date
     - field.field.node.news.field_tags
@@ -28,6 +29,7 @@ content:
 hidden:
   field_author: true
   field_content: true
+  field_content_title: true
   field_metatags: true
   field_publish_date: true
   field_tags: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.page.field_banner
     - field.field.node.page.field_content
+    - field.field.node.page.field_content_title
     - field.field.node.page.field_metatags
     - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_media
@@ -39,6 +40,7 @@ content:
     weight: 1
     region: content
 hidden:
+  field_content_title: true
   field_metatags: true
   field_tags: true
   field_teaser_media: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.search_result.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.search_result
     - field.field.node.page.field_banner
     - field.field.node.page.field_content
+    - field.field.node.page.field_content_title
     - field.field.node.page.field_metatags
     - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_media
@@ -35,6 +36,7 @@ content:
 hidden:
   field_banner: true
   field_content: true
+  field_content_title: true
   field_metatags: true
   field_tags: true
   field_teaser_media: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.page.field_banner
     - field.field.node.page.field_content
+    - field.field.node.page.field_content_title
     - field.field.node.page.field_metatags
     - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_media
@@ -27,6 +28,7 @@ content:
 hidden:
   field_banner: true
   field_content: true
+  field_content_title: true
   field_metatags: true
   field_tags: true
   field_teaser_media: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -49,6 +49,7 @@ module:
   linkit: 0
   mailchimp_transactional: 0
   mailsystem: 0
+  markup: 0
   maxlength: 0
   media: 0
   media_library: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_content_title.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_content_title.yml
@@ -1,0 +1,25 @@
+uuid: b75bd46a-00c4-4eb2-80a5-b705cb3be9e4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content_title
+    - node.type.event
+  module:
+    - markup
+id: node.event.field_content_title
+field_name: field_content_title
+entity_type: node
+bundle: event
+label: 'Content Title'
+description: ''
+required: false
+translatable: true
+default_value:
+  - {  }
+default_value_callback: ''
+settings:
+  markup:
+    value: "<h2>Page Content</h2>\r\n"
+    format: basic_html
+field_type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.news.field_content_title.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.news.field_content_title.yml
@@ -1,0 +1,25 @@
+uuid: 363b2da0-fc83-42bc-bd44-4567e67e0717
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content_title
+    - node.type.news
+  module:
+    - markup
+id: node.news.field_content_title
+field_name: field_content_title
+entity_type: node
+bundle: news
+label: 'Content Title'
+description: ''
+required: false
+translatable: true
+default_value:
+  - {  }
+default_value_callback: ''
+settings:
+  markup:
+    value: "<h2>Page Content</h2>\r\n"
+    format: basic_html
+field_type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_content_title.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_content_title.yml
@@ -1,0 +1,25 @@
+uuid: 00550a42-e73f-4cce-aa7f-0ac72558b979
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content_title
+    - node.type.page
+  module:
+    - markup
+id: node.page.field_content_title
+field_name: field_content_title
+entity_type: node
+bundle: page
+label: 'Content Title'
+description: ''
+required: false
+translatable: false
+default_value:
+  - {  }
+default_value_callback: ''
+settings:
+  markup:
+    value: "<h2>Page Content</h2>\r\n"
+    format: basic_html
+field_type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_content_title.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_content_title.yml
@@ -1,0 +1,19 @@
+uuid: d244a6dd-8d92-47fe-b978-948a4f0e7b7c
+langcode: en
+status: true
+dependencies:
+  module:
+    - markup
+    - node
+id: node.field_content_title
+field_name: field_content_title
+entity_type: node
+type: markup
+settings: {  }
+module: markup
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/js/node-edit-form.js
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/js/node-edit-form.js
@@ -1,0 +1,19 @@
+(function drupal(Drupal) {
+  Drupal.behaviors.ysCoreNodeEditForm = {
+    attach: function attach(context, settings) {
+      once("nodeEditForm", "html").forEach(function nodeEditForm() {
+        const nodeTitle = context.getElementById("edit-title-0-value");
+        const teaserTitle = context.getElementById(
+          "edit-field-teaser-title-0-value"
+        );
+        // Set teaser placeholder initially on page load.
+        teaserTitle.placeholder = nodeTitle.value;
+
+        // Automatically set teaser placeholder on change of node title.
+        nodeTitle.addEventListener("keyup", function titleKeyUp() {
+          teaserTitle.placeholder = nodeTitle.value;
+        });
+      });
+    },
+  };
+})(Drupal);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.libraries.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.libraries.yml
@@ -1,0 +1,3 @@
+node_edit_form:
+  js:
+    js/node-edit-form.js : {}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -69,6 +69,7 @@ function ys_core_form_alter(&$form, $form_state, $form_id) {
 
   if (in_array($form_id, $nodeForms)) {
     $form['#attached']['library'][] = 'ys_core/node_edit_form';
+    unset($form['field_content']['widget']['#title']);
   }
 }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -56,6 +56,20 @@ function ys_core_form_alter(&$form, $form_state, $form_id) {
   if (isset($form['sticky'])) {
     $form['sticky']['widget']['value']['#title'] = t('Pin to the beginning of list');
   }
+
+  // Form ID's of forms to add Javascript interaction.
+  $nodeForms = [
+    'node_page_form',
+    'node_page_edit_form',
+    'node_event_form',
+    'node_event_edit_form',
+    'node_news_form',
+    'node_news_edit_form',
+  ];
+
+  if (in_array($form_id, $nodeForms)) {
+    $form['#attached']['library'][] = 'ys_core/node_edit_form';
+  }
 }
 
 /**

--- a/web/themes/custom/ys_admin_theme/css/admin-ui.css
+++ b/web/themes/custom/ys_admin_theme/css/admin-ui.css
@@ -7,4 +7,12 @@
   color: transparent !important;
 }
 
+.field--name-field-content fieldset {
+  border: 0;
+}
+
+.field--name-field-content-title {
+  border-bottom: 1px solid var(--gin-border-color);
+}
+
 /*# sourceMappingURL=admin-ui.css.map */

--- a/web/themes/custom/ys_admin_theme/css/admin-ui.css
+++ b/web/themes/custom/ys_admin_theme/css/admin-ui.css
@@ -7,8 +7,11 @@
   color: transparent !important;
 }
 
-.field--name-field-content fieldset {
+.field--name-field-content .fieldset {
   border: 0;
+}
+.field--name-field-content .fieldset__wrapper {
+  margin: 0;
 }
 
 .field--name-field-content-title {

--- a/web/themes/custom/ys_admin_theme/css/admin-ui.css.map
+++ b/web/themes/custom/ys_admin_theme/css/admin-ui.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sourceRoot":"","sources":["../scss/admin-ui.scss"],"names":[],"mappings":"AAAA;EACE;;;AAGF;EACE;EACA;;;AAGF;EACE;;;AAGF;EACE","file":"admin-ui.css"}
+{"version":3,"sourceRoot":"","sources":["../scss/admin-ui.scss"],"names":[],"mappings":"AAAA;EACE;;;AAGF;EACE;EACA;;;AAIA;EACE;;AAEF;EACE;;;AAIJ;EACE","file":"admin-ui.css"}

--- a/web/themes/custom/ys_admin_theme/css/admin-ui.css.map
+++ b/web/themes/custom/ys_admin_theme/css/admin-ui.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sourceRoot":"","sources":["../scss/admin-ui.scss"],"names":[],"mappings":"AAAA;EACE;;;AAGF;EACE;EACA;;;AAIA;EACE;;AAEF;EACE;;;AAIJ;EACE","file":"admin-ui.css"}
+{"version":3,"sourceRoot":"","sources":["../scss/admin-ui.scss"],"names":[],"mappings":"AAAA;EACE;;;AAGF;EACE;EACA;;;AAIA;EACE;;AAGF;EACE;;;AAIJ;EACE","file":"admin-ui.css"}

--- a/web/themes/custom/ys_admin_theme/css/admin-ui.css.map
+++ b/web/themes/custom/ys_admin_theme/css/admin-ui.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sourceRoot":"","sources":["../scss/admin-ui.scss"],"names":[],"mappings":"AAAA;EACE;;;AAGF;EACE;EACA","file":"admin-ui.css"}
+{"version":3,"sourceRoot":"","sources":["../scss/admin-ui.scss"],"names":[],"mappings":"AAAA;EACE;;;AAGF;EACE;EACA;;;AAGF;EACE;;;AAGF;EACE","file":"admin-ui.css"}

--- a/web/themes/custom/ys_admin_theme/scss/admin-ui.scss
+++ b/web/themes/custom/ys_admin_theme/scss/admin-ui.scss
@@ -11,6 +11,7 @@
   .fieldset {
     border: 0;
   }
+
   .fieldset__wrapper {
     margin: 0;
   }

--- a/web/themes/custom/ys_admin_theme/scss/admin-ui.scss
+++ b/web/themes/custom/ys_admin_theme/scss/admin-ui.scss
@@ -6,3 +6,11 @@
   overflow: hidden;
   color: transparent !important;
 }
+
+.field--name-field-content fieldset {
+  border: 0;
+}
+
+.field--name-field-content-title {
+  border-bottom: 1px solid var(--gin-border-color);
+}

--- a/web/themes/custom/ys_admin_theme/scss/admin-ui.scss
+++ b/web/themes/custom/ys_admin_theme/scss/admin-ui.scss
@@ -7,8 +7,13 @@
   color: transparent !important;
 }
 
-.field--name-field-content fieldset {
-  border: 0;
+.field--name-field-content {
+  .fieldset {
+    border: 0;
+  }
+  .fieldset__wrapper {
+    margin: 0;
+  }
 }
 
 .field--name-field-content-title {


### PR DESCRIPTION
## [YALB-852: AX: Build follow up to fieldgroups work](https://yaleits.atlassian.net/browse/YALB-852)

### Description of work
- Moves teaser fields to the sidebar
- Placeholder text for teaser title is dynamically updated from the node title
- "Banner" renamed to "Intro Banner"
- Added "Page Content" H2 title inside the "Content" tab at the top

### Functional testing steps:
- [x] Create a new page
- [x] Verify that the "Intro Banner" tab exists
- [x] Verify that at the top of the edit form, the H2 title "Page Content" exists
- [x] Verify that the teaser fields are in the sidebar and are at the top of the sidebar
- [x] Start typing some text into the title field and verify that the teaser placeholder text is updated dynamically
