### PR TITLE
YALB-1163 - Create Button Link component

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/block_content.type.button_link.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block_content.type.button_link.yml
@@ -1,0 +1,33 @@
+uuid: 9bd04082-5494-4f5e-a5c3-e6ac176238d8
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_redirect
+third_party_settings:
+  entity_redirect:
+    redirect:
+      add:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+      edit:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+      delete:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+      anonymous:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+id: button_link
+label: 'Button Link'
+revision: 1
+description: 'Button link allows you to add a button link to your content.'

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.button_link.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.button_link.default.yml
@@ -1,0 +1,44 @@
+uuid: 3cb8d9c5-4e52-4701-9202-80c09ef7d56e
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.button_link
+    - field.field.block_content.button_link.field_button_link
+  module:
+    - hide_revision_field
+    - link
+id: block_content.button_link.default
+targetEntityType: block_content
+bundle: button_link
+mode: default
+content:
+  field_button_link:
+    type: link_default
+    weight: 82
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  revision_log:
+    type: hide_revision_field_log_widget
+    weight: 80
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+      show: true
+      default: ''
+      permission_based: false
+      allow_user_settings: true
+    third_party_settings: {  }
+hidden: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.button_link.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.button_link.default.yml
@@ -1,0 +1,28 @@
+uuid: 4f1cf619-54e4-4c7d-981a-f5f07b5aaf91
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.button_link
+    - field.field.block_content.button_link.field_button_link
+  module:
+    - link
+id: block_content.button_link.default
+targetEntityType: block_content
+bundle: button_link
+mode: default
+content:
+  field_button_link:
+    type: link_separate
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.button_link.field_button_link.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.button_link.field_button_link.yml
@@ -1,0 +1,23 @@
+uuid: 5db2b506-e24d-40b1-8f24-fdca808b0e9c
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.button_link
+    - field.storage.block_content.field_button_link
+  module:
+    - link
+id: block_content.button_link.field_button_link
+field_name: field_button_link
+entity_type: block_content
+bundle: button_link
+label: 'Button Link'
+description: 'Add one or two button links'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: link

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_button_link.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_button_link.yml
@@ -1,0 +1,19 @@
+uuid: c4bdb688-a51d-440a-9059-9e1e60cf6804
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - link
+id: block_content.field_button_link
+field_name: field_button_link
+entity_type: block_content
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 2
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/layout_builder_browser.layout_builder_browser_block.button_link.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/layout_builder_browser.layout_builder_browser_block.button_link.yml
@@ -1,0 +1,11 @@
+uuid: d54f55bd-51be-4145-bea0-fd7f05b3057e
+langcode: en
+status: true
+dependencies: {  }
+id: button_link
+block_id: 'inline_block:button_link'
+category: all_blocks
+label: 'Button Link'
+image_path: ''
+image_alt: ''
+weight: null


### PR DESCRIPTION
## [YALB-1163 - Create Button Link component](https://yaleits.atlassian.net/browse/YALB-1163)

### Description of work
- Adds button-link block type to layout-builder
- Allows two `link` fields to be added to the new button-link component

### Functional testing steps:
- [ ] Test here: 
