### PR TITLE
YALB-1183: Update labels on toolbar

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_toolbar/src/ToolbarItemsService.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_toolbar/src/ToolbarItemsService.php
@@ -118,7 +118,7 @@ class ToolbarItemsService {
     if ($this->showEditButton()) {
       $this->toolbarItems['toolbar_edit_link'] = $this->buildButton(
         'entity.node.edit_form',
-        'Edit'
+        'Setup'
       );
     }
 
@@ -126,7 +126,7 @@ class ToolbarItemsService {
     // ensure this link only appears on entities with layout overrides enabled.
     $this->toolbarItems['toolbar_layout_link'] = $this->buildButton(
       'layout_builder.overrides.node.view',
-      'Layout'
+      'Layout Builder'
     );
 
     // Add a publish button to the toolbar when viewing an unpublished node.


### PR DESCRIPTION
## [YALB-1183: Update labels on toolbar](https://yaleits.atlassian.net/browse/YALB-1183)

### Description of work
- On the admin toolbar, when viewing a node, update the toolbar links:
  - Rename ‘Edit’ → ‘Setup’
  - Rename ‘Layout’ → 'Layout Builder'

### Functional testing steps:
- [ ] View a node and confirm the new links display as described. Screenshot attached.
![Screen Shot 2023-05-05 at 3 43 42 PM](https://user-images.githubusercontent.com/9594124/236554922-0813fe09-6e4b-49ff-b0dd-615fb8198678.png)
