### PR TITLE
YALB-1370: Bug: Search results for "Bread" and "Crumb"

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -73,6 +73,7 @@
     "drupal/redirect": "^1.7",
     "drupal/search_api": "^1.25",
     "drupal/search_api_exclude": "^2.0",
+    "drupal/search_api_html_element_filter": "^1.0",
     "drupal/section_library": "^1.1",
     "drupal/selective_better_exposed_filters": "^3.0@beta",
     "drupal/simple_sitemap": "^4.1",
@@ -81,9 +82,9 @@
     "drupal/upgrade_status": "^3.18",
     "drupal/webform": "^6.2@beta",
     "drupal/wingsuit_companion": "^2.0@RC",
-    "yalesites-org/atomic": "1.16.3",
     "oomphinc/composer-installers-extender": "^2.0",
     "wikimedia/composer-merge-plugin": "^2.1",
+    "yalesites-org/atomic": "1.16.3",
     "yalesites-org/yale_cas": "^1.0"
   },
   "minimum-stability": "dev",

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -101,6 +101,7 @@ module:
   search_api: 0
   search_api_db: 0
   search_api_exclude: 0
+  search_api_html_element_filter: 0
   section_library: 0
   simple_sitemap: 0
   smart_date: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/search_api.index.node_index.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/search_api.index.node_index.yml
@@ -75,7 +75,7 @@ processor_settings:
   aggregated_field: {  }
   content_access:
     weights:
-      preprocess_query: -30
+      preprocess_query: -50
   entity_status: {  }
   entity_type: {  }
   highlight:
@@ -92,16 +92,34 @@ processor_settings:
   html_element_filter:
     weights:
       postprocess_query: -30
-      preprocess_index: -30
+      preprocess_index: -50
     all_fields: 0
     fields:
       - field_teaser_text
       - rendered_item
     css_selectors: .visually-hidden
+  html_filter:
+    weights:
+      preprocess_index: -49
+      preprocess_query: -48
+    all_fields: false
+    fields:
+      - field_teaser_text
+      - rendered_item
+    title: true
+    alt: true
+    tags:
+      b: 2
+      em: 1
+      h1: 5
+      h2: 3
+      h3: 2
+      strong: 2
+      u: 1
   ignorecase:
     weights:
-      preprocess_index: -20
-      preprocess_query: -20
+      preprocess_index: -48
+      preprocess_query: -47
     all_fields: true
     fields:
       - field_teaser_text
@@ -111,8 +129,8 @@ processor_settings:
   rendered_item: {  }
   stemmer:
     weights:
-      preprocess_index: 0
-      preprocess_query: 0
+      preprocess_index: -42
+      preprocess_query: -42
     all_fields: false
     fields:
       - field_teaser_text
@@ -120,10 +138,22 @@ processor_settings:
     exceptions:
       mexican: mexic
       texan: texa
+  tokenizer:
+    weights:
+      preprocess_index: -45
+      preprocess_query: -44
+    all_fields: false
+    fields:
+      - field_teaser_text
+      - rendered_item
+    spaces: ''
+    ignored: ._-
+    overlap_cjk: 1
+    minimum_word_size: '3'
   transliteration:
     weights:
-      preprocess_index: -20
-      preprocess_query: -20
+      preprocess_index: -47
+      preprocess_query: -46
     all_fields: true
     fields:
       - field_teaser_text

--- a/web/profiles/custom/yalesites_profile/config/sync/search_api.index.node_index.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/search_api.index.node_index.yml
@@ -9,6 +9,7 @@ dependencies:
     - node
     - search_api
     - search_api_exclude
+    - search_api_html_element_filter
 id: node_index
 name: 'Node Index'
 description: ''
@@ -88,6 +89,15 @@ processor_settings:
     exclude_fields: {  }
     highlight: always
     highlight_partial: false
+  html_element_filter:
+    weights:
+      postprocess_query: -30
+      preprocess_index: -30
+    all_fields: 0
+    fields:
+      - field_teaser_text
+      - rendered_item
+    css_selectors: .visually-hidden
   ignorecase:
     weights:
       preprocess_index: -20


### PR DESCRIPTION
## [YALB-1370: Bug: Search results for "Bread" and "Crumb"](https://yaleits.atlassian.net/browse/YALB-1370)

### Description of work
- Add and enable [Search API HTML Element Filter extension](https://www.drupal.org/project/search_api_html_element_filter)
  - Add `.visually-hidden` as a selector to remove before indexing
- Enable `Tokenizer` and `HTML Filter`

### Functional testing steps:
- [ ] Add a new Page
- [ ] Search for "Bread" or "crumb" or "Breadcrumb"
- [ ] Verify no results are found (unless they were actual content in a page)
- [ ] Edit the new Page
- [ ] Save the new Page
- [ ] Search for "Bread" or "crumb" or "Breadcrumb"
- [ ] Verify no results are found (unless they were actual content in a page)
- [ ] Log out of the site
- [ ] Search for "Bread" or "crumb" or "Breadcrumb"
- [ ] Verify no results are found (unless they were actual content in a page)
- [ ] Search for text that you do know exists on a page -- remember that the menu name in some cases does not match the title of the page it's linked to
- [ ] Verify results are properly found for the search term

NOTE: I ran it here, but existing sites will need to re-index for it to take the new processors.  Either go into the admin side and clear and re-index, or run: `terminus drush <site> -- search-api:index`