### PR TITLE
YALB-961: WYSIWYG: Text field size to reflect character limits

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.grand_hero.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.grand_hero.default.yml
@@ -88,7 +88,7 @@ content:
     weight: 6
     region: content
     settings:
-      rows: 5
+      rows: 3
       placeholder: ''
     third_party_settings:
       allowed_formats:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.pull_quote.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.pull_quote.default.yml
@@ -50,7 +50,7 @@ content:
     weight: 4
     region: content
     settings:
-      rows: 5
+      rows: 3
       placeholder: ''
     third_party_settings:
       allowed_formats:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.quick_links.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.quick_links.default.yml
@@ -65,7 +65,7 @@ content:
     weight: 2
     region: content
     settings:
-      rows: 5
+      rows: 3
       placeholder: ''
     third_party_settings:
       allowed_formats:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.video.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.video.default.yml
@@ -55,7 +55,7 @@ content:
     weight: 2
     region: content
     settings:
-      rows: 5
+      rows: 3
       placeholder: ''
     third_party_settings:
       allowed_formats:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.wrapped_image.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.wrapped_image.default.yml
@@ -69,7 +69,7 @@ content:
     weight: 2
     region: content
     settings:
-      rows: 5
+      rows: 3
       placeholder: ''
     third_party_settings:
       allowed_formats:


### PR DESCRIPTION
## [YALB-961: WYSIWYG: Text field size to reflect character limits](https://yaleits.atlassian.net/browse/YALB-961)

### Description of work (Multidev)
- Adds patch to allow CKEditor to calculate `--ck-min-height` variable based on rows defined
- Adds min-height to CKEditor displayed "text area" spaces to respect `--ck-min-height`
- Changes a multitude of block content rows values to 3

### Description of work (Branch)
- Changes a multitude of block content rows values to 3

### Functional testing steps:
- [ ] Attempt to add the following block, noticing the change in textarea height on each compared to other blocks.
  - [ ] Action Banner
  - [ ] Grand Hero
  - [ ] Image
  - [ ] Quote
  - [ ] Quick Links
  - [ ] Video
  - [ ] Wrapped Image

This branch is now based on master with D10, not needing the patch that was used previously to create the multidev.  For the truest experience of the result, bring local with D10.