### PR TITLE
YALB-1231: Create and populate categories

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.event.field_event_cta
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
+    - field.field.node.event.field_event_type
     - field.field.node.event.field_login_required
     - field.field.node.event.field_metatags
     - field.field.node.event.field_tags
@@ -48,7 +49,7 @@ third_party_settings:
         weight: -10
     group_logistics:
       children:
-        - field_event_format
+        - field_event_type
         - field_event_cta
         - field_event_date
       label: Logistics
@@ -97,7 +98,7 @@ content:
     third_party_settings: {  }
   field_event_cta:
     type: linkit
-    weight: 27
+    weight: 3
     region: content
     settings:
       placeholder_url: ''
@@ -107,7 +108,7 @@ content:
     third_party_settings: {  }
   field_event_date:
     type: smartdate_inline
-    weight: 28
+    weight: 4
     region: content
     settings:
       hide_date: 0
@@ -121,11 +122,15 @@ content:
         custom
       show_extra: false
     third_party_settings: {  }
-  field_event_format:
-    type: options_buttons
-    weight: 26
+  field_event_type:
+    type: entity_reference_autocomplete_tags
+    weight: 1
     region: content
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_login_required:
     type: boolean_checkbox
@@ -222,6 +227,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_event_format: true
   layout_builder__layout: true
   promote: true
   revision_log: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.post.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.post.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.post.field_author
+    - field.field.node.post.field_category
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -32,7 +33,7 @@ third_party_settings:
       label: Teaser
       region: content
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         classes: ''
@@ -47,7 +48,7 @@ third_party_settings:
       label: 'Publishing Settings'
       region: content
       parent_name: ''
-      weight: 8
+      weight: 9
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -70,6 +71,16 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_category:
+    type: entity_reference_autocomplete_tags
+    weight: 3
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_login_required:
     type: boolean_checkbox
     weight: 12
@@ -79,7 +90,7 @@ content:
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 7
+    weight: 8
     region: content
     settings:
       sidebar: true
@@ -93,7 +104,7 @@ content:
     third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete_tags
-    weight: 3
+    weight: 4
     region: content
     settings:
       match_operator: CONTAINS
@@ -133,18 +144,18 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 9
+    weight: 10
     region: content
     settings:
       display_label: true
@@ -165,7 +176,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.user.user.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.user.user.default.yml
@@ -33,6 +33,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  google_analytics:
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   language: true
   path: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.card.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.card.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.event.field_event_cta
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
+    - field.field.node.event.field_event_type
     - field.field.node.event.field_login_required
     - field.field.node.event.field_metatags
     - field.field.node.event.field_tags
@@ -69,6 +70,7 @@ content:
 hidden:
   field_category: true
   field_event_cta: true
+  field_event_type: true
   field_login_required: true
   field_metatags: true
   field_tags: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.event.field_event_cta
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
+    - field.field.node.event.field_event_type
     - field.field.node.event.field_login_required
     - field.field.node.event.field_metatags
     - field.field.node.event.field_tags
@@ -121,6 +122,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 2
+    region: content
+  field_event_type:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 5
     region: content
 hidden:
   field_login_required: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.list_item.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.list_item.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.event.field_event_cta
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
+    - field.field.node.event.field_event_type
     - field.field.node.event.field_login_required
     - field.field.node.event.field_metatags
     - field.field.node.event.field_tags
@@ -69,6 +70,7 @@ content:
 hidden:
   field_category: true
   field_event_cta: true
+  field_event_type: true
   field_login_required: true
   field_metatags: true
   field_tags: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.search_result.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.event.field_event_cta
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
+    - field.field.node.event.field_event_type
     - field.field.node.event.field_login_required
     - field.field.node.event.field_metatags
     - field.field.node.event.field_tags
@@ -41,6 +42,7 @@ hidden:
   field_event_cta: true
   field_event_date: true
   field_event_format: true
+  field_event_type: true
   field_login_required: true
   field_metatags: true
   field_tags: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.event.field_event_cta
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_format
+    - field.field.node.event.field_event_type
     - field.field.node.event.field_login_required
     - field.field.node.event.field_metatags
     - field.field.node.event.field_tags
@@ -33,6 +34,7 @@ hidden:
   field_event_cta: true
   field_event_date: true
   field_event_format: true
+  field_event_type: true
   field_login_required: true
   field_metatags: true
   field_tags: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.card.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.card.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.card
     - field.field.node.post.field_author
+    - field.field.node.post.field_category
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -48,6 +49,7 @@ content:
     region: content
 hidden:
   field_author: true
+  field_category: true
   field_login_required: true
   field_metatags: true
   field_publish_date: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.post.field_author
