### PR TITLE
YALB-1294: Install and configure Bugherd module for testing

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -113,6 +113,9 @@
       },
       "drupal/gin_lb": {
         "fix missing file field https://www.drupal.org/project/gin_lb/issues/3349745": "https://www.drupal.org/files/issues/2023-03-23/3349745-8-claro-preprocess-file-fields.patch"
+      },
+      "drupal/bugherd": {
+        "anonymous user unable to fill in email field https://www.drupal.org/project/bugherd/issues/3364305": "https://git.drupalcode.org/project/bugherd/-/merge_requests/4.diff"
       }
     }
   }

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -13,6 +13,7 @@
     "drupal/allowed_formats": "^2.0",
     "drupal/autosave_form": "^1.3",
     "drupal/better_exposed_filters": "^6.0",
+    "drupal/bugherd": "1.0",
     "drupal/calendar_link": "^3.0",
     "drupal/captcha": "^1.8",
     "drupal/cas": "^2.0",

--- a/web/profiles/custom/yalesites_profile/config/sync/bugherd.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/bugherd.settings.yml
@@ -1,0 +1,21 @@
+_core:
+  default_config_hash: A1YhiXDQT0YvWBBy9oxEiWz2gjzsJ9mFNQYiO-St8VI
+bugherd_project_key: 7wyg24qv0ivjykxkd3k5fa
+bugherd_widget_position: bottom-right
+bugherd_disable_on_admin: '0'
+reporter_email_autofill: 1
+email_required: 1
+tab_text: ''
+option_title_text: ''
+option_pin_text: ''
+option_site_text: ''
+feedback_entry_placeholder: ''
+feedback_email_placeholder: ''
+feedback_submit_text: ''
+confirm_success_text: ''
+confirm_loading_text: ''
+confirm_close_text: ''
+confirm_error_text: ''
+confirm_retry_text: ''
+confirm_extension_text: ''
+confirm_extension_link_text: ''

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -9,6 +9,7 @@ module:
   block: 0
   block_content: 0
   breakpoint: 0
+  bugherd: 0
   calendar_link: 0
   captcha: 0
   cas: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.anonymous.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.anonymous.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - bugherd
     - media
     - system
 _core:
@@ -12,5 +13,6 @@ label: 'Anonymous user'
 weight: 0
 is_admin: false
 permissions:
+  - 'access bugherd'
   - 'access content'
   - 'view media'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.authenticated.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.authenticated.yml
@@ -7,6 +7,7 @@ dependencies:
     - filter.format.heading_html
     - filter.format.restricted_html
   module:
+    - bugherd
     - filter
     - google_analytics
     - media
@@ -18,6 +19,7 @@ label: 'Authenticated user'
 weight: 1
 is_admin: false
 permissions:
+  - 'access bugherd'
   - 'access content'
   - 'opt-in or out of google analytics tracking'
   - 'use text format basic_html'


### PR DESCRIPTION
## [YALB-1294: Install and configure Bugherd module for testing](https://yaleits.atlassian.net/browse/YALB-1294)

### Description of work
- Adds and configures Bugherd module with Yalesites Upgrade Project ID
- Applies [patch](https://www.drupal.org/project/bugherd/issues/3364305) to allow anonymous users to fill in the email field when it is required

### Functional testing steps:
:warning: Disable any ad blocking extensions in your browser (Adblock Plus, uBlock Origin, etc)
- [ ] As an anonymous user, load a page and see the "Send feedback" button at the lower right
- [ ] As an authenticated user, load a page and see the "Send feedback" button at the lower right. When submitting, your email address should be pre-populated
