### PR TITLE
YALB-1564: Header: Mega Menu Description Link

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -404,9 +404,10 @@ function ys_core_save_menu_link_fields(array $form, FormStateInterface $form_sta
     // Only save the menu item extras if there is a menu link with a route.
     if ($link->getUrlObject()->getRouteName()) {
       $form_display = EntityFormDisplay::load('menu_link_content.' . $link->getMenuName() . '.default');
-      assert($form_display instanceof EntityFormDisplay);
-      $form_display->extractFormValues($link, $form['menu']['link']['extra'], $form_state);
-      $link->save();
+      if ($form_display instanceof EntityFormDisplay) {
+        $form_display->extractFormValues($link, $form['menu']['link']['extra'], $form_state);
+        $link->save();
+      }
     }
   }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -6,10 +6,12 @@
  */
 
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
+use Drupal\menu_item_extras\Entity\MenuItemExtrasMenuLinkContent;
 
 /**
  * @file
@@ -337,3 +339,94 @@ function ys_core_preprocess_image_widget(&$variables) {
 function ys_core_taxonomy_term_update() {
   Cache::invalidateTags(['rendered']);
 }
+
+/**
+ * The following functions add menu item extras fields to node add/edit forms.
+ *
+ * @see https://www.drupal.org/project/menu_item_extras/issues/2992096#comment-14140361
+ */
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function ys_core_form_node_page_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  ys_core_page_form_alter($form, $form_state);
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function ys_core_form_node_page_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  ys_core_page_form_alter($form, $form_state);
+}
+
+/**
+ * Alters the page node forms.
+ *
+ * @var array $form
+ *  The form array.
+ * @var Drupal\Core\Form\FormStateInterface $form_state
+ *  The current form state.
+ */
+function ys_core_page_form_alter(&$form, FormStateInterface $form_state) {
+
+  // Add menu link fields to node form.
+  if ($link = _ys_core_get_link($form_state)) {
+    $form_display = EntityFormDisplay::load('menu_link_content.' . $link->getMenuName() . '.default');
+    assert($form_display instanceof EntityFormDisplay);
+    $form['menu']['link']['extra'] = [
+      '#type' => 'container',
+      '#parents' => ['menu', 'extra'],
+    ];
+    $form_display->buildForm($link, $form['menu']['link']['extra'], $form_state);
+    // Only keep custom fields, other properties already are in the form.
+    foreach (Element::children($form['menu']['link']['extra']) as $key) {
+      if (strpos($key, 'field_') !== 0) {
+        unset($form['menu']['link']['extra'][$key]);
+      }
+    }
+
+    foreach (array_keys($form['actions']) as $action) {
+      if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
+        $form['actions'][$action]['#submit'][] = 'ys_core_save_menu_link_fields';
+      }
+    }
+  }
+}
+
+/**
+ * Saves the menu item extras when on the node add/edit pages.
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function ys_core_save_menu_link_fields(array $form, FormStateInterface $form_state) {
+  if ($link = _ys_core_get_link($form_state)) {
+    // Only save the menu item extras if there is a menu link with a route.
+    if ($link->getUrlObject()->getRouteName()) {
+      $form_display = EntityFormDisplay::load('menu_link_content.' . $link->getMenuName() . '.default');
+      assert($form_display instanceof EntityFormDisplay);
+      $form_display->extractFormValues($link, $form['menu']['link']['extra'], $form_state);
+      $link->save();
+    }
+  }
+}
+
+/**
+ * Gets any menu item extras content.
+ *
+ * @return Drupal\menu_item_extras\Entity\MenuItemExtrasMenuLinkContent
+ *   Menu item extras content.
+ */
+function _ys_core_get_link(FormStateInterface $form_state) {
+  /** @var Drupal\node\Entity $form_state */
+  $node = $form_state->getFormObject()->getEntity();
+  $defaults = menu_ui_get_menu_link_defaults($node);
+  if ($mlid = $defaults['entity_id']) {
+    return MenuItemExtrasMenuLinkContent::load($mlid);
+  }
+  return MenuItemExtrasMenuLinkContent::create($defaults);
+}
+
+/**
+ * End allow menu item extras fields to be included on node add and edit forms.
+ */


### PR DESCRIPTION
## [YALB-1564: Header: Mega Menu Description Link](https://yaleits.atlassian.net/browse/YALB-1564)

### Description of work
- Adds the ability to override the header menu link CTA text from within the page add/edit form.

### Functional testing steps:
- [x] Login to the site and create a new page
- [x] Title the page and open the right-sidebar if not already open
- [x] Open the "Menu settings" in the sidebar
- [x] Click "Provide a menu link"
- [x] Verify that you see a "Mega Menu Top Level Link Text" field at the bottom of the menu link settings form.

![Screenshot 2023-09-29 at 11 29 35 AM](https://github.com/yalesites-org/yalesites-project/assets/107938318/b9595c67-ba41-4e7d-8c36-cf84d13345df)

- [x] Enter some text to override the link text
- [x] Place this new page at the top level of the main navigation and save the page
- [x] Save layout builder
- [x] Create another page
- [x] Title the page and Open the "Menu settings" in the sidebar
- [x] Click "Provide a menu link"
- [x] Place this new page under the previously created page in the menu
- [x] No need to fill out the Top Level Link Text override
- [x] Save the page, then also save layout builder
- [x] Open the menu for the first page and verify that the overridden link text is what you typed in above

![Screenshot 2023-09-29 at 11 32 22 AM](https://github.com/yalesites-org/yalesites-project/assets/107938318/9903ce74-26e9-4c44-aabf-6e72eb3813a1)

- [x] Create a third page
- [x] Title it, but do not add a menu link to this page
- [x] Save the page and save layout builder
- [x] Verify no errors when saving or viewing the page
- [x] Edit the first page again, with the overridden menu link text
- [x] Remove the overridden link text and save the node
- [x] Verify that the fallback text "Explore [menu title]" is now the link text

![Capture-2023-09-29-113704](https://github.com/yalesites-org/yalesites-project/assets/107938318/6c5aca85-aa5f-40b3-8242-f034fc186e31)

- [x] Overriding of this link text can also be done via editing the menu item itself from `/admin/structure/menu/manage/main`