### PR TITLE
YALB-1295: Bug: Posts display date of creation and not Publish Date

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/pathauto.pattern.post.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/pathauto.pattern.post.yml
@@ -7,12 +7,12 @@ dependencies:
 id: post
 label: Post
 type: 'canonical_entities:node'
-pattern: '[yale:post_landing_page_path]/[node:created:custom:Y-m-d]-[node:title]'
+pattern: '[yale:post_landing_page_path]/[node:field_publish_date:date:custom:Y-m-d]-[node:title]'
 selection_criteria:
-  8a744808-8c9b-41fd-bb78-ada30c5622e8:
+  d2b465dc-45d7-44e9-bd6f-a0b2794f2767:
     id: 'entity_bundle:node'
     negate: false
-    uuid: 8a744808-8c9b-41fd-bb78-ada30c5622e8
+    uuid: d2b465dc-45d7-44e9-bd6f-a0b2794f2767
     context_mapping:
       node: node
     bundles:

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.post_cards.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.post_cards.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.card
     - node.type.post
   module:
+    - datetime
     - node
     - user
 id: post_cards
@@ -110,16 +111,14 @@ display:
             label: ''
             field_identifier: ''
           exposed: false
-        created:
-          id: created
-          table: node_field_data
-          field: created
+        field_publish_date_value:
+          id: field_publish_date_value
+          table: node__field_publish_date
+          field: field_publish_date_value
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: node
-          entity_field: created
-          plugin_id: date
+          plugin_id: datetime
           order: DESC
           expose:
             label: ''

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.post_list.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.post_list.yml
@@ -8,6 +8,7 @@ dependencies:
     - taxonomy.vocabulary.post_category
   module:
     - better_exposed_filters
+    - datetime
     - node
     - taxonomy
     - user
@@ -154,16 +155,14 @@ display:
             label: ''
             field_identifier: ''
           exposed: false
-        created:
-          id: created
-          table: node_field_data
-          field: created
+        field_publish_date_value:
+          id: field_publish_date_value
+          table: node__field_publish_date
+          field: field_publish_date_value
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: node
-          entity_field: created
-          plugin_id: date
+          plugin_id: datetime
           order: DESC
           expose:
             label: ''


### PR DESCRIPTION
## [YALB-1295: Bug: Posts display date of creation and not Publish Date](https://yaleits.atlassian.net/browse/YALB-1295)

### Description of work
- Changes post sorting for cards and lists to use "Publish Date" field instead of creation date.
- Also has an Atomic piece in [PR-142](https://github.com/yalesites-org/atomic/pull/142) that changes the visual display of the post date (in cards, lists, and default node view) from the creation date to the date in the "Publish Date" field.

### Functional testing steps:
- [x] Create 3 posts on the site with different publish dates
- [x] On a page, in layout builder, add a block of type "Post feed" and save the layout
- [x] Verify that on the page in the post feed, the posts are ordered in reverse chronological order and that the date listed in the feed is the published date set, not the creation date.

![Screenshot 2023-06-28 at 3 46 02 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/1874a950-d0b9-421f-ab33-afdc0eef8d1b)

- [x] Click through to one of the posts and verify that on the detail page, the post date is the published date and not the creation date.

![Screenshot 2023-06-28 at 3 47 07 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/59b423e4-998e-4aaf-863a-0b84661f4fb3)

- [x] Go back to the page and re-enter layout builder
- [x] Add a block of type "View"
- [x] Use the following parameters: "Posts" as "Post Card Grid" sorted by "Publish Date - older first".
- [x] Save the layout
- [x] Verify that the sort order of the posts in the view are from oldest to newest and that the date listed in the view is the published date set, not the creation date.

![Screenshot 2023-06-28 at 3 49 41 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/4c5982ed-0956-472a-838f-5ca9e95d7e73)

