### PR TITLE
YALB-1212: Enable taxonomy interfaces for authors

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.taxonomy_term.event_category.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.taxonomy_term.event_category.default.yml
@@ -1,0 +1,25 @@
+uuid: a0106ddd-5c87-46c5-ba54-c0964234f1ce
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.event_category
+id: taxonomy_term.event_category.default
+targetEntityType: taxonomy_term
+bundle: event_category
+mode: default
+content:
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  description: true
+  path: true
+  revision_log_message: true
+  simple_sitemap: true
+  status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.taxonomy_term.post_category.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.taxonomy_term.post_category.default.yml
@@ -1,0 +1,25 @@
+uuid: 20015c2c-4cf7-4848-9cd0-806c66b888c8
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.post_category
+id: taxonomy_term.post_category.default
+targetEntityType: taxonomy_term
+bundle: post_category
+mode: default
+content:
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  description: true
+  path: true
+  revision_log_message: true
+  simple_sitemap: true
+  status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.taxonomy_term.tags.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.taxonomy_term.tags.default.yml
@@ -1,0 +1,25 @@
+uuid: 664c8924-0e3e-46b0-9ec3-43810e9e7f8a
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+id: taxonomy_term.tags.default
+targetEntityType: taxonomy_term
+bundle: tags
+mode: default
+content:
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  description: true
+  path: true
+  revision_log_message: true
+  simple_sitemap: true
+  status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.event_category.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.event_category.yml
@@ -29,5 +29,5 @@ third_party_settings:
         external: ''
 name: 'Event Category'
 vid: event_category
-description: ''
+description: 'A vocabulary is used to classify events based on their categories, such as "Conferences," "Webinars," or "Workshops." This allows you to easily find and navigate events based on your interests and preferences.'
 weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.event_type.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.event_type.yml
@@ -29,5 +29,5 @@ third_party_settings:
         external: ''
 name: 'Event Type'
 vid: event_type
-description: ''
+description: 'Used to classify events based on their type, such as "Online" or "In-Person." This allows for easy categorization and organization of events on a website.'
 weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.post_category.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.post_category.yml
@@ -29,5 +29,5 @@ third_party_settings:
         external: ''
 name: 'Post Category'
 vid: post_category
-description: ''
+description: 'A vocabulary used to classify posts based on their categories, such as "News," "Opinion," or "How-To." This helps users easily find and navigate posts based on their interests and preferences.'
 weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.tags.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.tags.yml
@@ -1,8 +1,33 @@
 uuid: 2e4d620d-2f88-43fe-8490-42095ca9c77a
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - entity_redirect
+third_party_settings:
+  entity_redirect:
+    redirect:
+      anonymous:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+      add:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+      edit:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+      delete:
+        active: false
+        destination: default
+        url: ''
+        external: ''
 name: Tags
 vid: tags
