### PR TITLE
YALB-1043: Nav: Allow authors to use manage menu UI

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
@@ -26,3 +26,20 @@ ys_core.admin_footer_settings:
   route_name: ys_core.admin_footer_settings
   title: 'Footer Settings'
   weight: 20
+# main menu edit form.
+ys_core.menu_main_edit:
+  description: 'Manage main navigation'
+  parent: system.admin_content
+  route_name: entity.menu.edit_form
+  title: Manage Main Menu
+  route_parameters:
+    menu: 'main'
+  weight: 10
+ys_core.menu_utility_edit:
+  description: 'Manage utility navigation'
+  parent: system.admin_content
+  route_name: entity.menu.edit_form
+  title: Manage Utility Menu
+  route_parameters:
+    menu: 'utility-navigation'
+  weight: 15


### PR DESCRIPTION
## [YALB-1043: Nav: Allow authors to use manage menu UI](https://yaleits.atlassian.net/browse/YALB-1043)

### Description of work
- Adds menu items under "Content" menu to manage the main and utility navigation menus

### Functional testing steps:
- [ ] Login as a site administrator
- [ ] Verify that there are 2 new menu items under the "Content" menu for managing the main and utility navigation menus
- [ ] Verify that as a site administrator, you can't access `admin/structure/menu/manage/admin`
