### PR TITLE
YALB-941: Bug: Callout should require link text

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.callout_item.field_link.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.callout_item.field_link.yml
@@ -18,6 +18,6 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  title: 1
+  title: 2
   link_type: 17
 field_type: link


### PR DESCRIPTION
## [YALB-941: Bug: Callout should require link text](https://yaleits.atlassian.net/browse/YALB-941)

### Description of work
- Makes callout link text required.

### Functional testing steps:
- [x] Add a new page
- [x] Add a paragraph type of "Callout"
- [x] Verify that the "Link text" is required
