### PR TITLE
YALB-1239: Filter to show past events

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.view.field_view_params.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.view.field_view_params.yml
@@ -18,8 +18,8 @@ translatable: false
 default_value:
   -
     group_params:
-      params: '{"view_mode":"card","filters":{"types":["post"],"terms_include":null,"terms_exclude":null},"operator":"+","sort_by":null,"display":null,"limit":0}'
-    params: '{"view_mode":"card","filters":{"types":["post"],"terms_include":null,"terms_exclude":null},"operator":"+","sort_by":null,"display":null,"limit":0}'
+      params: '{"view_mode":"card","filters":{"types":["post"],"terms_include":null,"terms_exclude":null,"event_time_period":"future"},"operator":"+","sort_by":null,"display":null,"limit":0}'
+    params: '{"view_mode":"card","filters":{"types":["post"],"terms_include":null,"terms_exclude":null,"event_time_period":"future"},"operator":"+","sort_by":null,"display":null,"limit":0}'
 default_value_callback: ''
 settings: {  }
 field_type: views_basic_params

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
@@ -249,6 +249,46 @@ display:
           require_value: false
           reduce_duplicates: true
       filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         exclude_taxonomy_terms:
           id: exclude_taxonomy_terms
           table: node_field_data
@@ -288,6 +328,49 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        event_time_period:
+          id: event_time_period
+          table: node_field_data
+          field: event_time_period
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: event_time_period
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: ys_views_basic_dynamic_style
         options:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
@@ -3,7 +3,7 @@
 */
 
 .views-basic--params {
-  /* display: none; */
+  display: none;
 }
 
 .views-basic--group-user-selection .grouped-items {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
@@ -3,7 +3,7 @@
 */
 
 .views-basic--params {
-  display: none;
+  /* display: none; */
 }
 
 .views-basic--group-user-selection .grouped-items {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -272,13 +272,13 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
 
     $form['group_user_selection']['entity_specific']['event_time_period'] = [
       '#type' => 'radios',
-      '#title' => $this->t('Show'),
+      '#title' => $this->t('Event Time Period'),
       '#options' => [
-        '>=' => 'Future Events',
-        '<' => 'Past Events',
+        'future' => 'Future Events',
+        'past' => 'Past Events',
         'all' => 'All Events',
       ],
-      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('event_time_period', $items[$delta]->params) : '>=',
+      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('event_time_period', $items[$delta]->params) : 'future',
       '#states' => [
         'visible' => [
           ':input[name="settings[block_form][group_user_selection][entity_and_view_mode][entity_types]"]' => [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -274,9 +274,9 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       '#type' => 'radios',
       '#title' => $this->t('Event Time Period'),
       '#options' => [
-        'future' => 'Future Events',
-        'past' => 'Past Events',
-        'all' => 'All Events',
+        'future' => $this->t('Future Events'),
+        'past' => $this->t('Past Events'),
+        'all' => $this->t('All Events'),
       ],
       '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('event_time_period', $items[$delta]->params) : 'future',
       '#states' => [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -152,6 +152,10 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       ],
     ];
 
+    $form['group_user_selection']['entity_specific'] = [
+      '#type' => 'container',
+    ];
+
     $form['group_user_selection']['options'] = [
       '#type' => 'container',
       '#attributes' => [
@@ -264,6 +268,24 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       ],
       '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('operator', $items[$delta]->params) : '+',
 
+    ];
+
+    $form['group_user_selection']['entity_specific']['event_time_period'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Show'),
+      '#options' => [
+        '>=' => 'Future Events',
+        '<' => 'Past Events',
+        'all' => 'All Events',
+      ],
+      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('event_time_period', $items[$delta]->params) : '>=',
+      '#states' => [
+        'visible' => [
+          ':input[name="settings[block_form][group_user_selection][entity_and_view_mode][entity_types]"]' => [
+            'value' => 'event',
+          ],
+        ],
+      ],
     ];
 
     $form['group_user_selection']['options']['display'] = [
@@ -385,6 +407,7 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
           ],
           "terms_include" => $terms_include,
           "terms_exclude" => $terms_exclude,
+          "event_time_period" => $form['group_user_selection']['entity_specific']['event_time_period']['#value'],
         ],
         "operator" => $form['group_user_selection']['filter_options']['term_operator']['#value'],
         "sort_by" => $form_state->getValue(

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/EventTimePeriod.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/EventTimePeriod.php
@@ -3,7 +3,6 @@
 namespace Drupal\ys_views_basic\Plugin\views\filter;
 
 use Drupal\views\Plugin\views\filter\FilterPluginBase;
-use Drupal\views\Views;
 
 /**
  * Filter events by date.
@@ -24,22 +23,29 @@ class EventTimePeriod extends FilterPluginBase {
     }
     else {
 
-      // Showing all events, no filter needed.
-      if ($this->view->args[6] == 'all') {
-        return;
+      switch ($this->view->args[6]) {
+        case 'future':
+          $operator = '>=';
+          break;
+
+        case 'past':
+          $operator = '<';
+          break;
+
+        default:
+          return;
       }
-      else {
 
-        // Ensure the main table for this handler is in the query.
-        $this->ensureMyTable();
-        /** @var \Drupal\views\Plugin\views\query\Sql $query */
-        $query = $this->query;
+      // Ensure the main table for this handler is in the query.
+      $this->ensureMyTable();
+      /** @var \Drupal\views\Plugin\views\query\Sql $query */
+      $query = $this->query;
 
-        $lookupTable = $query->addTable('node__field_event_date');
-        $field = "$lookupTable.field_event_date_end_value";
+      $lookupTable = $query->addTable('node__field_event_date');
+      $field = "$lookupTable.field_event_date_end_value";
 
-        $query->addWhere($this->options['group'], $field, time(), $this->view->args[6]);
-      }
+      $query->addWhere($this->options['group'], $field, time(), $operator);
+
     }
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/EventTimePeriod.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/EventTimePeriod.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\ys_views_basic\Plugin\views\filter;
+
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+use Drupal\views\Views;
+
+/**
+ * Filter events by date.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("event_time_period")
+ */
+class EventTimePeriod extends FilterPluginBase {
+
+  /**
+   * Add this filter to the query.
+   */
+  public function query() {
+
+    if (!isset($this->view->args[6])) {
+      return;
+    }
+    else {
+
+      // Showing all events, no filter needed.
+      if ($this->view->args[6] == 'all') {
+        return;
+      }
+      else {
+
+        // Ensure the main table for this handler is in the query.
+        $this->ensureMyTable();
+        /** @var \Drupal\views\Plugin\views\query\Sql $query */
+        $query = $this->query;
+
+        $lookupTable = $query->addTable('node__field_event_date');
+        $field = "$lookupTable.field_event_date_end_value";
+
+        $query->addWhere($this->options['group'], $field, time(), $this->view->args[6]);
+      }
+    }
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -145,11 +145,13 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
      * to use.
      *
      * The order of these arguments is required as follows:
-     * 1) Content type machine name (can combine content types with + or ,)
-     * 2) Taxonomy term ID (can combine with + or ,)
+     * 0) Content type machine name (can combine content types with + or ,)
+     * 1) Taxonomy term ID to include (can combine with + or ,)
+     * 2) Taxonomy term ID to exclude (can combine with + or ,)
      * 3) Sort field and direction (in format field_name:ASC)
      * 4) View mode machine name (i.e. teaser)
      * 5) Items per page (set to 0 for all items)
