### PR TITLE
YALB-1452: Bug: StarterKit Migrations failed: Update Drush

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "cweagans/composer-patches": "^1.7",
     "drupal/core-composer-scaffold": "^9.2",
     "drupal/core-recommended": "^9.2",
-    "drush/drush": "^10",
+    "drush/drush": "^11 || ^12",
     "pantheon-systems/drupal-integrations": "^9",
     "yalesites-org/yalesites_profile": "*"
   },


### PR DESCRIPTION
## [YALB-1452: Bug: StarterKit Migrations failed: Update Drush](https://yaleits.atlassian.net/browse/YALB-1452)

### Description of work
- Drush 10 is no longer supported. This issue upgrades Drush to 11 to fix issues with `migrate:import --group` no longer working from migrate_tools, since it has deprecated support for Drush 10: https://www.drupal.org/project/migrate_tools/issues/3373882

### Functional testing steps:
- [ ] Check drush version is > 10: `terminus drush yalesites-platform.pr-355 -- version`