+    - field.field.node.post.field_category
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -84,6 +85,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_category:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 1
     region: content
 hidden:
   field_login_required: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.list_item.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.list_item.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.list_item
     - field.field.node.post.field_author
+    - field.field.node.post.field_category
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -48,6 +49,7 @@ content:
     region: content
 hidden:
   field_author: true
+  field_category: true
   field_login_required: true
   field_metatags: true
   field_publish_date: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.search_result.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.post.field_author
+    - field.field.node.post.field_category
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -36,6 +37,7 @@ content:
     region: content
 hidden:
   field_author: true
+  field_category: true
   field_login_required: true
   field_metatags: true
   field_publish_date: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.teaser.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.post.field_author
+    - field.field.node.post.field_category
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -28,6 +29,7 @@ content:
     region: content
 hidden:
   field_author: true
+  field_category: true
   field_login_required: true
   field_metatags: true
   field_publish_date: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_event_type.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_event_type.yml
@@ -1,0 +1,29 @@
+uuid: f58a6cdd-eda2-44ae-92d4-1c7a1b0fe66d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_type
+    - node.type.event
+    - taxonomy.vocabulary.event_type
+id: node.event.field_event_type
+field_name: field_event_type
+entity_type: node
+bundle: event
+label: 'Event Type'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      event_type: event_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_category.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_category.yml
@@ -1,0 +1,29 @@
+uuid: b64f1eda-d43c-4fdf-877c-d0f175ffaa54
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_category
+    - node.type.post
+    - taxonomy.vocabulary.post_category
+id: node.post.field_category
+field_name: field_category
+entity_type: node
+bundle: post
+label: Category
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      post_category: post_category
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_event_type.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_event_type.yml
@@ -1,0 +1,20 @@
+uuid: e08fa5c0-8d17-4b94-aebf-af9e0ab0f2ed
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_event_type
+field_name: field_event_type
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/migrate_plus.migration.ys_posts.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/migrate_plus.migration.ys_posts.yml
@@ -11,7 +11,7 @@ field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null
 migration_group: ys_starterkit
-label: 'Starterkit Posts'
+label: 'Starterkit Post'
 source:
   plugin: url
   data_fetcher_plugin: file
@@ -21,7 +21,7 @@ source:
   item_selector: /data/posts
   fields:
     -
-      name: src_post
+      name: src_unique_id
       label: 'Unique ID'
       selector: unique_id
     -
@@ -33,7 +33,7 @@ source:
       label: Author
       selector: field_author
   ids:
-    src_post:
+    src_unique_id:
       type: string
   constants:
     date_format: Y-m-d

--- a/web/profiles/custom/yalesites_profile/config/sync/migrate_plus.migration.ys_terms.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/migrate_plus.migration.ys_terms.yml
@@ -1,0 +1,48 @@
+uuid: 3bd796d7-5ec4-4d46-aba2-d2ac96826026
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - ys_starterkit
+id: ys_terms
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: ys_starterkit
+label: 'Starterkit Terrms'
+source:
+  plugin: url
+  data_fetcher_plugin: file
+  data_parser_plugin: json
+  urls:
+    - profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/terms.json
+  item_selector: /data/terms
+  fields:
+    -
+      name: src_unique_id
+      label: 'Unique ID'
+      selector: unique_id
+    -
+      name: vocabulary
+      label: Vocabulary
+      selector: vocabulary
+    -
+      name: name
+      label: Name
+      selector: name
+  ids:
+    src_unique_id:
+      type: string
+  constants:
+    date_format: Y-m-d
+process:
+  vid: vocabulary
+  name: name
+  uid:
+    plugin: default_value
+    default_value: 1
+destination:
+  plugin: 'entity:taxonomy_term'
+migration_dependencies: null

--- a/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.event_format.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.event_format.yml
@@ -1,0 +1,33 @@
+uuid: bd9564f7-fe74-463c-a500-8529f38c1120
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_redirect
+third_party_settings:
+  entity_redirect:
+    redirect:
+      anonymous:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+      add:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+      edit:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+      delete:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+name: 'Event Format'
+vid: event_format
+description: ''
+weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.event_type.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.event_type.yml
@@ -1,4 +1,4 @@
-uuid: bd9564f7-fe74-463c-a500-8529f38c1120
+uuid: cca4f998-9ffe-4975-87a6-7e57e434e4b2
 langcode: en
 status: true
 dependencies:
@@ -27,7 +27,7 @@ third_party_settings:
         destination: default
         url: ''
         external: ''
-name: 'Event Format'
-vid: event_format
+name: 'Event Type'
+vid: event_type
 description: ''
 weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.post_category.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.post_category.yml
