### PR TITLE
YALB-1450: Link field truncates and breaks long links

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.button_link.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.button_link.default.yml
@@ -16,11 +16,11 @@ content:
     type: link_separate
     label: hidden
     settings:
-      trim_length: 80
+      trim_length: null
       url_only: false
       url_plain: false
-      rel: ''
-      target: ''
+      rel: '0'
+      target: '0'
     third_party_settings: {  }
     weight: 1
     region: content

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.content_spotlight.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.content_spotlight.default.yml
@@ -33,11 +33,11 @@ content:
     type: link_separate
     label: hidden
     settings:
-      trim_length: 80
+      trim_length: null
       url_only: false
       url_plain: false
-      rel: ''
-      target: ''
+      rel: '0'
+      target: '0'
     third_party_settings: {  }
     weight: 4
     region: content

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.cta_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.cta_banner.default.yml
@@ -31,11 +31,11 @@ content:
     type: link_separate
     label: hidden
     settings:
-      trim_length: 80
+      trim_length: null
       url_only: false
       url_plain: false
-      rel: ''
-      target: ''
+      rel: '0'
+      target: '0'
     third_party_settings: {  }
     weight: 3
     region: content

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.grand_hero.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.grand_hero.default.yml
@@ -31,11 +31,11 @@ content:
     type: link_separate
     label: hidden
     settings:
-      trim_length: 80
+      trim_length: null
       url_only: false
       url_plain: false
-      rel: ''
-      target: ''
+      rel: '0'
+      target: '0'
     third_party_settings: {  }
     weight: 3
     region: content

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.quick_links.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.quick_links.default.yml
@@ -28,11 +28,11 @@ content:
     type: link_separate
     label: hidden
     settings:
-      trim_length: 80
+      trim_length: null
       url_only: false
       url_plain: false
-      rel: ''
-      target: ''
+      rel: '0'
+      target: '0'
     third_party_settings: {  }
     weight: 1
     region: content

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.callout_item.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.callout_item.default.yml
@@ -26,7 +26,7 @@ content:
     type: link_separate
     label: hidden
     settings:
-      trim_length: 80
+      trim_length: null
       url_only: false
       url_plain: false
       rel: '0'

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.custom_card.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.custom_card.default.yml
@@ -36,11 +36,11 @@ content:
     type: link_separate
     label: hidden
     settings:
-      trim_length: 80
+      trim_length: null
       url_only: false
       url_plain: false
-      rel: ''
-      target: ''
+      rel: '0'
+      target: '0'
     third_party_settings: {  }
     weight: 3
     region: content


### PR DESCRIPTION
## [YALB-1450: Link field truncates and breaks long links](https://yaleits.atlassian.net/browse/YALB-1450)

### Description of work
- Disabled the 'truncation' settings for links fields for the following instances:
  - Block "Button Link", link field
  - Block "Content Spotlight", link field
  - Block "Action Banner", link field
  - Block "Grand Hero", link field
  - Block "Custom Cards", in the "Custom Card" paragraph, link field
  - Block "Callouts", in the "Callout Item" paragraph, link field

### Functional testing steps:
- [x] Login and create a new page in Drupal.
- [ ] Add each of the blocks mentioned above. For the link field, use the URL "https://yale.service-now.com/it?id=it_sc_cat_item&sys_id=7607df598789e5109d170dcd8bbb3564"
- [ ] Save a view the page. Verify that the link is correctly added for each link field. Previously the URLs were truncated to 80 chars and creating faulty/broken URLs.
