### PR TITLE
YALB-1303: Finding content tagged with a specific tag

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/chosen.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/chosen.settings.yml
@@ -1,17 +1,21 @@
 _core:
   default_config_hash: exRaKE0s6uZbfQrl_2WFEcTlc_1t81xEqCLuCCteUSk
-minimum_single: 20
+minimum_single: 15
 minimum_multiple: 20
 disable_search_threshold: 0
 minimum_width: 0
+max_shown_results: null
 use_relative_width: false
 jquery_selector: 'select:visible'
 search_contains: false
 disable_search: false
 allow_single_deselect: false
+disabled_themes:
+  claro: '0'
+  atomic: '0'
+  gin: '0'
+  ys_admin_theme: '0'
+chosen_include: 2
 placeholder_text_multiple: 'Choose some options'
 placeholder_text_single: 'Choose an option'
 no_results_text: 'No results match'
-max_shown_results: null
-disabled_themes: {  }
-chosen_include: 2

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.profile.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.profile.default.yml
@@ -24,6 +24,7 @@ dependencies:
     - node.type.profile
   module:
     - allowed_formats
+    - chosen_field
     - field_group
     - maxlength
     - media_library
@@ -227,14 +228,10 @@ content:
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_tags:
-    type: entity_reference_autocomplete_tags
+    type: chosen_select
     weight: 7
     region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
   field_teaser_media:
     type: media_library_widget

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.content.yml
@@ -2,8 +2,12 @@ uuid: 0b1bf4a4-27a1-4497-8779-67a194cb50fb
 langcode: en
 status: true
 dependencies:
+  config:
+    - field.storage.node.field_tags
+    - taxonomy.vocabulary.tags
   module:
     - node
+    - taxonomy
     - user
 _core:
   default_config_hash: vBKWYGGDoAX-tFd1JErB8tZLSxx3lJ0foouVsgpcbB4
@@ -111,6 +115,69 @@ display:
           entity_field: type
           plugin_id: field
           label: 'Content type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_tags:
+          id: field_tags
+          table: node__field_tags
+          field: field_tags
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Tags
           exclude: false
           alter:
             alter_text: false
@@ -536,6 +603,55 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_tags_target_id:
+          id: field_tags_target_id
+          table: node__field_tags
+          field: field_tags_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_tags_target_id_op
+            label: Tags
+            description: ''
+            use_operator: false
+            operator: field_tags_target_id_op
+            operator_limit_selection: false
+            operator_list:
+              and: and
+            identifier: tags
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              platform_admin: '0'
+              site_admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: tags
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: true
         status:
           id: status
           table: node_field_data
@@ -684,7 +800,8 @@ display:
         - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.field_tags'
   page_1:
     id: page_1
     display_title: Page
@@ -719,4 +836,5 @@ display:
         - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.field_tags'

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.content.yml
@@ -648,7 +648,7 @@ display:
             group_items: {  }
           reduce_duplicates: false
           vid: tags
-          type: textfield
+          type: select
           hierarchy: false
           limit: true
           error_message: true

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_events.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_events.yml
@@ -3,14 +3,19 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.field_category
     - field.storage.node.field_event_date
     - field.storage.node.field_event_format
+    - field.storage.node.field_tags
     - node.type.event
     - system.menu.admin
+    - taxonomy.vocabulary.event_category
+    - taxonomy.vocabulary.tags
   module:
     - node
     - options
     - smart_date
+    - taxonomy
     - user
 id: manage_events
 label: 'Manage Events'
@@ -252,6 +257,132 @@ display:
           type: list_default
           settings: {  }
           group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_tags:
+          id: field_tags
+          table: node__field_tags
+          field: field_tags
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Tags
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_category:
+          id: field_category
+          table: node__field_category
+          field: field_category
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Categories
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -639,6 +770,102 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_tags_target_id:
+          id: field_tags_target_id
+          table: node__field_tags
+          field: field_tags_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_tags_target_id_op
+            label: Tags
+            description: ''
+            use_operator: false
+            operator: field_tags_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_tags_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              platform_admin: '0'
+              site_admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: tags
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: true
+        field_category_target_id:
+          id: field_category_target_id
+          table: node__field_category
+          field: field_category_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_category_target_id_op
+            label: Categories
+            description: ''
+            use_operator: false
+            operator: field_category_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_category_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              platform_admin: '0'
+              site_admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: event_category
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: true
         status:
           id: status
           table: node_field_data
