### PR TITLE
YALB-1462: Bug: Content Spotlight Requires Link

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_link.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_link.yml
@@ -13,7 +13,7 @@ entity_type: block_content
 bundle: content_spotlight
 label: Link
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
## [YALB-1462: Bug: Content Spotlight Requires Link](https://yaleits.atlassian.net/browse/YALB-1462)

### Description of work
- Makes link field for Content Spotlight optional
- Double checked that no atomic/CL changes were needed

### Functional testing steps:
- [ ] Visit [PR Multidev](https://pr-418-yalesites-platform.pantheonsite.io)
- [ ] On a page, add a content spotlight
- [ ] Leave the link section blank, but fill out any required fields
- [ ] Add the block to the page
- [ ] Verify that there are no remnants of HTML referring to a link in the output
- [ ] Edit the block
- [ ] Add a link
- [ ] Verify that the link exists on the outputted page

As stated in the Jira ticket:

Example: https://yalesites.yale.edu/our-vision-guiding-principles Guiding principles would work very well in cascading Content Spotlights, but the required single CTA link prevents this Block from being used as intended.

A proof of concept for this is using the modified content spotlight is at [https://pr-418-yalesites-platform.pantheonsite.io/daves-content-spotlight](https://pr-418-yalesites-platform.pantheonsite.io/daves-content-spotlight)