### PR TITLE
YALB-1010: Views Sorting

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
@@ -11,7 +11,7 @@ dependencies:
 id: views_basic_scaffold
 label: 'Views Basic Scaffold'
 module: views
-description: ''
+description: 'View that is overridden by Views Basic custom module code'
 tag: ''
 base_table: node_field_data
 base_field: nid
@@ -94,7 +94,21 @@ display:
         type: tag
         options: {  }
       empty: {  }
-      sorts: {  }
+      sorts:
+        views_basic_sort:
+          id: views_basic_sort
+          table: node_field_data
+          field: views_basic_sort
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: views_basic_sort
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       arguments: {  }
       filters:
         views_basic_filter:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
@@ -2,7 +2,7 @@
 * @todo Possibly move these styles into admin theme.
 */
 .views-basic--params {
-  display: none;
+  /* display: none; */
 }
 
 .views-basic--group-user-selection .grouped-items,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
@@ -2,7 +2,7 @@
 * @todo Possibly move these styles into admin theme.
 */
 .views-basic--params {
-  /* display: none; */
+  display: none;
 }
 
 .views-basic--group-user-selection .grouped-items,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldFormatter/ViewsBasicDefaultFormatter.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldFormatter/ViewsBasicDefaultFormatter.php
@@ -131,6 +131,11 @@ class ViewsBasicDefaultFormatter extends FormatterBase implements ContainerFacto
       $filters['views_basic_filter']['value'] = $paramsDecoded;
       $view->display_handler->overrideOption('filters', $filters);
 
+      // Overrides sorts using out custom views sorts plugin - ViewsBasicSort.
+      $sorts = $view->display_handler->getOption('sorts');
+      $sorts['views_basic_sort']['value'] = $paramsDecoded;
+      $view->display_handler->overrideOption('sorts', $sorts);
+
       // Sets items per page.
       $view->setItemsPerPage($paramsDecoded['limit']);
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldFormatter/ViewsBasicPreviewFormatter.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldFormatter/ViewsBasicPreviewFormatter.php
@@ -104,15 +104,18 @@ class ViewsBasicPreviewFormatter extends FormatterBase implements ContainerFacto
         'view_mode' => '',
         'tags' => [],
         'limit' => '',
+        'sort_by' => '',
       ];
       $paramsDecoded = json_decode($item->params, TRUE);
 
       // Gets the entity labels and view modes.
       foreach ($paramsDecoded['filters']['types'] as $type) {
-        $entityLabel = $this->viewsBasicManager->getEntityLabel($type);
+        $entityLabel = $this->viewsBasicManager->getLabel($type, 'entity');
         array_push($paramsForRender['types'], $entityLabel);
-        $viewModeLabel = $this->viewsBasicManager->getViewModeLabel($type, $paramsDecoded['view_mode']);
+        $viewModeLabel = $this->viewsBasicManager->getLabel($type, 'view_modes', $paramsDecoded['view_mode']);
+        $sortByLabel = $this->viewsBasicManager->getLabel($type, 'sort_by', $paramsDecoded['sort_by']);
         $paramsForRender['view_mode'] = $viewModeLabel;
+        $paramsForRender['sort_by'] = $sortByLabel;
       }
 
       // Gets the tag labels.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/sort/ViewsBasicSort.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/sort/ViewsBasicSort.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\ys_views_basic\Plugin\views\sort;