+     * 6) Event time period (future, past, all)
      */
 
     $filterType = implode('+', $paramsDecoded['filters']['types']);
@@ -190,6 +192,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
         'sort' => $paramsDecoded['sort_by'],
         'view' => $paramsDecoded['view_mode'],
         'items' => $itemsLimit,
+        'event_time_period' => $paramsDecoded['filters']['event_time_period'],
       ]
     );
 
@@ -340,6 +343,10 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
 
       case 'limit':
         $defaultParam = (empty($paramsDecoded['limit'])) ? 10 : (int) $paramsDecoded['limit'];
+        break;
+
+      case 'event_time_period':
+        $defaultParam = (empty($paramsDecoded['filters']['event_time_period'])) ? '>=' : $paramsDecoded['filters']['event_time_period'];
         break;
 
       default:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -192,7 +192,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
         'sort' => $paramsDecoded['sort_by'],
         'view' => $paramsDecoded['view_mode'],
         'items' => $itemsLimit,
-        'event_time_period' => $paramsDecoded['filters']['event_time_period'],
+        'event_time_period' => str_contains($filterType, 'event') ? $paramsDecoded['filters']['event_time_period'] : NULL,
       ]
     );
 
@@ -346,7 +346,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
         break;
 
       case 'event_time_period':
-        $defaultParam = (empty($paramsDecoded['filters']['event_time_period'])) ? '>=' : $paramsDecoded['filters']['event_time_period'];
+        $defaultParam = (empty($paramsDecoded['filters']['event_time_period'])) ? 'future' : $paramsDecoded['filters']['event_time_period'];
         break;
 
       default:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -49,4 +49,12 @@ function ys_views_basic_views_data_alter(array &$data) {
       'id' => 'exclude_taxonomy_terms',
     ],
   ];
+  $data['node_field_data']['event_time_period'] = [
+    'title' => t('Event Time Period'),
+    'filter' => [
+      'help' => t('Show future, past, or all events'),
+      'id' => 'event_time_period',
+    ],
+  ];
+
 }


### PR DESCRIPTION
## [YALB-1239: Filter to show past events](https://yaleits.atlassian.net/browse/YALB-1239)

### Description of work
- Adds the ability to filter events in the views tool to show only future events, only past events, or all events.
- Forces all views to only show published nodes.

### Functional testing steps:
- [x] Create some events on the site and set the event date of a few of them in the past, and a few others in the future. You may want to title them with "future" or "past" for ease of testing.
- [x] Create a page, title it, save, and enter layout builder.
- [x] Add a block of type "View"
- [x] Fill out the Administrative label and select "Events" under "I want to show"
- [x] Verify that when "Events" is selected, a new filter option becomes available lower on the form to filter when the event takes place.
![Screenshot 2023-05-31 at 6 12 38 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/30e51ef9-147c-403a-b060-d38416966a6c)

- [x] Make sure "Future" is selected under "Event Time Period"
- [x] Add the block.
- [x] Verify that the results of the view show only future events.
![Screenshot 2023-05-31 at 6 13 24 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/e4314410-9571-46f3-b765-68103324c122)

- [x] Configure the block and change the Time Period to "Past Events" and update the block.
- [x] Verify that the results change to only show past events.
- [x] Finally, change the option to "All Events" and verify that all events are shown.
