### PR TITLE
YALB-1419 - OPAC: Move admin toolbar to top

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/ys_admin_theme.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_admin_theme.settings.yml
@@ -13,7 +13,7 @@ accent_color: ''
 preset_focus_color: dark
 focus_color: ''
 high_contrast_mode: 0
-classic_toolbar: vertical
+classic_toolbar: horizontal
 secondary_toolbar_frontend: 1
 show_description_toggle: 1
 show_user_theme_settings: 0


### PR DESCRIPTION
## [YALB-1419 - OPAC: Move admin toolbar to top](https://yaleits.atlassian.net/browse/YALB-1419)

### Description of work
- Add a config change to set `classic_toolbar: horizontal` instead of `vertical`
- Makes the secondary toolbar `position: fixed` and sets the `top` property equal to the height of the primary toolbar. 
- Adds the height of the secondary toolbar to the `body.gin--horizontal-toolbar` styles so that the secondary toolbar pushes the content down and doesn't cover up the header or an alert.


### Functional testing steps:
- [ ] Login: https://pr-345-yalesites-platform.pantheonsite.io
- [ ] Edit any page: https://pr-345-yalesites-platform.pantheonsite.io/aprils-test-page
- [ ] Scroll down the page and verify the secondary menu is stacked under the primary and renders "fixed" on scroll. 


https://github.com/yalesites-org/yalesites-project/assets/366413/b7df0e0b-37dc-4618-a56a-88eddc05efc7


