### PR TITLE
YALB-1408: WYSIWYG: Enable CKEditor a11y plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,29 @@
     },
     "drupal": {
       "type": "composer",
-      "url": "https://packages.drupal.org/8"
+      "url": "https://packages.drupal.org/8",
+      "exclude": [
+        "drupal/ckeditor_a11ychecker"
+      ]
+    },
+    "drupal/ckeditor_a11ychecker": {
+      "type": "package",
+      "package": {
+        "name": "drupal/ckeditor_a11ychecker",
+        "version": "dev-custom",
+        "type": "drupal-module",
+        "source": {
+          "type": "git",
+          "url": "https://git.drupalcode.org/issue/ckeditor_a11ychecker-3394274.git",
+          "reference": "3394274-create-a-version"
+        }
+      }
     }
   },
   "require": {
     "composer/installers": "^1.9",
     "cweagans/composer-patches": "^1.7",
+    "drupal/ckeditor_a11ychecker": "dev-custom#3daf1d88f5ecf624350a3bc87d1b735647ef970e",
     "drupal/core-composer-scaffold": "^9.2",
     "drupal/core-recommended": "^9.2",
     "drush/drush": "^11 || ^12",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
   "require": {
     "composer/installers": "^1.9",
     "cweagans/composer-patches": "^1.7",
-    "drupal/ckeditor_a11ychecker": "dev-custom#3daf1d88f5ecf624350a3bc87d1b735647ef970e",
     "drupal/core-composer-scaffold": "^9.2",
     "drupal/core-recommended": "^9.2",
     "drush/drush": "^11 || ^12",

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -20,6 +20,7 @@
     "drupal/captcha": "1.10.0",
     "drupal/cas": "^2.0",
     "drupal/chosen": "^4.0",
+    "drupal/ckeditor_a11ychecker": "dev-custom#3daf1d88f5ecf624350a3bc87d1b735647ef970e",
     "drupal/components": "^3.0",
     "drupal/config_filter": "^2.4",
     "drupal/config_ignore": "^3.0",

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -129,9 +129,6 @@
       "drupal/bugherd": {
         "anonymous user unable to fill in email field https://www.drupal.org/project/bugherd/issues/3364305": "https://git.drupalcode.org/project/bugherd/-/merge_requests/4.diff"
       },
-      "drupal/smart_date": {
-        "add PHP c date format": "patches/add-php-c-format.patch"
-      },
       "drupal/gin": {
         "fix description toggle for CKEditor fields https://www.drupal.org/project/gin/issues/3316265": "https://git.drupalcode.org/project/gin/-/merge_requests/227.patch",
         "update dark mode localstorage https://www.drupal.org/project/gin/issues/3387653": "https://git.drupalcode.org/project/gin/-/merge_requests/304.diff"

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -20,6 +20,7 @@ module:
   chosen_field: 0
   chosen_lib: 0
   ckeditor5: 0
+  ckeditor_a11ychecker: 0
   components: 0
   config: 0
   config_filter: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/editor.editor.basic_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/editor.editor.basic_html.yml
@@ -26,6 +26,7 @@ settings:
       - insertTable
       - '|'
       - sourceEditing
+      - a11ychecker
   plugins:
     ckeditor5_heading:
       enabled_headings:

--- a/web/profiles/custom/yalesites_profile/config/sync/editor.editor.restricted_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/editor.editor.restricted_html.yml
@@ -15,6 +15,7 @@ settings:
       - italic
       - '|'
       - link
+      - a11ychecker
   plugins:
     linkit_extension:
       linkit_enabled: true


### PR DESCRIPTION
## [YALB-1408: WYSIWYG: Enable CKEditor a11y plugin](https://yaleits.atlassian.net/browse/YALB-1408)

### Description of work
- Adds CKEditor5 development branch of module
- Enables module for `basic_html` and `restricted_html` content

### Functional testing steps:
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...

Something feels dirty here; still working on it.