### PR TITLE
Hide revision field patch cleanup

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -95,9 +95,6 @@
       "drupal/core": {
         "plural results summary https://www.drupal.org/project/drupal/issues/2888320": "https://www.drupal.org/files/issues/2021-12-15/2888320-78.patch"
       },
-      "drupal/hide_revision_field": {
-        "fix deprecated function unserialize https://www.drupal.org/project/hide_revision_field/issues/3260101": "https://www.drupal.org/files/issues/2022-01-24/3260101-2.patch"
-      },
       "drupal/entity_redirect": {
         "fix layout route https://www.drupal.org/project/entity_redirect/issues/3352265": "https://git.drupalcode.org/project/entity_redirect/-/merge_requests/6.patch"
       },


### PR DESCRIPTION
### Description of work
- Removes patch that has now been incorporated not the latest version of the hide revision field module.
- Fixes an error during `composer install` where this patch could not be applied.

### Functional testing steps:
- [ ] Verify there are no `Deprecated function` errors loading the site
- [ ] Verify there are no `Deprecated function` errors in the logs