### PR TITLE
YALB-1382: Bug: NetID Required on node does not restrict page

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.install
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Install, uninstall and update hooks for ys_node_access.
+ */
+
+/**
+ * Implements hook_install().
+ *
+ * Rebuild the node access permissions to remove default nid 0 entry.
+ */
+function ys_node_access_install() {
+  node_access_rebuild();
+}


### PR DESCRIPTION
## [YALB-1382: Bug: NetID Required on node does not restrict page](https://yaleits.atlassian.net/browse/YALB-1382)

The default node_access entry is added from core when there are no other access entries in the node_access database.  However, all queries include that for access, resulting in our own ys_node_access permissions being bypassed due to this being present.  This removes the entry from the database as it appears that it is a catchall if you were not use any specific node_access requirements.

### Description of work
- Rebuilds the node access permissions to remove the `nid: 0` entry in an update hook

### Functional testing steps:
- [x] [Go in as a platform/site admin](https://pr-397-yalesites-platform.pantheonsite.io/cas)
- [x] [Enable `CAS required` on the right side under `Publish Settings`](https://pr-397-yalesites-platform.pantheonsite.io/node/20/edit) and save
- [x] [Open this page in incognito mode](https://pr-397-yalesites-platform.pantheonsite.io/administrative-office)
- [x] Verify that you are redirected to CAS
- [x] Verify that after logging into CAS, you can see the page
- [x] In your platform/site admin window, manage settings again and disable 'CAS required' and save
- [x] [Verify that in a new incognito window that you can now see the page without logging into CAS](https://pr-397-yalesites-platform.pantheonsite.io/administrative-office)

Note: Search also adheres to this, so a CAS required page will not show in the results for anonymous users.