### PR TITLE
fix(yalb-alignment): increase wrapped image width

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory.
+- 'this is a test'

--- a/README.md
+++ b/README.md
@@ -40,4 +40,3 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory.
-- 'this is a test'

--- a/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.image_float.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.image_float.yml
@@ -24,7 +24,7 @@ image_style_mappings:
   -
     image_mapping_type: sizes
     image_mapping:
-      sizes: '(min-width: 992px) 448px, (min-width: 838px) 896px, 100vw'
+      sizes: '(min-width: 992px) 640px, (min-width: 838px) 896px, 100vw'
       sizes_image_styles:
         - max_width_1120
         - max_width_1280

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -42,7 +42,6 @@ text_with_image:
     values:
       equal: 'Equal Focus'
       image: 'Image Focus'
-      content: 'Content Focus'
     default: equal
 quick_links:
   field_style_variation:


### PR DESCRIPTION
### Tickets
- [YALB-1055 - Alignment: Text to Left Edge and Text to Right Edge](https://yaleits.atlassian.net/browse/YALB-1055)
  - Components now have a left alignment with a limited inner width so text doesn't run too long while aligning along the left-hand rail. 
- [YALB-1056 - Alignment: Menus ](https://yaleits.atlassian.net/browse/YALB-1056)
  - the primary menu top item text should now properly align with the site name, and do so whether left or right aligned
- [YALB-1065 - Alignment: Wire changes to Drupal](https://yaleits.atlassian.net/browse/YALB-1065)
- [YALB-1023 - Feedback: Consistant grid across components](https://yaleits.atlassian.net/browse/YALB-1023)
  - We reviewed the wrapped image and text spotlight components during a working group session. From this meeting we agreed to remove the text spotlight option for `focus-content` so as not to compete, so-to-say, with the wrapped image component.
  
### Description of work
Bundles all alignment work into this branch, spread over three repositories (including this one): 
- https://github.com/yalesites-org/component-library-twig/pull/213
- https://github.com/yalesites-org/atomic/pull/102

#### Components that needed updates:
- Custom cards - change to site-width
- Quicklinks subtle version - left align and remain at `content` width when used on `pages`, on `news/events` it will render `content` width and `center` aligned. 
- Quicklinks promotional version - full width `site` width inner
- Mega Menu - expanded menu outside of boundaries
- Images/quotes/media - `content` width and `left` aligned
- Quotes - now have limited left-aligned width, with agreed upon spacing
- Wrapped Image - content width and left aligned
- Text Spotlight (text with image) - `site` width and focus `equal` and `image` only

### Functional testing steps:
- [ ] Review example components on a News article here: https://pr-235-yalesites-platform.pantheonsite.io/news/2023-01-12-longform-article
- [ ] On the news article, verify that only the Quicklinks `full` variation renders wider than `content` width.
- [ ] Review example components on a Page here: https://pr-235-yalesites-platform.pantheonsite.io/standard-page-one
- [ ] Verify the only components which render wider than `site` width are `banner`, `grand hero`, `quicklinks promotional/full` and `callout` components. Note that all component `inner` sections allow the text within each component to be left aligned. Only the background elements extend beyond.
- [ ] Make sure each page components aligns with the alignment documentation here: https://yaleedu.sharepoint.com/:w:/r/sites/YaleSitesUpgradeProgram/_layouts/15/doc2.aspx?action=editNew&sourcedoc=%7B182c4a7d-f583-4c01-84ea-79411d3f7ed3%7D&wdOrigin=TEAMS-ELECTRON.teamsSdk.openFilePreview&wdExp=TEAMS-CONTROL&wdhostclicktime=1679328572492&web=1&cid=08b56ff2-c80d-4abd-8b4f-12b31a933908

---

### Help wanted
@nJim 
- For the `text with image` component, I removed the `content: 'Content Focus'` option, but it is still appearing in Drupal. See here: https://github.com/yalesites-org/yalesites-project/pull/235/files#diff-a6693039cfb1016cdd359a414ad0a347655669621d540b94007514d61d8d6e26L45
- Is there anything special we need to do to remove the option?



https://user-images.githubusercontent.com/366413/228938381-0cc5eac9-3453-4fef-a28a-4d985a4700dc.mp4