-description: ''
+description: 'A custom vocabulary that allows you to add any tag you want to classify and organize content on your website. Users can freely tag content with any term they like, making it easy to navigate and find related content.'
 weight: 0

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/taxonomy-form.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/taxonomy-form.css
@@ -1,0 +1,3 @@
+.replacement-taxonomy-help ~ p {
+  display: none;
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.libraries.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.libraries.yml
@@ -3,3 +3,7 @@ node_layout_form:
     theme:
       css/layout-builder-browser.css: {}
       css/multifield-form.css: { }
+taxonomy_form:
+  css:
+    theme:
+      css/taxonomy-form.css: {}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
@@ -50,3 +50,34 @@ ys_core.menu_utility_edit:
   route_parameters:
     menu: "utility-navigation"
   weight: 15
+# Taxonomy interface
+ys_core.taxonomy_interface:
+  description: "Manage taxonomy terms"
+  parent: system.admin_content
+  route_name: entity.taxonomy_vocabulary.collection
+  title: Manage Taxonomy
+  weight: 20
+# Taxonomy interface - Event Category
+ys_core.taxonomy_interface_event_category:
+  description: "Manage event category taxonomy"
+  parent: ys_core.taxonomy_interface
+  route_name: entity.taxonomy_vocabulary.overview_form
+  title: Event Category
+  route_parameters:
+    taxonomy_vocabulary: "event_category"
+# Taxonomy interface - Post Category
+ys_core.taxonomy_interface_post_category:
+  description: "Manage post category taxonomy"
+  parent: ys_core.taxonomy_interface
+  route_name: entity.taxonomy_vocabulary.overview_form
+  title: Post Category
+  route_parameters:
+    taxonomy_vocabulary: "post_category"
+# Taxonomy interface - Tags
+ys_core.taxonomy_interface_tags:
+  description: "Manage tags taxonomy"
+  parent: ys_core.taxonomy_interface
+  route_name: entity.taxonomy_vocabulary.overview_form
+  title: Tags
+  route_parameters:
+    taxonomy_vocabulary: "tags"

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -80,6 +80,15 @@ function ys_core_form_alter(&$form, $form_state, $form_id) {
   if (in_array($form_id, $vocabularyForms)) {
     $form['relations']['#access'] = FALSE;
   }
+
+  // Add vocabulary description to the taxonomy overview form.
+  if ($form_id == 'taxonomy_overview_terms') {
+    $replacements['@description'] = $form_state->getBuildInfo()['args'][0]->getDescription();
+    $form['help']['description'] = [
+      '#type' => 'markup',
+      '#markup' => "<p>" . t('@description', $replacements) . "</p>",
+    ];
+  }
 }
 
 /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -69,6 +69,11 @@ function ys_core_form_alter(&$form, $form_state, $form_id) {
   if (isset($form['sticky'])) {
     $form['sticky']['widget']['value']['#title'] = t('Pin to the beginning of list');
   }
+
+  // Hide Relations on taxonomy term edit page.
+  if ($form_id == 'taxonomy_term_tags_form') {
+    $form['relations']['#access'] = FALSE;
+  }
 }
 
 /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
  * @file
@@ -81,6 +82,17 @@ function ys_core_form_alter(&$form, $form_state, $form_id) {
     $form['relations']['#access'] = FALSE;
   }
 
+  // Increase length of taxonomy vocabulary description field.
+  if ($form_id == 'taxonomy_vocabulary_form') {
+    $form['description']['#maxlength'] = 256;
+  }
+
+  // Hide core taxonomy description.
+  // @see ys_core_help()
+  if ($form_id == 'taxonomy_overview_vocabularies') {
+    $form['#attached']['library'][] = 'ys_core/taxonomy_form';
+  }
+
   // Add vocabulary description to the taxonomy overview form.
   if ($form_id == 'taxonomy_overview_terms') {
     $replacements['@description'] = $form_state->getBuildInfo()['args'][0]->getDescription();
@@ -146,5 +158,33 @@ function ys_core_preprocess_menu__main(&$variables) {
     // Add cloned item to the beginning of the menu.
     array_unshift($menuItem['below'], $clonedMenuItem);
 
+  }
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ */
+function ys_core_module_implements_alter(&$implementations, $hook) {
+  // Forces ys_core help hook to come before others.
+  // @see https://drupal.stackexchange.com/questions/242572/is-it-possible-to-modify-help-text-on-a-vocabulary-page
+  if ($hook == 'help') {
+    $implementations = ['ys_core' => $implementations['ys_core']] + $implementations;
+  }
+}
+
+/**
+ * Implements hook_help().
+ */
+function ys_core_help($route_name, RouteMatchInterface $route_match) {
+  // Overrides help description.
+  // This is "temporary" until core adds this functionality.
+  // Uses CSS to hide the core description.
+  // @see https://drupal.stackexchange.com/questions/242572/is-it-possible-to-modify-help-text-on-a-vocabulary-page
+  // @see https://www.drupal.org/project/drupal/issues/487386
+  switch ($route_name) {
+    case 'entity.taxonomy_vocabulary.collection':
+
+      $output = '<p class="replacement-taxonomy-help">' . t('Taxonomy is used to classify website content into groups called vocabularies. Each vocabulary contains a set of terms used to categorize content. For example, an "Event Type" vocabulary contains terms like "Online" and "In-Person". This allows for easy categorization and organization of content on a website.') . '</p>';
+      return $output;
   }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -71,7 +71,13 @@ function ys_core_form_alter(&$form, $form_state, $form_id) {
   }
 
   // Hide Relations on taxonomy term edit page.
-  if ($form_id == 'taxonomy_term_tags_form') {
+  $vocabularyForms = [
+    'taxonomy_term_tags_form',
+    'taxonomy_term_event_category_form',
+    'taxonomy_term_post_category_form',
+  ];
+
+  if (in_array($form_id, $vocabularyForms)) {
     $form['relations']['#access'] = FALSE;
   }
 }


### PR DESCRIPTION
## [YALB-1212: Enable taxonomy interfaces for authors](https://yaleits.atlassian.net/browse/YALB-1212)

### Description of work
- Adds menu items to manage taxonomy vocabularies for site-admins
- Adds vocabulary descriptions to the overview page as well as individual vocabulary management pages.
- Removes unnecessary fields from taxonomy term edit pages.

### Functional testing steps:
- [x] Login to CAS as a site administrator role
- [x] Verify there are new menu items under Content -> Manage Taxonomy and Content -> Manage Taxonomy -> Event Category, Post Category, and Tags
![Screenshot 2023-06-05 at 4 16 57 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/b26b72d3-b4ab-4ee6-ae58-4e46333631f4)

- [x] Visit the overview page by clicking on the "Manage Taxonomy" link or the Manage Taxonomy -> Overview link
- [x] Verify there is a custom taxonomy overview description on top, and there are descriptions for each of the different vocabularies.
![Screenshot 2023-06-05 at 4 18 17 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/58bf2e3f-87c1-43ed-8166-723980596a7d)

- [x] Click on "List terms" on the right side to view an individual vocabulary
- [x] Verify that the vocabulary specific description is at the top of the page.
![Screenshot 2023-06-05 at 4 19 31 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/c4dea1af-6d12-4b19-bd9a-7ae99bc0f26b)
- [x] On one of the vocabulary pages, click "Add term" in the upper right corner
- [x] Verify that on the "Add term" page, the only field available is the "Name" field.
![Screenshot 2023-06-05 at 4 21 53 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/df7a3d48-48eb-47a4-af2d-b7c1e150f42d)

