### PR TITLE
YALB-1443: Bug: Disable links in quicklink content field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,6 @@
       "type": "path",
       "url": "web/profiles/custom/yalesites_profile"
     },
-    "drupal/search_api_html_element_filter": {
-      "type": "git",
-      "url": "https://git.drupalcode.org/issue/search_api_html_element_filter-3390283.git"
-    },
     "drupal": {
       "type": "composer",
       "url": "https://packages.drupal.org/8"

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -141,6 +141,9 @@
       },
       "drupal/redirect": {
         "fix validation issue on adding url redirect": "https://www.drupal.org/files/issues/2023-08-09/3057250-65.patch"
+      },
+      "drupal/allowed_formats": {
+        "allowed formats missing default value": "https://www.drupal.org/files/issues/2022-02-02/2950548-allowed_formats-missing_default_value.patch"
       }
     }
   }

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -78,7 +78,7 @@
     "drupal/role_delegation": "^1.2",
     "drupal/search_api": "^1.25",
     "drupal/search_api_exclude": "^2.0",
-    "drupal/search_api_html_element_filter": "dev-3390283-drupal-10-symfony",
+    "drupal/search_api_html_element_filter": "^1.0",
     "drupal/section_library": "^1.1",
     "drupal/selective_better_exposed_filters": "^3.0@beta",
     "drupal/simple_sitemap": "^4.1",

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.quick_links.field_text.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.quick_links.field_text.yml
@@ -11,7 +11,7 @@ dependencies:
 third_party_settings:
   allowed_formats:
     allowed_formats:
-      - restricted_html
+      - heading_html
 id: block_content.quick_links.field_text
 field_name: field_text
 entity_type: block_content

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @file
+ * Install, uninstall and update hooks for ys_core module.
+ */
+
+use Drupal\Component\Utility\Xss;
+
+/**
+ * Implements hook_update().
+ *
+ * This update will update quicklinks blocks by removing any reference to a
+ * link tag, as well as set the format of the content block to heading_html.
+ */
+function ys_core_update_9001() {
+  $query = \Drupal::entityQuery('block_content')
+    ->condition('type', 'quick_links');
+  $ids = $query->execute();
+  $block_storage = \Drupal::entityTypeManager()->getStorage('block_content');
+  $blocks = $block_storage->loadMultiple($ids);
+
+  foreach ($blocks as $block) {
+    $body = $block->get('field_text')->getValue();
+    foreach ($body as $key => $array_value) {
+      $body[$key] = ys_core_sanitize_content($array_value, ['em', 'p', 'strong']);
+      $body[$key] = ys_core_set_format($array_value, 'heading_html');
+    }
+    $block->set('field_text', $body);
+    $block->save();
+  }
+}
+
+/**
+ * Sanitizes the value of an array object with allowed_tags.
+ *
+ * @param array $content_array
+ *   The content array.
+ * @param array $allowed_tags
+ *   The allowed tags.
+ *
+ * @return array
+ *   The sanitized content array.
+ */
+function ys_core_sanitize_content($content_array, $allowed_tags = []) {
+  if (!array_key_exists('value', $content_array)) {
+    return $content_array;
+  }
+
+  $value = $content_array['value'];
+  $content_array['value'] = Xss::filter($value, $allowed_tags);
+
+  return $content_array;
+}
+
+/**
+ * Sets the format of an array object.
+ *
+ * @param array $content_array
+ *   The content array.
+ * @param string $new_format
+ *   The new format.
+ *
+ * @return array
+ *   The content array with the new format.
+ */
+function ys_core_set_format($content_array, $new_format = 'heading_html') {
+  if (!array_key_exists('format', $content_array)) {
+    return $content_array;
+  }
+
+  $content_array['format'] = $new_format;
+
+  return $content_array;
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
@@ -15,19 +15,28 @@ use Drupal\Component\Utility\Xss;
  */
 function ys_core_update_9001() {
   $query = \Drupal::entityQuery('block_content')
-    ->condition('type', 'quick_links');
-  $ids = $query->execute();
-  $block_storage = \Drupal::entityTypeManager()->getStorage('block_content');
-  $blocks = $block_storage->loadMultiple($ids);
+    ->condition('type', 'quick_links')
+    ->allRevisions();
 
-  foreach ($blocks as $block) {
-    $body = $block->get('field_text')->getValue();
-    foreach ($body as $key => $array_value) {
-      $body[$key] = ys_core_sanitize_content($array_value, ['em', 'p', 'strong']);
-      $body[$key] = ys_core_set_format($array_value, 'heading_html');
+  $ids = $query->execute();
+  $block_content_storage = \Drupal::entityTypeManager()->getStorage('block_content');
+
+  foreach ($ids as $revision_id => $id) {
+    $block = $block_content_storage->loadRevision($revision_id);
+
+    if ($block && $block->id() == $id) {
+      $body = $block->get('field_text')->getValue();
+      foreach ($body as $key => $array_value) {
+        $array_value = ys_core_sanitize_content(
+          $array_value, ['em', 'p', 'strong']
+        );
+        $array_value = ys_core_set_format($array_value, 'heading_html');
+
+        $body[$key] = $array_value;
+      }
+      $block->set('field_text', $body);
+      $block->save();
     }
-    $block->set('field_text', $body);
-    $block->save();
   }
 }
 


### PR DESCRIPTION
## [YALB-1443: Bug: Disable links in quicklink content field](https://yaleits.atlassian.net/browse/YALB-1443)

### Description of work
- Sets `field_text` of `quick_links` block to `heading_html` format
- Create update hook to sanitize any existing `quick_links` content to remove any links and set the format of it to `heading_html`

### Functional testing steps:
- [x] Login as user 1 and verify that the `field_text` format allowed for the `quick_links` block is set to `heading_html`.
- [x] Change this temporarily to allow `restricted_html` (the previous default)
- [x] Create a page, and add a `quick_links` block.  Make sure to place links inside of the CKEditor after changing the format to `restricted_html`.  Or [visit a page I already created to help you test this](https://pr-431-yalesites-platform.pantheonsite.io/page-quick-links-it).  It should have a link in the content body already if the update hook has not already been tested.
- [ ] Manually run the update hook: `terminus drush php-eval 'module_load_install("ys_core"); echo ys_core_update_9001();'` (I unchecked this so it can be ran fresh to allow revisions to be updated)
- [x] Reload the page containing the block
- [x] Verify that any links on the page was reverted to just text.
- [ ] Verify in the mysql database that all `block_content_revision__field_text` with bundle "quick_links" show as sanitized of links, and has a formatter set to `heading_html`.
- [ ] If you still have allowed `restricted_html` on the admin side, make sure to undo that.
