### PR TITLE
YALB-971: LocalDev: Theme setup scripts fix

### DIFF
--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -179,10 +179,12 @@ function repo_has_changes() {
 # Main function that does the work
 function _local-git-checkout() {
   # Default values
-  local cl_branch="main"
-  local token_branch="main"
-  local atomic_branch="main"
-  local yalesites_branch="develop"
+  local default_branch="main"
+  local default_yalesites_branch="develop"
+  local cl_branch="$default_branch"
+  local token_branch="$default_branch"
+  local atomic_branch="$default_branch"
+  local yalesites_branch="$default_yalesites_branch"
   local debug=false
   local verbose=false
 
@@ -285,7 +287,7 @@ function _local-git-checkout() {
   _say "********************"
 
   # Move yalesites branch
-  clone_or_switch_branch "yalesites-project" "$yalesites_path" "$yalesites_branch"
+  clone_or_switch_branch "yalesites-project" "$yalesites_path" "$yalesites_branch" "$default_yalesites_branch"
   
   # If current branch did change
   if [ "$(current_branch_for_path "$atomic_path")" != "$atomic_branch" ]; then
@@ -293,7 +295,7 @@ function _local-git-checkout() {
   fi
 
   _say "Attempting to clone $atomic_branch branch of atomic repo"
-  clone_or_switch_branch "atomic" "$atomic_path" "$atomic_branch" "main" "composer"
+  clone_or_switch_branch "atomic" "$atomic_path" "$atomic_branch" "$default_branch" "composer"
 
   [ "$verbose" = true ] && _say "Moving to atomic repo"
   cd $atomic_path || (_error "Could not find atomic theme. Are you in the right directory?" && exit 1)
@@ -301,7 +303,7 @@ function _local-git-checkout() {
   [ ! -d "_yale-packages" ] && mkdir _yale-packages && _say "Creating _yale-packages directory for cloning"
 
   _say "Attempting to clone $token_branch branch of tokens repo"
-  clone_or_switch_branch "tokens" "_yale-packages/tokens" "$token_branch"
+  clone_or_switch_branch "tokens" "_yale-packages/tokens" "$token_branch" "$default_branch"
 
   _say "Moving into tokens repo and creating a global npm link"
   cd _yale-packages/tokens || (_error "Could not find tokens repo. Are you in the right directory?" && exit 1)
@@ -311,7 +313,7 @@ function _local-git-checkout() {
   cd ../..
 
   _say "Attempting to clone $cl_branch branch of component-library-twig repo"
-  clone_or_switch_branch "component-library-twig" "_yale-packages/component-library-twig" "$cl_branch"
+  clone_or_switch_branch "component-library-twig" "_yale-packages/component-library-twig" "$cl_branch" "$default_branch"
 
   [ "$verbose" = true ] && _say "Moving into component library"
   cd _yale-packages/component-library-twig || (_error "Could not find component-library-twig repo. Are you in the right directory?" && exit 1)

--- a/scripts/local/local-git-checkout.sh
+++ b/scripts/local/local-git-checkout.sh
@@ -25,9 +25,10 @@ function branch_exists() {
 
   local branch_name="$1"
   local git_path="${2-$(pwd)}"
+  local origin="${3-origin}"
   local remote_branches
 
-  if git -C "$git_path" rev-parse --quiet --verify "$branch_name" > /dev/null; then
+  if git -C "$git_path" rev-parse --quiet --verify "$origin/$branch_name" > /dev/null; then
     return 0
   fi
 
@@ -121,7 +122,7 @@ function clone_or_switch_branch() {
     # If there are no uncommitted changes, prepare to switch to the target branch
     if git -C "$git_path" diff --quiet --exit-code; then
       # If the target branch doesn't exist, switch to the backup branch
-      (! branch_exists "$target_branch" "$git_path") && _error "Target branch $target_branch does not exist, switching to $backup_branch" && target_branch="$backup_branch"
+      (! branch_exists "$target_branch" "$git_path" "$origin") && _error "Target branch $target_branch does not exist, switching to $backup_branch" && target_branch="$backup_branch"
 
       _say "Current branch of $name is $current_branch, switching to $target_branch"
       git_checkout "$git_path" "$target_branch" "$origin"
@@ -292,7 +293,7 @@ function _local-git-checkout() {
   fi
 
   _say "Attempting to clone $atomic_branch branch of atomic repo"
-  clone_or_switch_branch "atomic" "$atomic_path" "$atomic_branch"
+  clone_or_switch_branch "atomic" "$atomic_path" "$atomic_branch" "main" "composer"
 
   [ "$verbose" = true ] && _say "Moving to atomic repo"
   cd $atomic_path || (_error "Could not find atomic theme. Are you in the right directory?" && exit 1)


### PR DESCRIPTION
fix(YALB-971): force composer for atomic

When setting up a yalesites project, composer does not use the name 'origin', but instead uses a remote name of 'composer'.  This caused some issues when attepmting to switch branches on atomic, as there would be two tracking branches, and it didn't know which to take.  This now passes the 'composer' remote only for atomic and passes it through.

## [YALB-971: Localdev: Theme setup scripts](https://yaleits.atlassian.net/browse/YALB-971)

### Description of work
- Fix script to allow the `composer` remote for atomic only
- YaleSites repo defaults to `develop` if branch doesn't exist

### Functional testing steps:
- [ ] Create a fresh git clone of the project repo
- [ ] Run `npm run setup` to set up initial items
- [ ] Run `npm run local:git-checkout -- -b <branch name you care about)`
- [ ] Verify that you successfully retrieved the branches you needed, specifically from atomic, but others as well
