### PR TITLE
CI: remove tmate debug

### DIFF
--- a/.github/workflows/build_deploy_and_test.yml
+++ b/.github/workflows/build_deploy_and_test.yml
@@ -206,10 +206,6 @@ jobs:
         run: |
           ./.ci/build/build_frontend
 
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
-
       # Deploy to Pantheon
       - name: deploy to Pantheon
         env:


### PR DESCRIPTION
## CI: remove tmate debug

### Description of work
- Remove tmate debug step in Github Actions deploy job. It was useful when developing but now prevents action runs from failing fast.