### PR TITLE
YALB-863: Set default value callbacks for all block dials

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_style_position.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_style_position.yml
@@ -13,9 +13,9 @@ entity_type: block_content
 bundle: content_spotlight
 label: 'Image Position'
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
-default_value_callback: ''
+default_value_callback: ys_themes_default_value_function
 settings: {  }
 field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_style_variation.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_style_variation.yml
@@ -13,9 +13,9 @@ entity_type: block_content
 bundle: content_spotlight
 label: Focus
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
-default_value_callback: ''
+default_value_callback: ys_themes_default_value_function
 settings: {  }
 field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_style_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_style_width.yml
@@ -13,9 +13,9 @@ entity_type: block_content
 bundle: content_spotlight
 label: 'Image Size'
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
-default_value_callback: ''
+default_value_callback: ys_themes_default_value_function
 settings: {  }
 field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.divider.field_style_position.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.divider.field_style_position.yml
@@ -15,9 +15,7 @@ label: 'Divider Position'
 description: ''
 required: true
 translatable: true
-default_value:
-  -
-    value: left
-default_value_callback: ''
+default_value: {  }
+default_value_callback: ys_themes_default_value_function
 settings: {  }
 field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.divider.field_style_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.divider.field_style_width.yml
@@ -15,9 +15,7 @@ label: 'Divider Width'
 description: ''
 required: true
 translatable: true
-default_value:
-  -
-    value: 100%
-default_value_callback: ''
+default_value: {  }
+default_value_callback: ys_themes_default_value_function
 settings: {  }
 field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_style_position.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_style_position.yml
@@ -13,9 +13,9 @@ entity_type: block_content
 bundle: grand_hero
 label: 'Overlay Position'
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
-default_value_callback: ''
+default_value_callback: ys_themes_default_value_function
 settings: {  }
 field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_style_variation.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_style_variation.yml
@@ -13,9 +13,9 @@ entity_type: block_content
 bundle: grand_hero
 label: 'Media Size'
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
-default_value_callback: ''
+default_value_callback: ys_themes_default_value_function
 settings: {  }
 field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.wrapped_image.field_style_position.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.wrapped_image.field_style_position.yml
@@ -13,9 +13,9 @@ entity_type: block_content
 bundle: wrapped_image
 label: Position
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
-default_value_callback: ''
+default_value_callback: ys_themes_default_value_function
 settings: {  }
 field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.wrapped_image.field_style_variation.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.wrapped_image.field_style_variation.yml
@@ -13,9 +13,9 @@ entity_type: block_content
 bundle: wrapped_image
 label: Style
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
-default_value_callback: ''
+default_value_callback: ys_themes_default_value_function
 settings: {  }
 field_type: list_string


### PR DESCRIPTION
## [YALB-863: Set default value callbacks for all block dials](https://yaleits.atlassian.net/browse/YALB-863)

### Description of work
- Update all block dials (style fields) to make sure they are required and include `default_value_callback: ys_themes_default_value_function`

### Functional testing steps:
- [ ] Check the following block type. Verify that the style fields are required and have a default value:
  - [ ] Content Spotlight Block (field_style_position, field_style_variation, field_style_width.yml)
  - [ ] Divider Block (field_style_position, field_style_width)
  - [ ] Grand Hero Block (field_style_position, field_style_variation)
  - [ ] Wrapped Image Block (field_style_position, field_style_variation)