### PR TITLE
YALB-855: Close modal after adding block

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -104,6 +104,9 @@
       "drupal/layout_builder_restrictions_by_role": {
         "Fix user 1 https://www.drupal.org/project/layout_builder_restrictions_by_role/issues/3298638": "https://www.drupal.org/files/issues/2022-07-28/3298638--layout_builder_restrictions_by_role--user-1-exception-8.patch"
       },
+      "drupal/layout_builder_browser": {
+        "close modal on submit https://www.drupal.org/project/layout_builder_browser/issues/3352754": "https://www.drupal.org/files/issues/2023-04-19/layout_builder_browser-modal_does_not_close_on_submit-3352754-2.patch"
+      },
       "drupal/gin_lb": {
         "fix missing file field https://www.drupal.org/project/gin_lb/issues/3349745": "https://www.drupal.org/files/issues/2023-03-23/3349745-8-claro-preprocess-file-fields.patch"
       }


### PR DESCRIPTION
## [YALB-855: Close modal after adding block](https://yaleits.atlassian.net/browse/YALB-XX)

### Description of work
- Applies a patch to close the block modal after adding the block to the page.
- See https://www.drupal.org/project/layout_builder_browser/issues/3352754

### Functional testing steps:
- [x] Add a block to the page. Any type will do.
- [x] Fill out all fields on the Configure block form.
- [x] Click the 'Add Block' button on the bottom of the form.
- [x] Verify that the modal 'Configure block' form closes after adding the block.
