### PR TITLE
YALB-1313: Bug: Menu levers not updating website (BE)

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -158,9 +158,7 @@ function ys_themes_preprocess_page(&$variables) {
   $config = \Drupal::config('ys_themes.theme_settings');
   $variables['site_global__theme'] = $config->get('global_theme');
 
-  // Add the cache tag, so that the theme setting information is rebuilt when
-  // the config is saved.
-  // Via: https://drupal.stackexchange.com/questions/266379/how-to-clear-cache-for-config-entity-after-making-changes
+  // @see ys_themes_preprocess_block() for explanation.
   \Drupal::service('renderer')->addCacheableDependency($variables, $config);
 }
 
@@ -171,9 +169,7 @@ function ys_themes_preprocess_menu(&$variables) {
   if ($variables['menu_name'] == 'main') {
     $config = \Drupal::config('ys_themes.theme_settings');
 
-    // Add the cache tag, so that the theme setting information is rebuilt when
-    // the config is saved.
-    // Via: https://drupal.stackexchange.com/questions/266379/how-to-clear-cache-for-config-entity-after-making-changes
+    // @see ys_themes_preprocess_block() for explanation.
     \Drupal::service('renderer')->addCacheableDependency($variables, $config);
   }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -164,6 +164,17 @@ function ys_themes_preprocess_page(&$variables) {
   \Drupal::service('renderer')->addCacheableDependency($variables, $config);
 }
 
+function ys_themes_preprocess_menu(&$variables) {
+  if ($variables['menu_name'] == 'main') {
+    $config = \Drupal::config('ys_themes.theme_settings');
+
+    // Add the cache tag, so that the theme setting information is rebuilt when
+    // the config is saved.
+    // Via: https://drupal.stackexchange.com/questions/266379/how-to-clear-cache-for-config-entity-after-making-changes
+    \Drupal::service('renderer')->addCacheableDependency($variables, $config);
+  }
+}
+
 /**
  * Implements hook_form_alter().
  */

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -164,6 +164,9 @@ function ys_themes_preprocess_page(&$variables) {
   \Drupal::service('renderer')->addCacheableDependency($variables, $config);
 }
 
+/**
+ * Implements hook_preprocess_menu().
+ */
 function ys_themes_preprocess_menu(&$variables) {
   if ($variables['menu_name'] == 'main') {
     $config = \Drupal::config('ys_themes.theme_settings');


### PR DESCRIPTION
…hange

## [YALB-1313: Bug: Menu levers not updating website (BE)](https://yaleits.atlassian.net/browse/YALB-1313)

### Description of work
- Fixes a bug when changing the Navigation Type in the theme settings panel and saving the settings, the menu would not change until the cache was cleared. Now, when changing the Navigation Type and saving the settings, the change is immediate.

### Functional testing steps:
- [x] Visit a node - page, post, or event
- [x] At the top right, click "Theme Settings"
- [x] Scroll down to "Navigation Type"
- [x] Note the current main menu navigation type - either Mega or Basic
- [x] Change the navigation type to the other type, scroll down and click "Save configuration"
- [x] Verify that the menu navigation type changes immediately
- [x] Verify the same on an incognito window
