### PR TITLE
YALB-1006: Create views builder widget

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.basic_view.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.basic_view.default.yml
@@ -3,18 +3,37 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.basic_view.field_heading
     - field.field.paragraph.basic_view.field_vb_params
     - paragraphs.paragraphs_type.basic_view
   module:
+    - allowed_formats
+    - maxlength
+    - text
     - ys_views_basic
 id: paragraph.basic_view.default
 targetEntityType: paragraph
 bundle: basic_view
 mode: default
 content:
+  field_heading:
+    type: text_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+      maxlength:
+        maxlength_js: null
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: false
   field_vb_params:
     type: views_basic_default_widget
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.basic_view.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.basic_view.default.yml
@@ -3,21 +3,30 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.basic_view.field_heading
     - field.field.paragraph.basic_view.field_vb_params
     - paragraphs.paragraphs_type.basic_view
   module:
+    - text
     - ys_views_basic
 id: paragraph.basic_view.default
 targetEntityType: paragraph
 bundle: basic_view
 mode: default
 content:
+  field_heading:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
   field_vb_params:
     type: views_basic_default_formatter
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
 hidden:
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.basic_view.preview.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.basic_view.preview.yml
@@ -4,21 +4,30 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.basic_view.field_heading
     - field.field.paragraph.basic_view.field_vb_params
     - paragraphs.paragraphs_type.basic_view
   module:
+    - text
     - ys_views_basic
 id: paragraph.basic_view.preview
 targetEntityType: paragraph
 bundle: basic_view
 mode: preview
 content:
+  field_heading:
+    type: text_default
+    label: inline
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
   field_vb_params:
     type: views_basic_preview_formatter
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
 hidden:
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.basic_view.field_heading.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.basic_view.field_heading.yml
@@ -1,0 +1,26 @@
+uuid: df87722f-ecc0-4f76-8170-b063b94367ce
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_heading
+    - paragraphs.paragraphs_type.basic_view
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - heading_html
+id: paragraph.basic_view.field_heading
+field_name: field_heading
+entity_type: paragraph
+bundle: basic_view
+label: 'View Heading'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.basic_view.field_vb_params.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.basic_view.field_vb_params.yml
@@ -18,8 +18,8 @@ translatable: false
 default_value:
   -
     group_params:
-      params: '{"view_mode":"node.card","filters":{"types":["news"]}}'
-    params: '{"view_mode":"card","filters":{"types":["news"]}}'
+      params: '{"view_mode":"card","filters":{"types":["news"],"tags":[null]},"sort_by":null,"display":null,"limit":10}'
+    params: '{"view_mode":"card","filters":{"types":["news"],"tags":[null]},"sort_by":null,"display":null,"limit":0}'
 default_value_callback: ''
 settings: {  }
 field_type: views_basic_params

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/js/node-edit-form.js
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/js/node-edit-form.js
@@ -6,13 +6,18 @@
         const teaserTitle = context.getElementById(
           "edit-field-teaser-title-0-value"
         );
+
+        function titleKeyUp() {
+          teaserTitle.placeholder = nodeTitle.value;
+        }
+
         // Set teaser placeholder initially on page load.
         teaserTitle.placeholder = nodeTitle.value;
 
         // Automatically set teaser placeholder on change of node title.
-        nodeTitle.addEventListener("keyup", function titleKeyUp() {
-          teaserTitle.placeholder = nodeTitle.value;
-        });
+        ["blur", "keyup"].forEach((evt) =>
+          nodeTitle.addEventListener(evt, titleKeyUp)
+        );
       });
     },
   };

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
@@ -17,3 +17,7 @@
   display: flex;
   gap: 1rem;
 }
+
+.views-basic--parameter-preview {
+  margin-top: 1rem;
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
@@ -17,7 +17,3 @@
   display: flex;
   gap: 1rem;
 }
-
-.views-basic--view-mode {
-  display: block;
-}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
@@ -1,13 +1,15 @@
 /*
 * @todo Possibly move these styles into admin theme.
 */
