### PR TITLE
YALB-1434: Increate max video size

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.media.background_video.field_media_video_file.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.media.background_video.field_media_video_file.yml
@@ -22,6 +22,6 @@ settings:
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: mp4
-  max_filesize: '5 MB'
+  max_filesize: '12 MB'
   description_field: false
 field_type: file


### PR DESCRIPTION
## [YALB-1434: Increate max video size](https://yaleits.atlassian.net/browse/YALB-1434)

### Description of work
- Increase background video size from 5MB to 12MB.

### Functional testing steps:
- [ ] Login to the website and edit any page.
- [ ] Add a 'Grand Hero' banner.
- [ ] Upload a background video. This was previously limited to 5MB. Download this text video of 10MB size. https://freetestdata.com/video-files/mp4/
- [ ] Verify the video can be uploaded and added to a page. This text-content does not have any real motion, uploading is success for this ticket.
