### PR TITLE
hotfix: pin drupal/linkit to 6.0.0

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -49,7 +49,7 @@
     "drupal/layout_builder_restrictions": "^2.17",
     "drupal/layout_builder_restrictions_by_role": "^1.0@alpha",
     "drupal/libraries": "^4.0",
-    "drupal/linkit": "^6.0@RC",
+    "drupal/linkit": "6.0.0",
     "drupal/mailchimp_transactional": "^1.0",
     "drupal/mailsystem": "^4.3",
     "drupal/markup": "^1.0@beta",


### PR DESCRIPTION
A regression introduced in drupal/linkit 6.0.1 is causing PHP fatal errors when editing site settings. This PR pins linkit to 6.0.0.