### PR TITLE
YALB-1411/1412/1329: Update toolbar labels, add unpublish button

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/block.block.ys_admin_theme_local_tasks.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block.block.ys_admin_theme_local_tasks.yml
@@ -2,6 +2,8 @@ uuid: e03d9a42-6814-4262-aec2-1914178b1d69
 langcode: en
 status: true
 dependencies:
+  module:
+    - system
   theme:
     - ys_admin_theme
 _core:
@@ -19,4 +21,8 @@ settings:
   provider: core
   primary: true
   secondary: false
-visibility: {  }
+visibility:
+  request_path:
+    id: request_path
+    negate: true
+    pages: '/node/*'

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_admin_theme.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_admin_theme.settings.yml
@@ -13,7 +13,7 @@ accent_color: ''
 preset_focus_color: dark
 focus_color: ''
 high_contrast_mode: 0
-classic_toolbar: horizontal
+classic_toolbar: vertical
 secondary_toolbar_frontend: 1
 show_description_toggle: 1
 show_user_theme_settings: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_admin_theme.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_admin_theme.settings.yml
@@ -13,7 +13,7 @@ accent_color: ''
 preset_focus_color: dark
 focus_color: ''
 high_contrast_mode: 0
-classic_toolbar: vertical
+classic_toolbar: horizontal
 secondary_toolbar_frontend: 1
 show_description_toggle: 1
 show_user_theme_settings: 0

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_toolbar/src/ToolbarItemsService.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_toolbar/src/ToolbarItemsService.php
@@ -118,7 +118,7 @@ class ToolbarItemsService {
     if ($this->showEditButton()) {
       $this->toolbarItems['toolbar_edit_link'] = $this->buildButton(
         'entity.node.edit_form',
-        'Setup'
+        'Manage Settings'
       );
     }
 
@@ -126,7 +126,7 @@ class ToolbarItemsService {
     // ensure this link only appears on entities with layout overrides enabled.
     $this->toolbarItems['toolbar_layout_link'] = $this->buildButton(
       'layout_builder.overrides.node.view',
-      'Layout Builder'
+      'Edit Layout And Content'
     );
 
     // Add a publish button to the toolbar when viewing an unpublished node.
@@ -134,6 +134,14 @@ class ToolbarItemsService {
       $this->toolbarItems['toolbar_publish_link'] = $this->buildButton(
         'entity.node.publish',
         'Publish'
+      );
+    }
+
+    // Add an unpublish button to the toolbar when viewing a published node.
+    if ($this->showUnpublishButton()) {
+      $this->toolbarItems['toolbar_unpublish_link'] = $this->buildButton(
+        'entity.node.publish',
+        'Unpublish'
       );
     }
 
@@ -187,14 +195,25 @@ class ToolbarItemsService {
   }
 
   /**
-   * Chech if the dedicated 'publish' button should appear on the current route.
+   * Chech if a dedicated 'publish' button should appear on the current route.
    *
    * @return bool
-   *   True if the publish button should appear on the toolbar.
+   *   True if the button should appear on the toolbar.
    */
   protected function showPublishButton(): bool {
-    // Show the edit button on all node routes except the edit form.
+    // Show the button if viewing an unpublished node.
     return !$this->currentNode->isPublished() && $this->isViewRoute();
+  }
+
+  /**
+   * Chech if a dedicated 'unpublish' button should appear on the current route.
+   *
+   * @return bool
+   *   True if the button should appear on the toolbar.
+   */
+  protected function showUnpublishButton(): bool {
+    // Show the button if viewing a published node.
+    return $this->currentNode->isPublished() && $this->isViewRoute();
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_toolbar/ys_toolbar.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_toolbar/ys_toolbar.module
@@ -14,7 +14,7 @@ function ys_toolbar_toolbar_alter(&$items) {
   // all nodes. Change to "Manage this Page" to make it easier to understand.
   if (\Drupal::service('ys_toolbar.items')->isCurrentRouteNode()) {
     if (!empty($items['admin_toolbar_local_tasks']['tab']['#title'])) {
-      $items['admin_toolbar_local_tasks']['tab']['#title'] = 'Toolset';
+      $items['admin_toolbar_local_tasks']['tab']['#title'] = 'More Actions';
     }
   }
 


### PR DESCRIPTION
## [YALB-1411: Update admin toolbar labels](https://yaleits.atlassian.net/browse/YALB-1411)
## [YALB-1412: Add unpublished button to toolbar](https://yaleits.atlassian.net/browse/YALB-1412)
## [YALB-1329: Hide 3rd navigation in content type setup](https://yaleits.atlassian.net/browse/YALB-1329)

### Description of work
- Updates toolbar labels as described in the test plan below
- Adds an upbulish button to all published nodes.
- Hide these secondary tasks block on node forms in the admin theme

### Functional testing steps:
- [ ] Login to the multidev [http://pr-330-yalesites-platform.pantheonsite.io/](http://pr-330-yalesites-platform.pantheonsite.io/)
- [ ] Visit an existing page [https://pr-330-yalesites-platform.pantheonsite.io/faqs](https://pr-330-yalesites-platform.pantheonsite.io/faqs)
- [ ] Verify that when looking at a node the following label changes appear:
  - [ ] The node edit link is now named "Manage Settings"
  - [ ] The layout link is now named "Edit Layout And Content"
  - [ ] The local tasks bin is now named "More Actions"
- [ ] Publish a node and verify that an 'Unpublish' link appears in the toolbar.
- [ ] Unpublish a node and verify that a 'Publish' link appears in the toolbar.

