### PR TITLE
YALB-1318: Bug: media library - gallery block - multiple photos error

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -102,7 +102,8 @@
         "hide remove button": "https://www.drupal.org/files/issues/2020-05-13/hide_field_required_paragraphs_remove_button_1.patch"
       },
       "drupal/core": {
-        "plural results summary https://www.drupal.org/project/drupal/issues/2888320": "https://www.drupal.org/files/issues/2021-12-15/2888320-78.patch"
+        "plural results summary https://www.drupal.org/project/drupal/issues/2888320": "https://www.drupal.org/files/issues/2021-12-15/2888320-78.patch",
+        "Prevent media library item overflow https://www.drupal.org/project/drupal/issues/3059955": "https://www.drupal.org/files/issues/2023-03-18/3059955-167.patch"
       },
       "drupal/entity_redirect": {
         "fix layout route https://www.drupal.org/project/entity_redirect/issues/3352265": "https://git.drupalcode.org/project/entity_redirect/-/merge_requests/6.patch"


### PR DESCRIPTION
## [YALB-1318: Bug: media library - gallery block - multiple photos error](https://yaleits.atlassian.net/browse/YALB-1318)

### Description of work
- Prevents adding more media items to a limited media item field
- Requires [Atomic PR-139](https://github.com/yalesites-org/atomic/pull/139)

### Functional testing steps:
- [x] Add a page to the site, title it, save, and enter layout builder
- [x] Add a block of type "Gallery"
- [x] Under the "Image" area, click "Add media"
- [x] Select one existing media item
- [x] Click "Choose Files" at the top of the "Add or select media" modal
- [x] Select an image to upload, fill out the "Alternative text" and then click "Save"
- [x] Verify that there is now a warning message "There are currently 2 items selected. The maximum number of items for the field is 1. Please remove 1 item from the selection." above the selection.

![Screenshot 2023-06-27 at 4 07 17 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/3889a249-d695-4ccc-9bea-68205ec77d18)

- [x] Without changing the selected images, click "Insert selected"
- [x] Verify that it will prevent the insert of images until the selection is correct - one item, not two
- [x] Verify that the message changes color to an error message
- [x] Uncheck one of the images
- [x] Click "Insert selected"
- [x] Verify that the image inserts correctly