### PR TITLE
YALB-1297: Media: Verify images are using optimized styles

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.3_2_175.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.3_2_175.yml
@@ -1,0 +1,26 @@
+uuid: e3735d1b-89cc-4c70-8d33-b2d5bc317ead
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.card_3_2
+  module:
+    - crop
+name: '3_2_175'
+label: '3:2 (175)'
+effects:
+  ee8ef942-0610-41d1-91a4-c5a3f845b8c1:
+    uuid: ee8ef942-0610-41d1-91a4-c5a3f845b8c1
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: card_3_2
+      automatic_crop_provider: null
+  54d39acd-3cb2-4047-b307-681b72c26411:
+    uuid: 54d39acd-3cb2-4047-b307-681b72c26411
+    id: image_scale_and_crop
+    weight: 2
+    data:
+      width: 175
+      height: 116
+      anchor: center-center

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.3_2_540.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.3_2_540.yml
@@ -1,0 +1,26 @@
+uuid: e4750452-f1fb-48f7-ade6-d7e8b6a2170b
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.card_3_2
+  module:
+    - crop
+name: '3_2_540'
+label: '3:2 (540)'
+effects:
+  6dd6d0ec-cb48-4f87-b423-73bf8f81ca4a:
+    uuid: 6dd6d0ec-cb48-4f87-b423-73bf8f81ca4a
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: card_3_2
+      automatic_crop_provider: null
+  68d511f4-3c59-4dea-9368-9e52a83a7153:
+    uuid: 68d511f4-3c59-4dea-9368-9e52a83a7153
+    id: image_scale
+    weight: 2
+    data:
+      width: 540
+      height: 359
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.max_width_444.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.max_width_444.yml
@@ -1,0 +1,15 @@
+uuid: f364d8d2-036a-4205-8de9-0fd5aaed7c45
+langcode: en
+status: true
+dependencies: {  }
+name: max_width_444
+label: 'Max-width (444)'
+effects:
+  57247436-15fc-4d99-9875-fdb7195c1343:
+    uuid: 57247436-15fc-4d99-9875-fdb7195c1343
+    id: image_scale
+    weight: 1
+    data:
+      width: 444
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.max_width_540.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.max_width_540.yml
@@ -1,0 +1,15 @@
+uuid: facf799f-af7f-47e5-a7a6-ef6d44746083
+langcode: en
+status: true
+dependencies: {  }
+name: max_width_540
+label: 'Max-width (540)'
+effects:
+  2e977dbc-d875-4daf-a052-b71173db9f22:
+    uuid: 2e977dbc-d875-4daf-a052-b71173db9f22
+    id: image_scale
+    weight: 1
+    data:
+      width: 540
+      height: null
+      upscale: false

--- a/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.banner_16_5_.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.banner_16_5_.yml
@@ -23,9 +23,8 @@ image_style_mappings:
   -
     image_mapping_type: sizes
     image_mapping:
-      sizes: 100vw
+      sizes: '(min-width: 2400px) 2400px, 100vw'
       sizes_image_styles:
-        - '16_5_2400'
         - '16_5_1120'
         - '16_5_1280'
         - '16_5_1440'
@@ -34,6 +33,7 @@ image_style_mappings:
         - '16_5_1920'
         - '16_5_2080'
         - '16_5_2240'
+        - '16_5_2400'
         - '16_5_320'
         - '16_5_480'
         - '16_5_640'

--- a/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.card_featured_3_2.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.card_featured_3_2.yml
@@ -7,6 +7,7 @@ dependencies:
     - image.style.3_2_1280
     - image.style.3_2_1440
     - image.style.3_2_1600
+    - image.style.3_2_175
     - image.style.3_2_1760
     - image.style.3_2_1920
     - image.style.3_2_2080
@@ -14,6 +15,7 @@ dependencies:
     - image.style.3_2_2400
     - image.style.3_2_320
     - image.style.3_2_480
+    - image.style.3_2_540
     - image.style.3_2_640
     - image.style.3_2_800
     - image.style.3_2_960
@@ -23,12 +25,13 @@ image_style_mappings:
   -
     image_mapping_type: sizes
     image_mapping:
-      sizes: '(min-width: 2528px) 768px, (min-width: 992px) 30vw, 96vw'
+      sizes: '(min-width: 1344px) 768px, (min-width: 992px) 30vw, 96vw'
       sizes_image_styles:
         - '3_2_1120'
         - '3_2_1280'
         - '3_2_1440'
         - '3_2_1600'
+        - '3_2_175'
         - '3_2_1760'
         - '3_2_1920'
         - '3_2_2080'
@@ -36,6 +39,7 @@ image_style_mappings:
         - '3_2_2400'
         - '3_2_320'
         - '3_2_480'
+        - '3_2_540'
         - '3_2_640'
         - '3_2_800'
         - '3_2_960'

--- a/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.card_list_3_2.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.card_list_3_2.yml
@@ -7,6 +7,7 @@ dependencies:
     - image.style.3_2_1280
     - image.style.3_2_1440
     - image.style.3_2_1600
+    - image.style.3_2_175
     - image.style.3_2_1760
     - image.style.3_2_1920
     - image.style.3_2_2080
