### PR TITLE
YALB-1033, YALB-1298: Unpublished Content

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -113,9 +113,6 @@
       "drupal/layout_builder_browser": {
         "close modal on submit https://www.drupal.org/project/layout_builder_browser/issues/3352754": "https://www.drupal.org/files/issues/2023-04-19/layout_builder_browser-modal_does_not_close_on_submit-3352754-2.patch"
       },
-      "drupal/gin_lb": {
-        "fix missing file field https://www.drupal.org/project/gin_lb/issues/3349745": "https://www.drupal.org/files/issues/2023-03-23/3349745-8-claro-preprocess-file-fields.patch"
-      },
       "drupal/bugherd": {
         "anonymous user unable to fill in email field https://www.drupal.org/project/bugherd/issues/3364305": "https://git.drupalcode.org/project/bugherd/-/merge_requests/4.diff"
       },

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/src/EventSubscriber/NodeAccessEventSubscriber.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/src/EventSubscriber/NodeAccessEventSubscriber.php
@@ -52,7 +52,7 @@ class NodeAccessEventSubscriber extends HttpExceptionSubscriberBase {
          * If so, redirect to CAS login.
          */
         if ($node->hasField('field_login_required')) {
-          if (!$node->field_login_required->isEmpty()) {
+          if ($node->isPublished() && $node->field_login_required->first()->getValue()['value']) {
             $casRedirectUrl = Url::fromRoute('cas.login', ['destination' => $node->toUrl()->toString()])->toString();
             $returnResponse = new TrustedRedirectResponse($casRedirectUrl);
             $returnResponse->getCacheableMetadata()->setCacheMaxAge(0);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.module
@@ -12,6 +12,7 @@ use Drupal\ys_node_access\NodeAccessManager;
  * Implements hook_node_grants().
  */
 function ys_node_access_node_grants($account, $op) {
+
   $nodeAccessManager = new NodeAccessManager();
 
   // Only set grants for viewing a node.
@@ -42,7 +43,7 @@ function ys_node_access_node_access_records($node) {
   $nodeAccessManager = new NodeAccessManager();
   // Saving a node, check login required field to set the appropriate grants.
   if ($node->hasField('field_login_required')) {
-    if ($node->get('field_login_required')->getValue()[0]['value'] == 1) {
+    if ($node->get('field_login_required')->getValue()[0]['value'] == 1 || !$node->isPublished()) {
       $private = TRUE;
     }
     else {


### PR DESCRIPTION
- [YALB-1033: Bug: Unpublished items in menu (BE)](https://yaleits.atlassian.net/browse/YALB-1033)
- [YALB-1298: Bug: Unpublished content in search (BE)](https://yaleits.atlassian.net/browse/YALB-1298)

### Description of work
- Fixes unpublished items from showing in search and in menu items - these items will no longer show in these places if unpublished.

### Functional testing steps:
- [x] Login to the site and create the following 4 pages that have some searchable text in a text component (via layout builder) and are in the main menu. Make a note of the searchable text for testing below. "With CAS" means checking the box under: Sidebar -> Publishing Settings -> CAS Login Required.
     - [x] Published page without CAS
     - [x] Published page with CAS
     - [x] Unpublished page without CAS
     - [x] Unpublished page with CAS
- [x] View the site logged in, and verify that menu shows for all of the pages above
- [x] Verify that search results work for published pages only
- [x] Visit the site as an anonymous user (incognito window) and verify that:
     - [x] Published page without CAS - is viewable in menu and search results are viewable
     - [x] Published page with CAS - is not viewable in menu, no search results are viewable. If visiting direct URL, redirected to CAS
     - [x] Both Unpublished page without CAS and with CAS - Not viewable in menu, no search results viewable. If visiting direct URL, access denied