### PR TITLE
YALB-1333: Source correct location of say.sh

### DIFF
--- a/scripts/local/local-review-with-atomic-branch.sh
+++ b/scripts/local/local-review-with-atomic-branch.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # This script will checkout the specified branch of atomic for local review.
 
-source ./util/say.sh
+[ -e "./scripts/local/util/say.sh" ] || (echo -e "[$0] Say utility not found.  You must run this from the yalesites root directory: " && exit 1)
+source ./scripts/local/util/say.sh
 
 read -p "Which branch of the atomic repo do you need? " BRANCH
 

--- a/scripts/local/local-review-with-cl-branch.sh
+++ b/scripts/local/local-review-with-cl-branch.sh
@@ -4,7 +4,8 @@
 # folder so that any work-in-progress in the component library can be used
 # during development in Drupal.
 
-source ./util/say.sh
+[ -e "./scripts/local/util/say.sh" ] || (echo -e "[$0] Say utility not found.  You must run this from the yalesites root directory: " && exit 1)
+source ./scripts/local/util/say.sh
 
 read -p "Which branch of the component-library-twig repo do you need? " BRANCH
 


### PR DESCRIPTION
## [YALB-1333: Source correct location of say.sh](https://yaleits.atlassian.net/browse/YALB-1333)

While creating `say.sh`, I forgot to source the proper location of it in the local review scripts, resulting in error messages when attempting to write messages through the say command.  This now references correctly, as well as checking for the file so we can know when there is a problem.

### Description of work
- Replace execution of `./util/say.sh` to `source ./scripts/local/util/say.sh`
- Add guard clause check so if say.sh moves or is removed in the future, we know it's not loaded.

### Functional testing steps:
- [x] ensure you are on the root of the repo
- [ ] execute `npm run local:review-with-atomic-branch`
  - [x] make up a branch name to look for (doesn't have to exist)
  - [x] ensure you start to see messages in green (and not errors that it can't find say) -- Feel free to CTRL-C after you see the first couple as it shows it's working
- [x] execute `npm run local:review-with-cl-branch`
  - [x] make up a branch name to look for (doesn't have to exist)
  - [x] ensure you start to see messages in green (and not errors that it can't find say) -- Feel free to CTRL-C after you see the first couple as it shows it's working
- [x] execute `./scripts/local/local-review-with-atomic-branch`
  - [x] make up a branch name to look for (doesn't have to exist)
  - [x] ensure you start to see messages in green (and not errors that it can't find say) -- Feel free to CTRL-C after you see the first couple as it shows it's working
- [x] execute `./scripts/local/local-review-with-cl-branch`
  - [x] make up a branch name to look for (doesn't have to exist)
  - [x] ensure you start to see messages in green (and not errors that it can't find say) -- Feel free to CTRL-C after you see the first couple as it shows it's working