### PR TITLE
Hotfix: ChosenJS Composer Install Fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "drupal/core-composer-scaffold": "^9.2",
     "drupal/core-recommended": "^9.2",
     "drush/drush": "^11 || ^12",
+    "oomphinc/composer-installers-extender": "^2.0",
     "pantheon-systems/drupal-integrations": "^9",
     "yalesites-org/yalesites_profile": "*"
   },
@@ -57,6 +58,7 @@
         "[project-root]/.gitattributes": false
       }
     },
+    "installer-types": ["npm-asset"],
     "installer-paths": {
       "web/core": [
         "type:drupal-core"
@@ -87,6 +89,9 @@
       ],
       "web/private/scripts/quicksilver/{$name}/": [
         "type:quicksilver-script"
+      ],
+      "web/libraries/chosen": [
+        "jjj/chosen"
       ]
     },
     "enable-patching": true,
@@ -106,7 +111,8 @@
       "composer/installers": true,
       "cweagans/composer-patches": true,
       "drupal/core-composer-scaffold": true,
-      "drupal/console-extend-plugin": true
+      "drupal/console-extend-plugin": true,
+      "oomphinc/composer-installers-extender": true
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     "drupal/core-recommended": "^9.2",
     "drush/drush": "^11 || ^12",
     "pantheon-systems/drupal-integrations": "^9",
-    "wikimedia/composer-merge-plugin": "^2.1",
     "yalesites-org/yalesites_profile": "*"
   },
   "require-dev": {
@@ -94,14 +93,6 @@
     "composer-exit-on-patch-failure": true,
     "patchLevel": {
       "drupal/core": "-p2"
-    },
-    "allow-plugins": {
-      "JJJ/chosen": true
-    },
-    "merge-plugin": {
-      "include": [
-        "web/modules/contrib/chosen/composer.libraries.json"
-      ]
     }
   },
   "config": {
@@ -115,9 +106,7 @@
       "composer/installers": true,
       "cweagans/composer-patches": true,
       "drupal/core-composer-scaffold": true,
-      "drupal/console-extend-plugin": true,
-      "wikimedia/composer-merge-plugin": true,
-      "oomphinc/composer-installers-extender": true
+      "drupal/console-extend-plugin": true
     }
   },
   "scripts": {

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -81,6 +81,7 @@
     "drupal/upgrade_status": "^3.18",
     "drupal/webform": "^6.2@beta",
     "drupal/wingsuit_companion": "^2.0@RC",
+    "jjj/chosen": "^2.2",
     "yalesites-org/atomic": "1.17.0",
     "yalesites-org/yale_cas": "^1.0"
   },

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -82,28 +82,18 @@
     "drupal/webform": "^6.2@beta",
     "drupal/wingsuit_companion": "^2.0@RC",
     "yalesites-org/atomic": "1.17.0",
-    "oomphinc/composer-installers-extender": "^2.0",
-    "wikimedia/composer-merge-plugin": "^2.1",
     "yalesites-org/yale_cas": "^1.0"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,
   "config": {
-    "sort-packages": true,
-    "allow-plugins": {
-      "composer/installers": true,
-      "oomphinc/composer-installers-extender": true,
-      "wikimedia/composer-merge-plugin": true
-    }
+    "sort-packages": true
   },
   "extra": {
     "enable-patching": true,
     "composer-exit-on-patch-failure": true,
     "patchLevel": {
       "drupal/core": "-p2"
-    },
-    "installer-paths": {
-      "../../../../web/core": ["type:drupal-core"]
     },
     "patches": {
       "drupal/layout_paragraphs": {


### PR DESCRIPTION
## [YALB-1233: ChosenJS Composer Install Fix](https://yaleits.atlassian.net/browse/YALB-1233)

### Description of work
- Removes the use of wikimedia/composer-merge-plugin to install chosenJS
- Use `installer-paths` to properly place chosenJS into the correct location

### Functional testing steps:
- [x] Log in as an admin
- [x] Visit Extend and search for Chosen
- [x] Click "Configure"
- [x] Verify that you see the options (meaning that it successfully found chosenJS)
- [x] Attempt to create a new Post
- [x] Verify that the category drop down uses chosen
