### PR TITLE
YALB-1208: Link to documents in WYSIWYG links

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.default.yml
@@ -13,10 +13,9 @@ bundle: document
 mode: default
 content:
   field_media_file:
-    type: file_default
+    type: file_url_plain
     label: visually_hidden
-    settings:
-      use_description_as_link_text: true
+    settings: {  }
     third_party_settings: {  }
     weight: 0
     region: content

--- a/web/profiles/custom/yalesites_profile/config/sync/linkit.linkit_profile.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/linkit.linkit_profile.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - file
     - node
 _core:
   default_config_hash: Tt8DtxZ3Nooo0PoWPpJvszA3R_5d8MmpUW7LM_R-BzY
@@ -20,4 +21,20 @@ matchers:
       substitution_type: canonical
       limit: 100
       include_unpublished: false
+    weight: 0
+  9a7ef5fd-456e-45c4-b6be-7b2f60f82084:
+    id: 'entity:file'
+    uuid: 9a7ef5fd-456e-45c4-b6be-7b2f60f82084
+    settings:
+      metadata: Files
+      bundles: null
+      group_by_bundle: null
+      substitution_type: file
+      limit: 100
+      file_extensions: ''
+      file_status: 1
+      images:
+        show_dimensions: false
+        show_thumbnail: false
+        thumbnail_image_style: null
     weight: 0


### PR DESCRIPTION
## [YALB-1208: Link to documents in WYSIWYG links](https://yaleits.atlassian.net/browse/YALB-1208)

### Description of work
- Enables autocomplete tools for Drupal to create links to files within the CKEditor link tool.

### Functional testing steps:
- [ ] Edit a page an add a text block.
- [ ] Create and highlight some text. Click the 'link' icon to bring up the linkit interface.
- [ ] Type 'pdf' in the autocomplete field. Verify that site documents are appering in this list.
- [ ] Add a link to a document in a page. Confirm the link works correctly.
