### PR TITLE
YALB-1190: Fixes alert setting select bug

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/css/ys_alert.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/css/ys_alert.css
@@ -41,7 +41,7 @@
   background-image: url('../images/emergency.svg');
 }
 
-.ys-alert-settings .form-boolean--type-radio[checked="checked"] + label {
+.ys-alert-settings .form-boolean--type-radio:checked + label {
   border-color: #5B81FF;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 }


### PR DESCRIPTION
## [YALB-1190: Bug_ Alert setting select style](https://yaleits.atlassian.net/browse/YALB-1190)

### Description of work
- Fixes a bug on the alert form so the current selected option has a blue border and a darker border when using the keyboard tab.

### Functional testing steps:
- [ ] Go to the site and click on settings/alert settings in the admin menu.
- [ ] Verify the currently selected alert type has a light blue border
- [ ] Verify using the keyboard to tab and the arrows keys to select different alert types the border is dark blue.
- [ ] Verify that the light blue border no longer stays stuck on one option when using the keyboard navigation. (Should be moving with the arrows keys.)
