### PR TITLE
YALB-1083: Content Model: Restrict blocks by role

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -36,6 +36,8 @@
     "drupal/inline_entity_form": "^1.0@RC",
     "drupal/layout_builder_browser": "^1.4",
     "drupal/layout_builder_iframe_modal": "^1.3",
+    "drupal/layout_builder_restrictions": "^2.17",
+    "drupal/layout_builder_restrictions_by_role": "^1.0@alpha",
     "drupal/libraries": "^4.0",
     "drupal/linkit": "6.0.x-dev@dev",
     "drupal/mailchimp_transactional": "^1.0",
@@ -61,8 +63,8 @@
     "drupal/redirect": "^1.7",
     "drupal/search_api": "^1.25",
     "drupal/search_api_exclude": "^2.0",
-    "drupal/simple_sitemap": "^4.1",
     "drupal/section_library": "^1.1",
+    "drupal/simple_sitemap": "^4.1",
     "drupal/smart_date": "^3.5",
     "drupal/twig_tweak": "^3.1",
     "drupal/upgrade_status": "^3.18",
@@ -98,6 +100,9 @@
       },
       "drupal/entity_redirect": {
         "fix layout route https://www.drupal.org/project/entity_redirect/issues/3352265": "https://git.drupalcode.org/project/entity_redirect/-/merge_requests/6.patch"
+      },
+      "drupal/layout_builder_restrictions_by_role": {
+        "Fix user 1 https://www.drupal.org/project/layout_builder_restrictions_by_role/issues/3298638": "https://www.drupal.org/files/issues/2022-07-28/3298638--layout_builder_restrictions_by_role--user-1-exception-8.patch"
       }
     }
   }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - node.type.page
   module:
     - layout_builder
+    - layout_builder_restrictions
     - layout_discovery
     - user
     - ys_core
@@ -38,6 +39,31 @@ third_party_settings:
             weight: 0
             additional: {  }
         third_party_settings: {  }
+  layout_builder_restrictions:
+    allowed_block_categories: {  }
+    entity_view_mode_restriction:
+      allowed_layouts: {  }
+      denylisted_blocks: {  }
+      allowlisted_blocks: {  }
+      restricted_categories: {  }
+    entity_view_mode_restriction_per_role:
+      layout_restriction: all
+      allowed_layouts:
+        layout_onecol:
+          platform_admin: '0'
+          site_admin: '0'
+        layout_twocol_section:
+          platform_admin: '0'
+          site_admin: '0'
+        layout_threecol_section:
+          platform_admin: '0'
+          site_admin: '0'
+        layout_fourcol_section:
+          platform_admin: '0'
+          site_admin: '0'
+      __blocks:
+        platform_admin: {  }
+      override_defaults: true
 id: node.page.default
 targetEntityType: node
 bundle: page

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -46,6 +46,8 @@ module:
   improve_line_breaks_filter: 0
   layout_builder: 0
   layout_builder_browser: 0
+  layout_builder_restrictions: 0
+  layout_builder_restrictions_by_role: 0
   layout_discovery: 0
   libraries: 0
   link: 0


### PR DESCRIPTION
## [YALB-1083: Content Model: Restrict blocks by role](https://yaleits.atlassian.net/browse/YALB-1083)

### Description of work
- Adds layout builder restrictions and layout builder restrictions per role modules
- Enables modules
- Patches layout builder restrictions by role to allow user 1 to add any block
- Note: No restrictions are put in place by this PR as there were none defined in the data model. Therefore, functional testing steps will review how to add a restriction by role and test it
- Multidev here: https://pr-242-yalesites-platform.pantheonsite.io/

### Functional testing steps:
- [x] Visit the Manage display tab for the page content type here: `/admin/structure/types/manage/page/display`
- [x] Expand "Layout options"
- [x] Verify that "Override default "Per role" settings is checked
- [x] Expand "Blocks available for placement per role (all layouts & regions)"
- [x] For the "Site administrator", click "Manage allowed blocks"
- [x] Under "Inline blocks" click on "Restrict specific Inline blocks blocks"
- [x] Choose the "Accordion" to restrict
- [x] Scroll to the bottom and click "Save"
- [x] Save the "Manage display" page
- [x] Add a new page at `/node/add/page'
- [x] Add a title, and publish the page
- [x] After saving the site should redirect to the layout builder page. Click "Add block" below the breadcrumbs and title block
- [x] Verify that you can see the "Accordion" block in the sidebar
- [x] Add an accordion block with some dummy data
- [x] Save the layout at the top right corner of the screen
- [x] Create a user with the "Site administrator" role at `/admin/people/create`
- [x] Login with this user on an incognito browser window
- [x] Visit the page that was created with the admin user as the new "site administrator" role
- [ ] Verify that you can see the accordion block
- [x] Click "Layout" in the top toolbar
- [x] Click "Add block" below the accordion
- [x] Verify that "Accordion" is not in the list of allowed blocks to add
- [x] Close the sidebar
- [x] Verify that you can edit the existing accordion block by hovering over the existing accordion and clicking the pencil icon. You may need to close the sidebar using the sidebar icon in the top right corner