### PR TITLE
YALB-1211: Exclude a term in views

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.view.field_view_params.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.view.field_view_params.yml
@@ -18,8 +18,8 @@ translatable: false
 default_value:
   -
     group_params:
-      params: '{"view_mode":"card","filters":{"types":["post"],"tags":null,"event_category":null},"operator":"or","sort_by":null,"display":null,"limit":0}'
-    params: '{"view_mode":"card","filters":{"types":["post"],"tags":null,"event_category":null},"operator":"+","sort_by":null,"display":null,"limit":0}'
+      params: '{"view_mode":"card","filters":{"types":["post"],"terms_include":null,"terms_exclude":null},"operator":"+","sort_by":null,"display":null,"limit":0}'
+    params: '{"view_mode":"card","filters":{"types":["post"],"terms_include":null,"terms_exclude":null},"operator":"+","sort_by":null,"display":null,"limit":0}'
 default_value_callback: ''
 settings: {  }
 field_type: views_basic_params

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.taxonomy_lookup.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.taxonomy_lookup.yml
@@ -1,0 +1,310 @@
+uuid: 6213f4a1-3334-4afd-9cea-c32990ad96a7
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+    - user
+id: taxonomy_lookup
+label: 'Taxonomy Lookup'
+module: views
+description: 'Used in Views Basic to show terms with vocabulary for entity reference fields'
+tag: ''
+base_table: taxonomy_term_field_data
+base_field: tid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      fields:
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          convert_spaces: false
+        vid:
+          id: vid
+          table: taxonomy_term_field_data
+          field: vid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: vid
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: custom
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ name }} ({{ vid }})'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: taxonomy_term_field_data
+          field: status
+          entity_type: taxonomy_term
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  entity_reference_1:
+    id: entity_reference_1
+    display_title: 'Entity Reference'
+    display_plugin: entity_reference
+    position: 1
+    display_options:
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            name: name
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
@@ -222,7 +222,7 @@ display:
           title: ''
           default_argument_type: query_parameter
           default_argument_options:
-            query_param: terms
+            query_param: terms_include
             fallback: ''
             multiple: or
           default_argument_skip_url: false
@@ -248,7 +248,46 @@ display:
           add_table: false
           require_value: false
           reduce_duplicates: true
-      filters: {  }
+      filters:
+        exclude_taxonomy_terms:
+          id: exclude_taxonomy_terms
+          table: node_field_data
+          field: exclude_taxonomy_terms
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: exclude_taxonomy_terms
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       style:
         type: ys_views_basic_dynamic_style
         options:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -141,20 +141,6 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
 
     $form['group_user_selection']['filter_and_sort'] = [
       '#type' => 'container',
-      '#attributes' => [
-        'class' => [
-          'grouped-items',
-        ],
-      ],
-    ];
-
-    $form['group_user_selection']['additional_filters'] = [
-      '#type' => 'container',
-      '#attributes' => [
-        'class' => [
-          'grouped-items',
-        ],
-      ],
     ];
 
     $form['group_user_selection']['filter_options'] = [
@@ -222,16 +208,35 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       '#suffix' => '</div>',
     ];
 
