### PR TITLE
YALB-579: Improve homepage settings controls

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -110,10 +110,17 @@ class SiteSettingsForm extends ConfigFormBase {
     ];
 
     $form['site_page_front'] = [
-      '#type' => 'textfield',
-      '#description' => $this->t("Specify a relative URL to display as the front page."),
+      '#type' => 'linkit',
+      '#description' => $this->t("Specify a relative URL or autocomplete to display as the front page."),
       '#title' => $this->t('Front page'),
+      '#autocomplete_route_name' => 'linkit.autocomplete',
       '#default_value' => $siteConfig->get('page')['front'],
+      '#autocomplete_route_parameters' => [
+        'linkit_profile_id' => 'default',
+      ],
+      '#attributes' => [
+        'data-linkit-widget-title-autofill-enabled' => 'false',
+      ],
       '#required' => TRUE,
     ];
 


### PR DESCRIPTION
## [YALB-579: Improve homepage settings controls](https://yaleits.atlassian.net/browse/YALB-579)

### Description of work
- Replaced homepage text field, that is used to set the node of the homepage, with an autocomplete field
- Used Alerts setting form autocomplete field element as an example
- Note: Could not get it to work without setting attribute 'data-linkit-widget-title-autofill-enabled' => 'false', but was told the Alert setting autocomplete works without setting this?

### Functional testing steps:
- [ ] Open the settings page at '/admin/yalesites/settings'
- [ ] In the 'Front page' field, start typing the Title of the page you would like to set as the front page. Matching pages will be displayed.
- [ ] Once you select a page, the field should be populated with the node address of that page.
- [ ]  Save the settings page and verify that page is now the new homepage.
