### PR TITLE
YALB-1113: Enable modal layout browser

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/layout_builder_browser.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/layout_builder_browser.settings.yml
@@ -2,5 +2,5 @@ _core:
   default_config_hash: fFtMJuqkP65BjEBqTnAa-5fVJMy3cUCpJRv0FwXuDcE
 enabled_section_storages:
   - overrides
-use_modal: false
+use_modal: true
 auto_added_reusable_block_content_bundles: {  }


### PR DESCRIPTION
## [YALB-1113: Enable modal layout browser](https://yaleits.atlassian.net/browse/YALB-1113)

### Description of work
- Updates a layout browser setting to use the modal version. This resolves a current issue with the block search form.

### Functional testing steps:
- [x] Create a new page and navigate to the layout interface
- [x] Click the 'Add Block' button to expand the layout builder browser
- [x] Type 'image' into the block search tool and verify that the list is filtered to the two blocks with 'image' in the name.
