### PR TITLE
YALB-1518: View missing on resource library

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -167,14 +167,14 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
     // Get terms to include.
     if (isset($paramsDecoded['filters']['terms_include'])) {
       foreach ($paramsDecoded['filters']['terms_include'] as $term) {
-        $termsIncludeArray[] = (int) $term;
+        $termsIncludeArray[] = $this->getTermId($term);
       }
     }
 
     // Get terms to exclude.
     if (isset($paramsDecoded['filters']['terms_exclude'])) {
       foreach ($paramsDecoded['filters']['terms_exclude'] as $term) {
-        $termsExcludeArray[] = (int) $term;
+        $termsExcludeArray[] = $this->getTermId($term);
       }
     }
 
@@ -343,7 +343,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
       case 'terms_exclude':
         if (!empty($paramsDecoded['filters'][$type])) {
           foreach ($paramsDecoded['filters'][$type] as $term) {
-            $defaultParam[] = (int) $term;
+            $defaultParam[] = $this->getTermId($term);
           }
         }
         break;
@@ -421,6 +421,24 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
     asort($tagList);
 
     return $tagList;
+  }
+
+  /**
+   * Returns an integer representation of the term.
+   *
+   * The term could be either the old Drupal way of an array with a
+   * target_id attribute containing a string representation of the id, or the
+   * chosen way of a string represenation of the id.  This ensures that the
+   * decision of what should be return is handled here and not elsewhere.
+   *
+   * @param mixed $term
+   *   The taxonomy term.
+   *
+   * @return int
+   *   The term ID.
+   */
+  private function getTermId($term) : int {
+    return (int) is_array($term) ? $term['target_id'] : $term;
   }
 
 }


### PR DESCRIPTION
## [YALB-1518: View missing on resource library](https://yaleits.atlassian.net/browse/YALB-1518)

The current issue is that when a view is accessed that was previously created using the Drupal autocomplete results in a truthy value (a 1) being placed for the ID, so that taxononmy term is used for all views matching this.  This fix properly evaluates whether the term is an object (the Drupal autocomplete) or an id (the chosen autocomplete) and has been extracted to its own private method to start to separate concerns.

### Description of work
- Evaluates the state of the data to determine the best way to get the node id
- Extracts this logic into its own private method for separation of concerns

### Functional testing steps:

#### On MultiDev
- [x] Create some posts with tags of your choice, keeping note of which you used.
- [x] Create a new page and add a view, including those tags you created in the include/exclude to play around
- [x] Ensure that the items shown match what you expected given the include/exclude of the view
- [x] Ensure that when you go in to edit the view, you still see these include/exclude tags selected and that they are the correct taxonomy names.

#### Locally
- [x] Attempt to get a database from dev.yalesites.yale.edu and install it (I did this via pantheon's export db feature.  If you go there, hopefully you see my download from August 14th)
- [x] Visit the `Community Trainings` page
- [x] Ensure that items display by default when visiting under `Live Trainings`
- [x] Edit the item and ensure that `Upcoming Trainings` is selected
