### PR TITLE
Remove media library upload button patch for Gin LB

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -113,9 +113,6 @@
       "drupal/layout_builder_browser": {
         "close modal on submit https://www.drupal.org/project/layout_builder_browser/issues/3352754": "https://www.drupal.org/files/issues/2023-04-19/layout_builder_browser-modal_does_not_close_on_submit-3352754-2.patch"
       },
-      "drupal/gin_lb": {
-        "fix missing file field https://www.drupal.org/project/gin_lb/issues/3349745": "https://www.drupal.org/files/issues/2023-03-23/3349745-8-claro-preprocess-file-fields.patch"
-      },
       "drupal/bugherd": {
         "anonymous user unable to fill in email field https://www.drupal.org/project/bugherd/issues/3364305": "https://git.drupalcode.org/project/bugherd/-/merge_requests/4.diff"
       },


### PR DESCRIPTION
### Description of work
- Removes the patch for Gin Layout Builder that adds a media upload button because it has been included in the latest version of Gin Layout Builder.
- Fixes local composer build errors

### Functional testing steps:
- [ ] Pull down clean copy of this repo
- [ ] Run `git checkout gin-lb-patch`
- [ ] Run `npm run setup`
- [ ] Verify that there are no more build errors related to composer
- [ ] Verify that Lando URL's work and the site is accessible locally
- [ ] Login as a "Site administrator" role
- [ ] Add a page to the site
- [ ] Title the page, save and enter layout builder
- [ ] Add an image-based component in Layout Builder
- [ ] Click "Add Media" and verify that there is still an "Add file" ("Choose File") upload button.
![Screenshot 2023-06-20 at 10 55 15 AM](https://github.com/yalesites-org/yalesites-project/assets/107938318/b564456d-247e-4050-8508-826db049030a)
