### PR TITLE
Bug: CAS user email addresses not being updated on login

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/cas.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/cas.settings.yml
@@ -29,8 +29,8 @@ forced_login:
 user_accounts:
   prevent_normal_login: true
   auto_register: true
-  email_assignment_strategy: 1
-  email_hostname: ''
+  email_assignment_strategy: 0
+  email_hostname: noreply.yale.edu
   email_attribute: mail
   auto_assigned_roles: {  }
   restrict_password_management: true

--- a/web/profiles/custom/yalesites_profile/config/sync/cas_attributes.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/cas_attributes.settings.yml
@@ -6,6 +6,7 @@ field:
   sync_frequency: 2
   overwrite: true
   mappings:
+    mail: '[cas:attribute:mail]'
     field_first_name: '[cas:attribute:givenname]'
     field_last_name: '[cas:attribute:sn]'
 role:


### PR DESCRIPTION
## [YALB-1471: Bug: CAS user email addresses not being updated on login](https://yaleits.atlassian.net/browse/YALB-1471)

### Description of work
- When a user is added manually as a CAS user, a dummy email address is required to create the account. This was supposed to be updated with the user's real email address from a CAS Attribute after login, but is not working. This adds an additional configuration to use the mail CAS Attribute.
- Also adds `noreply.yale.edu` as the default email hostname when creating a new user manually, so end users don't need to fill it in. The email on the user account gets updated from CAS Attributes on the user's next CAS login.

### Functional testing steps:
- [ ] Log in as user 1, create a new CAS user with your netID and set the email to username@noreply.yale.edu
- [ ] In a new browser session, log in through CAS with newly created user and edit the user account, verifying the email address has been updated from username@noreply.yale.edu
