### PR TITLE
YALB-1195: Events: Add to Calendar Link (BE)

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -12,6 +12,7 @@
     "drupal/admin_toolbar": "3.3.0",
     "drupal/allowed_formats": "^2.0",
     "drupal/autosave_form": "^1.3",
+    "drupal/calendar_link": "^3.0",
     "drupal/captcha": "^1.8",
     "drupal/cas": "^2.0",
     "drupal/chosen": "^3.0",

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -8,6 +8,7 @@ module:
   block: 0
   block_content: 0
   breakpoint: 0
+  calendar_link: 0
   captcha: 0
   cas: 0
   cas_attributes: 0


### PR DESCRIPTION
## [YALB-1195: Events: Add to Calendar Link (BE)](https://yaleits.atlassian.net/browse/YALB-1195)

### Description of work
- Installs and enables the calendar_link modules for the Atomic PR of the same name to function

### Functional testing steps:
- [ ] Visit the Extend page to verify that "Calendar Link" is installed and enabled