### PR TITLE
YALB-1256: Consistant 'add' label for reference fields

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.custom_cards.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.custom_cards.default.yml
@@ -30,7 +30,7 @@ content:
       closed_mode: summary
       autocollapse: all
       closed_mode_threshold: 0
-      add_mode: dropdown
+      add_mode: button
       form_display_mode: default
       default_paragraph_type: custom_card
       features:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.gallery.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.gallery.default.yml
@@ -30,7 +30,7 @@ content:
       closed_mode: summary
       autocollapse: all
       closed_mode_threshold: 0
-      add_mode: dropdown
+      add_mode: button
       form_display_mode: default
       default_paragraph_type: gallery_item
       features:


### PR DESCRIPTION
## [YALB-1256: Consistant 'add' label for reference fields](https://yaleits.atlassian.net/browse/YALB-1256)

### Description of work
- Update entity reference widgets to use button variation. This applies to the 'custom card' and 'gallery' blocks. We want to use the same controls as other blocks.

### Functional testing steps:
- [ ] Login and create a page.
- [ ] Add a 'custom card' block. Verify that the bottom of the content-add module it includes a link to 'add custom card' but does not include the suffix "to Cards". This is consistant with our other blocks like image grid, tabs, and accordions.

For reference, this controls originally looked like this on two of the block types:
![-old](https://github.com/yalesites-org/yalesites-project/assets/9594124/adaeda51-e92d-4cea-b8cc-7a2ed35d49e3)
But are now simply a button:
![-new](https://github.com/yalesites-org/yalesites-project/assets/9594124/35230177-3dae-45fe-8e7b-1577dcc17798)