### PR TITLE
YALB-1317): Bug: Paragraph duplicate function broken (BE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory.
+


### PR DESCRIPTION
## [YALB-1317: Bug: Paragraph duplicate function broken (BE)](https://yaleits.atlassian.net/browse/YALB-1317)

### Description of work
- Fixes error when duplicating gallery item paragraphs
- Note: Do not merge this PR - fix is in Atomic only. This PR is for multidev testing only.
- [Atomic PR-137](https://github.com/yalesites-org/atomic/pull/137) is the only code required for this fix.

### Functional testing steps:
- [x] Create a page on the site, title it, save, and enter layout builder
- [x] Add a block of type "Gallery"
- [x] Add in some copy and an image
- [x] Click "Add block"
- [x] Save the layout
- [x] Re-enter layout builder
- [x] Configure the gallery block that was just created
- [x] Click the three dots next to the Gallery Item that was created above and then click "Duplicate"
![Screenshot 2023-06-22 at 4 04 19 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/9a90eabf-8549-489c-8bf2-89043e1cd8b8)
- [x] Click 'Update" at the bottom of the block configuration
- [x] Verify there is no error after clicking "Update"
- [x] Save the layout
- [x] Verify that both image gallery items work by clicking on them to open the modal
