### PR TITLE
[Hotfix] YALB-1246: Replace linkit widget with native link control

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
@@ -15,7 +15,7 @@ dependencies:
     - field.field.block_content.content_spotlight.field_text
   module:
     - allowed_formats
-    - linkit
+    - link
     - markup
     - maxlength
     - media_library
@@ -48,15 +48,17 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_link:
-    type: linkit
+    type: link_default
     weight: 6
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: null
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: false
   field_media:
     type: media_library_widget
     weight: 2

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.cta_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.cta_banner.default.yml
@@ -13,7 +13,7 @@ dependencies:
     - field.field.block_content.cta_banner.field_text
   module:
     - allowed_formats
-    - linkit
+    - link
     - markup
     - maxlength
     - media_library
@@ -46,14 +46,12 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_link:
-    type: linkit
+    type: link_default
     weight: 11
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
     third_party_settings: {  }
   field_media:
     type: media_library_widget

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.grand_hero.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.grand_hero.default.yml
@@ -13,7 +13,7 @@ dependencies:
     - field.field.block_content.grand_hero.field_text
   module:
     - allowed_formats
-    - linkit
+    - link
     - markup
     - maxlength
     - media_library
@@ -46,14 +46,12 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_link:
-    type: linkit
+    type: link_default
     weight: 7
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
     third_party_settings: {  }
   field_media:
     type: media_library_widget

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.quick_links.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.quick_links.default.yml
@@ -11,7 +11,7 @@ dependencies:
     - field.field.block_content.quick_links.field_text
   module:
     - allowed_formats
-    - linkit
+    - link
     - markup
     - maxlength
     - media_library
@@ -44,14 +44,12 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_links:
-    type: linkit
+    type: link_default
     weight: 4
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
     third_party_settings: {  }
   field_media:
     type: media_library_widget

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.callout_item.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.callout_item.default.yml
@@ -9,7 +9,7 @@ dependencies:
     - paragraphs.paragraphs_type.callout_item
   module:
     - allowed_formats
-    - linkit
+    - link
     - maxlength
     - text
 id: paragraph.callout_item.default
@@ -32,14 +32,12 @@ content:
         maxlength_js: 80
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
   field_link:
-    type: linkit
+    type: link_default
     weight: 3
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
     third_party_settings: {  }
   field_text:
     type: text_textarea

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.custom_card.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.custom_card.default.yml
@@ -10,7 +10,7 @@ dependencies:
     - paragraphs.paragraphs_type.custom_card
   module:
     - allowed_formats
-    - linkit
+    - link
     - maxlength
     - media_library
     - media_library_edit
@@ -44,14 +44,12 @@ content:
       media_library_edit:
         show_edit: '1'
   field_link:
-    type: linkit
+    type: link_default
     weight: 3
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
     third_party_settings:
       maxlength:
         maxlength_js: null

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_toolbar/css/ys_toolbar.theme.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_toolbar/css/ys_toolbar.theme.css
@@ -1,4 +1,5 @@
 /* Swap Drupal drop for Yale logo */
 .toolbar .toolbar-bar #toolbar-item-administration-tray .toolbar-icon-admin-toolbar-tools-help.toolbar-icon-default::before {
+  -webkit-mask-image: url('../images/yale-university-press-1985-2010.svg') !important;
   mask-image: url('../images/yale-university-press-1985-2010.svg') !important;
 }


### PR DESCRIPTION
## [YALB-1246: Replace linkit widget with native link control](https://yaleits.atlassian.net/browse/YALB-1246)

### Description of work
- Replace the autocomplete widget with the native link control
- Add a vendor prefix to the CSS to display the Yale logo in the corner

### Functional testing steps:
- [x] Login as a site admin
- [x] Visit the layout builder page for a node
- [x] Add an Action Banner
- [x] Change the value of the link field. Verify that the autocomplete function works for internal links.
