### PR TITLE
YALB-1465: Switch CI scripts to use drush `deploy`

### DIFF
--- a/.ci/deploy/pantheon/dev-multidev
+++ b/.ci/deploy/pantheon/dev-multidev
@@ -23,16 +23,8 @@ fi
 # Wake the environment to make sure the database is reachable.
 terminus -n env:wake "$TERMINUS_SITE.$TERMINUS_ENV"
 
-# Update the Drupal database
-terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- updatedb  --no-cache-clear -y
-
-# If exported configuration is available, then import it.
-if [ -f "web/profiles/custom/yalesites_profile/config/sync/system.site.yml" ] ; then
-  terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- config-import --yes
-fi
-
-# Clear Drupal cache
-terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- cr
+# Run drush deploy - updb, cr, cim, cr, deploy:hook
+terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- deploy -v -y
 
 # Clear the environment cache
 terminus -n env:clear-cache "$TERMINUS_SITE.$TERMINUS_ENV"


### PR DESCRIPTION
## [YALB-1465: Switch CI scripts to use drush deploy](https://yaleits.atlassian.net/browse/YALB-1465)

### Description of work
- Replaces individual `updatedb`, `config:import`, `cache-rebuild` drush commands with single [`deploy`](https://www.drush.org/12.x/deploycommand/) command