### PR TITLE
YALB-1137: Dividers add new dials to divider block

### DIFF
--- a/scripts/local/local-review-with-cl-branch.sh
+++ b/scripts/local/local-review-with-cl-branch.sh
@@ -27,6 +27,6 @@ echo -e "${GREEN}Move into theme and create empty component-library-twig directo
 cd ../..
 mkdir node_modules/@yalesites-org/component-library-twig
 echo -e "${GREEN}Copy built dist folder${ENDCOLOR}"
-cp -r component-library-twig/dist node_modules/@yalesites-org/component-library-twig/.
+cp -r _yale-packages/component-library-twig/dist node_modules/@yalesites-org/component-library-twig/.
 echo -e "${GREEN}Copy built components folder${ENDCOLOR}"
-cp -r component-library-twig/components node_modules/@yalesites-org/component-library-twig/.
+cp -r _yale-packages/component-library-twig/components node_modules/@yalesites-org/component-library-twig/.

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.divider.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.divider.default.yml
@@ -5,6 +5,8 @@ dependencies:
   config:
     - block_content.type.divider
     - field.field.block_content.divider.field_instructions
+    - field.field.block_content.divider.field_style_position
+    - field.field.block_content.divider.field_style_width
   module:
     - markup
 id: block_content.divider.default
@@ -15,6 +17,18 @@ content:
   field_instructions:
     type: markup
     weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_style_position:
+    type: options_select
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_style_width:
+    type: options_select
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.divider.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.divider.default.yml
@@ -5,11 +5,29 @@ dependencies:
   config:
     - block_content.type.divider
     - field.field.block_content.divider.field_instructions
+    - field.field.block_content.divider.field_style_position
+    - field.field.block_content.divider.field_style_width
+  module:
+    - options
 id: block_content.divider.default
 targetEntityType: block_content
 bundle: divider
 mode: default
-content: {  }
+content:
+  field_style_position:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_style_width:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
 hidden:
   field_instructions: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.divider.field_style_position.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.divider.field_style_position.yml
@@ -1,0 +1,23 @@
+uuid: 89046ade-dfcb-4307-9396-9e7045e161d4
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.divider
+    - field.storage.block_content.field_style_position
+  module:
+    - options
+id: block_content.divider.field_style_position
+field_name: field_style_position
+entity_type: block_content
+bundle: divider
+label: 'Divider Position'
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: left
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.divider.field_style_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.divider.field_style_width.yml
@@ -1,0 +1,23 @@
+uuid: 9d407465-8907-4a5a-a6b4-f64ba1c770bb
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.divider
+    - field.storage.block_content.field_style_width
+  module:
+    - options
+id: block_content.divider.field_style_width
+field_name: field_style_width
+entity_type: block_content
+bundle: divider
+label: 'Divider Width'
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: 100%
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -93,3 +93,16 @@ grand_hero:
       full: Tall
       contained: Short
     default: full
+divider:
+  field_style_position:
+    values:
+      left: Left
+      center: Center
+    default: left
+  field_style_width:
+    values:
+      100%: 100
+      75%: 75
+      50%: 50
+      25%: 25
+    default: 100%

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
@@ -93,3 +93,16 @@ grand_hero:
       full: Tall
       contained: Short
     default: full
+divider:
+  field_style_position:
+    values:
+      left: Left
+      center: Center
+    default: left
+  field_style_width:
+    values:
+      '100%': 100
+      '75%': 75
+      '50%': 50
+      '25%': 25
+    default: 100%


### PR DESCRIPTION
## [YALB-1137: Dividers add new dials to divider block](https://yaleits.atlassian.net/browse/YALB-1137)

NOTE: [Atomic](https://github.com/yalesites-org/atomic/pull/120) and CL (merged) PRs must also be present (Same Branch Names)

### Description of work
- Adds YaleSites configuration updates that allow divider to have width and position dials
- Displays the divider in Drupal while respecting width and position dial settings
- Fix `local-review-with-cl` to copy from the _yale-packages folder after build

### Functional testing steps:
- [ ] Import new configuration using `lando drush cim`
- [ ] Visit Manage Pages and select "Standard page one"
- [ ] Click "Layout"
- [ ] Click "Add block" underneath the "Standard page one" heading
- [ ] Click "Divider" in the "Choose a block" menu on the right side
- [ ] Verify that you have the Divider Position option available
- [ ] Verify that you have the Divider Width option available
- [ ] Enter 'divider_dials1' for the Administrative label
- [ ] Change Divider Position to Center or Left
- [ ] Change Divider Width to a percentage of your choice (Preferably < 100 for this test)
- [ ] Click 'Add block"
- [ ] Verify that the divider displays above the "Add Block" button under the "Configure block" heading
- [ ] Click "Save" in the upper right corner of the page
- [ ] Verify that the divider is displaying in the position and width you specified
- [ ] Click "Layout"
- [ ] Mouseover the divider such that the pencil icon shows
- [ ] Use tab in an attempt to select the pencil icon and hit enter ([ticket already submitted for this](https://yaleits.atlassian.net/jira/software/projects/YALB/boards/368/backlog?selectedIssue=YALB-1192))
- [ ] Make any changes you'd like to the position or width
- [ ] Verify that changes are reflected
