### PR TITLE
YALB-1579: Fixing theme form error messages

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -258,10 +258,14 @@ function ys_themes_preprocess_form_element(array &$variables) {
 
       // Sets various values related to current element as well as global theme
       // to twig for cleaner twig templates.
-      $variables['label']['color_theme'] = $allOptions[$elementName]['values'][$value]['color_theme'];
-      $variables['label']['color_theme_2'] = $allOptions[$elementName]['values'][$value]['color_theme_2'];
-      $variables['label']['current_global_theme'] = $globalTheme;
-      $variables['label']['value'] = $value;
+      if (isset($allOptions[$elementName]['values'][$value]['color_theme'])) {
+        $variables['label']['#context']['color_theme'] = $allOptions[$elementName]['values'][$value]['color_theme'];
+      }
+      if (isset($allOptions[$elementName]['values'][$value]['color_theme_2'])) {
+        $variables['label']['#context']['color_theme_2'] = $allOptions[$elementName]['values'][$value]['color_theme_2'];
+      }
+      $variables['label']['#context']['current_global_theme'] = $globalTheme;
+      $variables['label']['#context']['value'] = $value;
     }
   }
 }


### PR DESCRIPTION
## [YALB-1579: Fixing theme form error messages](https://yaleits.atlassian.net/browse/YALB-1579)

### Description of work
- Passes properties from the theme settings form via #context array to prevent render array errors.
 
### Functional testing steps:
- [ ] Login the website as a site administrator.
- [ ] Navigate to any node
- [ ] Click the 'Theme Settings' link in the toolbar to expand the modal window
- [ ] Review the error logs and verify no new error messages appear (admin/reports/dblog). A screenshot of previous errors is included below for reference. These related to a malformed render array.

![Screen Shot 2023-10-05 at 8 36 27 AM](https://github.com/yalesites-org/yalesites-project/assets/9594124/85281097-460e-45ab-91e5-758feda9fcfa)

