### PR TITLE
YALB-1309: Rename webform to prebuilt form

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/block_content.type.webform.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block_content.type.webform.yml
@@ -30,4 +30,4 @@ third_party_settings:
 id: webform
 label: 'Pre-Built Form'
 revision: 1
-description: 'Pre-Built Form is a component that enables you to insert pre-built form components into your website. For a custom form or survey experience, you can use the embed component to add a Qualtrics form instead.'
+description: 'Add a pre-built Drupal form. Not intended for custom form creation.'

--- a/web/profiles/custom/yalesites_profile/config/sync/block_content.type.webform.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block_content.type.webform.yml
@@ -1,8 +1,33 @@
 uuid: 54d4b25a-7a4c-4a29-ac01-32b95e546f15
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - entity_redirect
+third_party_settings:
+  entity_redirect:
+    redirect:
+      add:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+      edit:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+      delete:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+      anonymous:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
 id: webform
-label: Webform
+label: 'Pre-Built Form'
 revision: 1
-description: 'Webform is a component that enables you to insert pre-built form components into your website. For a custom form or survey experience, you can use the embed component to add a Qualtrics form instead.'
+description: 'Pre-Built Form is a component that enables you to insert pre-built form components into your website. For a custom form or survey experience, you can use the embed component to add a Qualtrics form instead.'

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.webform.field_heading.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.webform.field_heading.yml
@@ -16,7 +16,7 @@ id: block_content.webform.field_heading
 field_name: field_heading
 entity_type: block_content
 bundle: webform
-label: 'Webform Component Title'
+label: 'Pre-Built Form Component Title'
 description: ''
 required: true
 translatable: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.webform.field_instructions.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.webform.field_instructions.yml
@@ -16,10 +16,11 @@ description: ''
 required: false
 translatable: true
 default_value:
-  - {  }
+  -
+    markup: null
 default_value_callback: ''
 settings:
   markup:
-    value: "<p>Webform is a component that enables you to insert pre-built form components into your website. For a custom form or survey experience, you can use the embed component to add a Qualtrics form instead.</p>\r\n"
+    value: "<p>Add a pre-built Drupal form. Not intended for custom form creation.</p>\r\n"
     format: basic_html
 field_type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/webform.webform.contact.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/webform.webform.contact.yml
@@ -16,7 +16,7 @@ archive: false
 id: contact
 title: Contact
 description: 'Basic email contact webform.'
-category: ''
+categories: {  }
 elements: |-
   name:
     '#type': textfield


### PR DESCRIPTION
## [YALB-1309: Rename webform to prebuilt form](https://yaleits.atlassian.net/browse/YALB-1309)

### Description of work
- Renames the block from "Webform" to "Pre-Built Form"
- Renames the block heading field from "Webform Component Title" to "Pre-Built Form Component Title"
- Updates the block instruction to read: "Add a pre-built Drupal form. Not intended for custom form creation."
- Updates the block description to read: "Add a pre-built Drupal form. Not intended for custom form creation."

### Functional testing steps:
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