-.views-basic--params {
-  display: none;
+
+.views-basic--group-user-selection .grouped-items {
+  align-items: flex-start;
+  display: flex;
+  gap: 5rem;
 }
 
-.views-basic--group-user-selection .grouped-items,
 .views-basic--user-selection {
-  align-items: center;
+  align-items: flex-start;
   display: flex;
   gap: 1rem;
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
@@ -2,6 +2,10 @@
 * @todo Possibly move these styles into admin theme.
 */
 
+.views-basic--params {
+  display: none;
+}
+
 .views-basic--group-user-selection .grouped-items {
   align-items: flex-start;
   display: flex;
@@ -12,4 +16,8 @@
   align-items: flex-start;
   display: flex;
   gap: 1rem;
+}
+
+.views-basic--view-mode {
+  display: block;
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldFormatter/ViewsBasicPreviewFormatter.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldFormatter/ViewsBasicPreviewFormatter.php
@@ -103,6 +103,7 @@ class ViewsBasicPreviewFormatter extends FormatterBase implements ContainerFacto
         'types' => [],
         'view_mode' => '',
         'tags' => [],
+        'display' => [],
         'limit' => '',
         'sort_by' => '',
         'pager' => '',
@@ -127,11 +128,14 @@ class ViewsBasicPreviewFormatter extends FormatterBase implements ContainerFacto
         }
       }
 
+      // Gets the display.
+      $paramsForRender['display'] = $paramsDecoded['display'];
+
       // Gets the limit.
       $paramsForRender['limit'] = $paramsDecoded['limit'];
 
-      // Gets the pager.
-      $paramsForRender['pager'] = $paramsDecoded['pager'];
+      // Gets the number of results for the view.
+      $paramsForRender['count'] = $this->viewsBasicManager->getView('count', $item->params);
 
       $elements[$delta] = [
         '#theme' => 'views_basic_formatter_preview',

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -99,8 +99,14 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
     $entity_list = $this->viewsBasicManager->entityTypeList();
     $content_type = ($items[$delta]->params) ? json_decode($items[$delta]->params, TRUE)['filters']['types'][0] : array_key_first($entity_list);
 
+    // Gets the value of the selected entity for Ajax callbacks.
+    // Via: https://www.drupal.org/project/drupal/issues/2758631
+    $entityValue = $formState->getValue(
+      ['group_user_selection', 'entity_and_view_mode', 'entity_types']
+    );
+
     $element['group_params'] = [
-      '#type' => 'fieldgroup',
+      '#type' => 'container',
       '#attributes' => [
         'class' => [
           'views-basic--params',
@@ -109,7 +115,7 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
     ];
 
     $form['group_user_selection'] = [
-      '#type' => 'fieldgroup',
+      '#type' => 'container',
       '#attributes' => [
         'class' => [
           'views-basic--group-user-selection',
@@ -126,10 +132,28 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       ],
     ];
 
+    $form['group_user_selection']['filter_and_sort'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => [
+          'grouped-items',
+        ],
+      ],
+    ];
+
+    $form['group_user_selection']['options'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => [
+          'grouped-items',
+        ],
+      ],
+    ];
+
     $form['group_user_selection']['entity_and_view_mode']['entity_types'] = [
-      '#type' => 'select',
+      '#type' => 'radios',
       '#options' => $this->viewsBasicManager->entityTypeList(),
-      '#title' => $this->t('Display'),
+      '#title' => $this->t('I Want To Show'),
       '#tree' => TRUE,
       '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('types', $items[$delta]->params) : NULL,
       '#wrapper_attributes' => [
@@ -139,20 +163,25 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
         ],
       ],
       '#ajax' => [
-        'callback' => [$this, 'updateViewModes'],
+        'callback' => [$this, 'updateOtherSettings'],
         'disable-refocus' => FALSE,
         'event' => 'change',
         'progress' => [
           'type' => 'throbber',
-          'message' => $this->t('Updating view modes...'),
+          'message' => $this->t('Updating other settings...'),
         ],
       ],
     ];
 
+    // Gets the view mode options based on Ajax callbacks or initial load.
+    $viewModeOptions = ($entityValue)
+      ? $this->viewsBasicManager->viewModeList($entityValue)
+      : $this->viewsBasicManager->viewModeList($content_type);
+
     $form['group_user_selection']['entity_and_view_mode']['view_mode'] = [
-      '#type' => 'select',
-      '#options' => $this->viewsBasicManager->viewModeList($content_type),
-      '#title' => $this->t('as'),
+      '#type' => 'radios',
+      '#options' => $viewModeOptions,
+      '#title' => $this->t('As'),
       '#tree' => TRUE,
       '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('view_mode', $items[$delta]->params) : NULL,
       '#wrapper_attributes' => [
@@ -168,7 +197,7 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
 
     // @todo add validation for only one term.
     // More info: https://www.drupal.org/project/drupal/issues/2951134
-    $form['group_user_selection']['tags'] = [
+    $form['group_user_selection']['filter_and_sort']['tags'] = [
       '#title' => $this->t('Filtered by tag'),
       '#description' => $this->t('At this time, only one term is supported. If multiple terms are added, only the last one will be used.'),
       '#type' => 'entity_autocomplete',
@@ -179,9 +208,14 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       ],
     ];
 
-    $form['group_user_selection']['sort_by'] = [
+    // Gets the view mode options based on Ajax callbacks or initial load.
+    $sortOptions = ($entityValue)
+      ? $this->viewsBasicManager->sortByList($entityValue)
+      : $this->viewsBasicManager->sortByList($content_type);
+
+    $form['group_user_selection']['filter_and_sort']['sort_by'] = [
       '#type' => 'select',
-      '#options' => $this->viewsBasicManager->sortByList($content_type),
+      '#options' => $sortOptions,
       '#title' => $this->t('Sorting by'),
       '#tree' => TRUE,
       '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('sort_by', $items[$delta]->params) : NULL,
@@ -190,19 +224,62 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       '#suffix' => '</div>',
     ];
 
-    $form['group_user_selection']['limit'] = [
-      '#title' => $this->t('Items to display'),
-      '#description' => $this->t('Enter 0 to show all items.'),
-      '#type' => 'number',
-      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('limit', $items[$delta]->params) : 0,
-      '#min' => 0,
-      '#required' => TRUE,
+    $form['group_user_selection']['options']['display'] = [
+      '#type' => 'select',
+      '#title' => $this
+        ->t('Number of Items to Display'),
+      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('display', $items[$delta]->params) : 'all',
+      '#options' => [
+        'all' => $this->t('Display all items'),
+        'limit' => $this->t('Limit to'),
+        'pager' => $this->t('Pagination after'),
+      ],
+      '#ajax' => [
+        'callback' => [$this, 'updateLimitField'],
+        'disable-refocus' => FALSE,
+        'event' => 'change',
+        'progress' => [
+          'type' => 'throbber',
+          'message' => $this->t('Updating limit field...'),
+        ],
+      ],
     ];
 
-    $form['group_user_selection']['pager'] = [
-      '#title' => $this->t('Enable Pager'),
-      '#type' => 'checkbox',
-      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('pager', $items[$delta]->params) : 0,
+    // This section calculates the title for the limit field based on display.
+    $numItemsValue = $formState->getValue(
+      ['group_user_selection', 'options', 'display']
+    );
+
+    if ($numItemsValue) {
+      switch ($numItemsValue) {
+        case 'limit':
+          $limitTitle = $this->t('Items');
+          break;
+
+        case 'pager':
+          $limitTitle = $this->t('Items per Page');
+          break;
+      }
+    }
+    else {
+      $limitTitle = $this->t('Items');
+    }
+
+    $form['group_user_selection']['options']['limit'] = [
+      '#title' => $limitTitle,
+      '#type' => 'number',
+      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('limit', $items[$delta]->params) : 0,
+      '#min' => 1,
+      '#required' => TRUE,
+      '#states' => [
+        'invisible' => [
+          ':input[name="group_user_selection[options][display]"]' => [
+            'value' => 'all',
+          ],
+        ],
+      ],
+      '#prefix' => '<div id="edit-limit">',
+      '#suffix' => '</div>',
     ];
 
     $element['group_params']['params'] = [
@@ -213,6 +290,13 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       '#attributes' => [
         'class'     => [
           'views-basic--params',
+        ],
+      ],
+      '#states' => [
+        'visible' => [
+          '*' => [
+            'value' => '',
+          ],
         ],
       ],
     ];
@@ -226,8 +310,12 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
    * Get data from user selection and save into params field.
    */
   public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
-    $tags = ($form_state->getValue(['group_user_selection', 'tags']))
-      ? $form_state->getValue(['group_user_selection', 'tags'])
+    $tags = ($form_state->getValue(
+        ['group_user_selection', 'filter_and_sort', 'tags']
+      ))
+      ? $form_state->getValue(
+          ['group_user_selection', 'filter_and_sort', 'tags']
+        )
       : NULL;
     foreach ($values as &$value) {
       $paramData = [
@@ -240,9 +328,15 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
             $tags,
           ],
         ],
-        "limit" => (int) $form_state->getValue(['group_user_selection', 'limit']),
-        "sort_by" => $form_state->getValue(['group_user_selection', 'sort_by']),
-        "pager" => $form_state->getValue(['group_user_selection', 'pager']),
+        "sort_by" => $form_state->getValue(
+          ['group_user_selection', 'filter_and_sort', 'sort_by']
+        ),
+        "display" => $form_state->getValue(
+          ['group_user_selection', 'options', 'display']
+        ),
+        "limit" => (int) $form_state->getValue(
+          ['group_user_selection', 'options', 'limit']
+        ),
       ];
       $value['params'] = json_encode($paramData);
     }
@@ -252,18 +346,25 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
   /**
    * Ajax callback to return only view modes for the specified content type.
    */
-  public function updateViewModes(array &$form, FormStateInterface $form_state) {
-    if ($selectedValue = $form_state->getValue(
-      ['group_user_selection', 'entity_and_view_mode', 'entity_types']
-      )) {
-      $form['group_user_selection']['entity_and_view_mode']['view_mode']['#options'] = $this->viewsBasicManager->viewModeList($selectedValue);
-      $form['group_user_selection']['sort_by']['#options'] = $this->viewsBasicManager->sortByList($selectedValue);
-    }
-
+  public function updateOtherSettings(array &$form, FormStateInterface $form_state) {
     $response = new AjaxResponse();
     $response->addCommand(new ReplaceCommand('#edit-view-mode', $form['group_user_selection']['entity_and_view_mode']['view_mode']));
-    $response->addCommand(new ReplaceCommand('#edit-sort-by', $form['group_user_selection']['sort_by']));
+    $response->addCommand(new ReplaceCommand('#edit-sort-by', $form['group_user_selection']['filter_and_sort']['sort_by']));
     return $response;
+  }
+
+  /**
+   * Ajax callback to update the limit field.
+   */
+  public function updateLimitField(array &$form, FormStateInterface $form_state) {
+    $displayValue = $form_state->getValue(
+      ['group_user_selection', 'options', 'display']
+    );
+    if ($displayValue != 'all') {
+      $response = new AjaxResponse();
+      $response->addCommand(new ReplaceCommand('#edit-limit', $form['group_user_selection']['options']['limit']));
+      return $response;
+    }
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -353,11 +353,11 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
     $displayValue = $form_state->getValue(
       ['group_user_selection', 'options', 'display']
     );
+    $response = new AjaxResponse();
     if ($displayValue != 'all') {
-      $response = new AjaxResponse();
       $response->addCommand(new ReplaceCommand('#edit-limit', $form['group_user_selection']['options']['limit']));
-      return $response;
     }
+    return $response;
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -178,12 +178,17 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       ? $this->viewsBasicManager->viewModeList($entityValue)
       : $this->viewsBasicManager->viewModeList($content_type);
 
+    /* @todo switch view_mode to radios. The problem with radios right now is
+     * setting the default value after an Ajax call. Tried a lot of different
+     * methods and eventually settled on keeping this as a select list for now
+     * as the default item for a new select list is the first item.
+     */
     $form['group_user_selection']['entity_and_view_mode']['view_mode'] = [
-      '#type' => 'radios',
+      '#type' => 'select',
       '#options' => $viewModeOptions,
       '#title' => $this->t('As'),
       '#tree' => TRUE,
-      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('view_mode', $items[$delta]->params) : NULL,
+      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('view_mode', $items[$delta]->params) : key($viewModeOptions),
       '#wrapper_attributes' => [
         'class' => [
           'views-basic--user-selection',
@@ -250,25 +255,18 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       ['group_user_selection', 'options', 'display']
     );
 
-    if ($numItemsValue) {
-      switch ($numItemsValue) {
-        case 'limit':
-          $limitTitle = $this->t('Items');
-          break;
+    $limitTitle = $this->t('Items');
 
-        case 'pager':
-          $limitTitle = $this->t('Items per Page');
-          break;
+    if ($numItemsValue) {
+      if ($numItemsValue == 'pager') {
+        $limitTitle = $this->t('Items per Page');
       }
-    }
-    else {
-      $limitTitle = $this->t('Items');
     }
 
     $form['group_user_selection']['options']['limit'] = [
       '#title' => $limitTitle,
       '#type' => 'number',
-      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('limit', $items[$delta]->params) : 0,
+      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('limit', $items[$delta]->params) : 10,
       '#min' => 1,
       '#required' => TRUE,
       '#states' => [
@@ -290,13 +288,6 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       '#attributes' => [
         'class'     => [
           'views-basic--params',
-        ],
-      ],
-      '#states' => [
-        'visible' => [
-          '*' => [
-            'value' => '',
-          ],
         ],
       ],
     ];

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -105,6 +105,21 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
     );
   }
 
+  /**
+   * Retrieves an overridden Views Basic Scaffold view.
+   *
+   * Views Basic Scaffold view is overridden with the data from the paragraph
+   * parameters.
+   *
+   * @param string $type
+   *   Can be either 'rendered' or 'count'.
+   * @param string $params
+   *   JSON of the parameter settings from the paragraph.
+   *
+   * @return array|int
+   *   An array of a rendered view or a count of the number of results based
+   *   on the parameters specified.
+   */
   public function getView($type, $params) {
     // Prevents views recursion.
     static $running;
@@ -129,8 +144,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
      * know what sorting, filters, view modes, or number if items in the pager
      * to use.
      *
-     * The order of these arguments is required as follows (and is
-     * automatically taken care of from paragraph params data):
+     * The order of these arguments is required as follows:
      * 1) Content type machine name (can combine content types with + or ,)
      * 2) Taxonomy term ID (can combine with + or ,)
      * 3) Sort field and direction (in format field_name:ASC)
@@ -147,7 +161,9 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
       $filterTags = 'all';
     }
 
-    if ($type == 'count' && $paramsDecoded['display'] != 'limit') {
+    if (
+      ($type == 'count' && $paramsDecoded['display'] != 'limit') ||
+      ($type == 'rendered' && $paramsDecoded['display'] == 'all')) {
       $itemsLimit = 0;
     }
     else {
@@ -163,6 +179,10 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
         'items' => $itemsLimit,
       ]
     );
+
+    /*
+     * End setting dynamic arguments.
+     */
 
     $view->execute();
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -7,6 +7,7 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityDisplayRepository;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\views\Views;
 
 /**
  * Service for managing the Views Basic plugins.
@@ -102,6 +103,88 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
       $container->get('entity_type.manager'),
       $container->get('entity_display.repository')
     );
+  }
+
+  public function getView($type, $params) {
+    // Prevents views recursion.
+    static $running;
+    if ($running) {
+      return NULL;
+    }
+    $running = TRUE;
+
+    // Set up the view and initial decoded parameters.
+    $view = Views::getView('views_basic_scaffold');
+    $view->setDisplay('block_1');
+    $paramsDecoded = json_decode($params, TRUE);
+
+    /*
+     * Sets the arguments that will get passed to contextual filters as well
+     * as to the custom sort plugin (ViewsBasicSort), custom style
+     * plugin (ViewsBasicDynamicStyle), and custom pager
+     * (ViewsBasicFullPager).
+     *
+     * This is coded this way to work with Ajax pagers specifically as
+     * without arguments, the subsequent Ajax calls to load more data do not
+     * know what sorting, filters, view modes, or number if items in the pager
+     * to use.
+     *
+     * The order of these arguments is required as follows (and is
+     * automatically taken care of from paragraph params data):
+     * 1) Content type machine name (can combine content types with + or ,)
+     * 2) Taxonomy term ID (can combine with + or ,)
+     * 3) Sort field and direction (in format field_name:ASC)
+     * 4) View mode machine name (i.e. teaser)
+     * 5) Items per page (set to 0 for all items)
+     */
+
+    $filterType = implode('+', $paramsDecoded['filters']['types']);
+
+    if (isset($paramsDecoded['filters']['tags'])) {
+      $filterTags = implode('+', $paramsDecoded['filters']['tags']);
+    }
+    else {
+      $filterTags = 'all';
+    }
+
+    if ($type == 'count' && $paramsDecoded['display'] != 'all') {
+      $itemsLimit = 0;
+    }
+    else {
+      $itemsLimit = $paramsDecoded['limit'];
+    }
+
+    $view->setArguments(
+      [
+        'type' => $filterType,
+        'tags' => $filterTags,
+        'sort' => $paramsDecoded['sort_by'],
+        'view' => $paramsDecoded['view_mode'],
+        'items' => $itemsLimit,
+      ]
+    );
+
+    $view->execute();
+
+    // Unset the pager. Needs to be done after view->execute();
+    if ($paramsDecoded['display'] != "pager") {
+      unset($view->pager);
+    }
+
+    switch ($type) {
+      case "rendered":
+        $view = $view->preview();
+        break;
+
+      case "count":
+        $view = count($view->result);
+        break;
+    }
+
+    // End current view run.
+    $running = FALSE;
+
+    return $view;
   }
 
   /**
@@ -220,7 +303,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
         break;
 
       case 'limit':
-        $defaultParam = (empty($paramsDecoded['limit'])) ? 0 : (int) $paramsDecoded['limit'];
+        $defaultParam = (empty($paramsDecoded['limit'])) ? 10 : (int) $paramsDecoded['limit'];
         break;
 
       default:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -147,7 +147,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
       $filterTags = 'all';
     }
 
-    if ($type == 'count' && $paramsDecoded['display'] != 'all') {
+    if ($type == 'count' && $paramsDecoded['display'] != 'limit') {
       $itemsLimit = 0;
     }
     else {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/templates/views-basic-formatter-preview.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/templates/views-basic-formatter-preview.html.twig
@@ -1,27 +1,40 @@
 <div>
-  Display {{ params.types|join(', ') }} as {{ params.view_mode }}
+  I want to show {{ params.types|join(', ') }} as {{ params.view_mode }}
 </div>
 {% if params.tags %}
   <div>
     Filtered by tag "{{ params.tags|join(', ') }}"
   </div>
 {% endif %}
+{% if params.sort_by %}
+  <div>
+    Sorted by {{ params.sort_by }}
+  </div>
+{% endif %}
 <div>
-  {% if params.limit and not params.pager %}
+  {% if params.display == 'all' %}
+    Showing all items
+  {% endif %}
+
+  {% if params.display == 'limit' %}
     Limited to
     {% trans %}
       {{ params.limit }} item
       {% plural params.limit %}
       {{ params.limit }} items
     {% endtrans %}
-  {% elseif params.limit and params.pager %}
-    Paged, showing {{ params.limit }} per page
-  {% else %}
-    Showing all items
+  {% endif %}
+
+  {% if params.display == 'pager' %}
+    Showing all items, paged to
+    {% trans %}
+      {{ params.limit }} item per page
+      {% plural params.limit %}
+      {{ params.limit }} items per page
+    {% endtrans %}
   {% endif %}
 </div>
-{% if params.sort_by %}
-  <div>
-    Sorted by {{ params.sort_by }}
-  </div>
-{% endif %}
+
+<div>
+Total results with these settings: {{ params.count }}
+</div>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/templates/views-basic-formatter-preview.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/templates/views-basic-formatter-preview.html.twig
@@ -1,40 +1,43 @@
-<div>
-  I want to show {{ params.types|join(', ') }} as {{ params.view_mode }}
-</div>
-{% if params.tags %}
+{{ attach_library('ys_views_basic/ys_views_basic') }}
+<div class="views-basic--parameter-preview">
   <div>
-    Filtered by tag "{{ params.tags|join(', ') }}"
+    I want to show {{ params.types|join(', ') }} as {{ params.view_mode }}
   </div>
-{% endif %}
-{% if params.sort_by %}
+  {% if params.tags %}
+    <div>
+      Filtered by tag "{{ params.tags|join(', ') }}"
+    </div>
+  {% endif %}
+  {% if params.sort_by %}
+    <div>
+      Sorted by {{ params.sort_by }}
+    </div>
+  {% endif %}
   <div>
-    Sorted by {{ params.sort_by }}
+    {% if params.display == 'all' %}
+      Showing all items
+    {% endif %}
+
+    {% if params.display == 'limit' %}
+      Limited to
+      {% trans %}
+        {{ params.limit }} item
+        {% plural params.limit %}
+        {{ params.limit }} items
+      {% endtrans %}
+    {% endif %}
+
+    {% if params.display == 'pager' %}
+      Showing all items, paged to
+      {% trans %}
+        {{ params.limit }} item per page
+        {% plural params.limit %}
+        {{ params.limit }} items per page
+      {% endtrans %}
+    {% endif %}
   </div>
-{% endif %}
-<div>
-  {% if params.display == 'all' %}
-    Showing all items
-  {% endif %}
 
-  {% if params.display == 'limit' %}
-    Limited to
-    {% trans %}
-      {{ params.limit }} item
-      {% plural params.limit %}
-      {{ params.limit }} items
-    {% endtrans %}
-  {% endif %}
-
-  {% if params.display == 'pager' %}
-    Showing all items, paged to
-    {% trans %}
-      {{ params.limit }} item per page
-      {% plural params.limit %}
-      {{ params.limit }} items per page
-    {% endtrans %}
-  {% endif %}
-</div>
-
-<div>
-Total results with these settings: {{ params.count }}
+  <div>
+    Total results with these settings: {{ params.count }}
+  </div>
 </div>


### PR DESCRIPTION
## [YALB-1006: Create views builder widget](https://yaleits.atlassian.net/browse/YALB-1006)

### Description of work
- Adds views heading field
- Reworks layout of widget to match mockup (see attached)
- Refactors some code from the default formatter into the manager for reusability
- Adds count of results to the preview so content authors know how many results before saving

### Additional context notes
- This ticket will not cover theming, that will be a separate ticket.
- The mockup shows an "Options" section that handles how many items and paging. As per a Teams conversation with Yale, it was agreed that since Views core handles paging in a certain way, we should mimic that same behavior. The second screenshot shows this reworked options area where the "Number of items to display" is a drop down, and when "Display all items" is selected, the limiter field will be hidden. Otherwise, the limit field will be shown and the label (and eventually help text) will change.
- Another [forthcoming PR in Atomic](https://github.com/yalesites-org/atomic/pull/98) in Atomic will add the appropriate `dom_id` class to allow Ajax paging to work.

### Functional testing steps:
- [x] Create 4-5 nodes of type news event
- [x] For each, change the "Publish Date" in the sidebar under "Publish Information" accordion to a date that is different for each
- [x] Make sure the title field includes the date in some way (this is because the publish date is not yet used in the templates)
- [x] Publish and save each news node
- [x] Create a new page and add a paragraph of type View
- [x] Verify that the View paragraph layout matches the rough mockup (icons and styling of headings to come later)
- [x] Put some text into the "View Heading"
- [x] Set "I want to show" to "Posts", choose either "news card grid" or "news list"
- [x] Set the "Sorting by" to either option
- [x] Save the paragraph
- [x] Verify that the paragraph preview shows the correct information for the settings specified and that the "Total results with these settings" has a value. If that value is 0, change some of the settings and resave the paragraph and see if the count of results show up.
- [x] Publish the page, and save the page.
- [x] Verify that the results are correct as per the settings
- [x] Edit the page and change some settings - specifically test out the "Number of items to display" select list and accompanying limit numeric value box as well as sort order.
- [x] Verify that the "Number of items to display" box selection changes the visibility and the title of the "Items" limit box.
- [x] Save the paragraph
- [x] Verify the preview is updated and, after save of the node, verify that the results change depending on the settings
- [x] You may repeat with events and or pages

Mockup:
![Views-Basic-Interface-Mockup](https://user-images.githubusercontent.com/107938318/222191539-06e72445-6f78-462a-b7ad-5524b75c308e.png)

Agreed upon changes for the "Options" section:
![Screenshot 2023-02-27 at 5 01 04 PM](https://user-images.githubusercontent.com/107938318/222191885-183246c0-36f2-432c-918c-d41ae037b57b.png)
