### PR TITLE
Event Sections

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/UpdateExistingNodes.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/UpdateExistingNodes.php
@@ -164,7 +164,7 @@ class UpdateExistingNodes {
       /** @var \Drupal\layout_builder\Field\LayoutSectionItemList $layout */
       $sections = $layout->getSections();
       foreach ($sections as $section) {
-        if ($section->getLayoutSettings()['label'] == '') {
+        if ($section->getLayoutSettings()['label'] != 'Title and Metadata') {
           $section->setThirdPartySetting(
             'layout_builder_lock',
             'lock',
@@ -179,20 +179,22 @@ class UpdateExistingNodes {
               $section_storage = $stored_data->data['section_storage'];
               $sections = $section_storage->getSections();
               foreach ($sections as $key => $section) {
-                if ($section->getLayoutSettings()['label'] == '') {
+                if ($section->getLayoutSettings()['label'] != 'Title and Metadata') {
                   $sectionToUpdate = $key;
                 }
               }
-              $section_storage
-                ->getSection($sectionToUpdate)
-                ->setThirdPartySetting(
-                  'layout_builder_lock',
-                  'lock',
-                  [
-                    6 => 6,
-                    7 => 7,
-                  ]
-                );
+              if (isset($sectionToUpdate)) {
+                $section_storage
+                  ->getSection($sectionToUpdate)
+                  ->setThirdPartySetting(
+                    'layout_builder_lock',
+                    'lock',
+                    [
+                      6 => 6,
+                      7 => 7,
+                    ]
+                  );
+              }
             }
           });
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/UpdateExistingNodes.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/UpdateExistingNodes.php
@@ -148,6 +148,61 @@ class UpdateExistingNodes {
   }
 
   /**
+   * Update existing events to disable adding more sections.
+   */
+  public function updateExistingEventsLock() {
+    // Find all event nodes to update existing.
+    $nids = \Drupal::entityQuery('node')
+      ->accessCheck(FALSE)
+      ->condition('type', 'event')
+      ->execute();
+
+    foreach ($nids as $nid) {
+      $node = Node::load($nid);
+      $layout = $node->get('layout_builder__layout');
+
+      /** @var \Drupal\layout_builder\Field\LayoutSectionItemList $layout */
+      $sections = $layout->getSections();
+      foreach ($sections as $section) {
+        if ($section->getLayoutSettings()['label'] == '') {
+          $section->setThirdPartySetting(
+            'layout_builder_lock',
+            'lock',
+            [
+              6 => 6,
+              7 => 7,
+            ]
+          );
+
+          $this->updateTempStore(function (&$stored_data) {
+            if ($stored_data->data['section_storage']->getContext('entity')->getContextData()->getEntity()->bundle() == 'event') {
+              $section_storage = $stored_data->data['section_storage'];
+              $sections = $section_storage->getSections();
+              foreach ($sections as $key => $section) {
+                if ($section->getLayoutSettings()['label'] == '') {
+                  $sectionToUpdate = $key;
+                }
+              }
+              $section_storage
+                ->getSection($sectionToUpdate)
+                ->setThirdPartySetting(
+                  'layout_builder_lock',
+                  'lock',
+                  [
+                    6 => 6,
+                    7 => 7,
+                  ]
+                );
+            }
+          });
+
+          $node->save();
+        }
+      }
+    }
+  }
+
+  /**
    * Updates Post Meta for existing nodes.
    */
   public function updateExistingPostMeta() {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.deploy.php
@@ -25,3 +25,11 @@ function ys_layouts_deploy_9001() {
   // Replaces old title section with new post meta block.
   $updateExistingNodes->updateExistingPostMeta();
 }
+
+/**
+ * Updates events to disable adding new sections.
+ */
+function ys_layouts_deploy_9002() {
+  $updateExistingNodes = new UpdateExistingNodes();
+  $updateExistingNodes->updateExistingEventsLock();
+}


### PR DESCRIPTION
### Description of work
- Updates existing events to disallow adding new sections

### Functional testing steps:
- [x] Login to the dev site here: https://dev-yalesites-platform.pantheonsite.io
- [x] Visit this existing event on the dev site: https://dev-yalesites-platform.pantheonsite.io/events/2022-05-29-featuring-past-events
- [x] Enter layout builder and verify that you can add new sections (existing issue)

![Screenshot 2023-09-14 at 4 28 57 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/67626b97-7a7b-4d25-bd45-3d4012a08b4f)

- [x] Login to the PR multidev here: https://pr-424-yalesites-platform.pantheonsite.io
- [x] Visit the same existing event on the multidev: https://pr-424-yalesites-platform.pantheonsite.io/events/2022-05-29-featuring-past-events
- [x] Enter layout builder and verify that you can't add new sections

![Screenshot 2023-09-14 at 4 27 50 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/6ca2ad29-aaff-44d8-8e70-1a95b608d62a)

- [x] Verify that you cannot add new sections on other existing events on the multidev.