+
+use Drupal\views\Plugin\views\sort\SortPluginBase;
+
+/**
+ * Sort that receives JSON overrides from a Views Basic field.
+ *
+ * @ingroup views_sort_handlers
+ *
+ * @ViewsSort("views_basic_sort")
+ */
+class ViewsBasicSort extends SortPluginBase {
+
+  /**
+   * Add this sort to the query.
+   */
+  public function query() {
+    $this->ensureMyTable();
+
+    /** @var \Drupal\views\Plugin\views\query\Sql $query */
+    $query = $this->query;
+
+    $sortBy = $this->options['value']['sort_by'];
+
+    // Split out the field and the sort direction.
+    $sortQueryOptions = explode(":", $sortBy);
+    if (str_starts_with($sortQueryOptions[0], 'field')) {
+      $lookupTable = $query->addTable('node__' . $sortQueryOptions[0]);
+      $field = "$lookupTable.$sortQueryOptions[0]_value";
+    }
+    else {
+      $field = $sortQueryOptions[0];
+    }
+
+    $query->addOrderBy(NULL, "{$field}", $sortQueryOptions[1], 'views_basic_sort');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -23,6 +23,9 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
    *     'view_mode_machine_name1' => 'Human readable label 1',
    *     'view_mode_machine_name2' => 'Human readable label 2',
    *   ],
+   *   'sort_by' => [
+   *     'field_machine_name:ASC' => 'Human readable sort label',
+   *   ]
    * ],
    *
    * @todo This seems fragile and would better be inside a config page for
@@ -60,8 +63,8 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
         'teaser' => 'Teasers',
       ],
       'sort_by' => [
-        'title:ASC' => 'Name - A-Z',
-        'title:DESC' => 'Name - Z-A',
+        'title:ASC' => 'Title - A-Z',
+        'title:DESC' => 'Title - Z-A',
       ],
     ],
   ];
@@ -144,25 +147,14 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
   }
 
   /**
-   * Returns an entity label given an entity type and machine name.
-   *
-   * @param string $type
-   *   A machine name of an entity type.
-   *
-   * @return string
-   *   The human readable label of an entity type.
-   */
-  public function getEntityLabel($type) {
-    return self::ALLOWED_ENTITIES[$type]['label'];
-  }
-
-  /**
-   * Returns a view mode label given an view mode type stored in the params.
+   * Returns a label given a content type and optional sub parameter.
    *
    * @param string $content_type
    *   Machine name of an entity type.
+   * @param string $label_type
+   *   Type of label to get: entity, view_mode, or sort_by.
    * @param string $sub_param
-   *   Machine name of a view mode.
+   *   Sub parameter name: view_mode or sort_by.
    *
    * @return string
    *   Human readable view mode label.
@@ -174,6 +166,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
     if ($sub_param) {
       return self::ALLOWED_ENTITIES[$content_type][$label_type][$sub_param];
     }
+    return '';
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -33,23 +33,35 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
 
   const ALLOWED_ENTITIES = [
     'news' => [
-      'label' => 'News articles',
+      'label' => 'Posts',
       'view_modes' => [
-        'card' => 'News cards',
-        'list_item' => 'News list items',
+        'card' => 'News Card Grid',
+        'list_item' => 'News List',
+      ],
+      'sort_by' => [
+        'field_publish_date:DESC' => 'Publish Date - newer first',
+        'field_publish_date:ASC' => 'Publish Date - older first',
       ],
     ],
     'event' => [
       'label' => 'Events',
       'view_modes' => [
-        'card' => 'Event cards',
-        'list_item' => 'Event list items',
+        'card' => 'Event Card Grid',
+        'list_item' => 'Event List',
+      ],
+      'sort_by' => [
+        'field_event_date:DESC' => 'Event Date - newer first',
+        'field_event_date:ASC' => 'Event Date - older first',
       ],
     ],
     'page' => [
       'label' => 'Pages',
       'view_modes' => [
         'teaser' => 'Teasers',
+      ],
+      'sort_by' => [
+        'title:ASC' => 'Name - A-Z',
+        'title:DESC' => 'Name - Z-A',
       ],
     ],
   ];
@@ -118,6 +130,20 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
   }
 
   /**
+   * Returns an array of sort by machine names and the human readable name.
+   *
+   * @param string $content_type
+   *   The entity machine name.
+   *
+   * @return array
+   *   An array of human readable sorts, with machine name as the key.
+   */
+  public function sortByList($content_type) {
+    $sortByList = self::ALLOWED_ENTITIES[$content_type]['sort_by'];
+    return $sortByList;
+  }
+
+  /**
    * Returns an entity label given an entity type and machine name.
    *
    * @param string $type
@@ -133,16 +159,21 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
   /**
    * Returns a view mode label given an view mode type stored in the params.
    *
-   * @param string $type
+   * @param string $content_type
    *   Machine name of an entity type.
-   * @param string $view_mode
+   * @param string $sub_param
    *   Machine name of a view mode.
    *
    * @return string
    *   Human readable view mode label.
    */
