### PR TITLE
YALB-1562 - Color: Update tokens for existing color palettes - remove global themes 4 and 5 - add header accent, footer accent

### DIFF
--- a/docs/color-theme.md
+++ b/docs/color-theme.md
@@ -12,7 +12,7 @@
 To add a new color value to the design system: 
 - **Step 1**: In the `tokens` repository ([github](https://github.com/yalesites-org/tokens)) 
   - open the `tokens/figma-export/tokens.json` file
-  - Locate the `color` key which should look like the following:
+  - Locate the `color` key which should look something like the following:
 ```
   "color": {
     "blue": {
@@ -20,14 +20,14 @@ To add a new color value to the design system:
         "value": "#00356b",
         "type": "color"
       },
-      "medium": {
-        "value": "#286dc0",
+      "athens": {
+        "value": "#3E75AD",
         "type": "color"
       },
-      "light": {
-        "value": "#63aaff",
+      "whipple": {
+        "value": "#779FB1",
         "type": "color"
-      }
+      },
     },
     "basic": {
       "white": {
@@ -84,45 +84,45 @@ Global themes are visualized here: https://yalesites-org.github.io/component-lib
   - Open the `tokens/tokens/base/color.yml` file
   - Locate the `global-themes` key which should look something like the following:
   ```
-  global-themes:
-    "one":
-      label:
-        value: "Old Blues"
-      colors:
-        slot-one:
-          value: "{color.blue.yale.value}"
-        slot-two:
-          value: "{color.blue.medium.value}"
-        slot-three:
-          value: "{color.blue.light.value}"
-        slot-four:
-          value: "{color.gray.100.value}"
-        slot-five:
-          value: "{color.gray.800.value}"
-  ```
-  - Add your new theme, following the same convention shown above. If there are `five` themes already entered, and yours would be number `six`, name it accordingly.
-  - For example (say we wanted to use the new `brown` value we added above): 
-
-```
-  "six":
+global-themes:
+  "one":
     label:
-      value: "New Town Brown"
+      value: "Old Blues"
     colors:
       slot-one:
         value: "{color.blue.yale.value}"
       slot-two:
-        value: "{color.blue.medium.value}"
+        value: "{color.blue.athens.value}"
+      slot-three:
+        value: "{color.blue.whipple.value}"
+      slot-four:
+        value: "{color.blue.yarmouth.value}"
+      slot-five:
+        value: "{color.gray.hale.value}"
+  ```
+  - Add your new theme, following the same convention shown above. If there are `three` themes already entered, and yours would be number `four`, name it accordingly.
+  - For example (say we wanted to use the new `brown` value we added above): 
+
+```
+  "four":
+    label:
+      value: "New Browntownswick"
+    colors:
+      slot-one:
+        value: "{color.blue.yale.value}"
+      slot-two:
+        value: "{color.blue.athens.value}"
       slot-three:
         value: "{color.brown.yale.value}"
       slot-four:
-        value: "{color.yellow.primary.value}"
+        value: "{color.green.overcast.value}"
       slot-five:
-        value: "{color.brown.yale.value}"
+        value: "{color.blue.yorktown.value}"
 ```
 
 - **Step 2**: Compile your changes
   - Following the [readme instructions in the Tokens repository](https://github.com/yalesites-org/tokens#developing-on-the-tokens-within-the-component-library)
-  - In your terminal window, navigate to your tokens repository. This is mostly likely here: `yalesites-project/web/themes/contrib/atomic/_yale-packages/tokens`. If you haven't created a new branch do so now. e.g. `yalb-add-global-theme-six`.
+  - In your terminal window, navigate to your tokens repository. This is mostly likely here: `yalesites-project/web/themes/contrib/atomic/_yale-packages/tokens`. If you haven't created a new branch do so now. e.g. `yalb-add-global-theme-four`.
   - When you're ready to compile changes, run `npm run build`. Your changes should be compiled.
   ---
   
@@ -138,7 +138,7 @@ Global themes are visualized here: https://yalesites-org.github.io/component-lib
 
 ---
 - **Step 5**: 
-  - Unless you are adding a brand new `slot-NUMBER` value (e.g. `slot-six`) to the new global theme, the new theme will be included in every component context which iterates over the global theme token values.
+  - Unless you are adding a brand new `slot-NUMBER` value (e.g. `slot-four`) to the new global theme, the new theme will be included in every component context which iterates over the global theme token values.
   - If you have added a new `slot-NUMBER` then you'll need to add a new variable and map it accodingly to each component in which it is applicable.
 
 ---
@@ -154,6 +154,7 @@ Component themes are visualized here: https://yalesites-org.github.io/component-
 
 **Component themes are used by the following components:**
 - Action Banner (`component-library-twig/components/02-molecules/banner/action/yds-action-banner.twig`)
+- Button CTA (`component-library-twig/components/01-atoms/controls/cta/yds-cta.twig`)
 - Grand Hero Banner (`component-library-twig/components/02-molecules/banner/grand-hero/yds-grand-hero.twig`)
 - Callouts (`component-library-twig/components/02-molecules/callout/yds-callout.twig`)
 - Pull Quotes (`component-library-twig/components/02-molecules/pull-quote/yds-pull-quote.twig`)
@@ -184,32 +185,44 @@ The process of updating these, more specific, component themes is the same as wh
   ```
   component-themes:
   "one":
+    background:
+      value: "{color.blue.yale.value}"
+    text:
+      value: "{color.basic.white.value}"
+    heading:
+      value: "{color.basic.white.value}"
     slot-one:
       value: "{color.blue.yale.value}"
     slot-two:
-      value: "{color.blue.secondary.value}"
+      value: "{color.blue.athens.value}"
     slot-three:
-      value: "{color.blue.light.value}"
+      value: "{color.blue.whipple.value}"
     slot-four:
-      value: "{color.gray.100.value}"
+      value: "{color.blue.yarmouth.value}"
     slot-five:
-      value: "{color.gray.800.value}"
+      value: "{color.gray.hale.value}"
   ```
   - Add your new theme following the same convention outlined here. If there are `three` themes already entered, and yours would be number `four`, name it accordingly.
   - For example (say we wanted to use the new `brown` value we added above): 
 
 ```
   "four":
+    background:
+      value: "{color.blue.yale.value}"
+    text:
+      value: "{color.basic.white.value}"
+    heading:
+      value: "{color.basic.white.value}"
     slot-one:
-      value: "{color.brown.yale.value}"
+      value: "{color.blue.yale.value}"
     slot-two:
-      value: "{color.blue.secondary.value}"
+      value: "{color.blue.athens.value}"
     slot-three:
-      value: "{color.blue.light.value}"
-    slot-four:
       value: "{color.brown.yale.value}"
+    slot-four:
+      value: "{color.green.overcast.value}"
     slot-five:
-      value: "{color.gray.800.value}" 
+      value: "{color.blue.yorktown.value}"
 ```
 
 - **Step 2**: Compile your changes
@@ -354,12 +367,14 @@ Commit your changes and open a PR.
 - **Callouts**:`component-library-twig/components/02-molecules/callout/_yds-callout.scss`. 
   - Uses color slots `one`, `four`, and `five`.
 - **CTA**: `component-library-twig/components/01-atoms/controls/cta/_yds-cta.scss` uses its own themes `data-cta-theme` themes. For instances in which a CTA is pulled in to other components, the existing component-specific CSS variables are used. This way we can re-map these variables within the component which uses it.
-  - Uses color slots `one`, `two` and `five`.
+  - Uses color slots `one`, `two` , `three`, `four`, `five`, `six`, `seven`.
 - **Quote**: `component-library-twig/components/02-molecules/pull-quote/_yds-pull-quote.scss` uses global themes for `--color-pull-quote-accent` only.
   - Uses color slots `one`, `three`, and `five`.
 - **Site Header**: `component-library-twig/components/03-organisms/site-header/_yds-site-header.scss`
   - Uses color slots `one`, `two`, and `three`.
+  - Header Accents use slots `one`, `two` , `three`, `four`, `five`, `six`, `seven`. 
 - **Site Footer**: `component-library-twig/components/03-organisms/site-footer/_yds-site-footer.scss`
   - Uses color slots `one`, `three`, and `five`.
+  - Footer Accents use slots `one`, `two` , `three`, `four`, `five`, `six`, `seven`. 
 - **Tabs**: 
   - Uses color slots `one`, `two`, and `five`.

--- a/docs/color-theme.md
+++ b/docs/color-theme.md
@@ -99,6 +99,12 @@ global-themes:
         value: "{color.blue.yarmouth.value}"
       slot-five:
         value: "{color.gray.hale.value}"
+      slot-six:
+        value: "{color.blue.yale.value}"
+      slot-seven:
+        value: "{color.gray.800.value}"
+      slot-eight:
+        value: "{color.basic.white.value}"
   ```
   - Add your new theme, following the same convention shown above. If there are `three` themes already entered, and yours would be number `four`, name it accordingly.
   - For example (say we wanted to use the new `brown` value we added above): 
@@ -118,6 +124,12 @@ global-themes:
         value: "{color.green.overcast.value}"
       slot-five:
         value: "{color.blue.yorktown.value}"
+      slot-six:
+        value: "{color.blue.yale.value}"
+      slot-seven:
+        value: "{color.gray.800.value}"
+      slot-eight:
+        value: "{color.basic.white.value}"
 ```
 
 - **Step 2**: Compile your changes
@@ -201,6 +213,12 @@ The process of updating these, more specific, component themes is the same as wh
       value: "{color.blue.yarmouth.value}"
     slot-five:
       value: "{color.gray.hale.value}"
+    slot-six:
+      value: "{color.blue.yale.value}"
+    slot-seven:
+      value: "{color.gray.800.value}"
+    slot-eight:
+      value: "{color.basic.white.value}"
   ```
   - Add your new theme following the same convention outlined here. If there are `three` themes already entered, and yours would be number `four`, name it accordingly.
   - For example (say we wanted to use the new `brown` value we added above): 
@@ -223,6 +241,12 @@ The process of updating these, more specific, component themes is the same as wh
       value: "{color.green.overcast.value}"
     slot-five:
       value: "{color.blue.yorktown.value}"
+    slot-six:
+      value: "{color.blue.yale.value}"
+    slot-seven:
+      value: "{color.gray.800.value}"
+    slot-eight:
+      value: "{color.basic.white.value}"
 ```
 
 - **Step 2**: Compile your changes
@@ -294,6 +318,9 @@ We can also set any component-specific token-variables (such as `--color-callout
       --color-slot-three: var(--component-themes-#{$theme}-slot-three);
       --color-slot-four: var(--component-themes-#{$theme}-slot-four);
       --color-slot-five: var(--component-themes-#{$theme}-slot-five);
+      --color-slot-six: var(--component-themes-#{$theme}-slot-six);
+      --color-slot-seven: var(--component-themes-#{$theme}-slot-seven);
+      --color-slot-eight: var(--component-themes-#{$theme}-slot-eight);
     }
   }
 ```
@@ -313,6 +340,9 @@ Next, we set the component-theme slot values, based on the global theme:
       --color-slot-three: var(--global-themes-#{$globalTheme}-colors-slot-three);
       --color-slot-four: var(--global-themes-#{$globalTheme}-colors-slot-four);
       --color-slot-five: var(--global-themes-#{$globalTheme}-colors-slot-five);
+      --color-slot-six: var(--component-themes-#{$theme}-slot-six);
+      --color-slot-seven: var(--component-themes-#{$theme}-slot-seven);
+      --color-slot-eight: var(--component-themes-#{$theme}-slot-eight);
     }
   }
 ```

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-footer-block.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-footer-block.html.twig
@@ -5,6 +5,7 @@
 {% embed "@organisms/site-footer/yds-site-footer.twig" with {
   site_footer__border_thickness: '8',
   site_footer__theme: getThemeSetting('footer_theme'),
+  site_footer__accent: getThemeSetting('footer_accent'),
   site_footer__variation: footer_variation|default('basic'),
 }%}
   {% block footer__inner %}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.theme_settings.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.theme_settings.yml
@@ -1,6 +1,8 @@
 nav_position: 'left'
 nav_type: 'basic'
 header_theme: 'one'
+header_accent: 'one'
 footer_theme: 'one'
+footer_accent: 'one'
 global_theme: 'one'
 button_theme: 'one'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/levers.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/levers.css
@@ -5,6 +5,11 @@
   width: 100%;
 }
 
+.gin--dark-mode #drupal-off-canvas fieldset.ys-themes--global-settings > legend + .fieldset-wrapper,
+.gin--dark-mode #drupal-off-canvas fieldset.ys-themes--setting  > legend + .fieldset-wrapper {
+  padding: 0;
+}
+
 #drupal-off-canvas .ys-themes--global-settings legend {
   margin-bottom: var(--size-spacing-4);
 }
@@ -289,46 +294,60 @@
 /*
 */
 
-#drupal-off-canvas .form-item-header-theme {
+#drupal-off-canvas .form-item-header-theme,
+#drupal-off-canvas .form-item-header-accent {
   display: flex;
   align-items: center;
   gap: 1rem;
   margin-bottom: var(--size-spacing-8);
 }
 
-#drupal-off-canvas .form-item-header-theme label {
+#drupal-off-canvas .form-item-header-theme label,
+#drupal-off-canvas .form-item-header-accent label {
   flex: 1 auto;
 }
 
 #drupal-off-canvas .ys-themes--global-settings .form-item-header-theme:hover .color,
-#drupal-off-canvas .ys-themes--global-settings .form-item-header-theme:focus .color {
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-theme:focus .color,
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-accent:hover .color,
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-accent:focus .color {
   margin-right: 0.5rem;
 }
 
 #drupal-off-canvas .ys-themes--global-settings .form-item-header-theme:hover .colors > span,
-#drupal-off-canvas .ys-themes--global-settings .form-item-header-theme:focus .colors > span {
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-theme:focus .colors > span,
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-accent:hover .colors > span,
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-accent:focus .colors > span {
   border-color: var(--color-border-hover);
 }
 
 #drupal-off-canvas .ys-themes--global-settings .form-item-header-theme:hover > label,
-#drupal-off-canvas .ys-themes--global-settings .form-item-header-theme:focus > label {
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-theme:focus > label,
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-accent:hover > label,
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-accent:focus > label {
   color: var(--color-border-hover);
   border-color: var(--color-border-hover);
 }
 
 #drupal-off-canvas .ys-themes--global-settings .form-item-header-theme:hover input[checked="checked"] + label .colors > span,
-#drupal-off-canvas .ys-themes--global-settings .form-item-header-theme:focus input[checked="checked"] + label .colors > span {
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-theme:focus input[checked="checked"] + label .colors > span,
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-accent:hover input[checked="checked"] + label .colors > span,
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-accent:focus input[checked="checked"] + label .colors > span {
   border-color: var(--color-border-lightest);
 }
 
-#drupal-off-canvas .form-item-header-theme input[checked="checked"] + label {
+#drupal-off-canvas .form-item-header-theme input[checked="checked"] + label,
+#drupal-off-canvas .form-item-header-accent input[checked="checked"] + label {
   background-color: var(--color-text-primary);
   color: var(--color-background-primary);
 }
 
 #drupal-off-canvas .ys-themes--global-settings .form-item-header-theme input[checked="checked"] + label:hover,
 #drupal-off-canvas .ys-themes--global-settings .form-item-header-theme:hover input[checked="checked"] + label,
