### PR TITLE
YALB-651: Bugfix for CAS-restricted nodes

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/src/EventSubscriber/NodeAccessEventSubscriber.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/src/EventSubscriber/NodeAccessEventSubscriber.php
@@ -5,7 +5,7 @@ namespace Drupal\ys_node_access\EventSubscriber;
 use Drupal\Core\EventSubscriber\HttpExceptionSubscriberBase;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use Drupal\Core\Routing\TrustedRedirectResponse;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 
 /**
@@ -54,7 +54,8 @@ class NodeAccessEventSubscriber extends HttpExceptionSubscriberBase {
         if ($node->hasField('field_login_required')) {
           if (!$node->field_login_required->isEmpty()) {
             $casRedirectUrl = Url::fromRoute('cas.login', ['destination' => $node->toUrl()->toString()])->toString();
-            $returnResponse = new RedirectResponse($casRedirectUrl);
+            $returnResponse = new TrustedRedirectResponse($casRedirectUrl);
+            $returnResponse->getCacheableMetadata()->setCacheMaxAge(0);
             $event->setResponse($returnResponse);
           }
         }


### PR DESCRIPTION
## [YALB-651: Bugfix for CAS-restricted nodes](https://yaleits.atlassian.net/browse/YALB-651)

### Description of work
- Fixes caching issue when reverting a CAS required page to not require CAS login, cache will no longer redirect viewing of node

### Functional testing steps:
- [x] Edit a page, news, or event
- [x] In the sidebar under "Publish Options", select "CAS Login Required" and then save the node.
- [x] View the node logged out (incognito window) and verify that you get redirected to the CAS login page
- [x] Edit the node and uncheck the "CAS Login Required" and save the node.
- [x] View the node logged out (incognito window) and verify that you can see the page fine, with no need to clear the cache.