### PR TITLE
YALB-1135: Allow titles to be visually hidden

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/ys_admin_theme.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_admin_theme.settings.yml
@@ -13,7 +13,7 @@ accent_color: ''
 preset_focus_color: dark
 focus_color: ''
 high_contrast_mode: 0
-classic_toolbar: horizontal
+classic_toolbar: vertical
 secondary_toolbar_frontend: 1
 show_description_toggle: 1
 show_user_theme_settings: 0

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesTitleBreadcrumbBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesTitleBreadcrumbBlock.php
@@ -147,9 +147,9 @@ class YaleSitesTitleBreadcrumbBlock extends BlockBase implements ContainerFactor
       '#title' => $this->t('Title Display'),
       '#default_value' => $config['page_title_display'] ?? '',
       '#options' => [
-        'visible' => 'Display Title',
-        'visually-hidden' => 'Visually Hidden',
-        'hidden' => 'Hide Title',
+        'visible' => $this->t('Display Title'),
+        'visually-hidden' => $this->t('Visually Hidden'),
+        'hidden' => $this->t('Hide Title'),
       ],
     ];
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesTitleBreadcrumbBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesTitleBreadcrumbBlock.php
@@ -149,7 +149,7 @@ class YaleSitesTitleBreadcrumbBlock extends BlockBase implements ContainerFactor
       '#options' => [
         'visible' => 'Display Title',
         'visually-hidden' => 'Visually Hidden',
-        'hidden' => 'Hide Title'
+        'hidden' => 'Hide Title',
       ],
     ];
 
@@ -157,11 +157,11 @@ class YaleSitesTitleBreadcrumbBlock extends BlockBase implements ContainerFactor
   }
 
   /**
-  * {@inheritdoc}
-  */
+   * {@inheritdoc}
+   */
   public function blockSubmit($form, FormStateInterface $form_state) : void {
     parent::blockSubmit($form, $form_state);
     $this->configuration['page_title_display'] = $form_state->getValue('page_title_display');
- }
+  }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesTitleBreadcrumbBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesTitleBreadcrumbBlock.php
@@ -4,6 +4,7 @@ namespace Drupal\ys_core\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Controller\TitleResolver;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -128,8 +129,39 @@ class YaleSitesTitleBreadcrumbBlock extends BlockBase implements ContainerFactor
     return [
       '#theme' => 'ys_title_breadcrumb',
       '#page_title' => $page_title,
+      '#page_title_display' => $this->configuration['page_title_display'] ?? '',
       '#breadcrumbs_placeholder' => $breadcrumbs_placeholder,
     ];
   }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) : array {
+    $form = parent::blockForm($form, $form_state);
+    $config = $this->getConfiguration();
+
+    // The form field is defined and added to the form array here.
+    $form['page_title_display'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Title Display'),
+      '#default_value' => $config['page_title_display'] ?? '',
+      '#options' => [
+        'visible' => 'Display Title',
+        'visually-hidden' => 'Visually Hidden',
+        'hidden' => 'Hide Title'
+      ],
+    ];
+
+    return $form;
+  }
+
+  /**
+  * {@inheritdoc}
+  */
+  public function blockSubmit($form, FormStateInterface $form_state) : void {
+    parent::blockSubmit($form, $form_state);
+    $this->configuration['page_title_display'] = $form_state->getValue('page_title_display');
+ }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-title-breadcrumb.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-title-breadcrumb.html.twig
@@ -8,4 +8,6 @@
 
 {% include "@molecules/page-title/yds-page-title.twig" with {
   page_title__heading: page_title,
+  page_title__display: page_title_display,
+  page_title__additional_classes: page_title_display
 } %}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -48,6 +48,7 @@ function ys_core_theme($existing, $type, $theme, $path): array {
     'ys_title_breadcrumb' => [
       'variables' => [
         'page_title' => NULL,
+        'page_title_display' => NULL,
         'breadcrumbs_placeholder' => [],
       ],
     ],


### PR DESCRIPTION
## [YALB-1135: Allow titles to be visually hidden](https://yaleits.atlassian.net/browse/YALB-1135)

### Description of work
- Add a 'page_title__display' variable to the page title to switch the display between: 'display', 'hidden', or 'visually-hidden'.
  - Display: renders the same code as before without a perceivable change.
  - Hidden: No longer renders the page title block.
  - Visually Hidden: Adds the class to the block to visually hide using preexisting styles.
- Sets these three options as configuration on the Title/Breadcrumbs block for pages

### Functional testing steps:
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