-#drupal-off-canvas .ys-themes--global-settings .form-item-header-theme:focus input[checked="checked"] + label {
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-theme:focus input[checked="checked"] + label,
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-accent input[checked="checked"] + label:hover,
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-accent:hover input[checked="checked"] + label,
+#drupal-off-canvas .ys-themes--global-settings .form-item-header-accent:focus input[checked="checked"] + label  {
   color: var(--color-background-primary);
 }
 
@@ -337,36 +356,46 @@
 /*
 */
 
-#drupal-off-canvas .form-item-footer-theme {
+#drupal-off-canvas .form-item-footer-theme,
+#drupal-off-canvas .form-item-footer-accent {
   display: flex;
   align-items: center;
   gap: 1rem;
   margin-bottom: var(--size-spacing-8);
 }
 
-#drupal-off-canvas .form-item-footer-theme label {
+#drupal-off-canvas .form-item-footer-theme label,
+#drupal-off-canvas .form-item-footer-accent label {
   flex: 1 auto;
 }
 
 #drupal-off-canvas .ys-themes--global-settings .form-item-footer-theme:hover .color,
-#drupal-off-canvas .ys-themes--global-settings .form-item-footer-theme:focus .color {
+#drupal-off-canvas .ys-themes--global-settings .form-item-footer-theme:focus .color,
+#drupal-off-canvas .ys-themes--global-settings .form-item-footer-accent:hover .color,
+#drupal-off-canvas .ys-themes--global-settings .form-item-footer-accent:focus .color {
   margin-right: 0.5rem;
 }
 
 #drupal-off-canvas .ys-themes--global-settings .form-item-footer-theme:hover > label,
