### PR TITLE
YALB-1425: Disallow GIF uploads

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.media.image.field_media_image.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.media.image.field_media_image.yml
@@ -24,7 +24,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'png gif jpg jpeg'
+  file_extensions: 'png jpg jpeg'
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
@@ -33,7 +33,7 @@ settings:
   title_field: false
   title_field_required: false
   default_image:
-    uuid: null
+    uuid: ''
     alt: ''
     title: ''
     width: null


### PR DESCRIPTION
## [YALB-1425: Firefox - GIF being uploaded to multiple blocks](https://yaleits.atlassian.net/browse/YALB-1425)

This is an alternative solution to [Pull 428: Convert GIFS to static images](https://github.com/yalesites-org/yalesites-project/pull/428)

### Description of work
- Disallows gifs for field_media_image

### Functional testing steps:
- [ ] Visit media library
- [ ] Attempt to upload a gif file
- [ ] Verify that it will not allow your to upload a gif
