### PR TITLE
YALB-1538: Bug: Node redirects do not work

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -125,6 +125,9 @@
       },
       "drupal/gin": {
         "fix description toggle for CKEditor fields https://www.drupal.org/project/gin/issues/3316265": "https://git.drupalcode.org/project/gin/-/merge_requests/227.patch"
+      },
+      "drupal/redirect": {
+        "fix validation issue on adding url redirect": "https://www.drupal.org/files/issues/2023-08-09/3057250-65.patch"
       }
     }
   }


### PR DESCRIPTION
## [YALB-1538: Bug: Node redirects do not work](https://yaleits.atlassian.net/browse/YALB-1538)

Instead of allowing an ajax validation of whether a redirect happens to be an existing real path, move this into the server validator, allowing a successful save without needing to blur first.

This patch eliminates the ajax request from returning errors, and moves validation logic that the javascript version had into the form validator on the Drupal side.

Keep in mind, neither hindered users that really wanted to add a redirect to an existing real path; it was just a warning with a suggestion.

Known issue: https://www.drupal.org/project/redirect/issues/3057250

### Description of work
- Add [patch 65 from issue site](https://www.drupal.org/files/issues/2023-08-09/3057250-65.patch)

### Functional testing steps:
- [x] Visit [a page](https://pr-394-yalesites-platform.pantheonsite.io/daves-page-didnt-have-url-redirect-already), and click `Manage Settings`
- [x] On the right hand side of the side panel, expand `URL redirects`
- [x] Click `Add URL redirect`
  - A new tab/page will open
- [x] For the path, enter a unique name (do not tab off of the text box)
- [x] Click `Save`
- [x] Verify that the status message says `The redirect has been saved.`
- [x] Expand the right side->`URL redirects` again
- [x] Give the URL you created a try to validate that it works
- [x] Delete the URL redirect you made
- [x] Go back in and attempt to create a new URL redirect, this time, using the name of a valid existing real path, like `text-heavy-kitchens` (Do not click off of the text box)
- [x] Click `Save`
- [x] Verify that a warning message appears stating: `The source path text-heavy-kitchens appears to be a valid path.  It is preferred to create URL aliases for these paths rather than redirects.`
- [x] Verify that if you click `Save` again, it lets you create it.
- [x] Give the URL you created a try to validate that it works
- [x] Delete your URL redirect.
- [x] Feel free to try it one more time, this time being able to click off of the text box before hitting submit.
- [x] Remember to delete your URL redirect at the end if someone else is going to evaluate it.
