### PR TITLE
YALB-1577: Fix time format on condensed events

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.condensed.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.condensed.yml
@@ -54,15 +54,11 @@ bundle: event
 mode: condensed
 content:
   field_event_date:
-    type: smartdate_default
+    type: smartdate_plain
     label: hidden
     settings:
       timezone_override: ''
-      format_type: medium
-      format: html_datetime
-      force_chronological: false
-      add_classes: false
-      time_wrapper: true
+      separator: '-'
     third_party_settings: {  }
     weight: 0
     region: content


### PR DESCRIPTION
## [YALB-1577: Fix time format on condensed events](https://yaleits.atlassian.net/browse/YALB-1577)

### Description of work
- Update the fields formatter to use 'plain' text instead of the 'smartdate' format. This ensure the time is passed to the component library in the correct format.

### Functional testing steps:
- [ ] Login as a site administrator
- [ ] Create an event with a far future date. Save this event and make sure it is published.
- [ ] Add a basic 'views' component to a page-node. The view should show all future events in a 'condensed' layout.
- [ ] Save the page and view the content. Verify that the view displays events with the correct date for the event. Previously this was showing today's date for every event.