### PR TITLE
Views basic fixes

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/style/ViewsBasicDynamicStyle.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/style/ViewsBasicDynamicStyle.php
@@ -121,9 +121,7 @@ class ViewsBasicDynamicStyle extends StylePluginBase implements ContainerFactory
 
     // Get node type to pass to template to determine width.
     $entity = $this->routeMatch->getParameter('node');
-    if ($entity) {
-      $parentNode = $entity->getType();
-    }
+    $parentNode = isset($entity) ? $entity->getType() : NULL;
 
     return [
       '#theme' => 'views_basic_rows',

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -179,7 +179,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
     }
 
     // Set operator: "+" is "OR" and "," is "AND".
-    $operator = isset($paramsDecoded['operator']) ? $paramsDecoded['operator'] : '+';
+    $operator = $paramsDecoded['operator'] ?? '+';
     $termsInclude = isset($termsIncludeArray) ? implode($operator, $termsIncludeArray) : 'all';
     $termsExclude = isset($termsExcludeArray) ? implode($operator, $termsExcludeArray) : NULL;
 
@@ -192,7 +192,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
       $itemsLimit = $paramsDecoded['limit'];
     }
 
-    $eventTimePeriod = isset($paramsDecoded['filters']['event_time_period']) ? $paramsDecoded['filters']['event_time_period'] : NULL;
+    $eventTimePeriod = $paramsDecoded['filters']['event_time_period'] ?? NULL;
 
     $view->setArguments(
       [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -167,14 +167,14 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
     // Get terms to include.
     if (isset($paramsDecoded['filters']['terms_include'])) {
       foreach ($paramsDecoded['filters']['terms_include'] as $term) {
-        $termsIncludeArray[] = (int) $term;
+        $termsIncludeArray[] = (int) $term['target_id'];
       }
     }
 
     // Get terms to exclude.
     if (isset($paramsDecoded['filters']['terms_exclude'])) {
       foreach ($paramsDecoded['filters']['terms_exclude'] as $term) {
-        $termsExcludeArray[] = (int) $term;
+        $termsExcludeArray[] = (int) $term['target_id'];
       }
     }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -180,8 +180,9 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
 
     // Set operator: "+" is "OR" and "," is "AND".
     $operator = $paramsDecoded['operator'] ?? '+';
-    $termsInclude = isset($termsIncludeArray) ? implode($operator, $termsIncludeArray) : 'all';
-    $termsExclude = isset($termsExcludeArray) ? implode($operator, $termsExcludeArray) : NULL;
+
+    $termsInclude = (isset($termsIncludeArray) && is_array($termsIncludeArray)) ? implode($operator, $termsIncludeArray) : 'all';
+    $termsExclude = (isset($termsExcludeArray) && is_array($termsExcludeArray)) ? implode($operator, $termsExcludeArray) : NULL;
 
     if (
       ($type == 'count' && $paramsDecoded['display'] != 'limit') ||

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -167,14 +167,14 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
     // Get terms to include.
     if (isset($paramsDecoded['filters']['terms_include'])) {
       foreach ($paramsDecoded['filters']['terms_include'] as $term) {
-        $termsIncludeArray[] = (int) $term['target_id'];
+        $termsIncludeArray[] = (int) is_object($term) ? $term['target_id'] : $term;
       }
     }
 
     // Get terms to exclude.
     if (isset($paramsDecoded['filters']['terms_exclude'])) {
       foreach ($paramsDecoded['filters']['terms_exclude'] as $term) {
-        $termsExcludeArray[] = (int) $term['target_id'];
+        $termsExcludeArray[] = (int) is_object($term) ? $term['target_id'] : $term;
       }
     }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -179,7 +179,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
     }
 
     // Set operator: "+" is "OR" and "," is "AND".
-    $operator = isset($paramsDecoded['operator']) ?: '+';
+    $operator = isset($paramsDecoded['operator']) ? $paramsDecoded['operator'] : '+';
     $termsInclude = isset($termsIncludeArray) ? implode($operator, $termsIncludeArray) : 'all';
     $termsExclude = isset($termsExcludeArray) ? implode($operator, $termsExcludeArray) : NULL;
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -179,7 +179,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
     }
 
     // Set operator: "+" is "OR" and "," is "AND".
-    $operator = $paramsDecoded['operator'] ?: '+';
+    $operator = isset($paramsDecoded['operator']) ?: '+';
     $termsInclude = isset($termsIncludeArray) ? implode($operator, $termsIncludeArray) : 'all';
     $termsExclude = isset($termsExcludeArray) ? implode($operator, $termsExcludeArray) : NULL;
 
@@ -192,6 +192,8 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
       $itemsLimit = $paramsDecoded['limit'];
     }
 
+    $eventTimePeriod = isset($paramsDecoded['filters']['event_time_period']) ? $paramsDecoded['filters']['event_time_period'] : NULL;
+
     $view->setArguments(
       [
         'type' => $filterType,
@@ -200,7 +202,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
         'sort' => $paramsDecoded['sort_by'],
         'view' => $paramsDecoded['view_mode'],
         'items' => $itemsLimit,
-        'event_time_period' => str_contains($filterType, 'event') ? $paramsDecoded['filters']['event_time_period'] : NULL,
+        'event_time_period' => str_contains($filterType, 'event') ? $eventTimePeriod : NULL,
       ]
     );
 


### PR DESCRIPTION
### Description of work
- Adds checks to variables to prevent errors in logs when view is loaded in other ways (node indexing, for example)
- Fixes issue with taxonomy terms not filtering correctly on views after upgrading from Drupal autocomplete to Chosen library

### Functional testing steps:
- [ ] As an admin, visit the recent log messages page: `/admin/reports/dblog`
- [ ] In a separate tab, visit the Search API Node Index page: `/admin/config/search/search-api/index/node_index`
- [ ] Click "Clear all indexed data"
- [ ] Click "Confirm"
- [ ] Back on the Node Index screen, click "Index now"
- [ ] When it has finished, go back to the log messages tab, refresh, and verify that no errors are related to `ys_views_basic` module.
