### PR TITLE
YALB-261: Local Dev Setup Xdebug

### DIFF
--- a/.lando.local.example.yml
+++ b/.lando.local.example.yml
@@ -24,7 +24,7 @@ tooling:
       XDEBUG_MODE: "off"
   xdebug-off:
     # Set environment variable to off, re-enable page caching, remove the xdebug ini and kill the process, clear the cache, and display message to user
-    cmd: export XDEBUG_MODE=off && drush config-set system.performance cache.page.enabled 1 --yes && rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && pkill -o -USR2 php-fpm && drush cr && echo "Xdebug disabled; turn back on with `lando xdebug-on`"
+    cmd: export XDEBUG_MODE=off && drush config-set system.performance cache.page.enabled 1 --yes && rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && pkill -o -USR2 php-fpm && drush cr && echo "Xdebug disabled; turn back on with lando xdebug-on"
     description: Disable xdebug for nginx.
     service: appserver
     user: root
@@ -33,7 +33,7 @@ tooling:
   # The above query string tells PHP to start the debugging session.  From there you should be able to use the debuging environment of your choice.
   xdebug-on:
     # Set environment variable to debug, disable caching, remove any existing xdebug.ini so it can be remade, enable xdebug, restart php, clear cache, and display message to user
-    cmd: export XDEBUG_MODE=debug && drush config-set system.performance cache.page.enabled 0 --yes && rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && docker-php-ext-enable xdebug && pkill -o -USR2 php-fpm && drush cr && echo "Xdebug enabled; disable with `lando xdebug-off`"
+    cmd: export XDEBUG_MODE=debug && drush config-set system.performance cache.page.enabled 0 --yes && rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && docker-php-ext-enable xdebug && pkill -o -USR2 php-fpm && drush cr && echo "Xdebug enabled; disable with lando xdebug-off"
     description: Enable xdebug for nginx.
     service: appserver
     user: root

--- a/.lando.local.example.yml
+++ b/.lando.local.example.yml
@@ -24,7 +24,7 @@ tooling:
       XDEBUG_MODE: "off"
   xdebug-off:
     # Set environment variable to off, re-enable page caching, remove the xdebug ini and kill the process, clear the cache, and display message to user
-    cmd: export XDEBUG_MODE=off && drush config-set system.performance cache.page.enabled 1 --yes && rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && pkill -o -USR2 php-fpm && drush cr && echo "Xdebug disabled; turn back on with lando xdebug-on"
+    cmd: export XDEBUG_MODE=off && rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && pkill -o -USR2 php-fpm && drush cr && echo "Xdebug disabled; turn back on with lando xdebug-on"
     description: Disable xdebug for nginx.
     service: appserver
     user: root
@@ -33,7 +33,7 @@ tooling:
   # The above query string tells PHP to start the debugging session.  From there you should be able to use the debuging environment of your choice.
   xdebug-on:
     # Set environment variable to debug, disable caching, remove any existing xdebug.ini so it can be remade, enable xdebug, restart php, clear cache, and display message to user
-    cmd: export XDEBUG_MODE=debug && drush config-set system.performance cache.page.enabled 0 --yes && rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && docker-php-ext-enable xdebug && pkill -o -USR2 php-fpm && drush cr && echo "Xdebug enabled; disable with lando xdebug-off"
+    cmd: export XDEBUG_MODE=debug && rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && docker-php-ext-enable xdebug && pkill -o -USR2 php-fpm && drush cr && echo "Xdebug enabled; disable with lando xdebug-off"
     description: Enable xdebug for nginx.
     service: appserver
     user: root

--- a/.lando.local.example.yml
+++ b/.lando.local.example.yml
@@ -20,8 +20,27 @@ tooling:
     env:
       # Set base url based on above Lando project 'name'.
       DRUSH_OPTIONS_URI: "https://yalesites-platform.lndo.site/"
+      # Default xdebug to off
+      XDEBUG_MODE: "off"
+  xdebug-off:
+    # Set environment variable to off, re-enable page caching, remove the xdebug ini and kill the process, clear the cache, and display message to user
+    cmd: export XDEBUG_MODE=off && drush config-set system.performance cache.page.enabled 1 --yes && rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && pkill -o -USR2 php-fpm && drush cr && echo "Xdebug disabled; turn back on with `lando xdebug-on`"
+    description: Disable xdebug for nginx.
+    service: appserver
+    user: root
+  # To use xdebug, you'll need to add a query string to your website visits.  For instance, to start it after running this command, you'll visit:
+  # https://yalesites-platform.lndo.site/?XDEBUG_SESSION_START=1
+  # The above query string tells PHP to start the debugging session.  From there you should be able to use the debuging environment of your choice.
+  xdebug-on:
+    # Set environment variable to debug, disable caching, remove any existing xdebug.ini so it can be remade, enable xdebug, restart php, clear cache, and display message to user
+    cmd: export XDEBUG_MODE=debug && drush config-set system.performance cache.page.enabled 0 --yes && rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && docker-php-ext-enable xdebug && pkill -o -USR2 php-fpm && drush cr && echo "Xdebug enabled; disable with `lando xdebug-off`"
+    description: Enable xdebug for nginx.
+    service: appserver
+    user: root
 services:
   appserver:
     overrides:
       environment:
         COMPOSER_PROCESS_TIMEOUT: 1800