-  public function getViewModeLabel($type, $view_mode) {
-    return self::ALLOWED_ENTITIES[$type]['view_modes'][$view_mode];
+  public function getLabel($content_type, $label_type, $sub_param = NULL) {
+    if ($label_type == 'entity') {
+      return self::ALLOWED_ENTITIES[$content_type]['label'];
+    }
+    if ($sub_param) {
+      return self::ALLOWED_ENTITIES[$content_type][$label_type][$sub_param];
+    }
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -160,13 +160,16 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
    *   Human readable view mode label.
    */
   public function getLabel($content_type, $label_type, $sub_param = NULL) {
-    if ($label_type == 'entity') {
-      return self::ALLOWED_ENTITIES[$content_type]['label'];
+    $label = '';
+    switch ($label_type) {
+      case 'entity':
+        $label = self::ALLOWED_ENTITIES[$content_type]['label'];
+        break;
+
+      default:
+        $label = ($sub_param) ? self::ALLOWED_ENTITIES[$content_type][$label_type][$sub_param] : '';
     }
-    if ($sub_param) {
-      return self::ALLOWED_ENTITIES[$content_type][$label_type][$sub_param];
-    }
-    return '';
+    return $label;
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/templates/views-basic-formatter-preview.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/templates/views-basic-formatter-preview.html.twig
@@ -18,3 +18,8 @@
     Showing all items
   {% endif %}
 </div>
+<div>
+  {% if params.sort_by %}
+    Sorted by {{ params.sort_by }}
+  {% endif %}
+</div>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -35,4 +35,11 @@ function ys_views_basic_views_data_alter(array &$data) {
       'id' => 'views_basic_filter',
     ],
   ];
+  $data['node_field_data']['views_basic_sort'] = [
+    'title' => t('Views Basic Sort'),
+    'sort' => [
+      'help' => t('Creates a dynamic sort from Views Basic fields.'),
+      'id' => 'views_basic_sort',
+    ],
+  ];
 }


### PR DESCRIPTION
## [YALB-1010: Views Sorting](https://yaleits.atlassian.net/browse/YALB-1010)

### Description of work
- Adds sorting ability to the Views Basic interface.
- For now, the options are: Published Date (News), Event Date (Events), and Titles (Pages) with both ASC and DESC orders for each. Each sort label, field, and orders can and will be changed after Yale feedback.

### Additional contextual notes
Views Basic allows content editors to select some criteria to show lists of other content as you would normally do via the Views interface, but with a more controlled and limited interface. For now, the content type of "Pages" is a placeholder as we intend to replace pages with people profiles. Therefore, the Pages sort is an example of how we can change the context of the sort from date-based sorts (for News and Events) to text-based sorts.

### Functional testing steps:
- [x] Add three published News nodes to the site. In the sidebar, open "Publish Information" and change the publish date for each to a different date. Title the node with the date used. (This is because at the moment, the "Publish Date" field is not shown on the front-end template)
- [x] Add 3 published Event nodes to the site. Under the "Logistics" tab, make sure to add a date and time for the event and make all three different dates. (Events do show the event date correctly on the front-end)
- [x] Create a Page and add a paragraph of type "View" to that page.
- [x] In the "Create new View" modal, select either the "Posts" or "Events" at the top, and first verify that the "Sorting by" field changes to match the content type selected. Also verify that the view mode list (to the right of the content type) also changes when the content type is changed.
- [x] Select one of the "Sorting by" options and then save the view.
- [x] Publish and save the page and verify that the list of content in the view are in the correct order on the front-end as per the "Sorting by" option selected.
- [x] Go back and edit the page and change the content type and/or sort order and verify that the correct content type sort order is shown on the front-end.