### PR TITLE
YALB-1428: Bug: Action Banner Field Labels

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_heading.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_heading.yml
@@ -16,7 +16,7 @@ id: block_content.cta_banner.field_heading
 field_name: field_heading
 entity_type: block_content
 bundle: cta_banner
-label: 'CTA Banner Heading'
+label: 'Action Banner Heading'
 description: ''
 required: true
 translatable: false

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_link.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_link.yml
@@ -11,7 +11,7 @@ id: block_content.cta_banner.field_link
 field_name: field_link
 entity_type: block_content
 bundle: cta_banner
-label: Link
+label: Call-to-action
 description: ''
 required: true
 translatable: false

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_text.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_text.yml
@@ -16,7 +16,7 @@ id: block_content.cta_banner.field_text
 field_name: field_text
 entity_type: block_content
 bundle: cta_banner
-label: 'CTA Banner Content'
+label: 'Action Banner Content'
 description: ''
 required: false
 translatable: false


### PR DESCRIPTION
## [YALB-1428: Bug: Action Banner Field Labels](https://yaleits.atlassian.net/browse/YALB-1428)

### Description of work
- Rename `CTA Banner Heading` label to `Action Banner Heading`
- Rename `CTA Banner Content` label to `Action Banner Content`
- Rename `Link` heading for the link widget to `Call-to-action`

### Functional testing steps:
- [x] Attempt to add an action banner to a page
- [x] Verify that the form displays the renamed labels for the fields (No CTA should be present in the labels)
- [x] Verify that the overall heading of the Link section is now `Call-to-action`

