### PR TITLE
YALB-1566: Fix deployment for Berkeley Divinity

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/UpdateExistingNodes.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/UpdateExistingNodes.php
@@ -97,7 +97,8 @@ class UpdateExistingNodes {
 
           $section_storage = $stored_data->data['section_storage'];
           if (
-            $section_storage->getSections()[1]->getLayoutSettings()['label'] == 'Title Section'
+            !empty($section_storage->getSections()[1])
+            && $section_storage->getSections()[1]->getLayoutSettings()['label'] == 'Title Section'
             && $stored_data->data['section_storage']->getContext('entity')->getContextData()->getEntity()->bundle() == 'page') {
 
             $section_storage = $stored_data->data['section_storage'];


### PR DESCRIPTION
## [YALB-1566: Fix deployment for Berkeley Divinity](https://yaleits.atlassian.net/browse/YALB-1566)

### Description of work
- Adds a condition to the layout builder update hook to ensure content exists before updating the content.

### Functional testing steps:
- I have tested this locally to ensure it does not have any negative impacts. Since this is an update hook, it will not run on other environments so the scope is limited to Berkeley Divinity. I'm happy to setup a sandbox for testing if we want a more comprehensive test plan.