@@ -14,6 +15,7 @@ dependencies:
     - image.style.3_2_2400
     - image.style.3_2_320
     - image.style.3_2_480
+    - image.style.3_2_540
     - image.style.3_2_640
     - image.style.3_2_800
     - image.style.3_2_960
@@ -23,12 +25,14 @@ image_style_mappings:
   -
     image_mapping_type: sizes
     image_mapping:
-      sizes: '(min-width: 2528px) 792px, (min-width: 992px) 32vw, 96vw'
+      sizes: '(min-width: 1344px) 540px, (min-width: 992px) 32vw, 50vw'
       sizes_image_styles:
+        - '3_2_540'
         - '3_2_1120'
         - '3_2_1280'
         - '3_2_1440'
         - '3_2_1600'
+        - '3_2_175'
         - '3_2_1760'
         - '3_2_1920'
         - '3_2_2080'

--- a/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.card_secondary_3_2.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.card_secondary_3_2.yml
@@ -7,6 +7,7 @@ dependencies:
     - image.style.3_2_1280
     - image.style.3_2_1440
     - image.style.3_2_1600
+    - image.style.3_2_175
     - image.style.3_2_1760
     - image.style.3_2_1920
     - image.style.3_2_2080
@@ -14,6 +15,7 @@ dependencies:
     - image.style.3_2_2400
     - image.style.3_2_320
     - image.style.3_2_480
+    - image.style.3_2_540
     - image.style.3_2_640
     - image.style.3_2_800
     - image.style.3_2_960
@@ -23,12 +25,13 @@ image_style_mappings:
   -
     image_mapping_type: sizes
     image_mapping:
-      sizes: '(min-width: 2528px) 576px, (min-width: 992px) 22vw, 96vw'
+      sizes: '(min-width: 1344px) 480px, (min-width: 500px) 320px, (min-width: 400px) 175px, 100vw'
       sizes_image_styles:
         - '3_2_1120'
         - '3_2_1280'
         - '3_2_1440'
         - '3_2_1600'
+        - '3_2_175'
         - '3_2_1760'
         - '3_2_1920'
         - '3_2_2080'
@@ -36,6 +39,7 @@ image_style_mappings:
         - '3_2_2400'
         - '3_2_320'
         - '3_2_480'
+        - '3_2_540'
         - '3_2_640'
         - '3_2_800'
         - '3_2_960'

--- a/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.text_with_image_feature_equal.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.text_with_image_feature_equal.yml
@@ -13,19 +13,22 @@ dependencies:
     - image.style.max_width_2240
     - image.style.max_width_2400
     - image.style.max_width_320
+    - image.style.max_width_444
     - image.style.max_width_480
+    - image.style.max_width_540
     - image.style.max_width_640
     - image.style.max_width_800
     - image.style.max_width_896
     - image.style.max_width_960
 id: text_with_image_feature_equal
-label: 'Text with Image | Feature | Equal'
+label: 'Text with Image - Feature - Equal'
 image_style_mappings:
   -
     image_mapping_type: sizes
     image_mapping:
-      sizes: '(min-width: 1408px): 660px, (min-width: 992px): 47vw, 96vw'
+      sizes: '(min-width: 1500px) 800px,(min-width: 1408px) 540px, (min-width: 992px) 444px, 96vw'
       sizes_image_styles:
+        - max_width_320
         - max_width_1120
         - max_width_1280
         - max_width_1440
@@ -35,8 +38,9 @@ image_style_mappings:
         - max_width_2080
         - max_width_2240
         - max_width_2400
-        - max_width_320
+        - max_width_444
         - max_width_480
+        - max_width_540
         - max_width_640
         - max_width_800
         - max_width_896


### PR DESCRIPTION
## [YALB-1297: Media: Verify images are using optimized styles](https://yaleits.atlassian.net/browse/YALB-1297)

### Description of work
- CTA Banners = :purple_circle: - minor change added to PR
- Grand Hero = :heavy_check_mark:  (no changes needed)
- Image  / Content Image = :heavy_check_mark:  (no changes needed)
- Content Spotlight = :purple_circle: - minor change added to PR
- Custom Cards & Media Grid / 3:2 card secondary = :purple_circle: - minor change added to PR
- Views - Posts - List/Grid  3:2 card list = :purple_circle: - minor change added to PR
- Card List Featured | Responsive image style = :red_circle:  - minor change added to PR - However, this style is not currently in use. 

### Functional testing steps:
- [x] Review the test page here: https://pr-351-yalesites-platform.pantheonsite.io/page-all-media-images
- [x] Using the web inspector, inspect each image on the page. Test each at various breakpoints.

#### Desktop
https://github.com/yalesites-org/yalesites-project/assets/366413/c8e10380-542d-4119-b1cc-91dbb0d15c25

#### Mobile
https://github.com/yalesites-org/yalesites-project/assets/366413/0e56c28f-51e5-4387-b5d7-ceb3f1702ff8

- [x] Verify appropriately sized images are served for each component. Some images may be served slightly larger (<= 200px) than the exact pixel value, but that is because the image style is used for varying-width components. For example, the Content Spotlight can have a `medium` or `large` image size, or the focus can change. An image size was chosen based on the larger of the two required image sizes. 