+    # This is needed to expose the reverse proxy to the xdebug port (9003)
+    xdebug: true

--- a/docs/xdebug.md
+++ b/docs/xdebug.md
@@ -101,6 +101,7 @@ dap.configurations.twig = {
 
 #### Installation
 
+- Open VSCode by opening a terminal and typing `code .` from the root of your YaleSites project
 - Install the above extension
 - Create a `.vscode/launch.json` file with the following:
 
@@ -121,6 +122,9 @@ dap.configurations.twig = {
 }
 ```
 
+#### Usage
+
+- Open VSCode by opening a terminal and typing `code .` from the root of your YaleSites project
 - Visit the file you wish to debug, set breakpoints, start the debugger with your own keybindings, or with `F5`
 - Visit the local site in your browser, making sure to append the following to your query string:
   - `XDEBUG_SESSION_START=1`
@@ -129,6 +133,7 @@ dap.configurations.twig = {
 ## Notes and Caveats
 
 - Many things are singletons in drupal, so you may need to clear the cache to get the debugger to stop at your breakpoints.
+- If when visiting the debug window, you do not see such things as watch, callstack, and variables, you may need to open VSCode from the root of your YaleSites project through the terminal.
 
 ## Resources
 

--- a/docs/xdebug.md
+++ b/docs/xdebug.md
@@ -1,0 +1,143 @@
+# Xdebug with YaleSites
+
+## Purpose
+
+The following should help you set up the YaleSites local environment for a debugging session with the debugging interface of your choice using [xdebug](https://xdebug.org).
+
+## Notes
+
+`xdebug-on` and `xdebug-off` should be located inside the .local.lando.yml file.
+
+## Usage
+
+### Enabling xdebug on YaleSites
+
+```sh
+lando xdebug-on
+```
+
+The above command will do the following:
+
+- Set the environment variable XDEBUG_MODE within the appserver to debug
+- Disables page caching so that the debugger can run on each request
+- Removes any previous docker-php-ext-xdebug.ini files that may still exist
+- Enables the xdebug extension
+- Kills php-fpm so that the new configuration can be loaded
+- Clears the cache one more time (just in case)
+- Tells you that it has been completed
+
+### Disabling xdebug on YaleSites
+
+```sh
+lando xdebug-off
+```
+
+The above command will do the following:
+
+- Set the environment variable XDEBUG_MODE within the appserver to `off`
+- Enables page caching again as that is the default
+- Removes any previous docker-php-ext-xdebug.ini files that may still exist, disabling the extension
+- Kills php-fpm so that the new configuration can be loaded
+- Clears the cache one more time (just in case)
+- Tells you that it has been completed
+
+## Configuring your IDE
+
+### Neovim using nvim-dap
+
+#### Prerequesites
+
+- [Neovim (tested on 0.9+)](https://neovim.io)
+- [nvim-dap](https://github.com/mfussenegger/nvim-dap)
+- [nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui) (optional)
+
+#### Installation
+
+- Install the above plugins
+- Create a `$XDG_CONFIG/nvim/after/dap.lua` file or modify your existing dap configuration with the following:
+
+```lua
+local dap = require('dap')
+dap.adapters.php = {
+  type = "executable",
+  command = "node",
+  args = { os.getenv("HOME") .. "/code/vscode-php-debug/out/phpDebug.js" }
+}
+
+local drupal_configuration = {
+  type = "php",
+  request = "launch",
+  name = "Listen for Xdebug",
+  port = 9003,
+  pathMappings = {
+    ["/app/"] = "${workspaceFolder}"
+  }
+}
+
+dap.configurations.php = {
+  drupal_configuration,
+}
+
+dap.configurations.twig = {
+  drupal_configuration,
+}
+
+```
+
+- Visit the file you wish to debug, set breakpoints, start the debugger with your own keybindings, or with the following:
+```vim
+:lua require('dap').continue()
+```
+- Visit the local site in your browser, making sure to append the following to your query string:
+  - `XDEBUG_SESSION_START=1`
+- You should see the debugger stop at your breakpoints
+
+### VSCode
+
+#### Prerequisites
+
+- [VSCode (tested on of 1.77.3)](https://code.visualstudio.com)
+- [PHP Debug extension created by Xdebug (tested on of 1.32.1)](https://marketplace.visualstudio.com/items?itemName=xdebug.php-debug)
+
+#### Installation
+
+- Install the above extension
+- Create a `.vscode/launch.json` file with the following:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for Xdebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9003,
+      "pathMappings": {
+        "/app/": "${workspaceFolder}"
+      }
+    }
+  ]
+}
+```
+
+- Visit the file you wish to debug, set breakpoints, start the debugger with your own keybindings, or with `F5`
+- Visit the local site in your browser, making sure to append the following to your query string:
+  - `XDEBUG_SESSION_START=1`
+- You should see the debugger stop at your breakpoints
+
+## Notes and Caveats
+
+- For twig specific debugging, you'll need to use devel's `devel_breakpoint()` function.  This will breakpoint in that method.  Stepping should finally get you to where the templates are loading that you can dive into.
+- Many things are singletons in drupal, so you may need to clear the cache to get the debugger to stop at your breakpoints.
+
+## Resources
+
+The following were used to figure out how to implement this solution:
+
+- [Xdebug documentation](https://xdebug.org/docs/remote)
+- [Lando documentation](https://docs.lando.dev/guides/lando-phpstorm.html)
+
+## Contributions
+
+If you have any suggestions or improvements, please feel free to modify this document and submit a pull request.  Please follow the [contributing guidelines](https://github.com/yalesites-org/yalesites-project/blob/develop/docs/CONTRIBUTING.md) from the repository.

--- a/docs/xdebug.md
+++ b/docs/xdebug.md
@@ -19,7 +19,6 @@ lando xdebug-on
 The above command will do the following:
 
 - Set the environment variable XDEBUG_MODE within the appserver to debug
-- Disables page caching so that the debugger can run on each request
 - Removes any previous docker-php-ext-xdebug.ini files that may still exist
 - Enables the xdebug extension
 - Kills php-fpm so that the new configuration can be loaded
@@ -35,7 +34,6 @@ lando xdebug-off
 The above command will do the following:
 
 - Set the environment variable XDEBUG_MODE within the appserver to `off`
-- Enables page caching again as that is the default
 - Removes any previous docker-php-ext-xdebug.ini files that may still exist, disabling the extension
 - Kills php-fpm so that the new configuration can be loaded
 - Clears the cache one more time (just in case)

--- a/docs/xdebug.md
+++ b/docs/xdebug.md
@@ -92,6 +92,8 @@ dap.configurations.twig = {
   - `XDEBUG_SESSION_START=1`
 - You should see the debugger stop at your breakpoints
 
+- For twig specific debugging, you'll need to use devel's `devel_breakpoint()` function.  This will breakpoint in that method.  Stepping should finally get you to where the templates are loading that you can dive into.
+
 ### VSCode
 
 #### Prerequisites
@@ -128,7 +130,6 @@ dap.configurations.twig = {
 
 ## Notes and Caveats
 
-- For twig specific debugging, you'll need to use devel's `devel_breakpoint()` function.  This will breakpoint in that method.  Stepping should finally get you to where the templates are loading that you can dive into.
 - Many things are singletons in drupal, so you may need to clear the cache to get the debugger to stop at your breakpoints.
 
 ## Resources
@@ -137,6 +138,11 @@ The following were used to figure out how to implement this solution:
 
 - [Xdebug documentation](https://xdebug.org/docs/remote)
 - [Lando documentation](https://docs.lando.dev/guides/lando-phpstorm.html)
+
+## Known Issues
+
+- Debugging twig files are not as straightforward as debugging the PHP files.  If you find a more reliable way to do this, please submit a pull request.
+- Clearing cache is still an issue and probably should be done before each debugging request.  Again, if you find a way around this, please submit a pull request.
 
 ## Contributions
 


### PR DESCRIPTION
## [YALB-261: Local Dev Setup XDebug](https://yaleits.atlassian.net/browse/YALB-261)

### Description of work
- Add lando configuration commands to enable/disable xdebug sessions
- Ensure xdebug is off by default
- Add documentation of usage

### Functional testing steps:
- [ ] Set up development debugging environment in your editor of choice, possibly following steps in `/docs/xdebug.md`
- [ ] Open `./web/profiles/custom/yalesites_profile/modules/custom/ys_alert/src/AlertManager.php` and set a debug breakpoint at `line 25` where the constructor is located.
- [ ] Start a new debug session in your editor
- [ ] In terminal, type `lando drush cr` to clear the cache if not done already
- [ ] Copy new `.lando.local.example.yml` to `.lando.local.yml`
- [ ] Rebuild containers using `lando rebuild -y`
- [ ] Visit [http://yalesites-project.lndo/?XDEBUG_SESSION_START=1](https://yalesites-platform.lndo.site/?XDEBUG_SESSION_START=1) making sure that XDEBUG_SESSION_START=1 is appended as a query string parameter
- [ ] Observe that it does not debug
- [ ] In terminal, type `lando xdebug-on`
- [ ] Refresh the web page, making sure that the query string is still there
- [ ] Observe that your breakpoint was hit and waiting for you to inspect/continue
- [ ] Continue the execution
- [ ] In terminal, type `lando xdebug-off`
- [ ] Refresh the web page, making sure that the query string is still there
- [ ] Observe the page load without hitting the breakpoint again

### Questions/Concerns

- .lando.local.example.yml:  I was unsure where else this was used.  If pantheon uses this in some way, this could affect usage there.
- twig file debugging: I was able to get this working in Neovim/nvim-dap by executing devel_breakpoint() inside the twig file, which flowed to the PHP scripts that were executing the echo-ing of the output.  This did not work, however, inside of Visual Studio Code.  It may be easier to recommend utilizing Kint/dump instead for consistency?
- I did not link to the new document to any specific place; I was not sure which was appropriate, on the main README or inside one of the existing documents.