### PR TITLE
YALB-1044: Feedback: Error installing Linkit Patch

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -34,7 +34,7 @@
     "drupal/inline_entity_form": "^1.0@RC",
     "drupal/layout_paragraphs": "^2.0",
     "drupal/libraries": "^4.0",
-    "drupal/linkit": "^6.0@beta",
+    "drupal/linkit": "6.0.x-dev@dev",
     "drupal/mailchimp_transactional": "^1.0",
     "drupal/mailsystem": "^4.3",
     "drupal/markup": "^1.0@beta",
@@ -85,7 +85,7 @@
         "hide remove button": "https://www.drupal.org/files/issues/2020-05-13/hide_field_required_paragraphs_remove_button_1.patch"
       },
       "drupal/linkit": {
-        "add linkit widget to link fields": "https://www.drupal.org/files/issues/2022-07-22/2712951-293.patch"
+        "add linkit widget to link fields": "https://www.drupal.org/files/issues/2023-03-05/2712951_316.6.x.diff"
       },
       "drupal/core": {
         "plural results summary https://www.drupal.org/project/drupal/issues/2888320": "https://www.drupal.org/files/issues/2021-12-15/2888320-78.patch"

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -84,9 +84,6 @@
       "drupal/paragraphs": {
         "hide remove button": "https://www.drupal.org/files/issues/2020-05-13/hide_field_required_paragraphs_remove_button_1.patch"
       },
-      "drupal/linkit": {
-        "add linkit widget to link fields": "https://www.drupal.org/files/issues/2023-03-05/2712951_316.6.x.diff"
-      },
       "drupal/core": {
         "plural results summary https://www.drupal.org/project/drupal/issues/2888320": "https://www.drupal.org/files/issues/2021-12-15/2888320-78.patch"
       },


### PR DESCRIPTION
## [YALB-1044: Feedback: Error installing Linkit Patch](https://yaleits.atlassian.net/browse/YALB-1044)

### Description of work
- Fixes Link patching issue
- At version 6.0 dev branch
- Removes patch as this is now in the dev branch

### Functional testing steps:
- [ ] Clone repo locally, run `npm run setup`
- [ ] Verify there are no longer errors related to Linkit patch
- [ ] After site is installed, create a new page and add a "Text with Image" paragraph to the page
- [ ] Verify that the link field is auto-completing with Linkit
