### PR TITLE
YALB-1242: Use Pantheon Secrets

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -64,6 +64,7 @@
     "drupal/node_revision_delete": "^1.0@RC",
     "drupal/override_node_options": "^2.6",
     "drupal/pantheon_advanced_page_cache": "^2.1",
+    "drupal/pantheon_secrets": "1.0.1",
     "drupal/paragraphs": "^1.12",
     "drupal/paragraphs_features": "^2.0@beta",
     "drupal/pathauto": "^1.8",

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -56,6 +56,7 @@ module:
   jquery_ui_datepicker: 0
   jquery_ui_slider: 0
   jquery_ui_touch_punch: 0
+  key: 0
   layout_builder: 0
   layout_builder_browser: 0
   layout_builder_lock: 0
@@ -89,6 +90,7 @@ module:
   options: 0
   override_node_options: 0
   page_cache: 0
+  pantheon_secrets: 0
   paragraphs_features: 0
   path: 0
   path_alias: 0
@@ -125,8 +127,8 @@ module:
   ys_alert: 0
   ys_captcha: 0
   ys_layouts: 0
+  ys_mail: 0
   ys_node_access: 0
-  ys_secrets: 0
   ys_toolbar: 0
   ys_views_basic: 0
   hide_revision_field: 1
@@ -138,7 +140,6 @@ module:
   views: 10
   ys_core: 10
   ys_embed: 10
-  ys_mail: 10
   ys_starterkit: 10
   ys_themes: 10
   paragraphs: 11

--- a/web/profiles/custom/yalesites_profile/config/sync/key.config_override.mailchimp_transactional_api_key.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/key.config_override.mailchimp_transactional_api_key.yml
@@ -1,0 +1,14 @@
+uuid: 4c2195a0-b8d4-4a06-a771-45d276f60f8f
+langcode: en
+status: true
+dependencies:
+  config:
+    - key.key.mailchimp_transactional_api_key
+    - mailchimp_transactional.settings
+id: mailchimp_transactional_api_key
+label: 'Mailchimp Transactional API Key'
+config_type: system.simple
+config_prefix: ''
+config_name: mailchimp_transactional.settings
+config_item: mailchimp_transactional_api_key
+key_id: mailchimp_transactional_api_key

--- a/web/profiles/custom/yalesites_profile/config/sync/key.config_override.recaptcha_v2_secret_key.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/key.config_override.recaptcha_v2_secret_key.yml
@@ -1,0 +1,14 @@
+uuid: d5fe8b5d-7e04-4213-96a1-abf359497832
+langcode: en
+status: true
+dependencies:
+  config:
+    - key.key.recaptcha_v2_secret
+    - recaptcha.settings
+id: recaptcha_v2_secret_key
+label: 'reCAPTCHA v2 secret key'
+config_type: system.simple
+config_prefix: ''
+config_name: recaptcha.settings
+config_item: secret_key
+key_id: recaptcha_v2_secret

--- a/web/profiles/custom/yalesites_profile/config/sync/key.config_override.recaptcha_v2_site_key.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/key.config_override.recaptcha_v2_site_key.yml
@@ -1,0 +1,14 @@
+uuid: 1b8f475d-c8a0-4143-ae4c-c20538b872d7
+langcode: en
+status: true
+dependencies:
+  config:
+    - key.key.recaptcha_v2_key
+    - recaptcha.settings
+id: recaptcha_v2_site_key
+label: 'reCAPTCHA v2 site key'
+config_type: system.simple
+config_prefix: ''
+config_name: recaptcha.settings
+config_item: site_key
+key_id: recaptcha_v2_key

--- a/web/profiles/custom/yalesites_profile/config/sync/key.config_override.recaptcha_v3_secret_key.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/key.config_override.recaptcha_v3_secret_key.yml
@@ -1,0 +1,14 @@
+uuid: 11a93f3c-b4ab-4998-879e-e3fd06f3d539
+langcode: en
+status: true
+dependencies:
+  config:
+    - key.key.recaptcha_v3_secret
+    - recaptcha_v3.settings
+id: recaptcha_v3_secret_key
+label: 'reCAPTCHA v3 secret key'
+config_type: system.simple
+config_prefix: ''
+config_name: recaptcha_v3.settings
+config_item: secret_key
+key_id: recaptcha_v3_secret

--- a/web/profiles/custom/yalesites_profile/config/sync/key.config_override.recaptcha_v3_site_key.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/key.config_override.recaptcha_v3_site_key.yml
@@ -1,0 +1,14 @@
+uuid: f6795b10-907b-41a1-bc2b-e3c49593ffb0
+langcode: en
+status: true
+dependencies:
+  config:
+    - key.key.recaptcha_v3_key
+    - recaptcha_v3.settings
+id: recaptcha_v3_site_key
+label: 'reCAPTCHA v3 site key'
+config_type: system.simple
+config_prefix: ''
+config_name: recaptcha_v3.settings
+config_item: site_key
+key_id: recaptcha_v3_key

