### PR TITLE
YALB-1550: Single Content Sync

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -81,6 +81,7 @@
     "drupal/section_library": "^1.1",
     "drupal/selective_better_exposed_filters": "^3.0@beta",
     "drupal/simple_sitemap": "^4.1",
+    "drupal/single_content_sync": "^1.4",
     "drupal/smart_date": "^3.5",
     "drupal/twig_tweak": "^3.1",
     "drupal/upgrade_status": "^3.18",
@@ -111,7 +112,8 @@
       "drupal/core": {
         "plural results summary https://www.drupal.org/project/drupal/issues/2888320": "https://www.drupal.org/files/issues/2021-12-15/2888320-78.patch",
         "Prevent media library item overflow https://www.drupal.org/project/drupal/issues/3059955": "https://www.drupal.org/files/issues/2023-03-18/3059955-167.patch",
-        "Remove for Drupal 10 - CKEditor 5 should not grow to infinite height https://www.drupal.org/project/drupal/issues/3273755": "https://www.drupal.org/files/issues/2023-07-26/ckeditor-height-fix.patch"
+        "Remove for Drupal 10 - CKEditor 5 should not grow to infinite height https://www.drupal.org/project/drupal/issues/3273755": "https://www.drupal.org/files/issues/2023-07-26/ckeditor-height-fix.patch",
+        "Fix ZipArchive deprecation: https://www.drupal.org/project/single_content_sync/issues/3364535": "https://www.drupal.org/files/issues/2022-08-22/2850794-51.patch"
       },
       "drupal/entity_redirect": {
         "fix layout route https://www.drupal.org/project/entity_redirect/issues/3352265": "https://git.drupalcode.org/project/entity_redirect/-/merge_requests/6.patch"

--- a/web/profiles/custom/yalesites_profile/config/starterkit_config/.htaccess
+++ b/web/profiles/custom/yalesites_profile/config/starterkit_config/.htaccess
@@ -1,0 +1,27 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>
+<IfModule mod_php.c>
+  php_flag engine off
+</IfModule>

--- a/web/profiles/custom/yalesites_profile/config/starterkit_config/migrate_plus.migration.ys_images_files.yml
+++ b/web/profiles/custom/yalesites_profile/config/starterkit_config/migrate_plus.migration.ys_images_files.yml
@@ -1,0 +1,71 @@
+uuid: 9440b8ce-971f-47ff-bc8b-4a5fdbfba7ff
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - ys_starterkit
+id: ys_images_files
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: ys_starterkit
+label: 'Starterkit Images'
+source:
+  plugin: url
+  data_fetcher_plugin: file
+  data_parser_plugin: json
+  urls:
+    - profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/images.json
+  item_selector: /data/images
+  fields:
+    -
+      name: image_id
+      label: 'Image ID'
+      selector: image_id
+    -
+      name: image_url
+      label: 'Image URL'
+      selector: image_url
+  ids:
+    image_id:
+      type: integer
+  constants:
+    drupal_file_dest: 'public://starterkit/'
+process:
+  destination_filename:
+    -
+      plugin: callback
+      callable: basename
+      source: image_url
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Cannot import empty filename.'
+  destination_full_path:
+    -
+      plugin: concat
+      source:
+        - constants/drupal_file_dest
+        - '@destination_filename'
+    -
+      plugin: urlencode
+  uri:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: image_url
+    -
+      plugin: file_copy
+      source:
+        - image_url
+        - '@destination_full_path'
+      file_exists: rename
+      move: false
+  uid:
+    plugin: default_value
+    default_value: 1
+destination:
+  plugin: 'entity:file'
+migration_dependencies: {  }

--- a/web/profiles/custom/yalesites_profile/config/starterkit_config/migrate_plus.migration.ys_images_media.yml
+++ b/web/profiles/custom/yalesites_profile/config/starterkit_config/migrate_plus.migration.ys_images_media.yml
@@ -1,0 +1,66 @@
+uuid: 39d4e56f-4151-4461-b4d0-113dc14475fe
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - ys_starterkit
+id: ys_images_media
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: ys_starterkit
+label: 'Starterkit Media'
+source:
+  plugin: url
+  data_fetcher_plugin: file
+  data_parser_plugin: json
+  urls:
+    - profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/images.json
+  item_selector: /data/images
+  fields:
+    -
+      name: image_id
+      label: 'Image ID'
+      selector: image_id
+    -
+      name: image_url
+      label: 'Image URL'
+      selector: image_url
+    -
+      name: alt_text
+      label: 'Alternate text'
+      selector: alt_text
+  ids:
+    image_id:
+      type: integer
+process:
+  pseudo_destination_filename:
+    -
+      plugin: callback
+      callable: basename
+      source: image_url
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Cannot import empty filename.'
+  name: '@pseudo_destination_filename'
+  field_media_image/target_id:
+    plugin: migration_lookup
+    migration: ys_images_files
+    source: image_id
+  thumbnail/target_id:
+    plugin: migration_lookup
+    migration: ys_images_files
+    source: image_id
+  field_media_image/alt: alt_text
+  uid:
+    plugin: default_value
+    default_value: 1
+destination:
+  plugin: 'entity:media'
+  default_bundle: image
+migration_dependencies:
+  required:
+    - ys_images_files

--- a/web/profiles/custom/yalesites_profile/config/starterkit_config/migrate_plus.migration.ys_menu_links.yml
+++ b/web/profiles/custom/yalesites_profile/config/starterkit_config/migrate_plus.migration.ys_menu_links.yml
@@ -1,0 +1,93 @@
+uuid: 63dbb578-58f4-4dd9-b0a1-9edd3dbaa79f
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - ys_starterkit
+id: ys_menu_links
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: ys_starterkit
+label: 'Starterkit Menu Links'
+source:
+  plugin: url
+  data_fetcher_plugin: file
+  data_parser_plugin: json
+  urls:
+    - profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/menu_links.json
+  item_selector: data
+  fields:
+    -
+      name: src_unique_id
+      label: 'Unique ID'
+      selector: unique_id
+    -
+      name: page_migration_id
+      label: 'Reference to migrated page'
+      selector: page_migration_id
+    -
+      name: name
+      label: Name
+      selector: name
+    -
+      name: parent_ref
+      label: 'Parent menu link reference'
+      selector: parent_ref
+  constants:
+    path: 'entity:node/'
+  ids:
+    src_unique_id:
+      type: string
+process:
+  menu_name:
+    plugin: default_value
+    default_value: main
+  nid:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: page_migration_id
+    -
+      plugin: migration_lookup
+      migration: ys_pages
+  parent_link_id:
+    -
+      plugin: migration_lookup
+      migration: ys_menu_links
+      source: parent_ref
+    -
+      plugin: default_value
+      default_value: 0
+  title:
+    plugin: get
+    source: name
+    language: en
+  link/uri:
+    plugin: concat
+    source:
+      - constants/path
+      - '@nid'
+  parent:
+    plugin: menu_link_parent
+    source:
+      - parent_link_id
+      - main
+  external:
+    plugin: default_value
+    default_value: 0
+  expanded:
+    plugin: default_value
+    default_value: 0
+  enabled:
+    plugin: default_value
+    default_value: 1
+destination:
+  plugin: 'entity:menu_link_content'
+  bundle: menu_link_content
+  no_stub: true
+migration_dependencies:
+  required:
+    - ys_pages

--- a/web/profiles/custom/yalesites_profile/config/starterkit_config/migrate_plus.migration.ys_pages.yml
+++ b/web/profiles/custom/yalesites_profile/config/starterkit_config/migrate_plus.migration.ys_pages.yml
@@ -1,0 +1,47 @@
+uuid: 52099feb-f57f-4f06-a7b4-57f2fe441095
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - ys_starterkit
+id: ys_pages
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: ys_starterkit
+label: 'Starterkit Pages'
+source:
+  plugin: url
+  data_fetcher_plugin: file
+  data_parser_plugin: json
+  urls:
+    - profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/pages.json
+  item_selector: /data/pages
+  fields:
+    -
+      name: src_unique_id
+      label: 'Unique ID'
+      selector: unique_id
+    -
+      name: src_title
+      label: Title
+      selector: title
+  ids:
+    src_unique_id:
+      type: string
+process:
+  uid:
+    plugin: default_value
+    default_value: 1
+  status:
+    plugin: default_value
+    default_value: true
+  title: src_title
+destination:
+  plugin: 'entity:node'
+  default_bundle: page
+migration_dependencies:
+  required:
+    - ys_images_media

--- a/web/profiles/custom/yalesites_profile/config/starterkit_config/migrate_plus.migration.ys_posts.yml
+++ b/web/profiles/custom/yalesites_profile/config/starterkit_config/migrate_plus.migration.ys_posts.yml
@@ -1,0 +1,60 @@
+uuid: 04681e16-4ad0-4003-ad86-faff4e99879e
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - ys_starterkit
+id: ys_posts
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: ys_starterkit
+label: 'Starterkit Post'
+source:
+  plugin: url
+  data_fetcher_plugin: file
+  data_parser_plugin: json
+  urls:
+    - profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/posts.json
+  item_selector: /data/posts
+  fields:
+    -
+      name: src_unique_id
+      label: 'Unique ID'
+      selector: unique_id
+    -
+      name: src_title
+      label: Title
+      selector: title
+    -
+      name: src_author
+      label: Author
+      selector: field_author
+  ids:
+    src_unique_id:
+      type: string
+  constants:
+    date_format: Y-m-d
+process:
+  uid:
+    plugin: default_value
+    default_value: 1
+  status:
+    plugin: default_value
+    default_value: true
+  title: src_title
+  field_author: src_author
+  field_publish_date:
+    plugin: callback
+    callable: date
+    unpack_source: true
+    source:
+      - constants/date_format
+destination:
+  plugin: 'entity:node'
+  default_bundle: post
+migration_dependencies:
+  required:
+    - ys_images_media

--- a/web/profiles/custom/yalesites_profile/config/starterkit_config/migrate_plus.migration.ys_terms.yml
+++ b/web/profiles/custom/yalesites_profile/config/starterkit_config/migrate_plus.migration.ys_terms.yml
@@ -1,0 +1,48 @@
+uuid: 3bd796d7-5ec4-4d46-aba2-d2ac96826026
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - ys_starterkit
+id: ys_terms
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: ys_starterkit
+label: 'Starterkit Terms'
+source:
+  plugin: url
+  data_fetcher_plugin: file
+  data_parser_plugin: json
+  urls:
+    - profiles/custom/yalesites_profile/modules/custom/ys_starterkit/content/terms.json
+  item_selector: /data/terms
+  fields:
+    -
+      name: src_unique_id
+      label: 'Unique ID'
+      selector: unique_id
+    -
+      name: vocabulary
+      label: Vocabulary
+      selector: vocabulary
+    -
+      name: name
+      label: Name
+      selector: name
+  ids:
+    src_unique_id:
+      type: string
+  constants:
+    date_format: Y-m-d
+process:
+  vid: vocabulary
+  name: name
+  uid:
+    plugin: default_value
+    default_value: 1
+destination:
+  plugin: 'entity:taxonomy_term'
+migration_dependencies: null

--- a/web/profiles/custom/yalesites_profile/config/starterkit_config/single_content_sync.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/starterkit_config/single_content_sync.settings.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: F--1EKAki5zF_jdKTc4ZLmgN89WJ2SDrMOkwbqj06-Y
+allowed_entity_types:
+  block_content: {  }
+  media: {  }
+  menu_link_content: {  }
+  node: {  }
+  taxonomy_term: {  }
+site_uuid_check: true

--- a/web/profiles/custom/yalesites_profile/config/starterkit_config/system.action.export_content.yml
+++ b/web/profiles/custom/yalesites_profile/config/starterkit_config/system.action.export_content.yml
@@ -1,0 +1,13 @@
+uuid: 7efda88d-0650-4dcb-9207-4eb705eecfaa
+langcode: en
+status: true
+dependencies:
+  module:
+    - single_content_sync
+id: export_content
+label: 'Export content'
+type: node
+plugin: content_bulk_export
+configuration:
+  assets: '1'
+  translation: '1'

--- a/web/profiles/custom/yalesites_profile/config/starterkit_config/system.action.export_media.yml
+++ b/web/profiles/custom/yalesites_profile/config/starterkit_config/system.action.export_media.yml
@@ -1,0 +1,13 @@
+uuid: cc2c92e6-7d9d-46ba-972f-f84f3f8084ac
+langcode: en
+status: true
+dependencies:
+  module:
+    - ys_starterkit
+id: export_media
+label: 'Export media'
+type: media
+plugin: media_bulk_export
+configuration:
+  assets: 1
+  translation: 1

--- a/web/profiles/custom/yalesites_profile/config/starterkit_config/system.action.export_taxonomy.yml
+++ b/web/profiles/custom/yalesites_profile/config/starterkit_config/system.action.export_taxonomy.yml
@@ -1,0 +1,13 @@
+uuid: 5f2760c9-36a5-407d-a1d1-abde86c6b603
+langcode: en
+status: true
+dependencies:
+  module:
+    - ys_starterkit
+id: export_taxonomy
+label: 'Export taxonomy'
+type: taxonomy_term
+plugin: taxonomy_bulk_export
+configuration:
+  assets: 1
+  translation: 1

--- a/web/profiles/custom/yalesites_profile/config/starterkit_config/views.view.manage_taxonomy.yml
+++ b/web/profiles/custom/yalesites_profile/config/starterkit_config/views.view.manage_taxonomy.yml
@@ -1,0 +1,457 @@
+uuid: 0711490c-a01e-433f-bbd8-c8f1cd8424a0
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.admin
+  module:
+    - taxonomy
+    - user
+id: manage_taxonomy
+label: 'Manage Taxonomy'
+module: views
+description: ''
+tag: ''
+base_table: taxonomy_term_field_data
+base_field: tid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: Taxonomy
+      fields:
+        taxonomy_term_bulk_form:
+          id: taxonomy_term_bulk_form
+          table: taxonomy_term_data
+          field: taxonomy_term_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          plugin_id: bulk_form
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: exclude
+          selected_actions: {  }
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          convert_spaces: false
+        vid:
+          id: vid
+          table: taxonomy_term_field_data
+          field: vid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: vid
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        operations:
+          id: operations
+          table: taxonomy_term_data
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          plugin_id: entity_operations
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: false
+        changed:
+          id: changed
+          table: taxonomy_term_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: changed
+          plugin_id: field
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
+      filters: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            taxonomy_term_bulk_form: taxonomy_term_bulk_form
+            name: name
+            vid: vid
+          default: '-1'
+          info:
+            taxonomy_term_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            vid:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'export configuration'
+      defaults:
+        access: false
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
+      path: admin/content/taxonomy
+      menu:
+        type: normal
+        title: 'Manage All Taxonomy'
+        description: 'Manage Taxonomy Terms'
+        weight: 8
+        expanded: false
+        menu_name: admin
+        parent: system.admin_content
+        context: '1'
+      tab_options:
+        type: none
+        title: ''
+        description: ''
+        weight: 0
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -1,6 +1,7 @@
 _core:
   default_config_hash: R4IF-ClDHXxblLcG0L7MgsLvfBIMAvi_skumNFQwkDc
 module:
+  action: 0
   address: 0
   admin_toolbar: 0
   admin_toolbar_tools: 0
@@ -109,6 +110,7 @@ module:
   search_api_html_element_filter: 0
   section_library: 0
   simple_sitemap: 0
+  single_content_sync: 0
   smart_date: 0
   smart_date_recur: 0
   sophron: 0
@@ -131,6 +133,7 @@ module:
   ys_layouts: 0
   ys_mail: 0
   ys_node_access: 0
+  ys_starterkit: 0
   ys_toolbar: 0
   ys_views_basic: 0
   hide_revision_field: 1
@@ -142,7 +145,6 @@ module:
   views: 10
   ys_core: 10
   ys_embed: 10
-  ys_starterkit: 10
   ys_themes: 10
   paragraphs: 11
   yalesites_profile: 1000

--- a/web/profiles/custom/yalesites_profile/config/sync/single_content_sync.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/single_content_sync.settings.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: F--1EKAki5zF_jdKTc4ZLmgN89WJ2SDrMOkwbqj06-Y
+allowed_entity_types:
+  block_content: {  }
+  media: {  }
+  menu_link_content: {  }
+  node: {  }
+  taxonomy_term: {  }
+site_uuid_check: true

--- a/web/profiles/custom/yalesites_profile/config/sync/system.action.export_content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.action.export_content.yml
@@ -1,0 +1,13 @@
+uuid: 7efda88d-0650-4dcb-9207-4eb705eecfaa
+langcode: en
+status: true
+dependencies:
+  module:
+    - single_content_sync
+id: export_content
+label: 'Export content'
+type: node
+plugin: content_bulk_export
+configuration:
+  assets: '1'
+  translation: '1'

--- a/web/profiles/custom/yalesites_profile/config/sync/system.action.export_media.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.action.export_media.yml
@@ -1,0 +1,13 @@
+uuid: cc2c92e6-7d9d-46ba-972f-f84f3f8084ac
+langcode: en
+status: true
+dependencies:
+  module:
+    - ys_starterkit
+id: export_media
+label: 'Export media'
+type: media
+plugin: media_bulk_export
+configuration:
+  assets: 1
+  translation: 1

--- a/web/profiles/custom/yalesites_profile/config/sync/system.action.export_taxonomy.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.action.export_taxonomy.yml
@@ -1,0 +1,13 @@
+uuid: 5f2760c9-36a5-407d-a1d1-abde86c6b603
+langcode: en
+status: true
+dependencies:
+  module:
+    - ys_starterkit
+id: export_taxonomy
+label: 'Export taxonomy'
+type: taxonomy_term
+plugin: taxonomy_bulk_export
+configuration:
+  assets: 1
+  translation: 1

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.export_media.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.export_media.yml
@@ -1,0 +1,484 @@
+uuid: 07b3ea1a-5687-4550-be24-955b23f4b09b
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.admin
+  module:
+    - media
+    - user
+id: export_media
+label: 'Export Media'
+module: views
+description: ''
+tag: ''
+base_table: media_field_data
+base_field: mid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Export Media'
+      fields:
+        media_bulk_form:
+          id: media_bulk_form
+          table: media
+          field: media_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          plugin_id: bulk_form
+          label: 'Bulk Action'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: include
+          selected_actions:
+            - export_media
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: media
+          plugin_id: field
+          label: Name
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        bundle:
+          id: bundle
+          table: media_field_data
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: bundle
+          plugin_id: field
+          label: 'Media type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        status:
+          id: status
+          table: media_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: status
+          plugin_id: field
+          label: Published
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: default
+            format_custom_false: ''
+            format_custom_true: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        uid:
+          id: uid
+          table: media_field_revision
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: uid
+          plugin_id: field
+          label: 'Authored by'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        created:
+          id: created
+          table: media_field_revision
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: created
+          plugin_id: field
+          label: 'Authored on'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'export configuration'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
+      filters: {  }
+      style:
+        type: table
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
+      path: admin/config/system/export/media
+      menu:
+        type: normal
+        title: 'Export Media'
+        description: ''
+        weight: 8
+        expanded: false
+        menu_name: admin
+        parent: 'views_view:views.export_nodes.page_1'
+        context: '0'
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.export_nodes.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.export_nodes.yml
@@ -1,19 +1,19 @@
-uuid: ae64141c-0d51-4f15-967c-e3d7bbedaef8
+uuid: 7a4868d1-432f-4983-a524-e3e04652dfe9
 langcode: en
 status: true
 dependencies:
+  config:
+    - system.menu.admin
   module:
-    - media
+    - node
     - user
-_core:
-  default_config_hash: mF_CA96Q4unIl78LRoLKR5YPUDGdxn0wbSqyUbvrQjc
-id: media
-label: Media
+id: export_nodes
+label: 'Export Nodes'
 module: views
-description: 'Find and manage media.'
+description: ''
 tag: ''
-base_table: media_field_data
-base_field: mid
+base_table: node_field_data
+base_field: nid
 display:
   default:
     id: default
@@ -21,17 +21,17 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: Media
+      title: 'Export Nodes'
       fields:
-        media_bulk_form:
-          id: media_bulk_form
-          table: media
-          field: media_bulk_form
+        node_bulk_form:
+          id: node_bulk_form
+          table: node
+          field: node_bulk_form
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          plugin_id: bulk_form
+          entity_type: node
+          plugin_id: node_bulk_form
           label: ''
           exclude: false
           alter:
@@ -74,67 +74,20 @@ display:
           empty_zero: false
           hide_alter_empty: true
           action_title: Action
-          include_exclude: exclude
+          include_exclude: include
           selected_actions:
-            - export_media
-        name:
-          id: name
-          table: media_field_data
-          field: name
+            - export_content
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: media
+          entity_type: node
+          entity_field: nid
           plugin_id: field
-          label: 'Media name'
-          exclude: false
-          alter:
-            alter_text: false
-            make_link: false
-            absolute: false
-            word_boundary: false
-            ellipsis: false
-            strip_tags: false
-            trim: false
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-        bundle:
-          id: bundle
-          table: media_field_data
-          field: bundle
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: media
-          entity_field: bundle
-          plugin_id: field
-          label: Type
+          label: ID
           exclude: false
           alter:
             alter_text: false
@@ -175,11 +128,12 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_label
+          click_sort_column: value
+          type: number_integer
           settings:
-            link: false
-          group_column: target_id
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -189,17 +143,80 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        uid:
-          id: uid
-          table: media_field_data
-          field: uid
+        title:
+          id: title
+          table: node_field_data
+          field: title
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: uid
           plugin_id: field
-          label: Author
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: field
+          label: 'Content type'
           exclude: false
           alter:
             alter_text: false
@@ -254,17 +271,82 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        uuid:
+          id: uuid
+          table: node
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: uuid
+          plugin_id: field
+          label: UUID
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         status:
           id: status
-          table: media_field_data
+          table: node_field_data
           field: status
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
+          entity_type: node
           entity_field: status
           plugin_id: field
-          label: Status
+          label: Published
           exclude: false
           alter:
             alter_text: false
@@ -308,9 +390,9 @@ display:
           click_sort_column: value
           type: boolean
           settings:
-            format: custom
-            format_custom_false: Unpublished
-            format_custom_true: Published
+            format: default
+            format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -321,17 +403,17 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        changed:
-          id: changed
-          table: media_field_data
-          field: changed
+        uid:
+          id: uid
+          table: node_field_revision
+          field: uid
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: media
-          entity_field: changed
+          entity_type: node
+          entity_field: uid
           plugin_id: field
-          label: Updated
+          label: 'Authored by'
           exclude: false
           alter:
             alter_text: false
@@ -372,13 +454,11 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: timestamp
+          click_sort_column: target_id
+          type: entity_reference_label
           settings:
-            date_format: short
-            custom_date_format: ''
-            timezone: ''
-          group_column: value
+            link: true
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -388,57 +468,13 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        operations:
-          id: operations
-          table: media
-          field: operations
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: media
-          plugin_id: entity_operations
-          label: Operations
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          destination: true
+        created:
+          id: created
+          table: node_field_revision
+          field: created
+          entity_type: node
+          entity_field: created
+          plugin_id: field
       pager:
         type: full
         options:
@@ -447,8 +483,8 @@ display:
           total_pages: null
           id: 0
           tags:
-            next: 'Next ›'
-            previous: '‹ Previous'
+            next: ››
+            previous: ‹‹
             first: '« First'
             last: 'Last »'
           expose:
@@ -463,7 +499,7 @@ display:
       exposed_form:
         type: basic
         options:
-          submit_button: Filter
+          submit_button: Apply
           reset_button: false
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
@@ -473,256 +509,14 @@ display:
       access:
         type: perm
         options:
-          perm: 'access media overview'
+          perm: 'export configuration'
       cache:
         type: tag
         options: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text_custom
-          empty: true
-          content: 'No media available.'
-          tokenize: false
-      sorts:
-        created:
-          id: created
-          table: media_field_data
-          field: created
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: media
-          entity_field: created
-          plugin_id: date
-          order: DESC
-          expose:
-            label: ''
-            field_identifier: created
-          exposed: false
-          granularity: second
+      empty: {  }
+      sorts: {  }
       arguments: {  }
-      filters:
-        name:
-          id: name
-          table: media_field_data
-          field: name
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: media
-          entity_field: name
-          plugin_id: string
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: name_op
-            label: 'Media name'
-            description: ''
-            use_operator: false
-            operator: name_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: name
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-        bundle:
-          id: bundle
-          table: media_field_data
-          field: bundle
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: media
-          entity_field: bundle
-          plugin_id: bundle
-          operator: in
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: bundle_op
-            label: Type
-            description: ''
-            use_operator: false
-            operator: bundle_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: type
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-        status:
-          id: status
-          table: media_field_data
-          field: status
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: media
-          entity_field: status
-          plugin_id: boolean
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'True'
-            description: null
-            use_operator: false
-            operator: status_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: status
-            required: true
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: true
-          group_info:
-            label: 'Published status'
-            description: ''
-            identifier: status
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items:
-              1:
-                title: Published
-                operator: '='
-                value: '1'
-              2:
-                title: Unpublished
-                operator: '='
-                value: '0'
-        status_extra:
-          id: status_extra
-          table: media_field_data
-          field: status_extra
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: media
-          plugin_id: media_status
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-        langcode:
-          id: langcode
-          table: media_field_data
-          field: langcode
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: media
-          entity_field: langcode
-          plugin_id: language
-          operator: in
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: langcode_op
-            label: Language
-            description: ''
-            use_operator: false
-            operator: langcode_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: langcode
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
+      filters: {  }
       style:
         type: table
         options:
@@ -730,52 +524,18 @@ display:
           row_class: ''
           default_row_class: true
           columns:
-            name: name
-            bundle: bundle
-            changed: changed
-            uid: uid
-            status: status
-            thumbnail__target_id: thumbnail__target_id
-          default: changed
+            title: title
+            node_bulk_form: node_bulk_form
+          default: title
           info:
-            name:
+            title:
               sortable: true
               default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false
               responsive: ''
-            bundle:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            changed:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            uid:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            status:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            thumbnail__target_id:
-              sortable: false
-              default_sort_order: asc
+            node_bulk_form:
               align: ''
               separator: ''
               empty_column: false
@@ -783,7 +543,7 @@ display:
           override: true
           sticky: false
           summary: ''
-          empty_table: true
+          empty_table: false
           caption: ''
           description: ''
       row:
@@ -805,36 +565,36 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url
         - url.query_args
-        - user
+        - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-  media_page_list:
-    id: media_page_list
-    display_title: Media
+  page_1:
+    id: page_1
+    display_title: Page
     display_plugin: page
     position: 1
     display_options:
-      display_description: ''
-      display_extenders: {  }
-      path: admin/content/media
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
+      path: admin/config/system/export/nodes
       menu:
-        type: tab
-        title: Media
+        type: normal
+        title: 'Export Nodes'
         description: ''
-        weight: 0
+        weight: 8
         expanded: false
-        menu_name: main
-        parent: ''
+        menu_name: admin
+        parent: system.admin_config_system
         context: '0'
     cache_metadata:
       max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url
         - url.query_args
-        - user
+        - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.export_taxonomy.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.export_taxonomy.yml
@@ -1,0 +1,484 @@
+uuid: 4de3494f-4556-4075-8c5d-169bd5fd2774
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.admin
+  module:
+    - taxonomy
+    - user
+id: export_taxonomy
+label: 'Export Taxonomy'
+module: views
+description: ''
+tag: ''
+base_table: taxonomy_term_field_data
+base_field: tid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Export Taxonomy'
+      fields:
+        taxonomy_term_bulk_form:
+          id: taxonomy_term_bulk_form
+          table: taxonomy_term_data
+          field: taxonomy_term_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          plugin_id: bulk_form
+          label: 'Bulk update'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: include
+          selected_actions:
+            - export_taxonomy
+        tid:
+          id: tid
+          table: taxonomy_term_field_data
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: tid
+          plugin_id: field
+          label: 'Term ID'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
+          label: Name
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          convert_spaces: false
+        vid:
+          id: vid
+          table: taxonomy_term_field_data
+          field: vid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: vid
+          plugin_id: field
+          label: Vocabulary
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        uuid:
+          id: uuid
+          table: taxonomy_term_data
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: uuid
+          plugin_id: field
+          label: UUID
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        changed:
+          id: changed
+          table: taxonomy_term_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: changed
+          plugin_id: field
+          label: 'Updated date'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'export configuration'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
+      filters: {  }
+      style:
+        type: table
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
+      path: admin/config/system/export/taxonomy
+      menu:
+        type: normal
+        title: 'Export Taxonomy'
+        description: ''
+        weight: 8
+        expanded: false
+        menu_name: admin
+        parent: 'views_view:views.export_nodes.page_1'
+        context: '0'
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.media_library.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.media_library.yml
@@ -484,7 +484,24 @@ display:
         - 'url.query_args:sort_by'
         - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:core.entity_view_display.media.background_video.default'
+        - 'config:core.entity_view_display.media.background_video.media_library'
+        - 'config:core.entity_view_display.media.document.default'
+        - 'config:core.entity_view_display.media.document.media_library'
+        - 'config:core.entity_view_display.media.embed.default'
+        - 'config:core.entity_view_display.media.embed.media_library'
+        - 'config:core.entity_view_display.media.image.banner_16_5'
+        - 'config:core.entity_view_display.media.image.card_list_3_2'
+        - 'config:core.entity_view_display.media.image.card_secondary_3_2'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.image_content_width'
+        - 'config:core.entity_view_display.media.image.image_float'
+        - 'config:core.entity_view_display.media.image.profile_directory_card_1_1_'
+        - 'config:core.entity_view_display.media.image.text_with_image_feature_equal'
+        - 'config:core.entity_view_display.media.image.token'
+        - 'config:core.entity_view_display.media.video.default'
+        - 'config:core.entity_view_display.media.video.media_library'
   page:
     id: page
     display_title: Page
@@ -544,7 +561,8 @@ display:
           hide_alter_empty: true
           action_title: Action
           include_exclude: exclude
-          selected_actions: {  }
+          selected_actions:
+            - export_media
         name:
           id: name
           table: media_field_data
@@ -781,7 +799,24 @@ display:
         - 'url.query_args:sort_by'
         - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:core.entity_view_display.media.background_video.default'
+        - 'config:core.entity_view_display.media.background_video.media_library'
+        - 'config:core.entity_view_display.media.document.default'
+        - 'config:core.entity_view_display.media.document.media_library'
+        - 'config:core.entity_view_display.media.embed.default'
+        - 'config:core.entity_view_display.media.embed.media_library'
+        - 'config:core.entity_view_display.media.image.banner_16_5'
+        - 'config:core.entity_view_display.media.image.card_list_3_2'
+        - 'config:core.entity_view_display.media.image.card_secondary_3_2'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.image_content_width'
+        - 'config:core.entity_view_display.media.image.image_float'
+        - 'config:core.entity_view_display.media.image.profile_directory_card_1_1_'
+        - 'config:core.entity_view_display.media.image.text_with_image_feature_equal'
+        - 'config:core.entity_view_display.media.image.token'
+        - 'config:core.entity_view_display.media.video.default'
+        - 'config:core.entity_view_display.media.video.media_library'
   widget:
     id: widget
     display_title: Widget
@@ -1101,7 +1136,24 @@ display:
         - url.query_args
         - 'url.query_args:sort_by'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:core.entity_view_display.media.background_video.default'
+        - 'config:core.entity_view_display.media.background_video.media_library'
+        - 'config:core.entity_view_display.media.document.default'
+        - 'config:core.entity_view_display.media.document.media_library'
+        - 'config:core.entity_view_display.media.embed.default'
+        - 'config:core.entity_view_display.media.embed.media_library'
+        - 'config:core.entity_view_display.media.image.banner_16_5'
+        - 'config:core.entity_view_display.media.image.card_list_3_2'
+        - 'config:core.entity_view_display.media.image.card_secondary_3_2'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.image_content_width'
+        - 'config:core.entity_view_display.media.image.image_float'
+        - 'config:core.entity_view_display.media.image.profile_directory_card_1_1_'
+        - 'config:core.entity_view_display.media.image.text_with_image_feature_equal'
+        - 'config:core.entity_view_display.media.image.token'
+        - 'config:core.entity_view_display.media.video.default'
+        - 'config:core.entity_view_display.media.video.media_library'
   widget_table:
     id: widget_table
     display_title: 'Widget (table)'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/src/Plugin/Action/MediaBulkExport.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/src/Plugin/Action/MediaBulkExport.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\ys_starterkit\Plugin\Action;
+
+use Drupal\single_content_sync\Plugin\Action\ContentBulkExport;
+
+/**
+ * This action is used to export multiple contents in a bulk operation.
+ *
+ * @Action(
+ *  id = "media_bulk_export",
+ *  label = @Translation("Export media"),
+ *  type = "media",
+ * )
+ */
+class MediaBulkExport extends ContentBulkExport {
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/src/Plugin/Action/TaxonomyBulkExport.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/src/Plugin/Action/TaxonomyBulkExport.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\ys_starterkit\Plugin\Action;
+
+use Drupal\single_content_sync\Plugin\Action\ContentBulkExport;
+
+/**
+ * This action is used to export multiple taxonomies in a bulk operation.
+ *
+ * @Action(
+ *  id = "taxonomy_bulk_export",
+ *  label = @Translation("Export taxonomy"),
+ *  type = "taxonomy_term",
+ * )
+ */
+class TaxonomyBulkExport extends ContentBulkExport {
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/src/Plugin/SingleContentSyncFieldProcessor/Embed.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/src/Plugin/SingleContentSyncFieldProcessor/Embed.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\ys_starterkit\Plugin\SingleContentSyncFieldProcessor;
+
+use Drupal\single_content_sync\Plugin\SingleContentSyncFieldProcessor\SimpleField;
+
+/**
+ * Single Content Sync Embed Handler.
+ *
+ * @SingleContentSyncFieldProcessor(
+ *   id = "embed",
+ *   title = @Translation("Embed"),
+ *   field_type = "embed",
+ * )
+ */
+class Embed extends SimpleField {
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/src/Plugin/SingleContentSyncFieldProcessor/Markup.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/src/Plugin/SingleContentSyncFieldProcessor/Markup.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\ys_starterkit\Plugin\SingleContentSyncFieldProcessor;
+
+use Drupal\single_content_sync\Plugin\SingleContentSyncFieldProcessor\SimpleField;
+
+/**
+ * Single Content Sync Markup Handler.
+ *
+ * @SingleContentSyncFieldProcessor(
+ *   id = "markup",
+ *   title = @Translation("Markup"),
+ *   field_type = "markup",
+ * )
+ */
+class Markup extends SimpleField {
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/src/Plugin/SingleContentSyncFieldProcessor/SmartDate.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/src/Plugin/SingleContentSyncFieldProcessor/SmartDate.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\ys_starterkit\Plugin\SingleContentSyncFieldProcessor;
+
+use Drupal\single_content_sync\Plugin\SingleContentSyncFieldProcessor\SimpleField;
+
+/**
+ * Single Content Sync SmartDate Handler.
+ *
+ * @SingleContentSyncFieldProcessor(
+ *   id = "smartdate",
+ *   title = @Translation("SmartDate"),
+ *   field_type = "smartdate",
+ * )
+ */
+class SmartDate extends SimpleField {
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/src/Plugin/SingleContentSyncFieldProcessor/ViewsBasicParams.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_starterkit/src/Plugin/SingleContentSyncFieldProcessor/ViewsBasicParams.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\ys_starterkit\Plugin\SingleContentSyncFieldProcessor;
+
+use Drupal\single_content_sync\Plugin\SingleContentSyncFieldProcessor\SimpleField;
+
+/**
+ * Single Content Sync ViewsBasicParams Handler.
+ *
+ * @SingleContentSyncFieldProcessor(
+ *   id = "views_basic_params",
+ *   title = @Translation("Views Basic Params"),
+ *   field_type = "views_basic_params",
+ * )
+ */
+class ViewsBasicParams extends SimpleField {
+}


### PR DESCRIPTION
## [YALB-1550: Single Content Sync](https://yaleits.atlassian.net/browse/YALB-1550)

### Description of work
- Add [single content sync](https://www.drupal.org/project/single_content_sync) and supporting functionality around it for successful exporting of content/media/taxnonomy via views
- [Patch ZipArchive](https://www.drupal.org/project/single_content_sync/issues/3364535) for single content sync
- Create export code for media and taxonomy terms
- Creates new views for nodes, media, and taxonomy off of `/config/system` to assist in graphical exports

### Functional testing steps:

### Via drush
- [ ] Bring this repo local and run composer update single_content_sync
- [ ] In comand line:
  - [ ] Exporting
    - [ ] Run the following command: `lando drush content:export nodes ./exports --translate --assets`
    - [ ] Note the directory location of the zip, specifically after `/app/web/`
    - [ ] Note that in a real world example, you'd copy this file out and copy it to a new site under /web somewhere, noting the location to use in the drush import command.
    - [ ] Go onto the website and delete a node--make note of the node you deleted so you can verify that it was re-imported later.
  - [ ] Importing
    - [ ] In command line, type `lando drush content:import ./exports/<name_of_the_zip_file_that_was_made>`
    - [ ] Verify that after a little bit, you see `[notice] Message: Successfully imported the content.` and received no errors.
    - [ ] Visit the site and look for the node you deleted.
  - [ ] Do the same for media: `lando drush content:export media ./export --assets --translate`
  - [ ] Do the same for taxonomy terms: `lando drush content:export taxonomy_term ./export --assets --translate`

The reason the `--all-content` flag is not used is that it includes block_content as well.  If we'd like that, then --all-content could be passed to the first node version and it would return them all.  Technically since the UUIDs would be the same, it should be ok, but I'd be more explicit of what we're targeting.

### Via site
- [ ] Log in as the administrator
- [ ] Visit `Configuration->System->Export Node`
- [ ] Verify that `Export content` is in the Action drop down at the bottom of the listing
- [ ] Visit `Configuration->System->Export Node->Export Media`
- [ ] Verify that `Export media` is in the Action drop down at the bottom of the listing
- [ ] Visit `Configuration->System->Export Node->Export Taxonomy`
- [ ] Verify that `Export taxonomy` is in the Action drop down at the bottom of the listing
- [ ] Feel free to export any of those three to verify that they work.
  - [ ] Click on any of the above views
  - [ ] Click multiple check boxes in the list to select those items to export
  - [ ] Ensure the `Export X` is selected for the bulk action and click the `Apply to selected items` button
  - [ ] A link should be generated in the message back to the user.  Click the link to download the zip file of what you selected.
- [ ] In an incognito browser, visit the site and log in as a CAS user
- [ ] Verify that you cannot see any mention of imports or export links

#### Importing

Due to the size of the content zips, importing should be done via Drush