### PR TITLE
YALB-902: AX: Hide "Advanced" metadata tab

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/metatag.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/metatag.settings.yml
@@ -1,0 +1,14 @@
+entity_type_groups:
+  node:
+    event:
+      basic: basic
+    news:
+      basic: basic
+    page:
+      basic: basic
+tag_trim_method: beforeValue
+tag_trim_maxlength:
+  metatag_maxlength_abstract: null
+  metatag_maxlength_description: null
+  metatag_maxlength_title: null
+tag_scroll_max_height: ''


### PR DESCRIPTION
## [YALB-902: AX: Hide "Advanced" metadata tab](https://yaleits.atlassian.net/browse/YALB-902)

### Description of work
- Removes advanced metatags from node edit forms

### Functional testing steps:
- [x] Edit and existing or create a new node
- [x] In the sidebar, open the Metadata details accordion
- [x] Verify that there is only a "Basic tags" section and the "Advanced tags" no longer appears.
