### PR TITLE
YALB-1446: Feedback: Views UI Matching Labels

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic.css
@@ -147,6 +147,14 @@
   height: 150px;
 }
 
+/* while other items look great, the term-operators text was getting cut off
+ * so we need to adjust the label width and height for the term operators
+ */
+#drupal-off-canvas .grouped-items .fieldset--group .fieldset__wrapper--group .glb-form-type--radio input.term-operator-item + label {
+  width: 130px !important;
+  height: 150px !important;
+}
+
 /* second column */
 #drupal-off-canvas .grouped-items .fieldset--group.views-basic--view-mode .fieldset__wrapper--group .glb-form-type--radio label {
   width: 175px;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/js/views-basic.js
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/js/views-basic.js
@@ -1,35 +1,36 @@
 ((Drupal) => {
   Drupal.behaviors.ysViewsBasic = {
-    attach: function () { // eslint-disable-line
-    // Function to handle radio input checked behavior based on radio element selection.
+    attach: function() { // eslint-disable-line
+      // Function to handle radio input checked behavior based on radio element selection.
       function handleRadioInputs(radioGroup) {
         // Get references to the radio input elements within the specified group
         const radioInputs = document.querySelectorAll(radioGroup);
-      
+
         // Add event listener to each radio input
-        radioInputs.forEach(input => {
-          input.addEventListener('change', function() {
+        radioInputs.forEach((input) => {
+          input.addEventListener("change", function () {
             if (this.checked) {
-              this.setAttribute('checked', 'checked');
+              this.setAttribute("checked", "checked");
               // Remove the 'checked' attribute from other radio inputs
-              radioInputs.forEach(otherInput => {
+              radioInputs.forEach((otherInput) => {
                 if (otherInput !== this) {
-                  otherInput.removeAttribute('checked');
+                  otherInput.removeAttribute("checked");
                 }
               });
             }
           });
         });
       }
-      
+
       // Store radio input groups in an array
-      const radioGroups = [ 
+      const radioGroups = [
         'input[name="settings[block_form][group_user_selection][entity_and_view_mode][entity_types]"]',
-        'input[name="settings[block_form][group_user_selection][entity_and_view_mode][view_mode]"]'
+        'input[name="settings[block_form][group_user_selection][entity_and_view_mode][view_mode]"]',
+        'input[name="settings[block_form][group_user_selection][filter_and_sort][term_operator]"]',
       ];
-      
+
       // Apply the function to each radio input group
-      radioGroups.forEach(group => {
+      radioGroups.forEach((group) => {
         handleRadioInputs(group);
       });
     },

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -253,8 +253,8 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       '#title' => $this->t('Match Content That Has'),
       // Set operator: "+" is "OR" and "," is "AND".
       '#options' => [
-        '+' => $this->t('Any term listed in tags and categories'),
-        ',' => $this->t('All terms listed in tags and categories'),
+        '+' => $this->t('Can have any term listed in tags and categories'),
+        ',' => $this->t('Must have all terms listed in tags and categories'),
       ],
       '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('operator', $items[$delta]->params) : '+',
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -141,6 +141,11 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
 
     $form['group_user_selection']['filter_and_sort'] = [
       '#type' => 'container',
+      '#attributes' => [
+        'class' => [
+          'grouped-items',
+        ],
+      ],
     ];
 
     $form['group_user_selection']['filter_options'] = [
@@ -233,6 +238,23 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('terms_exclude', $items[$delta]->params) : [],
     ];
 
+    $form['group_user_selection']['filter_and_sort']['term_operator'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Match Content That Has'),
+      // Set operator: "+" is "OR" and "," is "AND".
+      '#options' => [
+        '+' => $this->t('Can have any term listed in tags and categories'),
+        ',' => $this->t('Must have all terms listed in tags and categories'),
+      ],
+      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('operator', $items[$delta]->params) : '+',
+      '#attributes' => [
+        'class'     => [
+          'term-operator-item',
+        ],
+      ],
+
+    ];
+
     // Gets the view mode options based on Ajax callbacks or initial load.
     $sortOptions = $this->viewsBasicManager->sortByList($entityValue);
 
@@ -246,18 +268,6 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       '#validated' => 'true',
       '#prefix' => '<div id="edit-sort-by">',
       '#suffix' => '</div>',
-    ];
-
-    $form['group_user_selection']['filter_options']['term_operator'] = [
-      '#type' => 'radios',
-      '#title' => $this->t('Match Content That Has'),
-      // Set operator: "+" is "OR" and "," is "AND".
-      '#options' => [
-        '+' => $this->t('Can have any term listed in tags and categories'),
-        ',' => $this->t('Must have all terms listed in tags and categories'),
-      ],
-      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('operator', $items[$delta]->params) : '+',
-
     ];
 
     $form['group_user_selection']['entity_specific']['event_time_period'] = [
@@ -399,7 +409,7 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
           "terms_exclude" => $terms_exclude,
           "event_time_period" => $form['group_user_selection']['entity_specific']['event_time_period']['#value'],
         ],
-        "operator" => $form['group_user_selection']['filter_options']['term_operator']['#value'],
+        "operator" => $form['group_user_selection']['filter_and_sort']['term_operator']['#value'],
         "sort_by" => $form_state->getValue(
           [
             'settings',


### PR DESCRIPTION
## [YALB-1446: Feedback: Views UI Matching Labels](https://yaleits.atlassian.net/browse/YALB-1446)

### Description of work
- Changes the any/all labels in the view block form to:
  - Any: 'Can have any term listed in tags and categories'
  - All: 'Must have all terms listed in tags and categories'
- Move the any/all match section to be next to the tag inclusion/exclusion fields
- Ensured that javascript selection still functioned
- Modified the CSS to give these items a little more breathing room on the sidebar as the text was bleeding out of the boundaries of the label

### Functional testing steps:
- [x] Attempt to add a view block
- [x] Note that the labels for "Match content that has" match the above descriptions of work
- [ ] Verify that the matches fields appear below the include/exclude tag fields
- [ ] Verify that upon click, it visually shows that it is selected
- [ ] Verify that upon edit, there is plenty of room for the text of these items for the labels they are in
- [ ] Verify that other labels/radios on this page are unchanged
