### PR TITLE
YALB-1290: Bug: Grand Hero Text alignment

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/filter.format.heading_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/filter.format.heading_html.yml
@@ -14,7 +14,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<em> <strong>'
+      allowed_html: '<em> <strong><p>'
       filter_html_help: false
       filter_html_nofollow: false
   improve_line_breaks_filter:


### PR DESCRIPTION
## [YALB-1290: Bug: Grand Hero Text alignment](https://yaleits.atlassian.net/browse/YALB-1290)

### Description of work
- Title is misleading. Another issue on this ticket was brought up by Ashley: "Text CTAs are also too close to the text (in action banners)."
- Heading HTML text format will no longer strip out `<p>` tags
- Fixes the issue with the text being too close to the CTA in action banners
- Tested all other components and all looked fine except for
- Quote component attribution broke - we need to address this in the component library CSS is my guess

### Functional testing steps:
- [ ] Create a page, title, save and enter layout builder
- [ ] Add a component of type "Action Banner"
- [ ] Fill out the heading, content, image, and link with dummy text
- [ ] Add the block and save the layout
- [ ] Reduce browser width to 990px or less
- [ ] Verify that the text and button have sufficient padding around each other, see screenshot

![Screenshot 2023-07-10 at 9 46 26 AM](https://github.com/yalesites-org/yalesites-project/assets/107938318/4546b4c8-5666-4a1f-a746-f777061776d9)

### After Joe has made a CSS fix (probably in Component Library):
- [ ] Add a component of type Quote to the page
- [ ] Fill out all of the information, save the block, and save the layout
- [ ] Verify that the quote attribution has the dash next to the attribution, not above it. **Current screenshot is the broken quote**:

![Screenshot 2023-07-07 at 1 27 45 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/b9c0608b-5d27-4e87-98f5-ed814dcc7d49)