@@ -798,11 +1025,14 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.field_category'
         - 'config:field.storage.node.field_event_date'
         - 'config:field.storage.node.field_event_format'
+        - 'config:field.storage.node.field_tags'
   page_1:
     id: page_1
     display_title: Page
@@ -830,8 +1060,11 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.field_category'
         - 'config:field.storage.node.field_event_date'
         - 'config:field.storage.node.field_event_format'
+        - 'config:field.storage.node.field_tags'

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_events.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_events.yml
@@ -814,7 +814,7 @@ display:
             group_items: {  }
           reduce_duplicates: false
           vid: tags
-          type: textfield
+          type: select
           hierarchy: false
           limit: true
           error_message: true
@@ -862,7 +862,7 @@ display:
             group_items: {  }
           reduce_duplicates: false
           vid: event_category
-          type: textfield
+          type: select
           hierarchy: false
           limit: true
           error_message: true

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_pages.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_pages.yml
@@ -634,7 +634,7 @@ display:
             group_items: {  }
           reduce_duplicates: false
           vid: tags
-          type: textfield
+          type: select
           hierarchy: false
           limit: true
           error_message: true

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_pages.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_pages.yml
@@ -3,10 +3,13 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.field_tags
     - node.type.page
     - system.menu.admin
+    - taxonomy.vocabulary.tags
   module:
     - node
+    - taxonomy
     - user
 id: manage_pages
 label: 'Manage Pages'
@@ -137,6 +140,69 @@ display:
           settings:
             link_to_entity: true
           group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_tags:
+          id: field_tags
+          table: node__field_tags
+          field: field_tags
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Tags
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -524,6 +590,54 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_tags_target_id:
+          id: field_tags_target_id
+          table: node__field_tags
+          field: field_tags_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_tags_target_id_op
+            label: Tags
+            description: ''
+            use_operator: false
+            operator: field_tags_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: tags
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              platform_admin: '0'
+              site_admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: tags
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: true
         status:
           id: status
           table: node_field_data
@@ -669,9 +783,11 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.field_tags'
   page_1:
     id: page_1
     display_title: Page
@@ -699,6 +815,8 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.field_tags'

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_posts.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_posts.yml
@@ -4,10 +4,15 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_author
+    - field.storage.node.field_category
+    - field.storage.node.field_tags
     - node.type.post
     - system.menu.admin
+    - taxonomy.vocabulary.post_category
+    - taxonomy.vocabulary.tags
   module:
     - node
+    - taxonomy
     - user
 id: manage_posts
 label: 'Manage Posts'
@@ -183,6 +188,132 @@ display:
           settings:
             link_to_entity: false
           group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_tags:
+          id: field_tags
+          table: node__field_tags
+          field: field_tags
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Tags
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_category:
+          id: field_category
+          table: node__field_category
+          field: field_category
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Categories
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -570,6 +701,102 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_tags_target_id:
+          id: field_tags_target_id
+          table: node__field_tags
+          field: field_tags_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_tags_target_id_op
+            label: Tags
+            description: ''
+            use_operator: false
+            operator: field_tags_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_tags_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              platform_admin: '0'
+              site_admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: tags
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: true
+        field_category_target_id:
+          id: field_category_target_id
+          table: node__field_category
+          field: field_category_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_category_target_id_op
+            label: Categories
+            description: ''
+            use_operator: false
+            operator: field_category_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_category_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              platform_admin: '0'
+              site_admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: post_category
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: true
         status:
           id: status
           table: node_field_data
@@ -717,10 +944,13 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
         - 'config:field.storage.node.field_author'
+        - 'config:field.storage.node.field_category'
+        - 'config:field.storage.node.field_tags'
   page_1:
     id: page_1
     display_title: Page
@@ -748,7 +978,10 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
         - 'config:field.storage.node.field_author'
+        - 'config:field.storage.node.field_category'
+        - 'config:field.storage.node.field_tags'

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_posts.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_posts.yml
@@ -745,7 +745,7 @@ display:
             group_items: {  }
           reduce_duplicates: false
           vid: tags
-          type: textfield
+          type: select
           hierarchy: false
           limit: true
           error_message: true
@@ -793,7 +793,7 @@ display:
             group_items: {  }
           reduce_duplicates: false
           vid: post_category
-          type: textfield
+          type: select
           hierarchy: false
           limit: true
           error_message: true

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_profiles.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_profiles.yml
@@ -8,10 +8,14 @@ dependencies:
     - field.storage.node.field_department
     - field.storage.node.field_position
     - field.storage.node.field_subtitle
