### PR TITLE
YALB-1423 - Feedback: Rename floated to inline | YALB-1425 - Bug: Firefox - GIF being uploaded to multiple blocks | YALB-1426 - Bug: Exposed taxonomy filter style on mobile

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.media.image.field_media_image.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.media.image.field_media_image.yml
@@ -24,7 +24,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'png gif jpg jpeg'
+  file_extensions: 'png jpg jpeg'
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
@@ -33,7 +33,7 @@ settings:
   title_field: false
   title_field_required: false
   default_image:
-    uuid: null
+    uuid: ''
     alt: ''
     title: ''
     width: null

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -79,7 +79,7 @@ wrapped_image:
     default: left
   field_style_variation:
     values:
-      floated: Floated
+      floated: Inline
       offset: Offset
     default: offset
 grand_hero:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
@@ -79,7 +79,7 @@ wrapped_image:
     default: left
   field_style_variation:
     values:
-      floated: Floated
+      floated: Inline
       offset: Offset
     default: offset
 grand_hero:


### PR DESCRIPTION
## [YALB-1423 - Feedback: Rename floated to inline](https://yaleits.atlassian.net/browse/YALB-1434)
## [YALB-1425 - Bug: Firefox - GIF being uploaded to multiple blocks](https://yaleits.atlassian.net/browse/YALB-1425)
## [YALB-1426 - Bug: Exposed taxonomy filter style on mobile](https://yaleits.atlassian.net/browse/YALB-1426)

### Description of work
- Bug: change `floated` label to `inline` on wrapped image component
- Bug: fix input and button on taxonomy filters

### Functional testing steps:
- [x] Login to the multidev: 

#### Testing [YALB-1423 - Feedback: Rename floated to inline](https://yaleits.atlassian.net/browse/YALB-1434)
- [x] Edit a page on the site, such as: https://pr-425-yalesites-platform.pantheonsite.io/node/3/layout
- [x] Edit the existing wrapped-image component ("Building with Block")
- [x] Verify that the options for "Style" now reads `inline` instead of `floated`

https://github.com/yalesites-org/yalesites-project/assets/366413/99e310ca-49c8-47df-a3f6-3347765d2780


--- 
#### Testing [YALB-1425 - Bug: Firefox - GIF being uploaded to multiple blocks](https://yaleits.atlassian.net/browse/YALB-1425)
- [x] Edit any page, such as: https://pr-425-yalesites-platform.pantheonsite.io/node/3/layout
- [x] Add a new image
- [x] Attempt to upload any animated gif
- [x] Verify that it will not allow you to upload a gif

---
#### Testing [YALB-1426 - Bug: Exposed taxonomy filter style on mobile](https://yaleits.atlassian.net/browse/YALB-1426)
- [x] Navigate to: https://pr-425-yalesites-platform.pantheonsite.io/posts
- [x] Bring your browser width down to mobile size or test on your phone
- [x] Verify the button now wraps to a new line and the input is no longer cut off like it is on production (See "Post Category"): https://dev-yalesites-sebastianna.pantheonsite.io/posts  

<img width="995" alt="Screenshot 2023-09-18 at 2 09 54 PM" src="https://github.com/yalesites-org/yalesites-project/assets/366413/7d4aa167-64ff-4839-92fe-eaed2ea4d1b2">