@@ -1,0 +1,33 @@
+uuid: e28ef563-141e-4dd9-9f2a-ce1ebb9bcd15
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_redirect
+third_party_settings:
+  entity_redirect:
+    redirect:
+      anonymous:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+      add:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+      edit:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+      delete:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+name: 'Post Category'
+vid: post_category
+description: ''
+weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -14,6 +14,9 @@ dependencies:
     - node.type.event
     - node.type.page
     - node.type.post
+    - taxonomy.vocabulary.event_category
+    - taxonomy.vocabulary.post_category
+    - taxonomy.vocabulary.tags
   module:
     - block
     - contextual
@@ -70,6 +73,9 @@ permissions:
   - 'create media'
   - 'create page content'
   - 'create post content'
+  - 'create terms in event_category'
+  - 'create terms in post_category'
+  - 'create terms in tags'
   - 'create url aliases'
   - 'create video media'
   - 'delete any background_video media'
@@ -91,6 +97,9 @@ permissions:
   - 'delete own page content'
   - 'delete own post content'
   - 'delete own video media'
+  - 'delete terms in event_category'
+  - 'delete terms in post_category'
+  - 'delete terms in tags'
   - 'edit any background_video media'
   - 'edit any document media'
   - 'edit any embed media'
@@ -109,6 +118,9 @@ permissions:
   - 'edit own post content'
   - 'edit own video media'
   - 'edit own webform submission'
+  - 'edit terms in event_category'
+  - 'edit terms in post_category'
+  - 'edit terms in tags'
   - 'mark as hidden in editoria11y'
   - 'override all authored by option'
   - 'override all authored on option'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -14,6 +14,9 @@ dependencies:
     - node.type.event
     - node.type.page
     - node.type.post
+    - taxonomy.vocabulary.event_category
+    - taxonomy.vocabulary.post_category
+    - taxonomy.vocabulary.tags
   module:
     - block
     - contextual
@@ -69,6 +72,9 @@ permissions:
   - 'create media'
   - 'create page content'
   - 'create post content'
+  - 'create terms in event_category'
+  - 'create terms in post_category'
+  - 'create terms in tags'
   - 'create url aliases'
   - 'create video media'
   - 'delete any background_video media'
@@ -90,6 +96,9 @@ permissions:
   - 'delete own page content'
   - 'delete own post content'
   - 'delete own video media'
+  - 'delete terms in event_category'
+  - 'delete terms in post_category'
+  - 'delete terms in tags'
   - 'edit any background_video media'
   - 'edit any document media'
   - 'edit any embed media'
@@ -108,6 +117,9 @@ permissions:
   - 'edit own post content'
   - 'edit own video media'
   - 'edit own webform submission'
+  - 'edit terms in event_category'
+  - 'edit terms in post_category'
+  - 'edit terms in tags'
   - 'mark as hidden in editoria11y'
   - 'override all sticky option'
   - 'override post authored on option'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/config/install/migrate_plus.migration.ys_terms.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/config/install/migrate_plus.migration.ys_terms.yml
@@ -1,0 +1,47 @@
+id: ys_terms
+label: Starterkit Terrms
+description: Create default terms.
+migration_tags: null
+migration_group: ys_starterkit
+source_type: 'JSON file from URL'
+
+source:
+  plugin: url
+  data_fetcher_plugin: file
+  data_parser_plugin: json
+  urls:
+    - profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/terms.json
+  item_selector: /data/terms
+  fields:
+    -
+      name: src_unique_id
+      label: 'Unique ID'
+      selector: unique_id
+    -
+      name: vocabulary
+      label: 'Vocabulary'
+      selector: vocabulary
+    -
+      name: name
+      label: 'Name'
+      selector: name
+  ids:
+    src_unique_id:
+      type: string
+  constants:
+    date_format: 'Y-m-d'
+
+process:
+  vid: vocabulary
+  name: name
+  uid:
+    plugin: default_value
+    default_value: 1
+
+destination:
+  plugin: entity:taxonomy_term
+
+dependencies:
+  enforced:
+    module:
+      - ys_starterkit

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/config/install/migrate_plus.migration.ys_terms.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/config/install/migrate_plus.migration.ys_terms.yml
@@ -28,8 +28,6 @@ source:
   ids:
     src_unique_id:
       type: string