+    - field.storage.node.field_tags
     - node.type.profile
     - system.menu.admin
+    - taxonomy.vocabulary.affiliation
+    - taxonomy.vocabulary.tags
   module:
     - node
+    - taxonomy
     - text
     - user
 id: manage_profiles
@@ -327,6 +331,69 @@ display:
           type: text_default
           settings: {  }
           group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_tags:
+          id: field_tags
+          table: node__field_tags
+          field: field_tags
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Tags
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -709,6 +776,102 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_tags_target_id:
+          id: field_tags_target_id
+          table: node__field_tags
+          field: field_tags_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_tags_target_id_op
+            label: Tags
+            description: ''
+            use_operator: false
+            operator: field_tags_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_tags_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              platform_admin: '0'
+              site_admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: tags
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: true
+        field_affiliation_target_id:
+          id: field_affiliation_target_id
+          table: node__field_affiliation
+          field: field_affiliation_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_affiliation_target_id_op
+            label: Affiliation
+            description: ''
+            use_operator: false
+            operator: field_affiliation_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_affiliation_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              platform_admin: '0'
+              site_admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: affiliation
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: true
         status:
           id: status
           table: node_field_data
@@ -880,6 +1043,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
@@ -887,6 +1051,7 @@ display:
         - 'config:field.storage.node.field_department'
         - 'config:field.storage.node.field_position'
         - 'config:field.storage.node.field_subtitle'
+        - 'config:field.storage.node.field_tags'
   page_1:
     id: page_1
     display_title: Page
@@ -911,6 +1076,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
@@ -918,3 +1084,4 @@ display:
         - 'config:field.storage.node.field_department'
         - 'config:field.storage.node.field_position'
         - 'config:field.storage.node.field_subtitle'
+        - 'config:field.storage.node.field_tags'

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_profiles.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_profiles.yml
@@ -820,7 +820,7 @@ display:
             group_items: {  }
           reduce_duplicates: false
           vid: tags
-          type: textfield
+          type: select
           hierarchy: false
           limit: true
           error_message: true
@@ -868,7 +868,7 @@ display:
             group_items: {  }
           reduce_duplicates: false
           vid: affiliation
-          type: textfield
+          type: select
           hierarchy: false
           limit: true
           error_message: true

--- a/web/themes/custom/ys_admin_theme/css/gin-custom.css
+++ b/web/themes/custom/ys_admin_theme/css/gin-custom.css
@@ -219,6 +219,10 @@
   color: var(--wool);
 }
 
+.gin--dark-mode .chosen-container-single .chosen-search-input {
+  color: var(--darkest-gray);
+}
+
 /* remove media button */
 .gin--dark-mode .media-library-add-form__remove-button {
   background-color: var(--robin-egg);


### PR DESCRIPTION
## [YALB-1303: Finding content tagged with a specific tag](https://yaleits.atlassian.net/browse/YALB-1303)

### Description of work
- Filter "Content" view and "Manage Pages" by tags
- Filter "Manage Posts" by tags and/or post categories
- Filter "Manage Events" by tags and/or event categories
- Filter "Manage Profiles" by tags and/or affiliation

### Functional testing steps:
- [x] Login and visit the "Content" page (`/admin/content`)
- [x] Verify that there is now an exposed filter for "Tags", the "Tags" field is now in the table, and that filtering on this field works as expected.
- [x] Visit Content -> Manage Pages (`/admin/content/manage-pages`)
- [x] Verify that there is now an exposed filter for "Tags", the "Tags" field is now in the table, and that filtering on this field works as expected.
- [x] Visit Content -> Manage Posts (`/admin/content/manage-posts`)
- [x] Verify there are 2 exposed filters for "Tags" and "Categories" and that filtering works as expected for these filters (Categories may need to be added to some posts to test this)
- [x] Visit Content -> Manage Events (`/admin/content/manage-events`)
- [x] Verify there are 2 exposed filters for "Tags" and "Categories" and that filtering works as expected for these filters (Categories may need to be added to some events to test this)

![Screenshot 2023-09-12 at 5 30 04 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/242b0de8-1455-44b7-a591-d7ad4bd14d19)

- [x] Visit Content -> Manage Profiles (`/admin/content/manage-profiles`)
- [x] Verify there are 2 exposed filters for "Tags" and "Affiliation" and that filtering works as expected for these filters (Profiles may need to be added to test)