### PR TITLE
YALB-457: sets max-length for teaser text fields

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
@@ -160,9 +160,9 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 150
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: false
+        maxlength_js_enforce: true
   field_teaser_title:
     type: string_textfield
     weight: 12

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
@@ -102,9 +102,9 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 150
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: false
+        maxlength_js_enforce: true
   field_teaser_title:
     type: string_textfield
     weight: 9

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.post.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.post.default.yml
@@ -120,9 +120,9 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: null
+        maxlength_js: 150
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: false
+        maxlength_js_enforce: true
   field_teaser_title:
     type: string_textfield
     weight: 9


### PR DESCRIPTION
## [YALB-457:  Metadata: Limit descriptions to 150 chars](https://yaleits.atlassian.net/browse/YALB-457)

### Description of work
- Sets the "Teaser Text" field to have a maximum length of 150 characters, on all content types.
- Sets the "Teaser Text" field to have a hard limit for all content types.

### Functional testing steps:
- [ ] Go to structure/content types
- [ ] Go to manage fields/manage form display for all content types (pages, posts, events)
- [ ] Check that the maximum length is set to 150 characters and "hard limit" is toggled on.
