### PR TITLE
YALB-309: Metadata: Teaser instruction and help text (UX/SB)

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -119,6 +119,9 @@
       },
       "drupal/smart_date": {
         "add PHP c date format": "patches/add-php-c-format.patch"
+      },
+      "drupal/gin": {
+        "fix description toggle for CKEditor fields https://www.drupal.org/project/gin/issues/3316265": "https://git.drupalcode.org/project/gin/-/merge_requests/227.patch"
       }
     }
   }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_teaser_media.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_teaser_media.yml
@@ -11,7 +11,7 @@ field_name: field_teaser_media
 entity_type: node
 bundle: event
 label: 'Teaser Media'
-description: ''
+description: 'If not specified, the Fallback teaser image is displayed'
 required: false
 translatable: true
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_teaser_text.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_teaser_text.yml
@@ -17,7 +17,7 @@ field_name: field_teaser_text
 entity_type: node
 bundle: event
 label: 'Teaser Text'
-description: ''
+description: 'Teaser details display in feeds, views, search engine result pages, and social sharing cards.'
 required: false
 translatable: true
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_teaser_title.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_teaser_title.yml
@@ -10,7 +10,7 @@ field_name: field_teaser_title
 entity_type: node
 bundle: event
 label: 'Teaser Title'
-description: ''
+description: 'If not specified, the content title is displayed'
 required: false
 translatable: true
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_teaser_media.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_teaser_media.yml
@@ -11,7 +11,7 @@ field_name: field_teaser_media
 entity_type: node
 bundle: page
 label: 'Teaser Media'
-description: ''
+description: 'If not specified, the Fallback teaser image is displayed'
 required: false
 translatable: true
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_teaser_text.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_teaser_text.yml
@@ -17,7 +17,7 @@ field_name: field_teaser_text
 entity_type: node
 bundle: page
 label: 'Teaser Text'
-description: ''
+description: 'Teaser details display in feeds, views, search engine result pages, and social sharing cards.'
 required: false
 translatable: true
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_teaser_title.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.page.field_teaser_title.yml
@@ -10,7 +10,7 @@ field_name: field_teaser_title
 entity_type: node
 bundle: page
 label: 'Teaser Title'
-description: ''
+description: 'If not specified, the content title is displayed'
 required: false
 translatable: true
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_teaser_media.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_teaser_media.yml
@@ -11,7 +11,7 @@ field_name: field_teaser_media
 entity_type: node
 bundle: post
 label: 'Teaser Media'
-description: ''
+description: 'If not specified, the Fallback teaser image is displayed'
 required: false
 translatable: false
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_teaser_text.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_teaser_text.yml
@@ -17,7 +17,7 @@ field_name: field_teaser_text
 entity_type: node
 bundle: post
 label: 'Teaser Text'
-description: ''
+description: 'Teaser details display in feeds, views, search engine result pages, and social sharing cards.'
 required: false
 translatable: false
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_teaser_title.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_teaser_title.yml
@@ -10,7 +10,7 @@ field_name: field_teaser_title
 entity_type: node
 bundle: post
 label: 'Teaser Title'
-description: ''
+description: 'If not specified, the content title is displayed'
 required: false
 translatable: false
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_admin_theme.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_admin_theme.settings.yml
@@ -15,6 +15,6 @@ focus_color: ''
 high_contrast_mode: 0
 classic_toolbar: vertical
 secondary_toolbar_frontend: 1
-show_description_toggle: 0
+show_description_toggle: 1
 show_user_theme_settings: 0
 layout_density: default

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_admin_theme.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_admin_theme.settings.yml
@@ -15,6 +15,6 @@ focus_color: ''
 high_contrast_mode: 0
 classic_toolbar: vertical
 secondary_toolbar_frontend: 1
-show_description_toggle: 1
+show_description_toggle: 0
 show_user_theme_settings: 0
 layout_density: default


### PR DESCRIPTION
## [YALB-309: Metadata: Teaser instruction and help text (UX/SB)](https://yaleits.atlassian.net/browse/YALB-309)

### Description of work
- Adds description text to teaser fields (title, text, and media) for Pages, Posts, and Events

### Functional testing steps:
- [ ] Login to the site
- [ ] Create a new page
- [ ] Verify that the Teaser Title, Teaser Text, and Teaser Media all have descriptions - click on the "?" icon to the right of the field label to reveal the description for that field.

![Screenshot 2023-07-11 at 2 50 44 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/666c7b9d-f8e1-43fb-811e-8676f85d99c5)

- [ ] Verify the same descriptions are on the Post and Event content type editing pages as well.