-    // @todo add validation for only one term.
-    // More info: https://www.drupal.org/project/drupal/issues/2951134
-    $form['group_user_selection']['filter_and_sort']['tags'] = [
-      '#title' => $this->t('Tagged as'),
+    $form['group_user_selection']['filter_and_sort']['terms_include'] = [
+      '#title' => $this->t('Include content that uses the following terms'),
       '#type' => 'entity_autocomplete',
       '#tags' => TRUE,
       '#target_type' => 'taxonomy_term',
-      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('tags', $items[$delta]->params) : [],
+      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('terms_include', $items[$delta]->params) : [],
+      '#selection_handler' => 'views',
       '#selection_settings' => [
-        'target_bundles' => ['tags'],
+        'view' => [
+          'view_name' => 'taxonomy_lookup',
+          'display_name' => 'entity_reference_1',
+          'arguments' => [],
+        ],
+      ],
+    ];
+
+    $form['group_user_selection']['filter_and_sort']['terms_exclude'] = [
+      '#title' => $this->t('Exclude content that uses the following terms'),
+      '#type' => 'entity_autocomplete',
+      '#tags' => TRUE,
+      '#target_type' => 'taxonomy_term',
+      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('terms_exclude', $items[$delta]->params) : [],
+      '#selection_handler' => 'views',
+      '#selection_settings' => [
+        'view' => [
+          'view_name' => 'taxonomy_lookup',
+          'display_name' => 'entity_reference_1',
+          'arguments' => [],
+        ],
       ],
     ];
 
@@ -247,24 +252,6 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       '#validated' => 'true',
       '#prefix' => '<div id="edit-sort-by">',
       '#suffix' => '</div>',
-    ];
-
-    $form['group_user_selection']['additional_filters']['event_category'] = [
-      '#title' => $this->t('Event Category'),
-      '#type' => 'entity_autocomplete',
-      '#tags' => TRUE,
-      '#target_type' => 'taxonomy_term',
-      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('event_category', $items[$delta]->params) : [],
-      '#selection_settings' => [
-        'target_bundles' => ['event_category'],
-      ],
-      '#states' => [
-        'visible' => [
-          ':input[name="settings[block_form][group_user_selection][entity_and_view_mode][entity_types]"]' => [
-            'value' => 'event',
-          ],
-        ],
-      ],
     ];
 
     $form['group_user_selection']['filter_options']['term_operator'] = [
@@ -351,13 +338,13 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
    * Get data from user selection and save into params field.
    */
   public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
-    $tags = ($form_state->getValue(
+    $terms_include = ($form_state->getValue(
         [
           'settings',
           'block_form',
           'group_user_selection',
           'filter_and_sort',
-          'tags',
+          'terms_include',
         ]
       ))
       ? $form_state->getValue(
@@ -366,17 +353,17 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
             'block_form',
             'group_user_selection',
             'filter_and_sort',
-            'tags',
+            'terms_include',
           ]
         )
       : NULL;
-    $eventCategory = ($form_state->getValue(
+    $terms_exclude = ($form_state->getValue(
         [
           'settings',
           'block_form',
           'group_user_selection',
-          'additional_filters',
-          'event_category',
+          'filter_and_sort',
+          'terms_exclude',
         ]
       ))
       ? $form_state->getValue(
@@ -384,8 +371,8 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
             'settings',
             'block_form',
             'group_user_selection',
-            'additional_filters',
-            'event_category',
+            'filter_and_sort',
+            'terms_exclude',
           ]
         )
       : NULL;
@@ -396,8 +383,8 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
           "types" => [
             $form['group_user_selection']['entity_and_view_mode']['entity_types']['#value'],
           ],
-          "tags" => $tags,
-          "event_category" => $eventCategory,
+          "terms_include" => $terms_include,
+          "terms_exclude" => $terms_exclude,
         ],
         "operator" => $form['group_user_selection']['filter_options']['term_operator']['#value'],
         "sort_by" => $form_state->getValue(

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/ExcludeTaxonomyTerms.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/ExcludeTaxonomyTerms.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\ys_views_basic\Plugin\views\filter;
+
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+use Drupal\views\Views;
+
+/**
+ * Excludes taxonomy terms by ID.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("exclude_taxonomy_terms")
+ */
+class ExcludeTaxonomyTerms extends FilterPluginBase {
+
+  /**
+   * Add this filter to the query.
+   */
+  public function query() {
+    // Ensure the main table for this handler is in the query.
+    $this->ensureMyTable();
+    $query = $this->query;
+
+    $configuration = array(
+      'table' => 'taxonomy_index',
+      'field' => 'nid',
+      'left_table' => 'node_field_data',
+      'left_formula' => 'node_field_data.nid',
+      'operator' => '=',
+      'extra' => array(
+        0 => array(
+          'field' => 'tid',
+          'value' => '2',
+        ),
+      ),
+    );
+    $join = Views::pluginManager('join')
+      ->createInstance('standard', $configuration);
+
+    $lookupTable = $query->addTable('taxonomy_index', NULL, $join);
+
+    //   ->condition('taxonomy_index.tid', '3', '=');
+    $field = "$lookupTable.tid";
+    $operator = 'IS NULL';
+    $this->query->addWhereExpression(0, "$field $operator");
+
+    //kint($query->query()->__toString());
+  }
+
+ }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/ExcludeTaxonomyTerms.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/ExcludeTaxonomyTerms.php
@@ -18,34 +18,64 @@ class ExcludeTaxonomyTerms extends FilterPluginBase {
    * Add this filter to the query.
    */
   public function query() {
-    // Ensure the main table for this handler is in the query.
-    $this->ensureMyTable();
-    $query = $this->query;
 
-    $configuration = array(
-      'table' => 'taxonomy_index',
-      'field' => 'nid',
-      'left_table' => 'node_field_data',
-      'left_formula' => 'node_field_data.nid',
-      'operator' => '=',
-      'extra' => array(
-        0 => array(
+    if (!isset($this->view->args[2])) {
+      return;
+    }
+    else {
+      $excludedTerms = $this->view->args[2];
+      switch ($excludedTerms) {
+        case str_contains($excludedTerms, ','):
+          $excludedTermsArray = explode(',', $excludedTerms);
+          break;
+
+        case str_contains($excludedTerms, '+'):
+          $excludedTermsArray = explode('+', $excludedTerms);
+          break;
+
+        default:
+          $excludedTermsArray[0] = $excludedTerms;
+          break;
+      }
+
+      foreach ($excludedTermsArray as $term) {
+        $joinSearch[] = [
           'field' => 'tid',
-          'value' => '2',
-        ),
-      ),
-    );
-    $join = Views::pluginManager('join')
-      ->createInstance('standard', $configuration);
+          'value' => $term,
+        ];
+      }
 
-    $lookupTable = $query->addTable('taxonomy_index', NULL, $join);
+      // Ensure the main table for this handler is in the query.
+      $this->ensureMyTable();
+      /** @var \Drupal\views\Plugin\views\query\Sql $query */
+      $query = $this->query;
 
-    //   ->condition('taxonomy_index.tid', '3', '=');
-    $field = "$lookupTable.tid";
-    $operator = 'IS NULL';
-    $this->query->addWhereExpression(0, "$field $operator");
+      // @see https://api.drupal.org/api/drupal/core%21modules%21views%21src%21Plugin%21views%21join%21JoinPluginBase.php/group/views_join_handlers/8.2.x
+      // @see https://api.drupal.org/api/drupal/core%21modules%21views%21src%21Plugin%21views%21query%21Sql.php/function/Sql%3A%3AaddTable/9
+      // Create join with extra to search for each term in the taxonomy index.
+      $configuration = [
+        'table' => 'taxonomy_index',
+        'field' => 'nid',
+        'left_table' => 'node_field_data',
+        'left_formula' => 'node_field_data.nid',
+        'operator' => '=',
+        'extra' => $joinSearch,
+      ];
+      $join = Views::pluginManager('join')
+        ->createInstance('standard', $configuration);
 
-    //kint($query->query()->__toString());
+      // Change operator of the search based on selection in views tool.
+      $join->extraOperator = 'OR';
+
+      // Add lookup table with new join.
+      $lookupTable = $query->addTable('taxonomy_index', NULL, $join);
+
+      $field = "$lookupTable.tid";
+      $operator = 'IS NULL';
+
+      // Add the where clause.
+      $query->addWhereExpression(0, "$field $operator");
+    }
   }
 
- }
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/pager/ViewsBasicFullPager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/pager/ViewsBasicFullPager.php
@@ -24,10 +24,10 @@ class ViewsBasicFullPager extends Full {
    * {@inheritdoc}
    */
   public function query() {
-    if (!isset($this->view->args[4])) {
+    if (!isset($this->view->args[5])) {
       return;
     }
-    $this->setItemsPerPage((int) $this->view->args[4]);
+    $this->setItemsPerPage((int) $this->view->args[5]);
     $limit = $this->options['items_per_page'];
     $offset = $this->current_page * $this->options['items_per_page'] + $this->options['offset'];
     if (!empty($this->options['total_pages'])) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/sort/ViewsBasicSort.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/sort/ViewsBasicSort.php
@@ -23,8 +23,8 @@ class ViewsBasicSort extends SortPluginBase {
     $query = $this->query;
 
     // Split out the field and the sort direction.
-    if (isset($this->view->args[2])) {
-      $sortBy = $this->view->args[2];
+    if (isset($this->view->args[3])) {
+      $sortBy = $this->view->args[3];
       if (str_contains($sortBy, ':')) {
         $sortQueryOptions = explode(":", $sortBy);
         if (str_starts_with($sortQueryOptions[0], 'field')) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/style/ViewsBasicDynamicStyle.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/style/ViewsBasicDynamicStyle.php
@@ -91,8 +91,8 @@ class ViewsBasicDynamicStyle extends StylePluginBase implements ContainerFactory
     if (!empty($this->view->rowPlugin)) {
 
       // Gets passed view mode from ViewsBasicDefaultFormatter and sets per row.
-      if (isset($this->view->args[3])) {
-        $viewMode = $this->view->args[3];
+      if (isset($this->view->args[4])) {
+        $viewMode = $this->view->args[4];
         $validViewModes = $this->entityDisplay->getViewModeOptions('node');
         if (array_key_exists($viewMode, $validViewModes)) {
           $this->view->rowPlugin->options['view_mode'] = $viewMode;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -45,7 +45,7 @@ function ys_views_basic_views_data_alter(array &$data) {
   $data['node_field_data']['exclude_taxonomy_terms'] = [
     'title' => t('Exclude Taxonomy Terms'),
     'filter' => [
-      'help' => t('Excludes Taxonomy Terms'),
+      'help' => t('Excludes taxonomy terms dynamically from the views tool'),
       'id' => 'exclude_taxonomy_terms',
     ],
   ];

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -42,4 +42,11 @@ function ys_views_basic_views_data_alter(array &$data) {
       'id' => 'views_basic_sort',
     ],
   ];
+  $data['node_field_data']['exclude_taxonomy_terms'] = [
+    'title' => t('Exclude Taxonomy Terms'),
+    'filter' => [
+      'help' => t('Excludes Taxonomy Terms'),
+      'id' => 'exclude_taxonomy_terms',
+    ],
+  ];
 }


### PR DESCRIPTION
## [YALB-1211: Exclude a term in views](https://yaleits.atlassian.net/browse/YALB-1211)

### Description of work
- Includes work from [PR 276 for YALB-1198](https://github.com/yalesites-org/yalesites-project/pull/276) as a starting point
- Adds the ability to exclude terms in a view
- Reworks how terms are chosen on the view settings form: there are two fields, one for including terms, and the other for excluding terms.
- When including terms, the "Any (OR) /All (AND)" operator works as expected
- When excluding terms, this will ignore the "Any/All" operator and instead default to "Any (OR)" as otherwise things get very confusing very quickly. We can change this if we want to add another "operator" control to control just the exclude in addition to the include.
- Adds an entity reference view to help when choosing terms for the two reference fields above. This new view simply adds the vocabulary name in parentheses when performing an autocomplete search to help find the correct term - say if the same term name was used in two different vocabularies.

### Functional testing steps:
- [x] Add some event categories and tags to the site. If logged in as an admin, this can be done [here for events](https://pr-290-yalesites-platform.pantheonsite.io/admin/structure/taxonomy/manage/event_category/add) and [here for tags](https://pr-290-yalesites-platform.pantheonsite.io/admin/structure/taxonomy/manage/tags/add). If not an admin, these can be added on the event and news edit pages as part of those fields.
- [x] Create some events on the site and title them in a way to help test out which categories and tags are part of each event. Add some categories and tags to each. Also, make sure to add a date or else they won't show up in the view.
- [x] Add a page to the site, add a title, and save. In Layout builder, after save, add a view.
- [x] Verify there are 2 fields for entering taxonomy terms: "Include content that uses the following terms" and "Exclude content that uses the following terms"

![Screenshot 2023-05-26 at 1 46 47 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/1d1b924c-ee03-4370-ad8f-ee537350c0f0)

- [x] Select "Events" under "I want To Show"
- [x] Add some terms via autocomplete into one or both boxes
- [x] Verify that when performing an autocomplete, the suggestions show the taxonomy vocabulary in parentheses next to the term to verify which vocabulary the term comes from.

![Screenshot 2023-05-26 at 1 47 24 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/42830aaa-6877-4bc4-9367-33f362668d80)

- [x] Save the block and verify that the view changes to represent the taxonomy filters.
- [x] Repeat as necessary to test different combinations of terms: multiple terms included with both the "Any" and "All" selector below, also testing the ability to exclude one or multiple.
- [x] Verify that excluding multiple terms will mean that those terms don't have to show up on the same node in order to be excluded. (Forced to be an "OR" for excluding).