### PR TITLE
fix(YALB-1123): Cache invalidated on alert save

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.module
@@ -24,3 +24,17 @@ function ys_alert_theme($existing, $type, $theme, $path) {
     ],
   ];
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function ys_alert_preprocess_page(&$variables) {
+  $config = \Drupal::config('ys_alert.settings');
+  $variables['alert'] = $config->get('alert');
+
+  // Add the cache tag, so that the theme setting information is rebuilt when
+  // the config is saved.
+  // Via: https://drupal.stackexchange.com/questions/266379/how-to-clear-cache-for-config-entity-after-making-changes
+  // Also used: https://github.com/yalesites-org/yalesites-project/blob/4cd183c8f568b771d656478adb3b76985501c3a1/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module#LL144C1-L144C1
+  \Drupal::service('renderer')->addCacheableDependency($variables, $config);
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.module
@@ -30,7 +30,6 @@ function ys_alert_theme($existing, $type, $theme, $path) {
  */
 function ys_alert_preprocess_page(&$variables) {
   $config = \Drupal::config('ys_alert.settings');
-  $variables['alert'] = $config->get('alert');
 
   // Add the cache tag, so that the theme setting information is rebuilt when
   // the config is saved.


### PR DESCRIPTION
## [YALB-1123: Bug: Front page without page defined does not respect cache invalidation of alert](https://yaleits.atlassian.net/browse/YALB-1123)

### Description of work
- Add ys_alert preprocessor hook to add a cache dependency such that updating invalidates rendered cache

### Functional testing steps:
- [x] Click `Settings->Alert Settings`
- [x] Change something about the current alert
- [x] Click the `Save configuration` button, waiting to see that the configuration was successfully saved
- [x] Visit the root site again
- [x] Verify that the alert has the changes you made
