### PR TITLE
fix(YALB-1569): Fix search indexing prevented by PostMetaBlock issue

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/search_api.index.node_index.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/search_api.index.node_index.yml
@@ -42,8 +42,9 @@ field_settings:
           event: default
           page: default
           post: default
+          profile: default
   status:
-    label: null
+    label: status
     datasource_id: 'entity:node'
     property_path: status
     type: boolean
@@ -53,7 +54,7 @@ field_settings:
       module:
         - node
   uid:
-    label: null
+    label: uid
     datasource_id: 'entity:node'
     property_path: uid
     type: integer

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PostMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PostMetaBlock.php
@@ -7,6 +7,7 @@ use Drupal\Core\Controller\TitleResolver;
 use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -95,16 +96,20 @@ class PostMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
    */
   public function build() {
 
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $this->requestStack->getCurrentRequest()->attributes->get('node');
+    if (!($node instanceof NodeInterface)) {
+      return [];
+    }
+
     $title = NULL;
     $author = NULL;
     $publishDate = NULL;
     $dateFormatted = NULL;
 
-    $request = $this->requestStack->getCurrentRequest();
     $route = $this->routeMatch->getRouteObject();
 
     if ($route) {
-      $node = $request->attributes->get('node');
       // Post fields.
       $title = $node->getTitle();
       $author = ($node->field_author->first()) ? $node->field_author->first()->getValue()['value'] : NULL;


### PR DESCRIPTION
## [YALB-1569: Bug: Search index failing on meta-content error](https://yaleits.atlassian.net/browse/YALB-1569)

### Description of work
- Fixes search indexing that was being halted by an error with the PostMetaBlock.
- Multidev testing here - https://pr-443-yalesites-platform.pantheonsite.io (Note this PR isn't connected to that multidev, and that PR was closed, so the multidev could go away at anytime)
- Local testing works too

### Functional testing steps:
- [x] Login to the as user 1
- [x] Visit the log messages at `/admin/reports/dblog`
- [x] Note the timestamp of the latest log message or, if you feel comfortable, delete all messages to get a clean slate
- [x] In another tab, visit the Node Index view page here: `/admin/config/search/search-api/index/node_index`
- [x] Click on "Clear all indexed data" button at the bottom
- [x] Click "Confirm"
- [x] Click on "Index now"
- [x] Wait until it finishes and verify that no error messages show up

![Screenshot 2023-09-28 at 1 05 44 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/0227e350-63da-44f5-993b-8af036cdac16)

- [x] Return to the log messages tab and refresh the page
- [x] Verify that there are no error messages related to Search API in the log
- [x] Visit the front-end of the site
- [x] Search for some terms and verify that search results are working and returning appropriate results.