### PR TITLE
feat(YALB-1423-1425-1426): Convert GIFs to static images

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -369,5 +369,7 @@ function ys_core_remove_animation_from_gifs($file_path) {
     // Clean up.
     imagedestroy($image);
     imagedestroy($new_image);
+
+    \Drupal::messenger()->addMessage(t('This gif was converted to a static image.'));
   }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -335,8 +335,6 @@ function ys_core_taxonomy_term_update() {
  * Checks if the image is a gif and if so, it will remove the animation.
  */
 function ys_core_media_presave($entity) {
-  // Log the instance type.
-  \Drupal::logger('ys_core')->notice('Media type: ' . $entity->bundle());
   // Test if it's an image and a gif.
   if ($entity->bundle() == 'image' && $entity->get('field_media_image')->entity->get('filemime')->value == 'image/gif') {
     // Get the file path.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -328,3 +328,48 @@ function ys_core_preprocess_image_widget(&$variables) {
 function ys_core_taxonomy_term_update() {
   Cache::invalidateTags(['rendered']);
 }
+
+/**
+ * Implements hook_ENTITY_insert().
+ *
+ * Checks if the image is a gif and if so, it will remove the animation.
+ */
+function ys_core_media_presave($entity) {
+  // Log the instance type.
+  \Drupal::logger('ys_core')->notice('Media type: ' . $entity->bundle());
+  // Test if it's an image and a gif.
+  if ($entity->bundle() == 'image' && $entity->get('field_media_image')->entity->get('filemime')->value == 'image/gif') {
+    // Get the file path.
+    $file_path = $entity->get('field_media_image')->entity->getFileUri();
+    ys_core_remove_animation_from_gifs($file_path);
+  }
+}
+
+/**
+ * Converts a gif to a static image.
+ *
+ * @param string $file_path
+ *   The path to the file.
+ */
+function ys_core_remove_animation_from_gifs($file_path) {
+  // Make sure it's a gif.
+  $file_info = pathinfo($file_path);
+
+  if (strtolower($file_info['extension'] == 'gif')) {
+    $image = imagecreatefromgif($file_path);
+
+    // Create a new truecolor images.
+    // https://www.php.net/manual/en/function.imagecreatetruecolor.php
+    $new_image = imagecreatetruecolor(imagesx($image), imagesy($image));
+    // Copy part of the image.
+    // https://www.php.net/manual/en/function.imagecopy.php
+    imagecopy($new_image, $image, 0, 0, 0, 0, imagesx($image), imagesy($image));
+
+    // Output image to file: https://www.php.net/manual/en/function.imagegif.php
+    imagegif($new_image, $file_path);
+
+    // Clean up.
+    imagedestroy($image);
+    imagedestroy($new_image);
+  }
+}


### PR DESCRIPTION
## [YALB-1425: Firefox - GIF being uploaded to multiple blocks](https://yaleits.atlassian.net/browse/YALB-1425)

We take advantage of the built in GD functions that Pantheon has compiled PHP with to look at a media file on upload, detect if it's a GIF, and if so, removes any animation it might have.

Alternatively, there is another [Pull request 429: Disallow GIF uploads](https://github.com/yalesites-org/yalesites-project/pull/429)

### Description of work
- Takes any GIF and converts it to a static one

### Functional testing steps:
- [x] Visit media library
- [x] Upload an animated gif
- [x] Take a look at the image and verify it doesn't move.  ;)

Concerns:
- Will we run out of memory like my other ticket if the image is too big?
