### PR TITLE
YALB-892: Media: Update Character Limits (SB)

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.image.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.image.default.yml
@@ -46,9 +46,9 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: 120
+        maxlength_js: 200
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
+        maxlength_js_enforce: false
 hidden:
   info: true
   revision_log: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.video.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.video.default.yml
@@ -62,9 +62,9 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: 120
+        maxlength_js: 200
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
+        maxlength_js_enforce: false
 hidden:
   info: true
   revision_log: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.wrapped_image.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.wrapped_image.default.yml
@@ -34,9 +34,9 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: 120
+        maxlength_js: 150
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: false
+        maxlength_js_enforce: true
   field_instructions:
     type: markup
     weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.gallery_item.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.gallery_item.default.yml
@@ -50,9 +50,9 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: 120
+        maxlength_js: 200
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
+        maxlength_js_enforce: false
 hidden:
   created: true
   status: true


### PR DESCRIPTION
## [YALB-892: Media: Update Character Limits (SB)](https://yaleits.atlassian.net/browse/YALB-892)

### Description of work
Update the maxlength character limits for the following media text fields:
- Wrapped Image captions: 150 chars hard limit
- Video descriptions: 200 chars soft limit
- Image (standalone) captions: 200 chars soft limit
- Gallery Image Caption: 200 chars soft limit

### Functional testing steps:
- For each of the listed block types, verify the lengths and limit types. Links are provided below for each:
- [ ] Wrapped Image: `/admin/structure/block/block-content/manage/wrapped_image/form-display`
- [ ] Video: `/admin/structure/block/block-content/manage/video/form-display`
- [ ] Image: `/admin/structure/block/block-content/manage/image/form-display`
- [ ] Gallery Image (gallery_item): `/admin/structure/paragraphs_type/gallery_item/form-display`
