### PR TITLE
YALB-597: Enable linkit for homepage setting

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -111,11 +111,15 @@ class SiteSettingsForm extends ConfigFormBase {
     ];
 
     $form['site_page_front'] = [
-      '#type' => 'textfield',
-      '#description' => $this->t("Specify a relative URL to display as the front page."),
+      '#type' => 'linkit',
       '#title' => $this->t('Front page'),
+      '#description' => $this->t("Specify a relative URL to display as the front page. Typically this points to a page in Drupal and is referenced by a node id. Use this autocomplete field to select the correct node."),
+      '#autocomplete_route_name' => 'linkit.autocomplete',
       '#default_value' => $siteConfig->get('page')['front'],
       '#required' => TRUE,
+      '#autocomplete_route_parameters' => [
+        'linkit_profile_id' => 'default',
+      ],
     ];
 
     $form['site_page_posts'] = [


### PR DESCRIPTION
## [YALB-597: Enable linkit for homepage setting](https://yaleits.atlassian.net/browse/YALB-597)

### Description of work
- Adds a linkit field widget to site settings form for picking the site home page.

### Functional testing steps:
- [x] Login to the site as an admin
- [x] Navigate to the site settings form (admin/yalesites/settings)
- [x] Verify that the homepage field now uses an autocomplete widget
- [x] Pick a node using the autocomplete tool. Verify that this field saves the link value in the "/node/xxx" format. This is important for creating clean URLs in Drupal.
