### PR TITLE
YALB-609: Page lists and grid display modes

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -61,7 +61,8 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
     'page' => [
       'label' => 'Pages',
       'view_modes' => [
-        'teaser' => 'Teasers',
+        'card' => 'Page Grid',
+        'list_item' => 'Page List',
       ],
       'sort_by' => [
         'title:ASC' => 'Title - A-Z',


### PR DESCRIPTION
## [YALB-609: Page lists and grid display modes](https://yaleits.atlassian.net/browse/YALB-609)

### Description of work
- Updates allowed view modes on views basic to `card` or `list_item` to match other content types. 

### Functional testing steps:
- [ ] Login and edit a page or view this page: https://pr-287-yalesites-platform.pantheonsite.io/components and scroll to the bottom
- [ ] Add at least two views displays with the following options:
  - [ ] One, select `Pages` content in `Page Grid` format
  - [ ] Two, select `Pages` content in `Page List` format
  
![Screenshot-20230525123559-2337x1291](https://github.com/yalesites-org/yalesites-project/assets/366413/06464755-3985-462b-87be-0becdb1b09ce)

- [ ] Verify each render as they should

#### grid

![Screenshot-20230525123426-1822x1272](https://github.com/yalesites-org/yalesites-project/assets/366413/ba3166b2-7431-4091-9c54-acea4ef2064d)

#### list

![Screenshot-20230525123438-2030x1342](https://github.com/yalesites-org/yalesites-project/assets/366413/314c5ae6-28b1-4812-9f7b-4d11257451ef)

