### PR TITLE
YALB-1382: Bug: NetID Required on node does not restrict page fix

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.info.yml
@@ -3,3 +3,5 @@ type: module
 description: Manages node access to specific nodes based on field value
 core_version_requirement: '^9 || ^10'
 package: YaleSites
+dependencies:
+  - drupal:node


### PR DESCRIPTION
## [YALB-1382: Bug: NetID Required on node does not restrict page fix](https://yaleits.atlassian.net/browse/YALB-1382)

A fix for [YALB-1382: Bug: NetID Required on node does not restrict page](https://github.com/yalesites-org/yalesites-project/pull/397)

While manually installing worked, build-on-install imports errored due to not loading the node module to make node_access_rebuild available to the install method of the ys_node_access module.

My setting node as a dependency of this module, it knows to load this beforehand and successfully runs.

### Description of work
- Adds node as a dependency of the `ys_node_access` module

### Functional testing steps:
- [x] Locally pull these changes into your existing local code and attempt a `npm run build-with-install` or
- [ ] Pull this repo fresh and attempt to `npm run setup`
- [x] Verify that no errors occur when build-with-install runs stating that it can't find a definition of `node_access_rebuild` and successfully builds

NOTE: Also creating this as a PR to test how it does on fresh multidev deployment.