### PR TITLE
YALB-1363 - Bug: Media Grid images are different sizes on the main page

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.media_grid_item.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.media_grid_item.default.yml
@@ -14,7 +14,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: default
+      view_mode: card_secondary_3_2
       link: false
     third_party_settings: {  }
     weight: 0


### PR DESCRIPTION
## [YALB-1363 - Bug: Media Grid images are different sizes on the main page](https://yaleits.atlassian.net/browse/YALB-1363)

### Description of work
- Changes media grid image view_mode from `default` to `card_secondary_3_2` to match the gallery component's view_mode

### Functional testing steps:
- [x] View this test page: https://pr-331-yalesites-platform.pantheonsite.io/components
- [x] Verify all images in the grid are the same size/crop (it now matches the interactive image gallery)

![Screenshot-20230628141059-1212x966](https://github.com/yalesites-org/yalesites-project/assets/366413/c34f041f-0d89-4be8-95b5-bef4e135a779)



- [x] Edit the image grid on this page and upload a `portrait` oriented image, like the one attached here: 
![P7023470](https://github.com/yalesites-org/yalesites-project/assets/366413/0ce70db8-08c8-4072-9096-93e8aa3f8571)

- [x] Verify the image grid, with the portrait-oriented image, renders all images uniformly.

![Screenshot-20230628134656-1503x550](https://github.com/yalesites-org/yalesites-project/assets/366413/881ffa93-212e-4a00-8810-b7819eea5376)

