### PR TITLE
YALB-1554: Remove "Platform admin" from options for site admins when adding or managing site users

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -75,6 +75,7 @@
     "drupal/recaptcha": "^3.1",
     "drupal/recaptcha_v3": "^1.7",
     "drupal/redirect": "^1.7",
+    "drupal/role_delegation": "^1.2",
     "drupal/search_api": "^1.25",
     "drupal/search_api_exclude": "^2.0",
     "drupal/search_api_html_element_filter": "^1.0",

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -104,6 +104,7 @@ module:
   redirect: 0
   redirect_404: 0
   responsive_image: 0
+  role_delegation: 0
   search_api: 0
   search_api_db: 0
   search_api_exclude: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -35,6 +35,7 @@ dependencies:
     - publishcontent
     - quick_node_clone
     - redirect
+    - role_delegation
     - system
     - taxonomy
     - toolbar
@@ -61,6 +62,8 @@ permissions:
   - 'administer redirects'
   - 'administer users'
   - 'administer utility-navigation menu items'
+  - 'assign platform_admin role'
+  - 'assign site_admin role'
   - 'clone event content'
   - 'clone page content'
   - 'clone post content'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -34,6 +34,7 @@ dependencies:
     - publishcontent
     - quick_node_clone
     - redirect
+    - role_delegation
     - system
     - taxonomy
     - toolbar
@@ -58,6 +59,7 @@ permissions:
   - 'administer redirects'
   - 'administer users'
   - 'administer utility-navigation menu items'
+  - 'assign site_admin role'
   - 'clone event content'
   - 'clone page content'
   - 'clone post content'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -75,6 +75,15 @@ function ys_core_theme($existing, $type, $theme, $path): array {
  */
 function ys_core_form_alter(&$form, $form_state, $form_id) {
 
+  // Ensure the CAS bulk add only allows roles that role_delegate will allow.
+  if ($form_id == 'bulk_add_cas_users') {
+    $account = \Drupal::currentUser();
+    $delegatable_roles = \Drupal::service('delegatable_roles');
+
+    $delegatable_roles = $delegatable_roles->getAssignableRoles($account);
+    $form['roles']['#options'] = $delegatable_roles;
+  }
+
   // Load custom library.
   if (str_ends_with($form_id, '_layout_builder_form')) {
     $form['#attached']['library'][] = 'ys_core/node_layout_form';


### PR DESCRIPTION
## [YALB-1554: Remove "Platform admin" from options for site admins when adding or managing site users](https://yaleits.atlassian.net/browse/YALB-1554)

### Description of work
- Adds and enables `role_delegation` module
- Sets up `role_delegation` to only allow `site admins` to set `site admin` permission levels
- Update CAS bulk update form to use the `role_deleagation` module's settings to determine options to select from

### Functional testing steps:
- [x] Log in as the admin
- [x] Open the same site in an Incognito window and log in as your own CAS user
- [x] On both sites, visit `People`
 - [x] Take note of your CAS user's access level--it should be only `Platform administrator`; if not, please set it on the admin user account's page

#### Test adding non-CAS users
- [x] Do the following as your CAS user:
  - [x] Click `Add User` in the upper right corner
  - [x] Add in bogus data and ensure that on your logged in user side
  - [x] Verify that you have two options available for roles, `Platform administrator` and `Site administrator`
  - [x] Click submit and verify that the user you added has that role

#### Test adding CAS users
- [ ] Do the following as your CAS user:
  - [x] Click `Add CAS user(s)` in the upper right corner
  - [x] Add gas users, but verify that currently you have two roles available to select from, `Platform administrator` and `Site administrator`
- [ ] As your admin user:
  - [x] Find your CAS username in the people list and edit
  - [x] Unselect `Platform administrator` and ensure that `Site administrator` is selected and save.
- [ ] As your CAS user:
  - [x] Refresh the page; you should now only see `Site administrator` as the only role you can assign
  - [ ] Add any CAS users you can think of and submit
  - [ ] Verify that those users were added with the `Site administrator` role

NOTE: I noticed that each time our users log into the site via CAS, it gets the `Platform administrator role`.  My assumption given the CAS group name used is that this does not happen for our users of the platform.  If this is incorrect and any logged in CAS user gets this outside of our group, please let me know.