-#drupal-off-canvas .ys-themes--global-settings .form-item-footer-theme:focus > label {
+#drupal-off-canvas .ys-themes--global-settings .form-item-footer-theme:focus > label,
+#drupal-off-canvas .ys-themes--global-settings .form-item-footer-accent:hover > label,
+#drupal-off-canvas .ys-themes--global-settings .form-item-footer-accent:focus > label {
   color: var(--color-border-hover);
   border-color: var(--color-border-hover);
 }
 
-#drupal-off-canvas .ys-themes--global-settings .form-item-footer-theme input[checked="checked"] + label {
+#drupal-off-canvas .ys-themes--global-settings .form-item-footer-theme input[checked="checked"] + label,
+#drupal-off-canvas .ys-themes--global-settings .form-item-footer-accent:focus input[checked="checked"] + label .colors > span {
   background-color: var(--color-text-primary);
   color: var(--color-background-primary);
 }
 
 #drupal-off-canvas .ys-themes--global-settings .form-item-footer-theme input[checked="checked"] + label:hover,
 #drupal-off-canvas .ys-themes--global-settings .form-item-footer-theme:hover input[checked="checked"] + label,
-#drupal-off-canvas .ys-themes--global-settings .form-item-footer-theme:focus input[checked="checked"] + label {
+#drupal-off-canvas .ys-themes--global-settings .form-item-footer-theme:focus input[checked="checked"] + label,
+#drupal-off-canvas .ys-themes--global-settings .form-item-footer-accent input[checked="checked"] + label:hover,
+#drupal-off-canvas .ys-themes--global-settings .form-item-footer-accent:hover input[checked="checked"] + label,
+#drupal-off-canvas .ys-themes--global-settings .form-item-footer-accent:focus input[checked="checked"] + label {
   color: var(--color-background-primary);
 }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/levers.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/levers.css
