### PR TITLE
YALB-1288: Bug: Search no results message (BE)

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
@@ -115,7 +115,7 @@ display:
             offset: false
             offset_label: Offset
       exposed_form:
-        type: input_required
+        type: basic
         options:
           submit_button: Search
           reset_button: false
@@ -124,8 +124,6 @@ display:
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
-          text_input_required: 'Enter some search terms and then click submit.'
-          text_input_required_format: basic_html
       access:
         type: perm
         options:
@@ -244,6 +242,7 @@ display:
       tags:
         - 'config:field.storage.node.field_teaser_text'
         - 'config:search_api.index.node_index'
+        - 'search_api_list:node_index'
   page_1:
     id: page_1
     display_title: Page
@@ -269,3 +268,4 @@ display:
       tags:
         - 'config:field.storage.node.field_teaser_text'
         - 'config:search_api.index.node_index'
+        - 'search_api_list:node_index'


### PR DESCRIPTION
## [YALB-1288: Bug: Search no results message (BE)](https://yaleits.atlassian.net/browse/YALB-1288)

### Description of work
- Fixes bug where no results text wasn't showing properly.
- No results text will now show if search terms are entered and no results are found.
- New search text will now show if no search terms are entered. (i.e. on `/search` with no keywords query parameter)
- Requires [Atomic PR-136](https://github.com/yalesites-org/atomic/pull/136)

### Functional testing steps:
- [x] Use the top right search box and enter a search term that would produce no results (such as "asdfg") and hit Enter
- [x] Verify that the no results text shows up: "There were no results for your search."
- [x] Edit the URL of the page to simply `/search` and load the search page with no query parameters
- [x] Verify the new search text shows up: "Enter some search terms and then click search."