--- a/web/profiles/custom/yalesites_profile/config/sync/key.key.mailchimp_transactional_api_key.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/key.key.mailchimp_transactional_api_key.yml
@@ -1,0 +1,16 @@
+uuid: 21a0b3a7-8207-4e61-8393-72b3b1fcca21
+langcode: en
+status: true
+dependencies:
+  module:
+    - pantheon_secrets
+id: mailchimp_transactional_api_key
+label: mailchimp_transactional_api_key
+description: ''
+key_type: authentication
+key_type_settings: {  }
+key_provider: pantheon
+key_provider_settings:
+  secret_name: mailchimp_transactional_api_key
+key_input: none
+key_input_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/key.key.recaptcha_v2_key.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/key.key.recaptcha_v2_key.yml
@@ -1,0 +1,16 @@
+uuid: 389cc10d-00e3-405a-8651-da664d7913f8
+langcode: en
+status: true
+dependencies:
+  module:
+    - pantheon_secrets
+id: recaptcha_v2_key
+label: recaptcha_v2_key
+description: ''
+key_type: authentication
+key_type_settings: {  }
+key_provider: pantheon
+key_provider_settings:
+  secret_name: recaptcha_v2_key
+key_input: none
+key_input_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/key.key.recaptcha_v2_secret.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/key.key.recaptcha_v2_secret.yml
@@ -1,0 +1,16 @@
+uuid: 4e818d7f-a5a3-4e19-b198-6c89d6aaf475
+langcode: en
+status: true
+dependencies:
+  module:
+    - pantheon_secrets
+id: recaptcha_v2_secret
+label: recaptcha_v2_secret
+description: ''
+key_type: authentication
+key_type_settings: {  }
+key_provider: pantheon
+key_provider_settings:
+  secret_name: recaptcha_v2_secret
+key_input: none
+key_input_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/key.key.recaptcha_v3_key.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/key.key.recaptcha_v3_key.yml
@@ -1,0 +1,16 @@
+uuid: da7c8cb8-ee75-4766-9472-887a0e1eaaf6
+langcode: en
+status: true
+dependencies:
+  module:
+    - pantheon_secrets
+id: recaptcha_v3_key
+label: recaptcha_v3_key
+description: ''
+key_type: authentication
+key_type_settings: {  }
+key_provider: pantheon
+key_provider_settings:
+  secret_name: recaptcha_v3_key
+key_input: none
+key_input_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/key.key.recaptcha_v3_secret.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/key.key.recaptcha_v3_secret.yml
@@ -1,0 +1,16 @@
+uuid: 8bd613a1-129b-4395-a831-f488bb8348f6
+langcode: en
+status: true
+dependencies:
+  module:
+    - pantheon_secrets
+id: recaptcha_v3_secret
+label: recaptcha_v3_secret
+description: ''
+key_type: authentication
+key_type_settings: {  }
+key_provider: pantheon
+key_provider_settings:
+  secret_name: recaptcha_v3_secret
+key_input: none
+key_input_settings: {  }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/ys_captcha.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/ys_captcha.info.yml
@@ -3,5 +3,3 @@ type: module
 description: Settings for YaleSites Captcha
 core_version_requirement: '^9 || ^10'
 package: YaleSites
