### PR TITLE
fix(composer): installer-path added so profile knows where core is

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -97,6 +97,9 @@
     "patchLevel": {
       "drupal/core": "-p2"
     },
+    "installer-paths": {
+      "../../../../web/core": ["type:drupal-core"]
+    },
     "patches": {
       "drupal/layout_paragraphs": {
         "save close tweaks": "https://git.drupalcode.org/project/layout_paragraphs/-/merge_requests/80.patch"


### PR DESCRIPTION
## update_develop with installer-path fix

### Description of work
- Adds installer-path for profile so it can find core location

Remember, this is branched off of update_branch, and the merge is to update_develop.  I only changed to merge to develop so that the multidev could be tested.