### PR TITLE
YALB-1388 - Feedback: Embed Block | YALB-1390 - Remove transparency from banner overlay | YALB-1417 - Bug: Block picker in Posts and Events only have 2 columns compared to 3 on Pages | YALB-1463 - Bug: Content Spotlight Border severely impacts use/placement of Block | YALB-858 - Feedback: Site Name looks too small on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,3 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory.
-
-*** MULTIDEV GENERATION ONLY ***

--- a/README.md
+++ b/README.md
@@ -41,3 +41,5 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory.
+
+*** MULTIDEV GENERATION ONLY ***

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -56,17 +56,14 @@ function ys_core_theme($existing, $type, $theme, $path): array {
 }
 
 /**
- * Implements hook_form_FORMID_alter().
- */
-function ys_core_form_node_page_layout_builder_form_alter(&$form, $form_state, $form_id) {
-  // Add styles to the layout builder form.
-  $form['#attached']['library'][] = 'ys_core/node_layout_form';
-}
-
-/**
  * Implements hook_form_alter().
  */
 function ys_core_form_alter(&$form, $form_state, $form_id) {
+  // Load custom library
+  if (str_ends_with($form_id, '_layout_builder_form')) {
+    $form['#attached']['library'][] = 'ys_core/node_layout_form';
+  }
+  
   // Changes wording of sticky at top of lists.
   if (isset($form['sticky'])) {
     $form['sticky']['widget']['value']['#title'] = t('Pin to the beginning of list');

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -59,11 +59,12 @@ function ys_core_theme($existing, $type, $theme, $path): array {
  * Implements hook_form_alter().
  */
 function ys_core_form_alter(&$form, $form_state, $form_id) {
-  // Load custom library
+
+  // Load custom library.
   if (str_ends_with($form_id, '_layout_builder_form')) {
     $form['#attached']['library'][] = 'ys_core/node_layout_form';
   }
-  
+
   // Changes wording of sticky at top of lists.
   if (isset($form['sticky'])) {
     $form['sticky']['widget']['value']['#title'] = t('Pin to the beginning of list');


### PR DESCRIPTION
## [YALB-1388 - Feedback: Embed Block](https://yaleits.atlassian.net/browse/YALB-1388) | [YALB-1390 - Remove transparency from banner overlay](https://yaleits.atlassian.net/browse/YALB-1390) |  [YALB-1417 - Bug: Block picker in Posts and Events only have 2 columns compared to 3 on Pages](https://yaleits.atlassian.net/browse/YALB-1417) | [YALB-1463 - Bug: Content Spotlight Border severely impacts use/placement of Block](https://yaleits.atlassian.net/browse/YALB-1463) | [YALB-858 - Feedback: Site Name looks too small on mobile](https://yaleits.atlassian.net/browse/YALB-858)

### Test here: https://github.com/yalesites-org/component-library-twig/pull/276

### Description: 
-  [ ] In this branch, a page-specific hook was  removed and a new hook was added to make sure our custom library (and css) loads for all content types. This will make sure the modal grid of components, when adding a block, is consistently presented in 3-columns. Thank you, Marc. (Marc really did this work). 