### PR TITLE
(hotfix) YALB-1140: File upload field is missing

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -103,6 +103,9 @@
       },
       "drupal/layout_builder_restrictions_by_role": {
         "Fix user 1 https://www.drupal.org/project/layout_builder_restrictions_by_role/issues/3298638": "https://www.drupal.org/files/issues/2022-07-28/3298638--layout_builder_restrictions_by_role--user-1-exception-8.patch"
+      },
+      "drupal/gin_lb": {
+        "fix missing file field https://www.drupal.org/project/gin_lb/issues/3349745": "https://www.drupal.org/files/issues/2023-03-23/3349745-8-claro-preprocess-file-fields.patch"
       }
     }
   }

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.media.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.media.yml
@@ -1,6 +1,6 @@
 uuid: ae64141c-0d51-4f15-967c-e3d7bbedaef8
 langcode: en
-status: false
+status: true
 dependencies:
   module:
     - media


### PR DESCRIPTION
## [(hotfix) YALB-1140: File upload field is missing](https://yaleits.atlassian.net/browse/YALB-1140)
## [YALB-1170: AX: Allow access to media library UI](https://yaleits.atlassian.net/browse/YALB-1170)

### Description of work
- Patches the gin_lb module to fix an issue where the file upload field is missing. See https://www.drupal.org/project/gin_lb/issues/3349745 
- Also includes a configuration change to enable the media library views so that site admins can see this interface.
- These changes are made as a hotfix to the master branch so that we can release the changes without pushing levers and dials forward. All changes will be backported to develop once approved.

### Functional testing steps:
- [x] Log in as a site admin
- [x] Add an 'image' block to a page and verify that the user can upload a new image. This field was previously missing.
![Screen Shot 2023-04-25 at 4 36 39 PM](https://user-images.githubusercontent.com/9594124/234398566-4bf231d9-e813-4e3a-8efb-87ee46f100fa.png)
- [x] Verify that the 'Media' interface appears in the menu and that site admins can view all of the media in the library.
![Screen Shot 2023-04-25 at 5 06 12 PM](https://user-images.githubusercontent.com/9594124/234403939-9aa00b2f-7c22-45ec-a82b-8a874e242a0c.png)


