### PR TITLE
YALB-971: LocalDev theme setup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,8 @@ reference
 # Yalesites profile assets
 web/profiles/custom/yalesites_profile/composer.lock
 web/profiles/custom/yalesites_profile/vendor/
+
+# Local development symlinks
+atomic
+component-library-twig
+tokens

--- a/.gitignore
+++ b/.gitignore
@@ -125,8 +125,3 @@ reference
 # Yalesites profile assets
 web/profiles/custom/yalesites_profile/composer.lock
 web/profiles/custom/yalesites_profile/vendor/
-
-# Local development symlinks
-atomic
-component-library-twig
-tokens

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,8 @@ reference
 # Yalesites profile assets
 web/profiles/custom/yalesites_profile/composer.lock
 web/profiles/custom/yalesites_profile/vendor/
+
+# Ignore symlinks for dev
+/atomic
+/component-library-twig
+/tokens

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "local:review-with-cl-branch": "./scripts/local/local-review-with-cl-branch.sh",
     "local:cl-dev": "./scripts/local/local-cl-dev.sh",
     "local:theme-link": "./scripts/local/local-theme-link.sh",
+    "local:git-checkout": "./scripts/local/local-git-checkout.sh",
     "prettier": "prettier '{.github,docs,web/profiles/custom,web/modules/custom,web/themes/contrib/atomic,web/themes/custom}/**/*.{json,md,js,html,scss,html}' --ignore-unknown --list-different",
     "setup": "./scripts/local/setup.sh",
     "test": "./scripts/local/test.sh"

--- a/scripts/local/local-cl-dev.sh
+++ b/scripts/local/local-cl-dev.sh
@@ -11,46 +11,14 @@
 # through the regular component library release process, and be included in an
 # official release of Atomic.
 
