### PR TITLE
YALB-1565): Set Google Analytics to scope to subdomain

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/google_analytics.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/google_analytics.settings.yml
@@ -1,7 +1,7 @@
 _core:
   default_config_hash: dwMYPgAnj9KBO77SLEv9Z42NDJAbuxe0uU9eGC8qw3M
 account: ''
-domain_mode: 0
+domain_mode: 1
 cross_domains: ''
 visibility:
   request_path_mode: 0


### PR DESCRIPTION
## [YALB-1565: Title](https://yaleits.atlassian.net/browse/YALB-1565)

### Description of work
Our current Google Analytics config is causing GA cookies to be scoped to .yale.edu, which is causing too many [yale.edu](http://yale.edu/) cookies accumulating in client browsers. This is causing issues with some services that do not ignore tracking cookies, resulting in “400 Bad Request – Request Header Or Cookie Too Large” when too many cookies are stored in a user's browser and have been scoped to `.yale.edu`.

This config change toggles the Google Analytics module config to set the cookie_domain to subdomain instead of top level domain.