### PR TITLE
YALB-1385: Feedback: Yale Logo with submenus

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_toolbar/css/ys_toolbar.theme.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_toolbar/css/ys_toolbar.theme.css
@@ -4,6 +4,11 @@
   mask-image: url('../images/yale-university-press-1985-2010.svg') !important;
 }
 
+/* Hide yalesiites tools help menu as it has no text associated */
+.toolbar .toolbar-bar #toolbar-item-administration-tray.toolbar-tray-vertical ul.toolbar-menu.root li.menu-item.menu-item--expanded.menu-item__admin_toolbar_tools-help.level-1 {
+  display: none;
+}
+
 .gin--horizontal-toolbar #toolbar-administration .toolbar-icon-admin-toolbar-tools-help::before {
   width: 28px !important;
 }


### PR DESCRIPTION
## [YALB-1385: Feedback: Yale Logo with submenus](https://yaleits.atlassian.net/browse/YALB-1385)

On mobile, the Yale logo present in the admin-tools section of the menu has no text associated, making it look strange.  This hides that list item all together so that it only shows when the vertical menus are not visible.

### Description of work
- Adds css to `ys_toolbar` to hide the vertical list item for `tools-help`

### Functional testing steps:
- [x] Visit the PR multidev
- [x] Verify that the Yale logo appears in the upper left corner when the menu is horizontal
- [x] Change your resolution to squish the window until the admin menu goes vertical
- [x] Verify that the Yale logo disappears and the first list item in the Manage menu is `Content`
- [x] Ensure that when enlarging the window, you see the Yale logo again when the horizontal menu appears
