### PR TITLE
YALB-1091 - Style admin forms that appear in atomic

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.frontpage.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.frontpage.yml
@@ -248,6 +248,7 @@ display:
           replica: false
           query_tags: {  }
       relationships: {  }
+      css_class: layout--centered
       header: {  }
       footer: {  }
       display_extenders: {  }
@@ -300,7 +301,10 @@ display:
     display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
       path: node
     cache_metadata:
       max-age: -1

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.layouts.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.layouts.yml
@@ -2,7 +2,7 @@ ys_layout_banner:
   label: 'Banner'
   path: layouts/banner
   template: layout--banner
-  library: ys_layout_onecol/banner
+  library: ys_layouts/ys_layout_banner
   category: 'Columns: 1'
   default_region: content
   icon_map:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/ys-themes.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/ys-themes.css
@@ -5,3 +5,40 @@
   height: 100%;
   z-index: 100;
 }
+
+/* center layout */
+.main-content > .layout--centered {
+  width: 100%;
+  max-width: 1344px;
+  margin: 2rem auto;
+}
+
+.main-content > .layout--centered .form-actions {
+  display: flex;
+  align-items: stretch;
+  gap: 2rem;
+  margin: var(--size-spacing-6) 0;
+}
+
+
+/* buttons */
+.main-content > .layout--centered .button {
+  transition: color, background-color var(--animation-speed-default) ease-in-out 0ms;
+  flex: 0 1;
+  border: var(--border-thickness-4) solid var(--color-basic-black);
+  border-radius: var(--radius-4);
+  background-color:var(--color-basic-black);
+  color: var(--color-basic-white);
+  font-weight: var(--font-weights-mallory-medium);
+  padding: var(--size-spacing-3) var(--size-spacing-6);
+  text-decoration: none;
+  text-align: center;
+  min-height: var(--size-click-target-minimum);
+  cursor: pointer;
+}
+
+.main-content > .layout--centered .button:hover {
+  border: var(--border-thickness-4) solid var(--color-basic-black);
+  background-color: transparent;
+  color: var(--color-basic-black);
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/ys-themes.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/ys-themes.css
@@ -16,10 +16,20 @@
 .main-content > .layout--centered .form-actions {
   display: flex;
   align-items: stretch;
-  gap: 2rem;
+  gap: 1rem;
   margin: var(--size-spacing-6) 0;
 }
 
+
+/* add admin css variables */
+.layout--centered {
+  --color-admin-button-primary: rgb(50, 117, 224);
+  --color-admin-button-primary-hover: rgb(43, 99, 190);
+  --color-admin-button-light-text: white;
+  --color-admin-button-dark-text: black;
+  --color-admin-button-secondary: rgb(233, 227, 66);
+  --color-admin-button-secondary-hover: rgb(221, 216, 86);
+}
 
 /* buttons */
 /* emulate gin theme buttons */
@@ -27,8 +37,8 @@
   transition: color, background-color var(--animation-speed-default) ease-in-out 0ms;
   flex: 0 1;
   border-radius: 6px;
-  background-color: var(--gin-color-primary);
-  color: var(--gin-color-button-text);
+  background-color: var(--color-admin-button-primary);
+  color: var(--color-admin-button-light-text);
   font-weight: 700;
   padding: var(--size-spacing-3) var(--size-spacing-6);
   text-decoration: none;
@@ -38,17 +48,17 @@
 }
 
 .main-content > .layout--centered .button:hover {
-  background-color: var(--gin-color-primary-hover);
-  color: var(--gin-color-button-text);
+  background-color: var(--color-admin-button-primary-hover);
+  color: var(--color-admin-button-light-text);
 }
 
 /* edit button */
 .main-content > .layout--centered .button[data-drupal-selector="edit-cancel"] {
-  background-color: var(--gin-color-warning);
-  color: var(--gin-color-title);
+  background-color: var(--color-admin-button-secondary);
+  color: var(--color-admin-button-dark-text);
 }
 
 .main-content > .layout--centered .button[data-drupal-selector="edit-cancel"]:hover {
-  background-color: var(--gin-color-warning-light);
-  color: var(--gin-color-title);
+  background-color: var(--color-admin-button-secondary-hover);
+  color: var(--color-admin-button-dark-text);
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/ys-themes.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/ys-themes.css
@@ -33,8 +33,15 @@
 
 /* buttons */
 /* emulate gin theme buttons */
-.main-content > .layout--centered .button {
+
+.main-content .cas-login-link {
+  margin-bottom: var(--size-spacing-8);
+}
+
+.main-content > .layout--centered .button,
+.main-content > .layout--centered .cas-login-link {
   transition: color, background-color var(--animation-speed-default) ease-in-out 0ms;
+  display: inline-flex;
   flex: 0 1;
   border-radius: 6px;
   background-color: var(--color-admin-button-primary);
@@ -43,11 +50,12 @@
   padding: var(--size-spacing-3) var(--size-spacing-6);
   text-decoration: none;
   text-align: center;
-  min-height: var(--size-click-target-minimum);
+  min-height: 2rem;
   cursor: pointer;
 }
 
-.main-content > .layout--centered .button:hover {
+.main-content > .layout--centered .button:hover,
+.main-content > .layout--centered .cas-login-link:hover {
   background-color: var(--color-admin-button-primary-hover);
   color: var(--color-admin-button-light-text);
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/ys-themes.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/ys-themes.css
@@ -22,14 +22,14 @@
 
 
 /* buttons */
+/* emulate gin theme buttons */
 .main-content > .layout--centered .button {
   transition: color, background-color var(--animation-speed-default) ease-in-out 0ms;
   flex: 0 1;
-  border: var(--border-thickness-4) solid var(--color-basic-black);
-  border-radius: var(--radius-4);
-  background-color:var(--color-basic-black);
-  color: var(--color-basic-white);
-  font-weight: var(--font-weights-mallory-medium);
+  border-radius: 6px;
+  background-color: var(--gin-color-primary);
+  color: var(--gin-color-button-text);
+  font-weight: 700;
   padding: var(--size-spacing-3) var(--size-spacing-6);
   text-decoration: none;
   text-align: center;
@@ -38,7 +38,17 @@
 }
 
 .main-content > .layout--centered .button:hover {
-  border: var(--border-thickness-4) solid var(--color-basic-black);
-  background-color: transparent;
-  color: var(--color-basic-black);
+  background-color: var(--gin-color-primary-hover);
+  color: var(--gin-color-button-text);
+}
+
+/* edit button */
+.main-content > .layout--centered .button[data-drupal-selector="edit-cancel"] {
+  background-color: var(--gin-color-warning);
+  color: var(--gin-color-title);
+}
+
+.main-content > .layout--centered .button[data-drupal-selector="edit-cancel"]:hover {
+  background-color: var(--gin-color-warning-light);
+  color: var(--gin-color-title);
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -152,4 +152,11 @@ function ys_themes_form_alter(&$form, $form_state, $form_id) {
     $form['settings']['label_display']['#default_value'] = FALSE;
     $form['settings']['label_display']['#access'] = FALSE;
   }
+
+  // Allow front-end theming of the layout builder discard changes form.
+  if ($form_id == 'layout_builder_discard_changes') {
+    $form['#attributes']['class'][] = 'layout--centered';
+    $form['#attached']['library'][] = 'ys_themes/ys_themes';
+  }
+
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -154,7 +154,13 @@ function ys_themes_form_alter(&$form, $form_state, $form_id) {
   }
 
   // Allow front-end theming of the layout builder discard changes form.
-  if ($form_id == 'layout_builder_discard_changes') {
+  $formsToStyle = [
+    'layout_builder_revert_overrides',
+    'layout_builder_discard_changes',
+    'user_login_form',
+  ];
+
+  if (in_array($form_id, $formsToStyle)) {
     $form['#attributes']['class'][] = 'layout--centered';
     $form['#attached']['library'][] = 'ys_themes/ys_themes';
   }


### PR DESCRIPTION
## [YALB-1091: Style admin forms that appear in atomic](https://yaleits.atlassian.net/browse/YALB-1091)

### Description of work
- Adds theming for admin pages that need to be centered and to have a max-width applied
- Adds a template to Atomic here: https://github.com/yalesites-org/atomic/pull/116

### Functional testing steps:
- [x] Navigate to the homepage: https://pr-253-yalesites-platform.pantheonsite.io/
  - [x] Verify the content is centered 
![Screenshot-20230501154903-2099x821](https://user-images.githubusercontent.com/366413/235528824-6ad3a914-6fea-4f19-a2e9-d00c78590fc0.png)

---
  
- [x] Navigate to the login page: https://pr-253-yalesites-platform.pantheonsite.io/user
  - [x] Verify the login form is centered
![Screenshot-20230501163657-2553x1350](https://user-images.githubusercontent.com/366413/235535945-ad8a1632-0469-4f5d-8dc8-3d05166bc00e.png)

---

- [x] Navigate to: https://pr-253-yalesites-platform.pantheonsite.io/node/1/layout/revert
  - [x] Verify the form is centered
![Screenshot-20230501151814-2548x1047](https://user-images.githubusercontent.com/366413/235526671-23a0e2b0-7a47-45c3-902e-e16568693fed.png)

---

- [x] Navigate to: https://pr-253-yalesites-platform.pantheonsite.io/node/7/layout/discard-changes
  - [x] Verify the form is centered
![Screenshot-20230501151804-2078x923](https://user-images.githubusercontent.com/366413/235526713-b1ae5013-0ef1-4309-af14-becbd2c4f86b.png)

---
- [x] Edit any page and add a component
- [x] Save the node and verify the status message (`The layout override has been saved.`) is now centered: 
![Screenshot-20230501153807-2189x1242](https://user-images.githubusercontent.com/366413/235526984-c390a058-214c-4bc7-8fa6-5a596fbf1249.png)

 
