### PR TITLE
fix(YALB-1189): Site admins should not be able to configure site-wide…

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -18,7 +18,6 @@ dependencies:
     - taxonomy.vocabulary.post_category
     - taxonomy.vocabulary.tags
   module:
-    - block
     - contextual
     - editoria11y
     - file
@@ -52,7 +51,6 @@ permissions:
   - 'access toolbar'
   - 'access user profiles'
   - 'access webform overview'
-  - 'administer blocks'
   - 'administer main menu items'
   - 'administer redirects'
   - 'administer users'


### PR DESCRIPTION
## [YALB-1189: Bug: Remove "Configure Block" from Alert banner](https://yaleits.atlassian.net/browse/YALB-1189)

### Description of work
- Removes the ability for site admin role to see pencil icon and edit system-level blocks.
- System-level blocks are still editable by platform admins.
- Site admins can still edit layout builder blocks.

### Functional testing steps:
- [x] Login to the site as a site administrator role in an incognito window and also have either user 1 or platform admin role in another browser window. Note: if using CAS, double check the role of the testing user (with user 1) AFTER logging in because CAS Can add in the platform admin role and mess up testing.
- [x] Visit the front-end of the site
- [x] Hover over the alert banner and verify that the pencil icon on the right-hand side is missing and there is no way to configure / remove the alert banner as a block.

You should NOT see this when hovering as a site admin:
![Screenshot 2023-06-23 at 2 09 09 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/40b80174-48ae-4e07-8689-c11c9c782f04)

- [x] Visit the `/search` page as a site administrator and hover over the title "Search" and verify that there is no pencil icon on the right-hand side.
- [x] Verify that as user 1 or platform admin role, these pencil icons do show up.
- [x] Add a page, title, save, and enter layout builder.
- [x] Verify that you can add and edit layout builder blocks as a site administrator.