-dependencies:
-  - ys_secrets

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/ys_captcha.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/ys_captcha.module
@@ -10,10 +10,11 @@
  */
 function ys_captcha_form_recaptcha_admin_settings_alter(&$form, &$form_state, $form_id) {
   // Disable the recaptcha v2 API key fields from the admin form as
-  // the value is set via Drupal\ys_captcha\Config\CaptchaV2ConfigOverrides.
-  $secrets = \Drupal::service('ys_secrets.manager');
-  $secrets->disableField($form['general']['recaptcha_site_key']);
-  $secrets->disableField($form['general']['recaptcha_secret_key']);
+  // the value is set by Key via Pantheon Secrets.
+  $form['general']['recaptcha_site_key']['#disabled'] = TRUE;
+  $form['general']['recaptcha_secret_key']['#disabled'] = TRUE;
+  $form['general']['recaptcha_site_key']['#default_value'] = 'HIDDEN';
+  $form['general']['recaptcha_secret_key']['#default_value'] = 'HIDDEN';
 }
 
 /**
@@ -21,8 +22,9 @@ function ys_captcha_form_recaptcha_admin_settings_alter(&$form, &$form_state, $f
  */
 function ys_captcha_form_recaptcha_v3_settings_alter(&$form, &$form_state, $form_id) {
   // Disable the recaptcha v3 API key fields from the admin form as
-  // the value is set via Drupal\ys_captcha\Config\CaptchaV3ConfigOverrides.
-  $secrets = \Drupal::service('ys_secrets.manager');
-  $secrets->disableField($form['site_key']);
-  $secrets->disableField($form['secret_key']);
+  // the value is set by Key via Pantheon Secrets.
+  $form['site_key']['#disabled'] = TRUE;
+  $form['secret_key']['#disabled'] = TRUE;
+  $form['site_key']['#default_value'] = "HIDDEN";
+  $form['secret_key']['#default_value'] = "HIDDEN";
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/ys_captcha.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/ys_captcha.module
@@ -12,8 +12,8 @@ function ys_captcha_form_recaptcha_admin_settings_alter(&$form, &$form_state, $f
   // Disable the recaptcha v2 API key fields from the admin form as
   // the value is set by Key via Pantheon Secrets.
   $form['general']['recaptcha_site_key']['#disabled'] = TRUE;
-  $form['general']['recaptcha_secret_key']['#disabled'] = TRUE;
   $form['general']['recaptcha_site_key']['#default_value'] = 'HIDDEN';
+  $form['general']['recaptcha_secret_key']['#disabled'] = TRUE;
   $form['general']['recaptcha_secret_key']['#default_value'] = 'HIDDEN';
 }
 
@@ -24,7 +24,7 @@ function ys_captcha_form_recaptcha_v3_settings_alter(&$form, &$form_state, $form
   // Disable the recaptcha v3 API key fields from the admin form as
   // the value is set by Key via Pantheon Secrets.
   $form['site_key']['#disabled'] = TRUE;
-  $form['secret_key']['#disabled'] = TRUE;
   $form['site_key']['#default_value'] = "HIDDEN";
+  $form['secret_key']['#disabled'] = TRUE;
   $form['secret_key']['#default_value'] = "HIDDEN";
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mail/ys_mail.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mail/ys_mail.info.yml
@@ -3,5 +3,3 @@ type: module
 description: Email support for YaleSites
 core_version_requirement: '^9 || ^10'
 package: YaleSites
-dependencies:
-  - ys_secrets

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mail/ys_mail.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mail/ys_mail.module
@@ -10,9 +10,9 @@
  */
 function ys_mail_form_mailchimp_transactional_admin_settings_alter(&$form, &$form_state, $form_id) {
   // Disable the mailchimp_transactional_api_key field from the admin form as
-  // the value is set via Drupal\ys_mail\Config\MailConfigOverrides.
-  $secrets = \Drupal::service('ys_secrets.manager');
-  $secrets->disableField($form['mailchimp_transactional_api_key']);
+  // the value is set via Key via Pantheon Secrets.
+  $form['mailchimp_transactional_api_key']['#disabled'] = TRUE;
+  $form['mailchimp_transactional_api_key']['#default_value'] = 'HIDDEN';
 }
 
 /**

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -25,17 +25,6 @@ include __DIR__ . "/settings.pantheon.php";
  */
 // $settings['skip_permissions_hardening'] = TRUE;
 
-/**
- * Override config with values from the secrets file.
- */
-$secrets_json_text = file_get_contents('/files/private/secrets.json');
-$secrets_data = json_decode($secrets_json_text, TRUE);
-$config['recaptcha.settings']['site_key'] = $secrets_data['recaptcha_v2_key'];
-$config['recaptcha.settings']['secret_key'] = $secrets_data['recaptcha_v2_secret'];
-$config['recaptcha_v3.settings']['site_key'] = $secrets_data['recaptcha_v3_key'];
-$config['recaptcha_v3.settings']['secret_key'] = $secrets_data['recaptcha_v3_secret'];
-$config['mailchimp_transactional.settings']['mailchimp_transactional_api_key'] = $secrets_data['mailchimp_transactional_api_key'];
-
 // Config split for production environments.
 $config['config_split.config_split.local_config']['status'] = FALSE;
 $config['config_split.config_split.production_config']['status'] = TRUE;
@@ -50,4 +39,3 @@ if (file_exists($local_settings)) {
 
 // Set the install profile as the source of site config.
 $settings['config_sync_directory'] = 'profiles/custom/yalesites_profile/config/sync';
-


### PR DESCRIPTION
## [YALB-1242: Use Pantheon Secrets](https://yaleits.atlassian.net/browse/YALB-1242)

### Description of work
- Adds [Pantheon Secrets](https://www.drupal.org/project/pantheon_secrets) and [Key](https://www.drupal.org/project/key) modules so that secrets can be sourced directly from Pantheon Secrets Manager
- Adds Key module config overrides to replace items with values sourced from Pantheon
- Removes `ys_secrets` module as a dependency for `ys_captcha` and `ys_mail` modules, setting form overrides directly in `ys_captcha` and `ys_mail`
- Removes logic from `settings.php`

### Functional testing steps:
- [ ] Log into multidev, verify that Key module (`admin/config/system/keys`) config overrides are in place
- [ ] On Mailchimp Transactional settings page, verify key is not visible
- [ ] On reCAPTCHA and reCAPTCHA v3 settings, verify key and secret are not visible

### Todo
- [YALB-1541: Remove ys_secrets](https://yaleits.atlassian.net/browse/YALB-1541)
