### PR TITLE
YALB-1136: Move bugherd button to the left

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/block_content.type.pull_quote.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block_content.type.pull_quote.yml
@@ -1,8 +1,33 @@
 uuid: d367d8b9-e740-4122-b741-80374ca7fbfc
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - entity_redirect
+third_party_settings:
+  entity_redirect:
+    redirect:
+      add:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+      edit:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+      delete:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+      anonymous:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
 id: pull_quote
 label: Quote
-revision: 0
+revision: 1
 description: 'Quotes allow you to highlight text from, or in reference to, a larger body of work. For instance, you can highlight from a blog, a post, or a personal phrase on a profile.'

--- a/web/profiles/custom/yalesites_profile/config/sync/block_content.type.text.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block_content.type.text.yml
@@ -1,8 +1,33 @@
 uuid: b110da7c-f687-4372-9b36-7868f635a610
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - entity_redirect
+third_party_settings:
+  entity_redirect:
+    redirect:
+      add:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+      edit:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+      delete:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+      anonymous:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
 id: text
 label: Text
-revision: 0
+revision: 1
 description: 'Text is used as your main source of text content on your page.'

--- a/web/profiles/custom/yalesites_profile/config/sync/bugherd.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/bugherd.settings.yml
@@ -1,7 +1,7 @@
 _core:
   default_config_hash: A1YhiXDQT0YvWBBy9oxEiWz2gjzsJ9mFNQYiO-St8VI
 bugherd_project_key: 7wyg24qv0ivjykxkd3k5fa
-bugherd_widget_position: bottom-right
+bugherd_widget_position: bottom-left
 bugherd_disable_on_admin: '0'
 reporter_email_autofill: 1
 email_required: 1


### PR DESCRIPTION
## [YALB-1136: Move bugherd button to the left](https://yaleits.atlassian.net/browse/YALB-1136)
## [YALB-1179: Tech debt: Add revisioning to quote and text blocks](https://yaleits.atlassian.net/browse/YALB-1179)

### Description of work
- Changes the bugherd module setting to move the button to the left side of the screen for submitting feedback.
- Adds revisioning to missing blocks. This is pure tech debt and has no functional or testable change on the site.

### Functional testing steps:
- [ ] [Visit the multidev](https://pr-329-yalesites-platform.pantheonsite.io/) and verify the the bugherd form is now floated to the left side of the page and not longer blocking the a11y tools.
