### PR TITLE
YALB-1022: Bug: Grand Hero Design Option labels flipped

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.install
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @file
+ * Install, uninstall and update hooks for ys_themes module.
+ */
+
+/**
+ * Change grand hero field_style_position and field_style_variation keys.
+ */
+function ys_themes_update_9001() {
+
+  // Changes 'reduced' to 'contained' for grand hero positioning.
+  $positionTables = [
+    'block_content__field_style_position',
+    'block_content_revision__field_style_position',
+  ];
+
+  foreach ($positionTables as $table) {
+    $query = \Drupal::database()->update($table);
+    $query->fields([
+      'field_style_position_value' => 'contained',
+    ]);
+    $query->condition('bundle', 'grand_hero');
+    $query->condition('field_style_position_value', 'reduced');
+    $query->execute();
+  }
+
+  // Changes 'contained' to 'reduced' for grand hero variation.
+  $variationTables = [
+    'block_content__field_style_variation',
+    'block_content_revision__field_style_variation',
+  ];
+
+  foreach ($variationTables as $table) {
+    $query = \Drupal::database()->update($table);
+    $query->fields([
+      'field_style_variation_value' => 'reduced',
+    ]);
+    $query->condition('bundle', 'grand_hero');
+    $query->condition('field_style_variation_value', 'contained');
+    $query->execute();
+  }
+
+}


### PR DESCRIPTION
## [YALB-1022: Bug: Grand Hero Design Option labels flipped](https://yaleits.atlassian.net/browse/YALB-1022)

### Description of work
- Updates grand hero components that were created previous to variation and position key changes.
- Changes `reduced` to `contained` for grand hero positioning.
- Changes `contained` to `reduced` for grand hero variation.

### Functional testing steps:
- [x] This is best tested locally as the Pantheon multidev already has the update in place and it is easier to change configs
- [x] Pull down a clean copy of the repo
- [x] Run `npm run setup`
- [x] Run `git checkout YALB-1022--grand-hero-labels`
- [x] First, we will need to mimic the old config:
- [x] Edit `web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml`
- [x] Change line 89 from `contained: 'Floating Box'` to `reduced: 'Floating Box'`
- [x] Change line 94 from `reduced: Short` to `contained: Short`
- [x] Save the file
- [x] Run `lando drush cim`
- [x] Login to the site and create a page
- [x] In Layout Builder, add one Grand Hero component. Use the heading title "Old Grand Hero"
- [x] Set the "Media Size" to "Short" and the "Overlay Position" to "Floating Box"
- [x] Add the block and save layout builder.
![Screenshot 2023-06-15 at 5 04 33 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/41cf8287-4d2e-4a81-b252-3ba2a32bcab8)
- [x] Now that we have an older version of the Grand Hero, we'll revert our changes to config and create a newer version of the Grand Hero.
- [x] Revert the changes in `web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml`
- [x] Run `lando drush cim`
- [x] Back on the site, go back into Layout Builder for the same page and add a second Grand Hero with the same settings. Use the heading "New Grand Hero" and the same text in the content area.
- [x] Save the layout.
- [x] Verify that there is a visual change between both blocks.
![Screenshot 2023-06-15 at 5 09 20 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/3ed4ab77-d41c-4a9c-b648-c03a3a51a9cb)
- [x] Now, we will run the database updates which will change the Grand Hero keys of the old one to match the new one:
- [x] Visit `/update.php`
- [x] Verify there is pending update
- [x] Click "Apply pending updates"
- [x] Go back to the page that has the tests and verify that both Grand Hero's now appear the same
![Screenshot 2023-06-15 at 5 12 34 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/cb58bb56-7901-4693-88bb-ec29ed534449)