-[ $# -eq 1 ] && [ "$1" == "-h" ] && echo "Usage: $0 [-d]" && exit
-[ $# -eq 1 ] && [ "$1" == "-d" ] && _say "Debug mode enabled" && set -x
-
-[ -f "./scripts/local/util/say.sh" ] || (echo -e "You must run this from the yalesites root directory" && exit)
+[ -e "./scripts/local/util/say.sh" ] || (echo -e "[$0] Say utility not found.  You must run this from the yalesites root directory: " && exit 1)
 source ./scripts/local/util/say.sh
 
- _say "Moving to atomic repo"
-cd web/themes/contrib/atomic || (_error "Could not find atomic theme. Are you in the right directory?" && exit)
+if ! ./scripts/local/local-git-checkout.sh -c develop -a develop; then
+  exit 1
+fi
 
-_say "Attempting to clone tokens repo"
-[ ! -d "_yale-packages/tokens" ] && git clone git@github.com:yalesites-org/tokens.git _yale-packages/tokens
-
-_say "Moving into tokens repo and creating a global npm link"
-cd _yale-packages/tokens || (_error "Could not find tokens repo. Are you in the right directory?" && exit)
-npm link
-
-_say "Moving back to atomic"
-cd ../..
-
-_say "Attempting to clone component-library-twig repo"
-[ ! -d "_yale-packages/component-library-twig" ] && git clone git@github.com:yalesites-org/component-library-twig.git _yale-packages/component-library-twig
-
-_say "Moving into component library and creating a global npm link"
-cd _yale-packages/component-library-twig || (_error "Could not find component-library-twig repo. Are you in the right directory?" && exit)
-npm link
-
-_say "Moving back to atomic"
-cd ../..
-
-_say "Using the component-library global npm link inside the atomic theme"
-npm link @yalesites-org/component-library-twig
-
-_say "Moving into the component library"
-cd _yale-packages/component-library-twig || (_error "Could not find component-library-twig repo. Are you in the right directory?" && exit)
-
-_say "Running clean install so we can patch Twig.js"
-npm ci -y
-
-_say "Using the tokens global npm link inside the component library"
-npm link @yalesites-org/tokens
+cd atomic || exit
 
 _say "Running the develop script in the component library"
 npm run develop

--- a/scripts/local/local-cl-dev.sh
+++ b/scripts/local/local-cl-dev.sh
@@ -11,26 +11,26 @@
 # through the regular component library release process, and be included in an
 # official release of Atomic.
 
-GREEN='\033[1;32m'
-ENDCOLOR='\033[0m'
+[ -e "./scripts/local/util/say.sh" ] || (echo -e "[$0] Say utility not found.  You must run this from the yalesites root directory: " && exit 1)
+source ./scripts/local/util/say.sh
 
-echo -e "${GREEN}Move into tokens repo and create a global link${ENDCOLOR}"
+_say "Move into tokens repo and create a global link"
 cd web/themes/contrib/atomic
 [ ! -d "_yale-packages/tokens" ] && git clone git@github.com:yalesites-org/tokens.git _yale-packages/tokens
 cd _yale-packages/tokens || exit
 npm link
 cd ../..
-echo -e "${GREEN}Move into component library and create a global link${ENDCOLOR}"
+_say "Move into component library and create a global link"
 [ ! -d "_yale-packages/component-library-twig" ] && git clone git@github.com:yalesites-org/component-library-twig.git _yale-packages/component-library-twig
 cd _yale-packages/component-library-twig || exit
 npm link
-echo -e "${GREEN}Move into Atomic and use the component-library global link${ENDCOLOR}"
+_say "Move into Atomic and use the component-library global link"
 cd ../..
 npm link @yalesites-org/component-library-twig
-echo -e "${GREEN}Move into the component-library and use the tokens global link${ENDCOLOR}"
+_say "Move into the component-library and use the tokens global link"
 cd _yale-packages/component-library-twig || exit
 # Run npm ci. This is required to patch our version of Twig.js.
 npm ci
 npm link @yalesites-org/tokens
-echo -e "${GREEN}Run the develop script in the component library${ENDCOLOR}"
+_say "Run the develop script in the component library"
 npm run develop

--- a/scripts/local/local-cl-dev.sh
+++ b/scripts/local/local-cl-dev.sh
@@ -11,10 +11,12 @@
 # through the regular component library release process, and be included in an
 # official release of Atomic.
 
-source ./util/say.sh
+[ $# -eq 1 ] && [ "$1" == "-h" ] && echo "Usage: $0 [-d]" && exit
+[ $# -eq 1 ] && [ "$1" == "-d" ] && _say "Debug mode enabled" && set -x
 
-_say "Move into tokens repo and create a global link"
-cd web/themes/contrib/atomic
+[ -f "./scripts/local/util/say.sh" ] || (echo -e "You must run this from the yalesites root directory" && exit)
+source ./scripts/local/util/say.sh
+
 [ ! -d "_yale-packages/tokens" ] && git clone git@github.com:yalesites-org/tokens.git _yale-packages/tokens
 cd _yale-packages/tokens || exit
 npm link

--- a/scripts/local/local-cl-dev.sh
+++ b/scripts/local/local-cl-dev.sh
@@ -17,21 +17,40 @@
 [ -f "./scripts/local/util/say.sh" ] || (echo -e "You must run this from the yalesites root directory" && exit)
 source ./scripts/local/util/say.sh
 
+ _say "Moving to atomic repo"
+cd web/themes/contrib/atomic || (_error "Could not find atomic theme. Are you in the right directory?" && exit)
+
+_say "Attempting to clone tokens repo"
 [ ! -d "_yale-packages/tokens" ] && git clone git@github.com:yalesites-org/tokens.git _yale-packages/tokens
-cd _yale-packages/tokens || exit
+
+_say "Moving into tokens repo and creating a global npm link"
+cd _yale-packages/tokens || (_error "Could not find tokens repo. Are you in the right directory?" && exit)
 npm link
+
+_say "Moving back to atomic"
 cd ../..
-_say "Move into component library and create a global link"
+
+_say "Attempting to clone component-library-twig repo"
 [ ! -d "_yale-packages/component-library-twig" ] && git clone git@github.com:yalesites-org/component-library-twig.git _yale-packages/component-library-twig
-cd _yale-packages/component-library-twig || exit
+
+_say "Moving into component library and creating a global npm link"
+cd _yale-packages/component-library-twig || (_error "Could not find component-library-twig repo. Are you in the right directory?" && exit)
 npm link
-_say "Move into Atomic and use the component-library global link"
+
+_say "Moving back to atomic"
 cd ../..
+
+_say "Using the component-library global npm link inside the atomic theme"
 npm link @yalesites-org/component-library-twig
-_say "Move into the component-library and use the tokens global link"
-cd _yale-packages/component-library-twig || exit
-# Run npm ci. This is required to patch our version of Twig.js.
-npm ci
+
+_say "Moving into the component library"
+cd _yale-packages/component-library-twig || (_error "Could not find component-library-twig repo. Are you in the right directory?" && exit)
+
+_say "Running clean install so we can patch Twig.js"
+npm ci -y
+
+_say "Using the tokens global npm link inside the component library"
 npm link @yalesites-org/tokens
-_say "Run the develop script in the component library"
+
+_say "Running the develop script in the component library"
 npm run develop

--- a/scripts/local/local-cl-dev.sh
+++ b/scripts/local/local-cl-dev.sh
@@ -11,26 +11,25 @@
 # through the regular component library release process, and be included in an
 # official release of Atomic.
 
-GREEN='\033[1;32m'
-ENDCOLOR='\033[0m'
+source ./util/say.sh
 
-echo -e "${GREEN}Move into tokens repo and create a global link${ENDCOLOR}"
+_say "Move into tokens repo and create a global link"
 cd web/themes/contrib/atomic
 [ ! -d "_yale-packages/tokens" ] && git clone git@github.com:yalesites-org/tokens.git _yale-packages/tokens
 cd _yale-packages/tokens || exit
 npm link
 cd ../..
-echo -e "${GREEN}Move into component library and create a global link${ENDCOLOR}"
+_say "Move into component library and create a global link"
 [ ! -d "_yale-packages/component-library-twig" ] && git clone git@github.com:yalesites-org/component-library-twig.git _yale-packages/component-library-twig
 cd _yale-packages/component-library-twig || exit
 npm link
-echo -e "${GREEN}Move into Atomic and use the component-library global link${ENDCOLOR}"
+_say "Move into Atomic and use the component-library global link"
 cd ../..
 npm link @yalesites-org/component-library-twig
-echo -e "${GREEN}Move into the component-library and use the tokens global link${ENDCOLOR}"
+_say "Move into the component-library and use the tokens global link"
 cd _yale-packages/component-library-twig || exit
 # Run npm ci. This is required to patch our version of Twig.js.
 npm ci
 npm link @yalesites-org/tokens
-echo -e "${GREEN}Run the develop script in the component library${ENDCOLOR}"
+_say "Run the develop script in the component library"
 npm run develop

--- a/scripts/local/local-cl-dev.sh
+++ b/scripts/local/local-cl-dev.sh
@@ -11,14 +11,26 @@
 # through the regular component library release process, and be included in an
 # official release of Atomic.
 
-[ -e "./scripts/local/util/say.sh" ] || (echo -e "[$0] Say utility not found.  You must run this from the yalesites root directory: " && exit 1)
-source ./scripts/local/util/say.sh
+GREEN='\033[1;32m'
+ENDCOLOR='\033[0m'
 
-if ! ./scripts/local/local-git-checkout.sh -c develop -a develop; then
-  exit 1
-fi
-
-cd atomic || exit
-
-_say "Running the develop script in the component library"
+echo -e "${GREEN}Move into tokens repo and create a global link${ENDCOLOR}"
+cd web/themes/contrib/atomic
+[ ! -d "_yale-packages/tokens" ] && git clone git@github.com:yalesites-org/tokens.git _yale-packages/tokens
+cd _yale-packages/tokens || exit
+npm link
+cd ../..
+echo -e "${GREEN}Move into component library and create a global link${ENDCOLOR}"
+[ ! -d "_yale-packages/component-library-twig" ] && git clone git@github.com:yalesites-org/component-library-twig.git _yale-packages/component-library-twig
+cd _yale-packages/component-library-twig || exit
+npm link
+echo -e "${GREEN}Move into Atomic and use the component-library global link${ENDCOLOR}"
+cd ../..
+npm link @yalesites-org/component-library-twig
+echo -e "${GREEN}Move into the component-library and use the tokens global link${ENDCOLOR}"
+cd _yale-packages/component-library-twig || exit
+# Run npm ci. This is required to patch our version of Twig.js.
+npm ci
+npm link @yalesites-org/tokens
+echo -e "${GREEN}Run the develop script in the component library${ENDCOLOR}"
 npm run develop

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -20,7 +20,7 @@ function current_branch_for_path() {
 # params:
 #  branch_name: the name of the branch
 #
-branch_exists() {
+function branch_exists() {
   [ -z "$1" ] && _error "You must provide a branch name" && exit 1
 
   local branch_name="$1"

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -122,6 +122,18 @@ npm ci -y
 _say "Using the tokens global npm link inside the component library"
 npm link @yalesites-org/tokens
 
+cd ../..
+
+_say "Attempting to npm link tokens inside atomic"
+npm link @yalesites-org/tokens
+
+_say "Moving to tokens repo"
+cd _yale-packages/tokens || (_error "Could not find tokens repo. Are you in the right directory?" && exit 1)
+
+_say "Building tokens"
+cd ../tokens || (_error "Could not find tokens repo. Are you in the right directory?" && exit 1)
+npm run build
+
 _say "Symlinking to root directory"
 cd ../../../../../..
 [ ! -L "atomic" ] && ln -s web/themes/contrib/atomic atomic

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -108,6 +108,18 @@ function clone_or_switch_branch() {
 
       _say "Current branch of $name is $current_branch, switching to $target_branch"
       git -C "$git_path" checkout "$target_branch" || git -C "$git_path" checkout --track "$origin/$target_branch"
+
+      current_branch=$(current_branch_for_path "$git_path")
+      if [ "$current_branch" != "$target_branch" ]; then
+        _error "Failed to switch to $target_branch branch of $name repo"
+        _say "Attempting to switch to $backup_branch branch of $name repo"
+        git -C "$git_path" checkout "$backup_branch" || git -C "$git_path" checkout --track "$origin/$backup_branch"
+        current_branch=$(current_branch_for_path "$git_path")
+        if [ "$current_branch" != "$backup_branch" ]; then
+          _error "Failed to switch to $backup_branch branch of $name repo"
+          exit 1
+        fi
+      fi
     else
       _error "You have uncommitted changes to the $name repo.  Please commit or stash them before running this script."
       exit 1

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -109,13 +109,18 @@ function clone_or_switch_branch() {
       _say "Current branch of $name is $current_branch, switching to $target_branch"
       git -C "$git_path" checkout "$target_branch" || git -C "$git_path" checkout --track "$origin/$target_branch"
 
+      # Verify that the checkout was successful
       current_branch=$(current_branch_for_path "$git_path")
       if [ "$current_branch" != "$target_branch" ]; then
+        # If not successful, try the backup branch
         _error "Failed to switch to $target_branch branch of $name repo"
         _say "Attempting to switch to $backup_branch branch of $name repo"
         git -C "$git_path" checkout "$backup_branch" || git -C "$git_path" checkout --track "$origin/$backup_branch"
+
+        # check if that was successful
         current_branch=$(current_branch_for_path "$git_path")
         if [ "$current_branch" != "$backup_branch" ]; then
+          # If not successful, fail
           _error "Failed to switch to $backup_branch branch of $name repo"
           exit 1
         fi
@@ -174,7 +179,7 @@ function _local-git-checkout() {
   local atomic_changed=false
 
   # getopts - Parse the options to then use
-  while getopts ":dvc:t:a:b:" opt; do
+  while getopts ":dvc:t:a:b:m:" opt; do
     case ${opt} in
       d )
         debug=true

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -157,6 +157,8 @@ clone_or_switch_branch "atomic" "web/themes/contrib/atomic" "$atomic_branch"
 [ "$verbose" = true ] && _say "Moving to atomic repo"
 cd web/themes/contrib/atomic || (_error "Could not find atomic theme. Are you in the right directory?" && exit 1)
 
+[ ! -d "_yale-packages" ] && mkdir _yale-packages && _say "Creating _yale-packages directory for cloning"
+
 _say "Attempting to clone $token_branch branch of tokens repo"
 clone_or_switch_branch "tokens" "_yale-packages/tokens" "$token_branch"
 

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -166,26 +166,33 @@ while getopts ":dvc:t:a:b:" opt; do
   esac
 done
 
-[ -e "./scripts/local/util/say.sh" ] || (echo -e "[$0] Say utility not found.  You must run this from the yalesites root directory: " && exit 1)
+utils_path="./scripts/local/util"
+[ -e "$utils_path" ] || (echo -e "[$0] Utilities not found.  You must run this from the yalesites root directory: " && exit 1)
+
+atomic_path="web/themes/contrib/atomic"
+tokens_path="$atomic_path/_yale-packages/tokens"
+cl_path="$atomic_path/_yale-packages/component-library"
+
+[ -e "$utils_path/say.sh" ] || (echo -e "[$0] Say utility not found.  You must run this from the yalesites root directory: " && exit 1)
 source ./scripts/local/util/say.sh
 
 [ "$debug" = true ] && _say "Debug mode enabled" && set -x
 [ "$verbose" = true ] && _say "Verbose mode enabled"
 
 # Shortcircuit running if there are changes already present
-repo_has_changes 'web/themes/contrib/atomic'
+repo_has_changes '$atomic_path'
 if [ $? -eq 1 ]; then
   _error "You have uncommitted changes to the atomic repo.  Please commit or stash them before running this script."
   exit 1
 fi
 
-repo_has_changes 'web/themes/contrib/atomic/_yale-packages/tokens'
+repo_has_changes '$atomic_path/_yale-packages/tokens'
 if [ $? -eq 1 ]; then
   _error "You have uncommitted changes to the tokens repo.  Please commit or stash them before running this script."
   exit 1
 fi
 
-repo_has_changes 'web/themes/contrib/atomic/_yale-packages/component-library-twig'
+repo_has_changes '$atomic_path/_yale-packages/component-library-twig'
 if [ $? -eq 1 ]; then
   _error "You have uncommitted changes to the component-library-twig repo.  Please commit or stash them before running this script."
   exit 1
@@ -196,15 +203,15 @@ _say "********************"
 
 atomic_changed=false
 # If current branch did change
-if [ "$(current_branch_for_path 'web/themes/contrib/atomic')" != "$atomic_branch" ]; then
+if [ "$(current_branch_for_path '$atomic_path')" != "$atomic_branch" ]; then
   atomic_changed=true
 fi
 
 _say "Attempting to clone $atomic_branch branch of atomic repo"
-clone_or_switch_branch "atomic" "web/themes/contrib/atomic" "$atomic_branch"
+clone_or_switch_branch "atomic" "$atomic_path" "$atomic_branch"
 
 [ "$verbose" = true ] && _say "Moving to atomic repo"
-cd web/themes/contrib/atomic || (_error "Could not find atomic theme. Are you in the right directory?" && exit 1)
+cd $atomic_path || (_error "Could not find atomic theme. Are you in the right directory?" && exit 1)
 
 [ ! -d "_yale-packages" ] && mkdir _yale-packages && _say "Creating _yale-packages directory for cloning"
 
@@ -268,7 +275,7 @@ npm run build
 
 _say "Symlinking to root directory"
 cd ../../../../../..
-[ ! -L "atomic" ] && ln -s web/themes/contrib/atomic atomic
+[ ! -L "atomic" ] && ln -s $atomic_path atomic
 [ ! -L "component-library-twig" ] && ln -s atomic/_yale-packages/component-library-twig component-library-twig
 [ ! -L "tokens" ] && ln -s atomic/_yale-packages/tokens tokens
 
@@ -278,7 +285,7 @@ _say "********************"
 _say "All done!"
 _say "********************"
 _say "Current branches"
-_say "Atomic:            $(current_branch_for_path 'web/themes/contrib/atomic')"
-_say "Component Library: $(current_branch_for_path 'web/themes/contrib/atomic/_yale-packages/component-library-twig')"
-_say "Tokens:            $(current_branch_for_path 'web/themes/contrib/atomic/_yale-packages/tokens')"
+_say "Atomic:            $(current_branch_for_path '$atomic_path')"
+_say "Component Library: $(current_branch_for_path '$atomic_path/_yale-packages/component-library-twig')"
+_say "Tokens:            $(current_branch_for_path '$atomic_path/_yale-packages/tokens')"
 _say "********************"

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -83,7 +83,7 @@ function repo_has_changes() {
 }
 
 # getopts
-while getopts ":dvc:t:a:" opt; do
+while getopts ":dvc:t:a:b:" opt; do
   case ${opt} in
     d )
       debug=true
@@ -100,12 +100,17 @@ while getopts ":dvc:t:a:" opt; do
     v )
       verbose=true
       ;;
+    b )
+      atomic_branch=$OPTARG
+      cl_branch=$OPTARG
+      token_branch=$OPTARG
+      ;;
     \? )
-      echo "Usage: $0 [-d] [-c <component-library-branch>] [-t <tokens-branch>] [-a <atomic-branch>]"
+      echo "Usage: $0 [-d] [-b <branch-for-all-repos>] [-c <component-library-branch>] [-t <tokens-branch>] [-a <atomic-branch>]"
       exit 1
       ;;
     :)
-      echo "Usage: $0 [-d] [-c <component-library-branch>] [-t <tokens-branch>] [-a <atomic-branch>]"
+      echo "Usage: $0 [-d] [-b <branch-for-all-repos>] [-c <component-library-branch>] [-t <tokens-branch>] [-a <atomic-branch>]"
       echo "Option -$OPTARG requires an argument." >&2
       exit 1
       ;;

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -7,6 +7,10 @@ atomic_branch="main"
 debug=false
 verbose=false
 
+atomic_path="web/themes/contrib/atomic"
+tokens_path="$atomic_path/_yale-packages/tokens"
+cl_path="$atomic_path/_yale-packages/component-library-twig"
+
 # current_branch_for_path
 #
 # This function will return the current branch for a given path.
@@ -169,10 +173,6 @@ done
 utils_path="./scripts/local/util"
 [ -e "$utils_path" ] || (echo -e "[$0] Utilities not found.  You must run this from the yalesites root directory: " && exit 1)
 
-atomic_path="web/themes/contrib/atomic"
-tokens_path="$atomic_path/_yale-packages/tokens"
-cl_path="$atomic_path/_yale-packages/component-library"
-
 [ -e "$utils_path/say.sh" ] || (echo -e "[$0] Say utility not found.  You must run this from the yalesites root directory: " && exit 1)
 source ./scripts/local/util/say.sh
 
@@ -192,7 +192,7 @@ if [ $? -eq 1 ]; then
   exit 1
 fi
 
-repo_has_changes '$atomic_path/_yale-packages/component-library-twig'
+repo_has_changes '$cl_path'
 if [ $? -eq 1 ]; then
   _error "You have uncommitted changes to the component-library-twig repo.  Please commit or stash them before running this script."
   exit 1
@@ -286,6 +286,6 @@ _say "All done!"
 _say "********************"
 _say "Current branches"
 _say "Atomic:            $(current_branch_for_path '$atomic_path')"
-_say "Component Library: $(current_branch_for_path '$atomic_path/_yale-packages/component-library-twig')"
+_say "Component Library: $(current_branch_for_path '$cl_path')"
 _say "Tokens:            $(current_branch_for_path '$tokens_path')"
 _say "********************"

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -186,7 +186,7 @@ if [ $? -eq 1 ]; then
   exit 1
 fi
 
-repo_has_changes '$atomic_path/_yale-packages/tokens'
+repo_has_changes '$tokens_path'
 if [ $? -eq 1 ]; then
   _error "You have uncommitted changes to the tokens repo.  Please commit or stash them before running this script."
   exit 1
@@ -287,5 +287,5 @@ _say "********************"
 _say "Current branches"
 _say "Atomic:            $(current_branch_for_path '$atomic_path')"
 _say "Component Library: $(current_branch_for_path '$atomic_path/_yale-packages/component-library-twig')"
-_say "Tokens:            $(current_branch_for_path '$atomic_path/_yale-packages/tokens')"
+_say "Tokens:            $(current_branch_for_path '$tokens_path')"
 _say "********************"

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -254,3 +254,11 @@ cd ../../../../../..
 
 [ "$atomic_changed" = true ] && _say "Atomic theme changed, so we need to clear Drupal cache; this could take a while" && lando drush cr
 
+_say "********************"
+_say "All done!"
+_say "********************"
+_say "Current branches"
+_say "Atomic:            $(current_branch_for_path 'web/themes/contrib/atomic')"
+_say "Component Library: $(current_branch_for_path 'web/themes/contrib/atomic/_yale-packages/component-library-twig')"
+_say "Tokens:            $(current_branch_for_path 'web/themes/contrib/atomic/_yale-packages/tokens')"
+_say "********************"

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -150,6 +150,12 @@ while getopts ":dvc:t:a:b:" opt; do
       ;;
     \? )
       echo "Usage: $0 [-d] [-b <branch-for-all-repos>] [-c <component-library-branch>] [-t <tokens-branch>] [-a <atomic-branch>]"
+      echo "-d: debug mode"
+      echo "-v: verbose mode"
+      echo "-b <branch>: branch for all repos - use if all repos are on the same branch name"
+      echo "-c <branch>: component library branch to use"
+      echo "-t <branch>: tokens branch to use"
+      echo "-a <branch>: atomic branch to use"
       exit 1
       ;;
     :)

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -266,6 +266,12 @@ _say "Rebuilding component library to have dist folder"
 cd ../component-library-twig || (_error "Could not find component-library-twig repo. Are you in the right directory?" && exit 1)
 npm run build
 
+_say "Symlinking to root directory"
+cd ../../../../../..
+[ ! -L "atomic" ] && ln -s web/themes/contrib/atomic atomic
+[ ! -L "component-library-twig" ] && ln -s atomic/_yale-packages/component-library-twig component-library-twig
+[ ! -L "tokens" ] && ln -s atomic/_yale-packages/tokens tokens
+
 [ "$atomic_changed" = true ] && _say "Atomic theme changed, so we need to clear Drupal cache; this could take a while" && lando drush cr
 
 _say "********************"

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -29,10 +29,10 @@ function current_branch_for_path() {
 #  branch_name: the name of the branch
 #
 branch_exists() {
-    local branch_name="$1"
-    local git_path="$2"
+  local branch_name="$1"
+  local git_path="$2"
 
-    git -C "$git_path" rev-parse --quiet --verify "$branch_name"
+  git -C "$git_path" rev-parse --quiet --verify "$branch_name" > /dev/null
 }
 
 # clone_or_switch_branch
@@ -61,11 +61,11 @@ function clone_or_switch_branch() {
   # Clone if directory doesn't exist
   [ ! -d "$git_path" ] && 
     _say "Cloning the $target_branch branch of the $name repo" && 
-    git clone git@github.com:yalesites-org/"$name".git "$git_path" -b "$target_branch"
+    git clone git@github.com:yalesites-org/"$name".git "$git_path" -b "$origin/$target_branch"
 
   # Check if branch existed, and do a backup
   [ ! -d "$git_path" ] && _error "$target_branch not found, defaulting to $backup_branch" && 
-    git clone git@github.com:yalesites-org/"$name".git "$git_path" -b "$backup_branch"
+    git clone git@github.com:yalesites-org/"$name".git "$git_path" -b "$origin/$backup_branch"
 
   # Fail if still not there
   [ ! -d "$git_path" ] && _error "$backup_branch not found; houston, we have a problem..." && exit 1 
@@ -82,7 +82,7 @@ function clone_or_switch_branch() {
       (! branch_exists "$target_branch" "$git_path") && _error "Target branch $target_branch does not exist, switching to $backup_branch" && target_branch="$backup_branch"
 
       _say "Current branch of $name is $current_branch, switching to $target_branch"
-      git -C "$git_path" checkout --track "$origin/$target_branch"
+      git -C "$git_path" checkout "$target_branch" || git -C "$git_path" checkout --track "$origin/$target_branch"
     else
       _error "You have uncommitted changes to the $name repo.  Please commit or stash them before running this script."
       exit 1
@@ -180,6 +180,8 @@ fi
 
 _say "Attempting to clone $atomic_branch branch of atomic repo"
 clone_or_switch_branch "atomic" "web/themes/contrib/atomic" "$atomic_branch"
+
+exit 
 
 [ "$verbose" = true ] && _say "Moving to atomic repo"
 cd web/themes/contrib/atomic || (_error "Could not find atomic theme. Are you in the right directory?" && exit 1)

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -266,12 +266,6 @@ _say "Rebuilding component library to have dist folder"
 cd ../component-library-twig || (_error "Could not find component-library-twig repo. Are you in the right directory?" && exit 1)
 npm run build
 
-_say "Symlinking to root directory"
-cd ../../../../../..
-[ ! -L "atomic" ] && ln -s web/themes/contrib/atomic atomic
-[ ! -L "component-library-twig" ] && ln -s atomic/_yale-packages/component-library-twig component-library-twig
-[ ! -L "tokens" ] && ln -s atomic/_yale-packages/tokens tokens
-
 [ "$atomic_changed" = true ] && _say "Atomic theme changed, so we need to clear Drupal cache; this could take a while" && lando drush cr
 
 _say "********************"

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -190,13 +190,24 @@ npm link @yalesites-org/tokens
 cd ../..
 
 _say "Attempting to npm link tokens inside atomic"
-npm link @yalesites-org/tokens
+# You can't do this because only one npm link can exist at a time on a node_module folder :(
+# npm link @yalesites-org/tokens
+# So we do it ourselves
+rm -rf node_modules/@yalesitesorg/tokens 
+cd node_modules/@yalesites-org || (_error "Could not find component-library-twig repo. Are you in the right directory?" && exit 1)
+ln -s ../../_yale-packages/tokens tokens
+cd ../..
 
 [ "$verbose" = true ] && _say "Moving to tokens repo"
 cd _yale-packages/tokens || (_error "Could not find tokens repo. Are you in the right directory?" && exit 1)
 
 _say "Building tokens"
 cd ../tokens || (_error "Could not find tokens repo. Are you in the right directory?" && exit 1)
+npm i -D
+npm run build
+
+_say "Rebuilding component library to have dist folder"
+cd ../component-library-twig || (_error "Could not find component-library-twig repo. Are you in the right directory?" && exit 1)
 npm run build
 
 _say "Symlinking to root directory"

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -61,6 +61,23 @@ function yalesites_git_clone() {
     git clone git@github.com:yalesites-org/"$name".git "$git_path" -b "$branch"
 }
 
+# git_checkout
+#
+# This function will checkout a branch if it exists.
+#
+# params:
+#  git_path: the path to the repo
+#  target_branch: the branch to switch to
+#  origin: the origin to use
+#
+function git_checkout() {
+  local git_path="${1-$(pwd)}"
+  local target_branch=${2:-main}
+  local origin=${3:-origin}
+
+  git -C "$git_path" checkout "$target_branch" || git -C "$git_path" checkout --track "$origin/$target_branch"
+}
+
 # clone_or_switch_branch
 #
 # This function will clone a repo if it doesn't exist, or switch to a branch if
@@ -107,7 +124,7 @@ function clone_or_switch_branch() {
       (! branch_exists "$target_branch" "$git_path") && _error "Target branch $target_branch does not exist, switching to $backup_branch" && target_branch="$backup_branch"
 
       _say "Current branch of $name is $current_branch, switching to $target_branch"
-      git -C "$git_path" checkout "$target_branch" || git -C "$git_path" checkout --track "$origin/$target_branch"
+      git_checkout "$git_path" "$target_branch" "$origin"
 
       # Verify that the checkout was successful
       current_branch=$(current_branch_for_path "$git_path")
@@ -115,7 +132,7 @@ function clone_or_switch_branch() {
         # If not successful, try the backup branch
         _error "Failed to switch to $target_branch branch of $name repo"
         _say "Attempting to switch to $backup_branch branch of $name repo"
-        git -C "$git_path" checkout "$backup_branch" || git -C "$git_path" checkout --track "$origin/$backup_branch"
+        git_checkout "$git_path" "$backup_branch" "$origin"
 
         # check if that was successful
         current_branch=$(current_branch_for_path "$git_path")

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -5,6 +5,20 @@ cl_branch="main"
 token_branch="main"
 atomic_branch="main"
 debug=false
+verbose=false
+
+# current_branch_for_path
+#
+# This function will return the current branch for a given path.
+#
+# params:
+#  git_path: the path to the repo
+#
+function current_branch_for_path() {
+  local git_path=${1-$(pwd)}
+
+  return $(git -C "$git_path" rev-parse --abbrev-ref HEAD)
+}
 
 # clone_or_switch_branch
 #
@@ -17,10 +31,12 @@ debug=false
 #  name: the name of the repo
 #  git_path: the path to the repo
 #  target_branch: the branch to switch to
+#
 function clone_or_switch_branch() {
   local name=$1
   local git_path=$2
   local target_branch=${3:-main}
+  local current_branch
 
   [ -z "$name" ] && _error "You must provide a name" && exit 1
   [ -z "$git_path" ] && _error "You must provide a git_path" && exit 1
@@ -31,7 +47,7 @@ function clone_or_switch_branch() {
     git clone git@github.com:yalesites-org/"$name".git "$git_path" -b "$target_branch"
 
   # Get current branch of repo
-  current_branch=$(git -C "$git_path" rev-parse --abbrev-ref HEAD)
+  current_branch=$(current_branch_for_path "$git_path")
 
   # If current branch is not the target branch
   if [ "$current_branch" != "$target_branch" ]; then
@@ -50,7 +66,7 @@ function clone_or_switch_branch() {
 }
 
 # getopts
-while getopts ":dc:t:a:" opt; do
+while getopts ":dvc:t:a:" opt; do
   case ${opt} in
     d )
       debug=true
@@ -63,6 +79,9 @@ while getopts ":dc:t:a:" opt; do
       ;;
     a )
       atomic_branch=$OPTARG
+      ;;
+    v )
+      verbose=true
       ;;
     \? )
       echo "Usage: $0 [-d] [-c <component-library-branch>] [-t <tokens-branch>] [-a <atomic-branch>]"
@@ -80,14 +99,21 @@ done
 source ./scripts/local/util/say.sh
 
 [ "$debug" = true ] && _say "Debug mode enabled" && set -x
+[ "$verbose" = true ] && _say "Verbose mode enabled"
 
 _say "Let the magic begin!"
 _say "********************"
 
+atomic_changed=false
+# If current branch did change
+if [ "$(current_branch_for_path 'web/themes/contrib/atomic')" != "$atomic_branch" ]; then
+  atomic_changed=true
+fi
+
 _say "Attempting to clone $atomic_branch branch of atomic repo"
 clone_or_switch_branch "atomic" "web/themes/contrib/atomic" "$atomic_branch"
 
-_say "Moving to atomic repo"
+[ "$verbose" = true ] && _say "Moving to atomic repo"
 cd web/themes/contrib/atomic || (_error "Could not find atomic theme. Are you in the right directory?" && exit 1)
 
 _say "Attempting to clone $token_branch branch of tokens repo"
@@ -97,23 +123,25 @@ _say "Moving into tokens repo and creating a global npm link"
 cd _yale-packages/tokens || (_error "Could not find tokens repo. Are you in the right directory?" && exit 1)
 npm link
 
-_say "Moving back to atomic"
+[ "$verbose" = true ] && _say "Moving back to atomic"
 cd ../..
 
 _say "Attempting to clone $cl_branch branch of component-library-twig repo"
 clone_or_switch_branch "component-library-twig" "_yale-packages/component-library-twig" "$cl_branch"
 
-_say "Moving into component library and creating a global npm link"
+[ "$verbose" = true ] && _say "Moving into component library"
 cd _yale-packages/component-library-twig || (_error "Could not find component-library-twig repo. Are you in the right directory?" && exit 1)
+
+_say "Using the tokens global npm link inside the component library"
 npm link
 
-_say "Moving back to atomic"
+[ "$verbose" = true ] && _say "Moving back to atomic"
 cd ../..
 
 _say "Using the component-library global npm link inside the atomic theme"
 npm link @yalesites-org/component-library-twig
 
-_say "Moving into the component library"
+[ "$verbose" = true ] && _say "Moving into the component library"
 cd _yale-packages/component-library-twig || (_error "Could not find component-library-twig repo. Are you in the right directory?" && exit 1)
 
 _say "Running clean install so we can patch Twig.js"
@@ -122,12 +150,13 @@ npm ci -y
 _say "Using the tokens global npm link inside the component library"
 npm link @yalesites-org/tokens
 
+[ "$verbose" = true ] && _say "Moving back to atomic"
 cd ../..
 
 _say "Attempting to npm link tokens inside atomic"
 npm link @yalesites-org/tokens
 
-_say "Moving to tokens repo"
+[ "$verbose" = true ] && _say "Moving to tokens repo"
 cd _yale-packages/tokens || (_error "Could not find tokens repo. Are you in the right directory?" && exit 1)
 
 _say "Building tokens"
@@ -139,3 +168,6 @@ cd ../../../../../..
 [ ! -L "atomic" ] && ln -s web/themes/contrib/atomic atomic
 [ ! -L "component-library-twig" ] && ln -s atomic/_yale-packages/component-library-twig component-library-twig
 [ ! -L "tokens" ] && ln -s atomic/_yale-packages/tokens tokens
+
+[ "$atomic_changed" = true ] && _say "Atomic theme changed, so we need to clear Drupal cache; this could take a while" && lando drush cr
+

--- a/scripts/local/local-review-with-atomic-branch.sh
+++ b/scripts/local/local-review-with-atomic-branch.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
 # This script will checkout the specified branch of atomic for local review.
 
-GREEN='\033[1;32m'
-ENDCOLOR='\033[0m'
+source ./util/say.sh
 
 read -p "Which branch of the atomic repo do you need? " BRANCH
 
-echo -e "${GREEN}Checking out the $BRANCH branch of Atomic${ENDCOLOR}"
+_say "Checking out the $BRANCH branch of Atomic"
 cd web/themes/contrib/atomic || exit
 git checkout develop
 git pull
 git checkout "$BRANCH"
 git pull
-echo -e "${GREEN}npm ci${ENDCOLOR}"
+_say "npm ci"
 npm ci
-echo -e "${GREEN}Clear Drupal's cache${ENDCOLOR}"
+_say "Clear Drupal's cache"
 cd ../../../..
 lando drush cr

--- a/scripts/local/local-review-with-cl-branch.sh
+++ b/scripts/local/local-review-with-cl-branch.sh
@@ -4,29 +4,28 @@
 # folder so that any work-in-progress in the component library can be used
 # during development in Drupal.
 
-GREEN='\033[1;32m'
-ENDCOLOR='\033[0m'
+source ./util/say.sh
 
 read -p "Which branch of the component-library-twig repo do you need? " BRANCH
 
-echo -e "${GREEN}Move into atomic and checkout develop"
+_say "Move into atomic and checkout develop"
 cd web/themes/contrib/atomic || exit
-echo -e "${GREEN}Delete installed component library${ENDCOLOR}"
+_say "Delete installed component library"
 rm -rf node_modules/@yalesites-org/component-library-twig
-echo -e "${GREEN}Clone component library${ENDCOLOR}"
+_say "Clone component library"
 [ ! -d "_yale-packages/component-library-twig" ] && git clone git@github.com:yalesites-org/component-library-twig.git _yale-packages/component-library-twig
-echo -e "${GREEN}Move into component library${ENDCOLOR}"
+_say "Move into component library"
 cd _yale-packages/component-library-twig || exit
-echo -e "${GREEN}Checkout the specified branch${ENDCOLOR}"
+_say "Checkout the specified branch"
 git checkout "$BRANCH"
 git pull
-echo -e "${GREEN}npm ci and npm run build${ENDCOLOR}"
+_say "npm ci and npm run build"
 npm ci
 npm run build
-echo -e "${GREEN}Move into theme and create empty component-library-twig directory${ENDCOLOR}"
+_say "Move into theme and create empty component-library-twig directory"
 cd ../..
 mkdir node_modules/@yalesites-org/component-library-twig
-echo -e "${GREEN}Copy built dist folder${ENDCOLOR}"
+_say "Copy built dist folder"
 cp -r _yale-packages/component-library-twig/dist node_modules/@yalesites-org/component-library-twig/.
-echo -e "${GREEN}Copy built components folder${ENDCOLOR}"
+_say "Copy built components folder"
 cp -r _yale-packages/component-library-twig/components node_modules/@yalesites-org/component-library-twig/.

--- a/scripts/local/local-theme-link.sh
+++ b/scripts/local/local-theme-link.sh
@@ -11,23 +11,23 @@
 # through the regular component library release process, and be included in an
 # official release of Atomic.
 
-GREEN='\033[1;32m'
-ENDCOLOR='\033[0m'
+[ -e "./scripts/local/util/say.sh" ] || (echo -e "[$0] Say utility not found.  You must run this from the yalesites root directory: " && exit 1)
+source ./scripts/local/util/say.sh
 
-echo -e "${GREEN}Move into tokens repo and create a global link${ENDCOLOR}"
+_say "Move into tokens repo and create a global link"
 cd web/themes/contrib/atomic
 [ ! -d "_yale-packages/tokens" ] && git clone git@github.com:yalesites-org/tokens.git _yale-packages/tokens
 cd _yale-packages/tokens || exit
 npm link
 cd ../..
-echo -e "${GREEN}Move into component library and create a global link${ENDCOLOR}"
+_say "Move into component library and create a global link"
 [ ! -d "_yale-packages/component-library-twig" ] && git clone git@github.com:yalesites-org/component-library-twig.git _yale-packages/component-library-twig
 cd _yale-packages/component-library-twig || exit
 npm link
-echo -e "${GREEN}Move into Atomic and use the component-library global link${ENDCOLOR}"
+_say "Move into Atomic and use the component-library global link"
 cd ../..
 npm link @yalesites-org/component-library-twig
-echo -e "${GREEN}Move into the component-library and use the tokens global link${ENDCOLOR}"
+_say "Move into the component-library and use the tokens global link"
 cd _yale-packages/component-library-twig || exit
 # Run npm ci. This is required to patch our version of Twig.js.
 npm ci

--- a/scripts/local/local-theme-link.sh
+++ b/scripts/local/local-theme-link.sh
@@ -11,23 +11,4 @@
 # through the regular component library release process, and be included in an
 # official release of Atomic.
 
-source ./util/say.sh
-
-_say "Move into tokens repo and create a global link"
-cd web/themes/contrib/atomic
-[ ! -d "_yale-packages/tokens" ] && git clone git@github.com:yalesites-org/tokens.git _yale-packages/tokens
-cd _yale-packages/tokens || exit
-npm link
-cd ../..
-_say "Move into component library and create a global link"
-[ ! -d "_yale-packages/component-library-twig" ] && git clone git@github.com:yalesites-org/component-library-twig.git _yale-packages/component-library-twig
-cd _yale-packages/component-library-twig || exit
-npm link
-_say "Move into Atomic and use the component-library global link"
-cd ../..
-npm link @yalesites-org/component-library-twig
-_say "Move into the component-library and use the tokens global link"
-cd _yale-packages/component-library-twig || exit
-# Run npm ci. This is required to patch our version of Twig.js.
-npm ci
-npm link @yalesites-org/tokens
+echo -e "Use local-cl-dev.sh instead.  This script is deprecated."

--- a/scripts/local/local-theme-link.sh
+++ b/scripts/local/local-theme-link.sh
@@ -11,4 +11,24 @@
 # through the regular component library release process, and be included in an
 # official release of Atomic.
 
-echo -e "Use local-cl-dev.sh instead.  This script is deprecated."
+GREEN='\033[1;32m'
+ENDCOLOR='\033[0m'
+
+echo -e "${GREEN}Move into tokens repo and create a global link${ENDCOLOR}"
+cd web/themes/contrib/atomic
+[ ! -d "_yale-packages/tokens" ] && git clone git@github.com:yalesites-org/tokens.git _yale-packages/tokens
+cd _yale-packages/tokens || exit
+npm link
+cd ../..
+echo -e "${GREEN}Move into component library and create a global link${ENDCOLOR}"
+[ ! -d "_yale-packages/component-library-twig" ] && git clone git@github.com:yalesites-org/component-library-twig.git _yale-packages/component-library-twig
+cd _yale-packages/component-library-twig || exit
+npm link
+echo -e "${GREEN}Move into Atomic and use the component-library global link${ENDCOLOR}"
+cd ../..
+npm link @yalesites-org/component-library-twig
+echo -e "${GREEN}Move into the component-library and use the tokens global link${ENDCOLOR}"
+cd _yale-packages/component-library-twig || exit
+# Run npm ci. This is required to patch our version of Twig.js.
+npm ci
+npm link @yalesites-org/tokens

--- a/scripts/local/local-theme-link.sh
+++ b/scripts/local/local-theme-link.sh
@@ -11,23 +11,22 @@
 # through the regular component library release process, and be included in an
 # official release of Atomic.
 
-GREEN='\033[1;32m'
-ENDCOLOR='\033[0m'
+source ./util/say.sh
 
-echo -e "${GREEN}Move into tokens repo and create a global link${ENDCOLOR}"
+_say "Move into tokens repo and create a global link"
 cd web/themes/contrib/atomic
 [ ! -d "_yale-packages/tokens" ] && git clone git@github.com:yalesites-org/tokens.git _yale-packages/tokens
 cd _yale-packages/tokens || exit
 npm link
 cd ../..
-echo -e "${GREEN}Move into component library and create a global link${ENDCOLOR}"
+_say "Move into component library and create a global link"
 [ ! -d "_yale-packages/component-library-twig" ] && git clone git@github.com:yalesites-org/component-library-twig.git _yale-packages/component-library-twig
 cd _yale-packages/component-library-twig || exit
 npm link
-echo -e "${GREEN}Move into Atomic and use the component-library global link${ENDCOLOR}"
+_say "Move into Atomic and use the component-library global link"
 cd ../..
 npm link @yalesites-org/component-library-twig
-echo -e "${GREEN}Move into the component-library and use the tokens global link${ENDCOLOR}"
+_say "Move into the component-library and use the tokens global link"
 cd _yale-packages/component-library-twig || exit
 # Run npm ci. This is required to patch our version of Twig.js.
 npm ci

--- a/scripts/local/util/say.sh
+++ b/scripts/local/util/say.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+GREEN='\033[0;32m'
+ENDCOLOR='\033[0m'
+
+function _say() {
+    echo -e "${GREEN}$1${ENDCOLOR}"
+}

--- a/scripts/local/util/say.sh
+++ b/scripts/local/util/say.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
 GREEN='\033[0;32m'
+RED='\033[0;31m'
 ENDCOLOR='\033[0m'
 
 function _say() {
     echo -e "${GREEN}$1${ENDCOLOR}"
+}
+
+function _error() {
+    echo -e "${RED}$1${ENDCOLOR}"
 }

--- a/scripts/local/util/say.sh
+++ b/scripts/local/util/say.sh
@@ -5,9 +5,16 @@ RED='\033[0;31m'
 ENDCOLOR='\033[0m'
 
 function _say() {
-    echo -e "${GREEN}$1${ENDCOLOR}"
+    local script_name="${0##*/}"
+    echo -e "${GREEN}[$script_name] $1${ENDCOLOR}"
 }
 
 function _error() {
-    echo -e "${RED}$1${ENDCOLOR}"
+    local script_name="${0##*/}"
+    echo -e "${RED}[$script_name] $1${ENDCOLOR}"
+}
+
+function _error_and_exit() {
+    _error "$1"
+    exit
 }


### PR DESCRIPTION
## [YALB-971: LocalDev theme setup scripts](https://yaleits.atlassian.net/browse/YALB-971)

### Description of work
- Includes [YALB-715](https://yaleits.atlassian.net/jira/software/projects/YALB/boards/368?selectedIssue=YALB-715) as it's closely related
  - Script prepends script name to any output so you can know what is running (useful later when other scripts attempt to use this one)
- New script `local-git-checkout.sh` that can safely change branches on any of the 3 repositories (`token`, `component-library-twig`, and `atomic`)
- Create symlinks to each repo at the base directory to quickly get to the development versions (gitignored)
- Give error messages should the script error, such as directories not existing
- Clears Drupal cache if the `atomic` branch is changed
- Other scripts utilize new `say` utility method to help readability: i.e. `local-cl-dev.sh`
- It will not switch repos if there are conflicting git changes uncommitted

### Usage

For Help:
```bash
npm run local:git-checkout -- -h
```

To attempt to change all repo branches to the same (reverts back to main (or develop for yalesites) if doesn't exist):
```bash
npm run local:git-checkout -- -b YALB-xx-whatever-your-branch-name-is
```

To target individual branch names for each repo (-c = Component Library, -a = Atomic, -t = Token, -m = YaleSites main repo)
```bash
npm run local:git-checkout -- -c YALB-11 -a YALB-33 -t figma -m YALB-12
```

To debug any problems you might see:
```bash
npm run local:git-checkout -- -d
```

To get even more verbose execution messages:
```bash
npm run local:git-checkout -- -v
```

To set up CL, Atomic, and Tokens to main branch, and YaleSites main repo to develop, run without arguments:
```bash
npm run local:git-checkout
```

### Functional testing steps:
- [x] `cd` to `yalesites-project` directory (best on fresh version)
- [x] Run `npm run local:git-checkout`
- [x] Verify no errors occurred
- [x] Run `ls`
- [x] Verify that the following symlinks exist: `atomic`, `component-library-twig`, and `tokens`
- [x] Visit your local yalesites website and verify that the pages look like tokens are being loaded
- [x] Use it with a repo setup you're currently needing in case I missed a permutation

[YALB-715]: https://yaleits.atlassian.net/browse/YALB-715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