-  constants:
-    date_format: 'Y-m-d'
 
 process:
   vid: vocabulary

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/terms.json
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/terms.json
@@ -3,12 +3,12 @@
     "terms": [
       {
         "unique_id": 1,
-        "vocabulary": "event_format",
+        "vocabulary": "event_type",
         "name": "In-person"
       },
       {
         "unique_id": 2,
-        "vocabulary": "event_format",
+        "vocabulary": "event_type",
         "name": "Online"
       },
       {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/terms.json
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/terms.json
@@ -1,0 +1,141 @@
+{
+  "data": {
+    "terms": [
+      {
+        "unique_id": 1,
+        "vocabulary": "event_format",
+        "name": "In-person"
+      },
+      {
+        "unique_id": 2,
+        "vocabulary": "event_format",
+        "name": "Online"
+      },
+      {
+        "unique_id": 3,
+        "vocabulary": "event_category",
+        "name": "Academic Calendar"
+      },
+      {
+        "unique_id": 4,
+        "vocabulary": "event_category",
+        "name": "Arts & Humanities"
+      },
+      {
+        "unique_id": 5,
+        "vocabulary": "event_category",
+        "name": "Athletics & Recreation"
+      },
+      {
+        "unique_id": 6,
+        "vocabulary": "event_category",
+        "name": "Business & Entrepreneurship"
+      },
+      {
+        "unique_id": 7,
+        "vocabulary": "event_category",
+        "name": "Career & Professional Services"
+      },
+      {
+        "unique_id": 8,
+        "vocabulary": "event_category",
+        "name": "Cultural & International"
+      },
+      {
+        "unique_id": 9,
+        "vocabulary": "event_category",
+        "name": "Diversity, Equity, Inclusion & Belonging"
+      },
+      {
+        "unique_id": 10,
+        "vocabulary": "event_category",
+        "name": "Health & Medicine"
+      },
+      {
+        "unique_id": 11,
+        "vocabulary": "event_category",
+        "name": "Law, Politics & Society"
+      },
+      {
+        "unique_id": 12,
+        "vocabulary": "event_category",
+        "name": "Libraries, Museums & Galleries"
+      },
+      {
+        "unique_id": 13,
+        "vocabulary": "event_category",
+        "name": "Science & Technology"
+      },
+      {
+        "unique_id": 14,
+        "vocabulary": "event_category",
+        "name": "Social Sciences"
+      },
+      {
+        "unique_id": 15,
+        "vocabulary": "event_category",
+        "name": "Spiritual & Religious"
+      },
+      {
+        "unique_id": 16,
+        "vocabulary": "event_category",
+        "name": "Student Life"
+      },
+      {
+        "unique_id": 17,
+        "vocabulary": "event_category",
+        "name": "University Events"
+      },
+      {
+        "unique_id": 18,
+        "vocabulary": "event_category",
+        "name": "Yale & New Haven"
+      },
+      {
+        "unique_id": 19,
+        "vocabulary": "post_category",
+        "name": "Alumni"
+      },
+      {
+        "unique_id": 20,
+        "vocabulary": "post_category",
+        "name": "Arts & Humanities"
+      },
+      {
+        "unique_id": 21,
+        "vocabulary": "post_category",
+        "name": "Business"
+      },
+      {
+        "unique_id": 22,
+        "vocabulary": "post_category",
+        "name": "Campus & Community"
+      },
+      {
+        "unique_id": 23,
+        "vocabulary": "post_category",
+        "name": "Environment"
+      },
+      {
+        "unique_id": 24,
+        "vocabulary": "post_category",
+        "name": "International"
+      },
+      {
+        "unique_id": 25,
+        "vocabulary": "post_category",
+        "name": "Law"
+      },
+      {
+        "unique_id": 26,
+        "vocabulary": "post_category",
+        "name": "Science & Technology"
+      },
+      {
+        "unique_id": 27,
+        "vocabulary": "post_category",
+        "name": "Social Sciences"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## [YALB-1231: Create a populate categories](https://yaleits.atlassian.net/browse/YALB-1231)

### Description of work
- Creates a new 'post category' vocabulary and adds it to the post content type.
- Creates a new 'event type' vocabulary and adds it to the event content type.
- Deletes the existing 'event format' field.
- Defines a migration of starterkit terms for post category, event category, and event type.
- Sets permissions so that site admins can manage all vocabularies except event type.

### Functional testing steps:
- [ ] Login to the site as user 1
  - [ ] Verify that all taxonomy terms migrated into the site for the three taxonomies.
  - [ ] Logout
- [ ] Login to the site as a site admin
  - [ ] [Create a post](https://pr-291-yalesites-platform.pantheonsite.io/node/add/post) and verify that the new terms are present for the 'Category' fied.
  - [ ] Verify that you can add a new category term to this list through the add-post interface.
  - [ ] Repeat this process to check the category field on the [add an event](https://pr-291-yalesites-platform.pantheonsite.io/node/add/event) interface.
