### PR TITLE
HOTFIX: Fix Nodes not able to be viewed if no menu item

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.info.yml
@@ -3,5 +3,3 @@ type: module
 description: YaleSites Core Configuation
 core_version_requirement: '^9 || ^10'
 package: YaleSites
-dependencies:
-  - menu_item_extras

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -6,12 +6,10 @@
  */
 
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
-use Drupal\menu_item_extras\Entity\MenuItemExtrasMenuLinkContent;
 
 /**
  * @file
@@ -317,91 +315,3 @@ function ys_core_preprocess_image_widget(&$variables) {
 function ys_core_taxonomy_term_update() {
   Cache::invalidateTags(['rendered']);
 }
-
-/**
- * The following functions add menu item extras fields to node add/edit forms.
- *
- * @see https://www.drupal.org/project/menu_item_extras/issues/2992096#comment-14140361
- */
-
-/**
- * Implements hook_form_FORM_ID_alter().
- */
-function ys_core_form_node_page_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  ys_core_page_form_alter($form, $form_state);
-}
-
-/**
- * Implements hook_form_FORM_ID_alter().
- */
-function ys_core_form_node_page_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  ys_core_page_form_alter($form, $form_state);
-}
-
-/**
- * THe Drupal backend cache renderer service.
- *
- * @var array $form
- *  The form array.
- * @var Drupal\Core\Form\FormStateInterface $form_state
- *  The current form state.
- */
-function ys_core_page_form_alter(&$form, FormStateInterface $form_state) {
-
-  // Add menu link fields to node form.
-  if ($link = _ys_core_get_link($form_state)) {
-    $form_display = EntityFormDisplay::load('menu_link_content.' . $link->getMenuName() . '.default');
-    assert($form_display instanceof EntityFormDisplay);
-    $form['menu']['link']['extra'] = [
-      '#type' => 'container',
-      '#parents' => ['menu', 'extra'],
-    ];
-    $form_display->buildForm($link, $form['menu']['link']['extra'], $form_state);
-    // Only keep custom fields, other properties already are in the form.
-    foreach (Element::children($form['menu']['link']['extra']) as $key) {
-      if (strpos($key, 'field_') !== 0) {
-        unset($form['menu']['link']['extra'][$key]);
-      }
-    }
-
-    foreach (array_keys($form['actions']) as $action) {
-      if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
-        $form['actions'][$action]['#submit'][] = 'ys_core_save_menu_link_fields';
-      }
-    }
-  }
-}
-
-/**
- * Saves the menu item extras when on the node add/edit pages.
- *
- * @throws \Drupal\Core\Entity\EntityStorageException
- */
-function ys_core_save_menu_link_fields(array $form, FormStateInterface $form_state) {
-  if ($link = _ys_core_get_link($form_state)) {
-    $form_display = EntityFormDisplay::load('menu_link_content.' . $link->getMenuName() . '.default');
-    assert($form_display instanceof EntityFormDisplay);
-    $form_display->extractFormValues($link, $form['menu']['link']['extra'], $form_state);
-    $link->save();
-  }
-}
-
-/**
- * Gets any menu item extras content.
- *
- * @return Drupal\menu_item_extras\Entity\MenuItemExtrasMenuLinkContent
- *   Menu item extras content.
- */
-function _ys_core_get_link(FormStateInterface $form_state) {
-  /** @var Drupal\node\Entity $form_state */
-  $node = $form_state->getFormObject()->getEntity();
-  $defaults = menu_ui_get_menu_link_defaults($node);
-  if ($mlid = $defaults['entity_id']) {
-    return MenuItemExtrasMenuLinkContent::load($mlid);
-  }
-  return MenuItemExtrasMenuLinkContent::create($defaults);
-}
-
-/**
- * End allow menu item extras fields to be included on node add and edit forms.
- */


### PR DESCRIPTION
### Description of work
- It was discovered that with some custom code, if a node didn't have a menu item attached and you saved the node, it would mess up the site and prevent nodes (and the menu form) from being viewed and instead give missing route errors.
- This PR removes the custom code and to edit menu item extras (the heading CTA), content editors need to go into the menu item itself and can't be done on the node form.

### Functional testing steps:
- [x] Edit a node that does not have a link in the main menu
- [x] Save the node
- [x] View the node
- [x] Verify no errors show
