### PR TITLE
YALB-1519: Add semantic-release to project repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Create a release
+on:
+  push:
+    branches: master
+env:
+  GH_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+
+      - name: Install
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: npm install
+
+      - name: Release
+        run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -27,11 +27,8 @@
     "test": "./scripts/local/test.sh"
   },
   "devDependencies": {
-    "@yalesites-org/eslint-config-and-other-formatting": "^1.5.0",
-    "eslint-config-drupal": "^5.0.2",
-    "eslint-plugin-jsx-a11y": "^6.5.1",
-    "eslint-plugin-react": "^7.29.4",
-    "eslint-plugin-yml": "^0.14.0",
+    "@semantic-release/git": "^10.0.1",
+    "semantic-release-replace-plugin": "^1.2.7",
     "shelljs": "^0.8.5"
   },
   "lint-staged": {
@@ -43,6 +40,47 @@
     ],
     "web/**/*.{js,scss,php}": [
       "npm run prettier"
+    ]
+  },
+  "release": {
+    "branches": [
+      "master"
+    ],
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      [
+        "semantic-release-replace-plugin",
+        {
+          "replacements": [
+            {
+              "files": [
+                "web/profiles/custom/yalesites_profile/yalesites_profile.info.yml"
+              ],
+              "from": "version: .*",
+              "to": "version: ${nextRelease.version}",
+              "results": [
+                {
+                  "file": "web/profiles/custom/yalesites_profile/yalesites_profile.info.yml",
+                  "hasChanged": true,
+                  "numMatches": 1,
+                  "numReplacements": 1
+                }
+              ],
+              "countMatches": true
+            }
+          ]
+        }
+      ],
+      [
+        "@semantic-release/git",
+        {
+          "assets": [
+            "web/profiles/custom/yalesites_profile/yalesites_profile.info.yml"
+          ]
+        }
+      ],
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/github"
     ]
   }
 }

--- a/web/profiles/custom/yalesites_profile/yalesites_profile.info.yml
+++ b/web/profiles/custom/yalesites_profile/yalesites_profile.info.yml
@@ -1,5 +1,6 @@
 name: YaleSites Profile
 type: profile
+version: 1.0
 description: 'Install profile for managing YaleSites platform sites.'
 core_version_requirement: '^9 || ^10'
 


### PR DESCRIPTION
## [YALB-1519: Add semantic-release to project repo](https://yaleits.atlassian.net/browse/YALB-1519)

### Description of work
- Adds semantic-release to this repository on pushes to `master`
- Automatically increments yalesites_profile.info.yml version number on new release
- Adds intial `version: 1.0` to yalesites_profile.info.yml so semantic-release can modify it on next release