### PR TITLE
YALB-1304, YALB-1344: Alert Settings Bugs

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/src/Form/AlertSettings.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/src/Form/AlertSettings.php
@@ -116,8 +116,8 @@ class AlertSettings extends ConfigFormBase {
 
     $form['status'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Enabled?'),
-      '#description' => $this->t('Check this field if you want the alert to be visible across the site.'),
+      '#title' => $this->t('Turn on Alerts'),
+      '#description' => $this->t('When selected, your alert will be visible across the site.'),
       '#default_value' => $config->get('alert.status'),
       '#required' => FALSE,
     ];
@@ -158,12 +158,35 @@ class AlertSettings extends ConfigFormBase {
       '#title' => $this->t('Message'),
       '#default_value' => $config->get('alert.message'),
       '#required' => TRUE,
+      '#attributes' => [
+        'class' => [
+          'maxlength',
+        ],
+        'data-maxlength' => 255,
+        '#maxlength_js_enforce' => TRUE,
+      ],
+      '#attached' => [
+        'library' => [
+          'maxlength/maxlength',
+        ],
+      ],
     ];
 
     $form['link_wrapper'] = [
       '#type' => 'details',
       '#title' => $this->t('Link'),
       '#open' => TRUE,
+    ];
+
+    $form['link_wrapper']['link_url'] = [
+      '#type' => 'linkit',
+      '#title' => $this->t('URL'),
+      '#description' => $this->t('Type the URL or autocomplete for internal paths.'),
+      '#autocomplete_route_name' => 'linkit.autocomplete',
+      '#default_value' => $config->get('alert.link_url'),
+      '#autocomplete_route_parameters' => [
+        'linkit_profile_id' => 'default',
+      ],
     ];
 
     $form['link_wrapper']['link_title'] = [
@@ -175,17 +198,6 @@ class AlertSettings extends ConfigFormBase {
         'required' => [
           ':input[name="link_url"]' => ['filled' => TRUE],
         ],
-      ],
-    ];
-
-    $form['link_wrapper']['link_url'] = [
-      '#type' => 'linkit',
-      '#title' => $this->t('URL'),
-      '#description' => $this->t('Type the URL or autocomplete for internal paths.'),
-      '#autocomplete_route_name' => 'linkit.autocomplete',
-      '#default_value' => $config->get('alert.link_url'),
-      '#autocomplete_route_parameters' => [
-        'linkit_profile_id' => 'default',
       ],
     ];
 


### PR DESCRIPTION
* [YALB-1304: Bug: Alert char limits (BE)](https://yaleits.atlassian.net/browse/YALB-1304)
* [YALB-1344: Feedback: Alert settings the link fields are flipped order](https://yaleits.atlassian.net/browse/YALB-1344)

### Description of work
- Adds 255 hard character limit to alert description
- Swaps link text and link URL fields to match established order elsewhere on the site
- Changes alert copy for enabling alert

### Functional testing steps:
- [ ] Login to the site and visit `/admin/yalesites/alert`
- [ ] Verify that the toggle to enable alerts has new language "Turn on Alerts" with help text of "When selected, your alert will be visible across the site."
- [ ] Verify that the Message now has a hard character limit of 255
- [ ] Verify that the Link URL and title are in that order to match the rest of the site

![Screenshot 2023-06-23 at 10 48 11 AM](https://github.com/yalesites-org/yalesites-project/assets/107938318/ee984ad2-0b50-4116-a8eb-bdba535d577e)

