### PR TITLE
YALB-1539: Bug: Taxonomy terms do not update in post feed or calendar list visually until user hits "Apply"

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -5,6 +5,7 @@
  * Contains ys_core.module functions.
  */
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -302,4 +303,13 @@ function ys_core_preprocess_image_widget(&$variables) {
       $variables['data'][$child] = $element[$child];
     }
   }
+}
+
+/**
+ * Implements hook_ENTITY_update().
+ *
+ * Clears the cache for rendered items on taxonomy term update.
+ */
+function ys_core_taxonomy_term_update() {
+  Cache::invalidateTags(['rendered']);
 }


### PR DESCRIPTION
## [YALB-1539: Bug: Taxonomy terms do not update in post feed or calendar list visually until user hits "Apply"](https://yaleits.atlassian.net/browse/YALB-1539)

### Description of work
- Added `ys_core_taxonomy_term_update` hook to clear rendered cache

### Functional testing steps:
- [x] Add some events, categorizing them with a common category
- [x] Add some posts, categorizing them with a common category
- [x] Add a new page, adding the post feed and an event list
- [x] Take note of the items in the dropdown filters of each
- [x] Go to taxonomy terms and modify one of the ones you noted in each taxonomy type (Events and Posts)
- [x] Visit the page you created with the feed and event list and verify that the changed taxonomy terms are reflected in the drop down filters.
- [x] Visit the same page in an incognito window as an anonymous user and verify that it also shows the changed terms in the dropdown filters.
