### PR TITLE
YALB-814: Metatags Open Graph (SB/BE)

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.token.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.token.yml
@@ -1,0 +1,34 @@
+uuid: e028a28f-6a60-4b9c-b646-c60c91a5e034
+langcode: en
+status: false
+dependencies:
+  config:
+    - core.entity_view_mode.media.token
+    - field.field.media.image.field_media_image
+    - media.type.image
+  module:
+    - image
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: media.image.token
+targetEntityType: media
+bundle: image
+mode: token
+content:
+  field_media_image:
+    type: image_url
+    label: hidden
+    settings:
+      image_style: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -64,6 +64,7 @@ module:
   menu_link_content: 0
   menu_ui: 0
   metatag: 0
+  metatag_open_graph: 0
   metatag_views: 0
   migrate: 0
   migrate_plus: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/metatag.metatag_defaults.global.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/metatag.metatag_defaults.global.yml
@@ -8,4 +8,7 @@ id: global
 label: Global
 tags:
   canonical_url: '[current-page:url]'
+  og_site_name: '[site:name]'
+  og_type: website
+  og_url: '[current-page:url]'
   title: '[current-page:title] | [site:name]'

--- a/web/profiles/custom/yalesites_profile/config/sync/metatag.metatag_defaults.node.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/metatag.metatag_defaults.node.yml
@@ -7,6 +7,10 @@ _core:
 id: node
 label: Content
 tags:
-  title: '[node:title] | [site:name]'
-  description: '[node:summary]'
   canonical_url: '[node:url]'
+  description: '[node:field_teaser_text]'
+  og_description: '[node:field_teaser_text]'
+  og_image: '[node:field_teaser_media:entity:field_media_image]'
+  og_image_alt: '[node:field_teaser_media:entity:field_media_image:alt]'
+  og_title: '[yale:teaser_title_node_title]'
+  title: '[node:title] | [site:name]'

--- a/web/profiles/custom/yalesites_profile/config/sync/metatag.metatag_defaults.node__post.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/metatag.metatag_defaults.node__post.yml
@@ -1,0 +1,9 @@
+uuid: 2585655c-bb62-427d-88a4-d5edde17b830
+langcode: en
+status: true
+dependencies: {  }
+id: node__post
+label: 'Content: Post'
+tags:
+  article_published_time: '[node:field_publish_date:date:html_datetime]'
+  og_type: article

--- a/web/profiles/custom/yalesites_profile/config/sync/metatag.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/metatag.settings.yml
@@ -2,13 +2,17 @@ entity_type_groups:
   node:
     event:
       basic: basic
-    post:
-      basic: basic
     page:
       basic: basic
+    post:
+      basic: basic
+      open_graph: open_graph
 tag_trim_method: beforeValue
 tag_trim_maxlength:
   metatag_maxlength_abstract: null
   metatag_maxlength_description: null
   metatag_maxlength_title: null
+  metatag_maxlength_og_description: null
+  metatag_maxlength_og_site_name: null
+  metatag_maxlength_og_title: null
 tag_scroll_max_height: ''

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.tokens.inc
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.tokens.inc
@@ -24,6 +24,10 @@ function ys_core_token_info() {
     'name' => t('Events landing page'),
     'description' => t('The path alias for the events landing page.'),
   ];
+  $info['tokens']['yale']['teaser_title_node_title'] = [
+    'name' => t('Teaser title or node title'),
+    'description' => t('Will use the teaser title of the node if set, and if not will fallback to the node title'),
+  ];
   return $info;
 }
 
@@ -50,6 +54,14 @@ function ys_core_tokens($type, array $tokens, array $data, array $options, Bubbl
           // Landing page path is a site setting; fallback to '/event'.
           $config = \Drupal::config('ys_core.site');
           $replacements[$original] = $config->get('page.events') ?: '/events';
+          break;
+
+        case 'teaser_title_node_title':
+          if (!empty($data['node'])) {
+            $nodeTitle = $data['node']->getTitle();
+            $teaserTitle = ($data['node']->field_teaser_title->first()) ? $data['node']->field_teaser_title->first()->getString() : NULL;
+            $replacements[$original] = $teaserTitle ?: $nodeTitle;
+          }
           break;
       }
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.tokens.inc
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.tokens.inc
@@ -59,7 +59,11 @@ function ys_core_tokens($type, array $tokens, array $data, array $options, Bubbl
         case 'teaser_title_node_title':
           if (!empty($data['node'])) {
             $nodeTitle = $data['node']->getTitle();
-            $teaserTitle = ($data['node']->field_teaser_title) ? $data['node']->field_teaser_title->first()->getString() : NULL;
+            $teaserTitle = NULL;
+            if ($data['node']->field_teaser_title) {
+              $teaserTitle = ($data['node']->field_teaser_title->first()) ? $data['node']->field_teaser_title->first()->getString() : NULL;
+            }
+
             $replacements[$original] = $teaserTitle ?: $nodeTitle;
           }
           break;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.tokens.inc
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.tokens.inc
@@ -59,7 +59,7 @@ function ys_core_tokens($type, array $tokens, array $data, array $options, Bubbl
         case 'teaser_title_node_title':
           if (!empty($data['node'])) {
             $nodeTitle = $data['node']->getTitle();
-            $teaserTitle = ($data['node']->field_teaser_title->first()) ? $data['node']->field_teaser_title->first()->getString() : NULL;
+            $teaserTitle = ($data['node']->field_teaser_title) ? $data['node']->field_teaser_title->first()->getString() : NULL;
             $replacements[$original] = $teaserTitle ?: $nodeTitle;
           }
           break;


### PR DESCRIPTION
## [YALB-814: Metatags Open Graph (SB/BE)](https://yaleits.atlassian.net/browse/YALB-814)

### Description of work
- Adds a new token to get the teaser title if set, but if not, fallback to the node title.
- Enables and configures Open Graph metadata globally and also for articles

### Functional testing steps:
- [x] Edit a page on the site and add some teaser text (do not add teaser title for now), and a teaser image
- [x] Save the page
- [x] View the page and inspect the HTML
- [x] Verify that there are the following meta tags in the `head`:
     - [x] `description` - teaser text
     - [x] `og:site_name` - the site title
     - [x] `og:type` - "website"
     - [x] `og:url` - the URL of the current page
     - [x] `og:title` - the title of the current page
     - [x] `og:description` - teaser text
     - [x] `og:image` - URL to the teaser image
     - [x] `og:image:alt` - Alt text of the teaser image
- [x] Edit the page again and add a teaser title
- [x] Save the page
- [x] View the page and inspect the HTML
- [x] Verify that the following meta tag has changed in the `head`:
     - [x] `og:title` - teaser title instead of the page title
- [x] View a post node and inspect the HTML
- [x] Verify that there are the following additional meta tags in the `head`:
     - [x] `og:type` - changed to "article" instead of "website"
     - [x] `article:published_time` - matches the date in the Publish Date field in the post
