### PR TITLE
YALB-340: Google Analytics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,9 @@
       "composer/installers": true,
       "cweagans/composer-patches": true,
       "drupal/core-composer-scaffold": true,
-      "drupal/console-extend-plugin": true
+      "drupal/console-extend-plugin": true,
+      "phpstan/extension-installer": true,
+      "drupal/core-project-message": true
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -106,9 +106,7 @@
       "composer/installers": true,
       "cweagans/composer-patches": true,
       "drupal/core-composer-scaffold": true,
-      "drupal/console-extend-plugin": true,
-      "phpstan/extension-installer": true,
-      "drupal/core-project-message": true
+      "drupal/console-extend-plugin": true
     }
   },
   "scripts": {

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -30,6 +30,7 @@
     "drupal/field_group": "^3.2",
     "drupal/gin": "^3.0@beta",
     "drupal/gin_lb": "^1.0@RC",
+    "drupal/google_analytics": "^4.0",
     "drupal/hide_revision_field": "^2.2",
     "drupal/honeypot": "^2.1",
     "drupal/image_widget_crop": "^2.3",

--- a/web/profiles/custom/yalesites_profile/config/sync/config_ignore.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/config_ignore.settings.yml
@@ -1,6 +1,7 @@
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk
 ignored_config_entities:
+  - 'google_analytics.settings:account'
   - 'system.site*'
   - 'ys_alert.settings:alert'
   - 'ys_core*'

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -40,6 +40,7 @@ module:
   filter: 0
   gin_lb: 0
   gin_toolbar: 0
+  google_analytics: 0
   help: 0
   honeypot: 0
   image: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/google_analytics.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/google_analytics.settings.yml
@@ -1,0 +1,36 @@
+_core:
+  default_config_hash: dwMYPgAnj9KBO77SLEv9Z42NDJAbuxe0uU9eGC8qw3M
+account: ''
+domain_mode: 0
+cross_domains: ''
+visibility:
+  request_path_mode: 0
+  request_path_pages: "/admin\r\n/admin/*\r\n/batch\r\n/node/add*\r\n/node/*/*\r\n/user/*/*"
+  user_role_mode: 0
+  user_role_roles: {  }
+  user_account_mode: 1
+track:
+  outbound: true
+  mailto: true
+  tel: true
+  files: true
+  files_extensions: '7z|aac|arc|arj|asf|asx|avi|bin|csv|doc(x|m)?|dot(x|m)?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt(x|m)?|pot(x|m)?|pps(x|m)?|ppam|sld(x|m)?|thmx|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls(x|m|b)?|xlt(x|m)|xlam|xml|z|zip'
+  colorbox: true
+  linkid: false
+  urlfragments: false
+  userid: false
+  messages: {  }
+  site_search: false
+  adsense: false
+  displayfeatures: true
+privacy:
+  anonymizeip: true
+custom:
+  parameters: {  }
+codesnippet:
+  create: {  }
+  before: ''
+  after: ''
+translation_set: false
+cache: false
+debug: false

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.authenticated.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.authenticated.yml
@@ -8,6 +8,7 @@ dependencies:
     - filter.format.restricted_html
   module:
     - filter
+    - google_analytics
     - media
     - system
 _core:
@@ -18,6 +19,7 @@ weight: 1
 is_admin: false
 permissions:
   - 'access content'
+  - 'opt-in or out of google analytics tracking'
   - 'use text format basic_html'
   - 'use text format heading_html'
   - 'use text format restricted_html'

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_core.site.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_core.site.yml
@@ -5,5 +5,6 @@ search:
   enable_search_form: 1
 seo:
   google_site_verification: ''
+  google_analytics_id: ''
 image_fallback:
   teaser: ''

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/install/ys_core.site.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/install/ys_core.site.yml
@@ -5,5 +5,6 @@ search:
   enable_search_form: 1
 seo:
   google_site_verification: ''
+  google_analytics_id: ''
 image_fallback:
   teaser: ''

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -345,7 +345,7 @@ class SiteSettingsForm extends ConfigFormBase {
    */
   protected function validateGoogleAnalyticsId(FormStateInterface &$form_state, string $fieldId) {
     // Exit early if the google_analytics module changed and no longer applies.
-    if(!class_exists('Drupal\google_analytics\Constants\GoogleAnalyticsPatterns')) {
+    if (!class_exists('Drupal\google_analytics\Constants\GoogleAnalyticsPatterns')) {
       return;
     }
     if (($value = $form_state->getValue($fieldId))) {


### PR DESCRIPTION
## [YALB-340: Google Analytics](https://yaleits.atlassian.net/browse/YALB-340)

### Description of work
- Add and enable the google_analytics
- Updates the config-ignore list so that sites can have unique GA property IDs
- Adds a Google Analytics ID field to the site settings form, including validation.

### Functional testing steps:
- [x] Login and navigate to the [site settings form](https://pr-282-yalesites-platform.pantheonsite.io/admin/yalesites/settings)
- [x] Locate the field 'Google Analytics Web Property ID' and verify that this is an optional textfield with descriptive help text.
- [x] Test the validation but adding a bad code. For example, add 'HOWDY' and click 'Save Configuration'. Confirm that the user is given a validation error with instruction to provide a correct code.
- [x] Try a code the follow the correct format. For example 'G-12345678'.
- [ ] View the source code on any node and verify that the following tag has been added to the page
```html
<script async src="https://www.googletagmanager.com/gtag/js?id=G-12345678"></script>
```
![Screen Shot 2023-05-23 at 1 52 07 PM](https://github.com/yalesites-org/yalesites-project/assets/9594124/ecbfc475-c40a-4679-a553-319917bad340)
