### PR TITLE
YALB-1495: Fix image uploading and editing

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -231,72 +231,75 @@ function ys_core_preprocess_image_widget(&$variables) {
    */
   $element = $variables['element'];
 
-  $variables['attributes'] = [
-    'class' => [
-      'image-widget',
-      'js-form-managed-file',
-      'form-managed-file',
-      'clearfix',
-    ],
-  ];
+  if (isset($element['#use_favicon_preview'])) {
 
-  $config = \Drupal::config('system.site');
-  $variables['site_name'] = $config->get('name');
-
-  if (!empty($element['fids']['#value'])) {
-    $file = reset($element['#files']);
-    $element['file_' . $file->id()]['filename']['#suffix'] = ' <span class="file-size">(' . format_size($file->getSize()) . ')</span> ';
-    $file_variables = [
-      'style_name' => $element['#preview_image_style'],
-      'uri' => $file->getFileUri(),
+    $variables['attributes'] = [
+      'class' => [
+        'image-widget',
+        'js-form-managed-file',
+        'form-managed-file',
+        'clearfix',
+      ],
     ];
 
-    // Determine image dimensions.
-    if (isset($element['#value']['width']) && isset($element['#value']['height'])) {
-      $file_variables['width'] = $element['#value']['width'];
-      $file_variables['height'] = $element['#value']['height'];
-    }
-    else {
-      $image = \Drupal::service('image.factory')->get($file->getFileUri());
-      if ($image->isValid()) {
-        $file_variables['width'] = $image->getWidth();
-        $file_variables['height'] = $image->getHeight();
+    $config = \Drupal::config('system.site');
+    $variables['site_name'] = $config->get('name');
+
+    if (!empty($element['fids']['#value'])) {
+      $file = reset($element['#files']);
+      $element['file_' . $file->id()]['filename']['#suffix'] = ' <span class="file-size">(' . format_size($file->getSize()) . ')</span> ';
+      $file_variables = [
+        'style_name' => $element['#preview_image_style'],
+        'uri' => $file->getFileUri(),
+      ];
+
+      // Determine image dimensions.
+      if (isset($element['#value']['width']) && isset($element['#value']['height'])) {
+        $file_variables['width'] = $element['#value']['width'];
+        $file_variables['height'] = $element['#value']['height'];
       }
       else {
-        $file_variables['width'] = $file_variables['height'] = NULL;
+        $image = \Drupal::service('image.factory')->get($file->getFileUri());
+        if ($image->isValid()) {
+          $file_variables['width'] = $image->getWidth();
+          $file_variables['height'] = $image->getHeight();
+        }
+        else {
+          $file_variables['width'] = $file_variables['height'] = NULL;
+        }
       }
+
+      $element['preview'] = [
+        '#weight' => -10,
+        '#theme' => 'image_style',
+        '#width' => $file_variables['width'],
+        '#height' => $file_variables['height'],
+        '#style_name' => $file_variables['style_name'],
+        '#uri' => $file_variables['uri'],
+      ];
+
+      // Store the dimensions in the form so the file doesn't have to be
+      // accessed again. This is important for remote files.
+      $element['width'] = [
+        '#type' => 'hidden',
+        '#value' => $file_variables['width'],
+      ];
+      $element['height'] = [
+        '#type' => 'hidden',
+        '#value' => $file_variables['height'],
+      ];
+    }
+    else {
+      $variables['fallback_image'] = TRUE;
     }
 
-    $element['preview'] = [
-      '#weight' => -10,
-      '#theme' => 'image_style',
-      '#width' => $file_variables['width'],
-      '#height' => $file_variables['height'],
-      '#style_name' => $file_variables['style_name'],
-      '#uri' => $file_variables['uri'],
-    ];
+    // Sets a twig variable to use the favicon preview.
+    // @see web/themes/custom/ys_admin_theme/templates/content-edit/image-widget.html.twig
+    $variables['use_favicon_preview'] = $element['#use_favicon_preview'];
 
-    // Store the dimensions in the form so the file doesn't have to be
-    // accessed again. This is important for remote files.
-    $element['width'] = [
-      '#type' => 'hidden',
-      '#value' => $file_variables['width'],
-    ];
-    $element['height'] = [
-      '#type' => 'hidden',
-      '#value' => $file_variables['height'],
-    ];
-  }
-  else {
-    $variables['fallback_image'] = TRUE;
-  }
-
-  // Sets a twig variable to use the favicon preview.
-  // @see web/themes/custom/ys_admin_theme/templates/content-edit/image-widget.html.twig
-  $variables['use_favicon_preview'] = $element['#use_favicon_preview'];
-
-  $variables['data'] = [];
-  foreach (Element::children($element) as $child) {
-    $variables['data'][$child] = $element[$child];
+    $variables['data'] = [];
+    foreach (Element::children($element) as $child) {
+      $variables['data'][$child] = $element[$child];
+    }
   }
 }


### PR DESCRIPTION
## [YALB-1495: Branding: Customized favicon](https://yaleits.atlassian.net/browse/YALB-1495)

### Description of work
- Fixes uploading and editing of images

### Functional testing steps:
- [x] Enter layout builder for a page
- [x] Add or edit a component that has images
- [x] Add a new image by uploading a new image, not by choosing one from the media library
- [x] Verify that the image uploads, and that you get the screen to add alt text / crop the new image

![Screenshot 2023-08-23 at 9 49 24 AM](https://github.com/yalesites-org/yalesites-project/assets/107938318/9b4f6e85-3ff0-4715-a85e-20719ec55b9b)

- [x] On an existing image, click on the pencil icon to edit it

![Screenshot 2023-08-23 at 9 48 22 AM](https://github.com/yalesites-org/yalesites-project/assets/107938318/5a0c9118-e1d9-4573-a632-80bf6db60add)

- [x] Verify that the edit modal comes up

![Screenshot 2023-08-23 at 9 50 26 AM](https://github.com/yalesites-org/yalesites-project/assets/107938318/8d61caed-5e89-47c0-9bec-a07105b4a4c7)