@@ -31,7 +31,7 @@
   --color-text-primary: var(--color-gray-800);
 }
 
-/* 
+/*
 /* Set defaults for labels and inputs in this form
 /*
 */
@@ -109,7 +109,7 @@
 }
 
 #drupal-off-canvas .ys-themes--global-settings .form-item-global-theme:hover label,
-#drupal-off-canvas .ys-themes--global-settings .form-item-global-theme:focus label { 
+#drupal-off-canvas .ys-themes--global-settings .form-item-global-theme:focus label {
   background-color: var(--color-background-hover);
   border-color: var(--color-border-hover);
 }
@@ -139,10 +139,10 @@
   border-color: var(--color-border-lightest);
 }
 
-#drupal-off-canvas fieldset.form-item:not(:last-child) { 
+#drupal-off-canvas fieldset.form-item:not(:last-child) {
   padding-bottom: var(--size-spacing-8);
   margin-bottom: var(--size-spacing-8);
-  border-bottom: var(--thickness-divider) solid var(--color-divider); 
+  border-bottom: var(--thickness-divider) solid var(--color-divider);
 }
 
 /*
@@ -385,6 +385,8 @@
 }
 
 #drupal-off-canvas .ys-themes--global-settings .form-item-footer-theme input[checked="checked"] + label,
+#drupal-off-canvas .ys-themes--global-settings .form-item-footer-theme:focus input[checked="checked"] + label .colors > span,
+#drupal-off-canvas .ys-themes--global-settings .form-item-footer-accent input[checked="checked"] + label,
 #drupal-off-canvas .ys-themes--global-settings .form-item-footer-accent:focus input[checked="checked"] + label .colors > span {
   background-color: var(--color-text-primary);
   color: var(--color-background-primary);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/js/levers.js
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/js/levers.js
@@ -121,7 +121,9 @@
         'input[name="nav_type"]',
         'input[name="button_theme"]',
         'input[name="header_theme"]',
-        'input[name="footer_theme"]'
+        'input[name="header_accent"]',
+        'input[name="footer_theme"]',
+        'input[name="footer_accent"]',
       ];
       
       // Apply the function to each radio input group

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
@@ -92,8 +92,24 @@ class ThemeSettingsManager {
           'color_theme' => 'two',
         ],
         'three' => [
+          'label' => 'Highlight',
+          'color_theme' => 'three',
+        ],
+        'four' => [
+          'label' => 'Subtle',
+          'color_theme' => 'four',
+        ],
+        'five' => [
           'label' => 'Deep',
           'color_theme' => 'five',
+        ],
+        'six' => [
+          'label' => 'Yale Blue',
+          'color_theme' => 'six',
+        ],
+        'seven' => [
+          'label' => 'Gray 800',
+          'color_theme' => 'seven',
         ],
       ],
     ],

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
@@ -120,6 +120,46 @@ class ThemeSettingsManager {
         ],
       ],
     ],
+    'header_accent' => [
+      'name' => 'Header Accent',
+      'prop_type' => 'element',
+      'selector' => 'header[data-header-accent]',
+      'default' => 'one',
+      'values' => [
+        'one' => [
+          'label' => 'One',
+          'color_theme' => 'one',
+        ],
+        'two' => [
+          'label' => 'Two',
+          'color_theme' => 'two',
+        ],
+        'three' => [
+          'label' => 'Three',
+          'color_theme' => 'three',
+        ],
+        'four' => [
+          'label' => 'Four',
+          'color_theme' => 'four',
+        ],
+        'five' => [
+          'label' => 'Five',
+          'color_theme' => 'five',
+        ],
+        'six' => [
+          'label' => 'Six',
+          'color_theme' => 'six',
+        ],
+        'seven' => [
+          'label' => 'Seven',
+          'color_theme' => 'seven',
+        ],
+        'eight' => [
+          'label' => 'Eight',
+          'color_theme' => 'eight',
+        ],
+      ],
+    ],
     'footer_theme' => [
       'name' => 'Footer Theme',
       'prop_type' => 'element',

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
@@ -44,14 +44,6 @@ class ThemeSettingsManager {
           'label' => 'Shoreline Summer',
           'color_theme' => 'three',
         ],
-        'four' => [
-          'label' => 'Elm City Nights',
-          'color_theme' => 'four',
-        ],
-        'five' => [
-          'label' => 'Quiet Corner',
-          'color_theme' => 'five',
-        ],
       ],
     ],
     'nav_position' => [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
@@ -106,17 +106,17 @@ class ThemeSettingsManager {
         'one' => [
           'label' => 'Base & White',
           'color_theme' => 'one',
-          'color_theme_2' => '--color-basic-white',
+          'color_theme_2' => 'eight',
         ],
         'two' => [
           'label' => 'Action & Dark Gray',
           'color_theme' => 'two',
-          'color_theme_2' => '--color-gray-800',
+          'color_theme_2' => 'seven',
         ],
         'three' => [
           'label' => 'Highlight & Yale Blue',
           'color_theme' => 'three',
-          'color_theme_2' => '--color-blue-yale',
+          'color_theme_2' => 'six',
         ],
       ],
     ],
@@ -148,15 +148,15 @@ class ThemeSettingsManager {
         ],
         'six' => [
           'label' => 'Six',
-          'color_theme' => '--color-blue-yale',
+          'color_theme' => 'six',
         ],
         'seven' => [
           'label' => 'Seven',
-          'color_theme' => '--color-gray-800',
+          'color_theme' => 'seven',
         ],
         'eight' => [
           'label' => 'Eight',
-          'color_theme' => '--color-basic-white',
+          'color_theme' => 'eight',
         ],
       ],
     ],
@@ -169,17 +169,17 @@ class ThemeSettingsManager {
         'one' => [
           'label' => 'Base & White',
           'color_theme' => 'one',
-          'color_theme_2' => '--color-basic-white',
+          'color_theme_2' => 'eight',
         ],
         'two' => [
           'label' => 'Action & Dark Gray',
           'color_theme' => 'two',
-          'color_theme_2' => '--color-gray-800',
+          'color_theme_2' => 'seven',
         ],
         'three' => [
           'label' => 'Highlight & Yale Blue',
           'color_theme' => 'three',
-          'color_theme_2' => '--color-blue-yale',
+          'color_theme_2' => 'six',
         ],
       ],
     ],
@@ -211,15 +211,15 @@ class ThemeSettingsManager {
         ],
         'six' => [
           'label' => 'Six',
-          'color_theme' => '--color-blue-yale',
+          'color_theme' => 'six',
         ],
         'seven' => [
           'label' => 'Seven',
-          'color_theme' => '--color-gray-800',
+          'color_theme' => 'seven',
         ],
         'eight' => [
           'label' => 'Eight',
-          'color_theme' => '--color-basic-white',
+          'color_theme' => 'eight',
         ],
       ],
     ],

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
@@ -129,42 +129,34 @@ class ThemeSettingsManager {
         'one' => [
           'label' => 'One',
           'color_theme' => 'one',
-          'color_theme_2' => '--color-slot-one',
         ],
         'two' => [
           'label' => 'Two',
           'color_theme' => 'two',
-          'color_theme_2' => '--color-slot-two',
         ],
         'three' => [
           'label' => 'Three',
           'color_theme' => 'three',
-          'color_theme_2' => '--color-slot-three',
         ],
         'four' => [
           'label' => 'Four',
           'color_theme' => 'four',
-          'color_theme_2' => '--color-slot-four',
         ],
         'five' => [
           'label' => 'Five',
           'color_theme' => 'five',
-          'color_theme_2' => '--color-slot-five',
         ],
         'six' => [
           'label' => 'Six',
-          'color_theme' => 'six',
-          'color_theme_2' => '--color-blue-yale',
+          'color_theme' => '--color-blue-yale',
         ],
         'seven' => [
           'label' => 'Seven',
-          'color_theme' => 'seven',
-          'color_theme_2' => '--color-gray-800',
+          'color_theme' => '--color-gray-800',
         ],
         'eight' => [
           'label' => 'Eight',
-          'color_theme' => 'eight',
-          'color_theme_2' => '--color-basic-white',
+          'color_theme' => '--color-basic-white',
         ],
       ],
     ],
@@ -188,6 +180,46 @@ class ThemeSettingsManager {
           'label' => 'Highlight & Yale Blue',
           'color_theme' => 'three',
           'color_theme_2' => '--color-blue-yale',
+        ],
+      ],
+    ],
+    'footer_accent' => [
+      'name' => 'Footer Accent',
+      'prop_type' => 'element',
+      'selector' => 'footer[data-footer-accent]',
+      'default' => 'one',
+      'values' => [
+        'one' => [
+          'label' => 'One',
+          'color_theme' => 'one',
+        ],
+        'two' => [
+          'label' => 'Two',
+          'color_theme' => 'two',
+        ],
+        'three' => [
+          'label' => 'Three',
+          'color_theme' => 'three',
+        ],
+        'four' => [
+          'label' => 'Four',
+          'color_theme' => 'four',
+        ],
+        'five' => [
+          'label' => 'Five',
+          'color_theme' => 'five',
+        ],
+        'six' => [
+          'label' => 'Six',
+          'color_theme' => '--color-blue-yale',
+        ],
+        'seven' => [
+          'label' => 'Seven',
+          'color_theme' => '--color-gray-800',
+        ],
+        'eight' => [
+          'label' => 'Eight',
+          'color_theme' => '--color-basic-white',
         ],
       ],
     ],

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
@@ -129,34 +129,42 @@ class ThemeSettingsManager {
         'one' => [
           'label' => 'One',
           'color_theme' => 'one',
+          'color_theme_2' => '--color-slot-one',
         ],
         'two' => [
           'label' => 'Two',
           'color_theme' => 'two',
+          'color_theme_2' => '--color-slot-two',
         ],
         'three' => [
           'label' => 'Three',
           'color_theme' => 'three',
+          'color_theme_2' => '--color-slot-three',
         ],
         'four' => [
           'label' => 'Four',
           'color_theme' => 'four',
+          'color_theme_2' => '--color-slot-four',
         ],
         'five' => [
           'label' => 'Five',
           'color_theme' => 'five',
+          'color_theme_2' => '--color-slot-five',
         ],
         'six' => [
           'label' => 'Six',
           'color_theme' => 'six',
+          'color_theme_2' => '--color-blue-yale',
         ],
         'seven' => [
           'label' => 'Seven',
           'color_theme' => 'seven',
+          'color_theme_2' => '--color-gray-800',
         ],
         'eight' => [
           'label' => 'Eight',
           'color_theme' => 'eight',
+          'color_theme_2' => '--color-basic-white',
         ],
       ],
     ],

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
@@ -109,14 +109,14 @@ class ThemeSettingsManager {
           'color_theme_2' => '--color-basic-white',
         ],
         'two' => [
-          'label' => 'Highlight & Light Gray',
-          'color_theme' => 'three',
-          'color_theme_2' => '--color-gray-100',
+          'label' => 'Action & Dark Gray',
+          'color_theme' => 'two',
+          'color_theme_2' => '--color-gray-800',
         ],
         'three' => [
-          'label' => 'Highlight & Base',
+          'label' => 'Highlight & Yale Blue',
           'color_theme' => 'three',
-          'color_theme_2' => 'one',
+          'color_theme_2' => '--color-blue-yale',
         ],
       ],
     ],
@@ -129,27 +129,17 @@ class ThemeSettingsManager {
         'one' => [
           'label' => 'Base & White',
           'color_theme' => 'one',
-          'color_theme_2' => '--color-gray-100',
-        ],
-        'two' => [
-          'label' => 'Deep & White',
-          'color_theme' => 'five',
           'color_theme_2' => '--color-basic-white',
         ],
-        'three' => [
-          'label' => 'Highlight & Light Gray',
-          'color_theme' => 'three',
-          'color_theme_2' => '--color-gray-100',
-        ],
-        'four' => [
-          'label' => 'Highlight & Dark Gray',
-          'color_theme' => 'three',
+        'two' => [
+          'label' => 'Action & Dark Gray',
+          'color_theme' => 'two',
           'color_theme_2' => '--color-gray-800',
         ],
-        'five' => [
-          'label' => 'Highlight & Base',
+        'three' => [
+          'label' => 'Highlight & Yale Blue',
           'color_theme' => 'three',
-          'color_theme_2' => 'one',
+          'color_theme_2' => '--color-blue-yale',
         ],
       ],
     ],


### PR DESCRIPTION
## [YALB-1562 - Color: Update tokens for existing color palettes](https://yaleits.atlassian.net/browse/YALB-1562)

### Description of work
- Remove themes `four` and `five`
- Updates themes `one`, `two`, and `three` to match the following color slots
- Adds header accent and footer accent

![New Color Palettes](https://github.com/yalesites-org/tokens/assets/366413/a44e9749-c8d3-49ec-b00b-ca2fc5fedc62)

### Functional testing steps:
- [ ] Login and visit https://pr-441-yalesites-platform.pantheonsite.io/welcome
- [ ] Click "Edit Layout and Content"
- [ ] Verify you see the new color themes and change the theme along with other dial options (header accent, footer accent, button color)


https://github.com/yalesites-org/yalesites-project/assets/366413/aac31233-148d-4039-95b5-a4f3bed61496


