### PR TITLE
YALB-520: Links: Dynamically apply link treatments

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/CoreTwigExtension.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/CoreTwigExtension.php
@@ -188,6 +188,7 @@ class CoreTwigExtension extends AbstractExtension {
       'zip',
       'csv',
       'xml',
+      'rtf',
     ]);
     $extension = strtolower(pathinfo($url, PATHINFO_EXTENSION));
     return in_array($extension, $fileExtensions);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/CoreTwigExtension.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/CoreTwigExtension.php
@@ -151,7 +151,7 @@ class CoreTwigExtension extends AbstractExtension {
    *   TRUE if the URL is internal.
    */
   private function isInternal($url) {
-    return $this->urlHasCurrentDomain($url) || $this->isAnchor($url) || $this->isRelative($url) || $this->isData($url);
+    return $this->urlHasCurrentDomain($url) || $this->isQueryString($url) || $this->isAnchor($url) || $this->isRelative($url) || $this->isData($url);
   }
 
   /**
@@ -235,6 +235,19 @@ class CoreTwigExtension extends AbstractExtension {
    */
   private function isAnchor($url) {
     return str_starts_with($url, '#');
+  }
+
+  /**
+   * Check if a URL is a query string.
+   *
+   * @param string $url
+   *   The URL to check.
+   *
+   * @return bool
+   *   TRUE if the URL is a query string.
+   */
+  private function isQueryString($url) {
+    return str_starts_with($url, '?');
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/CoreTwigExtension.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/CoreTwigExtension.php
@@ -3,6 +3,7 @@
 namespace Drupal\ys_core;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -33,17 +34,35 @@ class CoreTwigExtension extends AbstractExtension {
   protected $yaleMediaManager;
 
   /**
+   * The Request Stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * The current domain.
+   *
+   * @var string
+   */
+  protected $currentDomain;
+
+  /**
    * Constructs the object.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   The configuration interface.
    * @param \Drupal\ys_core\YaleSitesMediaManager $yale_media_manager
    *   The YaleSites Media Manager.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+   *   The Request Stack to retrieve the domain.
    */
-  public function __construct(ConfigFactoryInterface $configFactory, YaleSitesMediaManager $yale_media_manager) {
+  public function __construct(ConfigFactoryInterface $configFactory, YaleSitesMediaManager $yale_media_manager, RequestStack $requestStack) {
     $this->yaleCoreSettings = $configFactory->getEditable('ys_core.site');
     $this->yaleHeaderSettings = $configFactory->getEditable('ys_core.header_settings');
     $this->yaleMediaManager = $yale_media_manager;
+    $this->requestStack = $requestStack;
+    $this->currentDomain = $this->getCurrentDomain();
   }
 
   /**
@@ -53,6 +72,7 @@ class CoreTwigExtension extends AbstractExtension {
     return [
       new TwigFunction('getCoreSetting', [$this, 'getCoreSetting']),
       new TwigFunction('getHeaderSetting', [$this, 'getHeaderSetting']),
+      new TwigFunction('getUrlType', [$this, 'getUrlType']),
     ];
   }
 
@@ -90,6 +110,170 @@ class CoreTwigExtension extends AbstractExtension {
     else {
       return($this->yaleHeaderSettings->get($setting_name));
     }
+  }
+
+  /**
+   * Given a URL, it will return the type of URL it is.
+   *
+   * @param string $url
+   *   The URL to check.
+   *
+   * @return string
+   *   The type of URL it is.
+   */
+  public function getUrlType($url) {
+    if ($this->isDownload($url)) {
+      $urlType = 'download';
+    }
+    elseif ($this->isInternal($url)) {
+      $urlType = 'internal';
+    }
+    elseif ($this->isMailTo($url)) {
+      $urlType = 'mailto';
+    }
+    elseif ($this->isExternal($url)) {
+      $urlType = 'external';
+    }
+    else {
+      $urlType = 'internal';
+    }
+
+    return $urlType;
+  }
+
+  /**
+   * Check if a URL is internal.
+   *
+   * @param string $url
+   *   The URL to check.
+   *
+   * @return bool
+   *   TRUE if the URL is internal.
+   */
+  private function isInternal($url) {
+    return $this->urlHasCurrentDomain($url) || $this->isAnchor($url) || $this->isRelative($url) || $this->isData($url);
+  }
+
+  /**
+   * Check if a URL is external.
+   *
+   * @param string $url
+   *   The URL to check.
+   *
+   * @return bool
+   *   TRUE if the URL is external.
+   */
+  private function isExternal($url) {
+    return !$this->isInternal($url);
+  }
+
+  /**
+   * Check if a URL is a download.
+   *
+   * @param string $url
+   *   The URL to check.
+   *
+   * @return bool
+   *   TRUE if the URL is download.
+   */
+  private function isDownload($url) {
+    $fileExtensions = array_map('strtolower', [
+      'pdf',
+      'doc',
+      'docx',
+      'xls',
+      'xlsx',
+      'ppt',
+      'pptx',
+      'zip',
+      'csv',
+      'xml',
+    ]);
+    $extension = strtolower(pathinfo($url, PATHINFO_EXTENSION));
+    return in_array($extension, $fileExtensions);
+  }
+
+  /**
+   * Check if a URL has the current domain.
+   *
+   * @param string $url
+   *   The URL to check.
+   *
+   * @return bool
+   *   TRUE if the URL has the current domain.
+   */
+  private function urlHasCurrentDomain($url) {
+    $urlDomain = parse_url($url, PHP_URL_HOST);
+
+    if (empty($urlDomain)) {
+      return TRUE;
+    }
+
+    return $urlDomain === $this->currentDomain;
+  }
+
+  /**
+   * Get the current domain.
+   *
+   * @return string
+   *   The current domain.
+   */
+  private function getCurrentDomain() {
+    $request = $this->requestStack->getCurrentRequest();
+
+    return $request->getHost();
+  }
+
+  /**
+   * Check if a URL is an anchor.
+   *
+   * @param string $url
+   *   The URL to check.
+   *
+   * @return bool
+   *   TRUE if the URL is an anchor.
+   */
+  private function isAnchor($url) {
+    return str_starts_with($url, '#');
+  }
+
+  /**
+   * Check if a URL is relative URL.
+   *
+   * @param string $url
+   *   The URL to check.
+   *
+   * @return bool
+   *   TRUE if the URL is a relative URL.
+   */
+  private function isRelative($url) {
+    return str_starts_with($url, '/');
+  }
+
+  /**
+   * Check if a URL is data URL.
+   *
+   * @param string $url
+   *   The URL to check.
+   *
+   * @return bool
+   *   TRUE if the URL is a data URL.
+   */
+  private function isData($url) {
+    return str_starts_with($url, 'data:');
+  }
+
+  /**
+   * Check if a URL is mailto.
+   *
+   * @param string $url
+   *   The URL to check.
+   *
+   * @return bool
+   *   TRUE if the URL is mailto.
+   */
+  private function isMailTo($url) {
+    return str_starts_with($url, 'mailto:');
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -318,7 +318,6 @@ function ys_core_page_attachments(array &$page) {
   foreach ($favicons as $name => $favicon) {
     $page['#attached']['html_head'][] = [$favicon, $name];
   }
-
 }
 
 /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.services.yml
@@ -9,7 +9,7 @@ services:
   # Twig functions for passing core settings to templates.
   ys_core.core_twig_extension:
     class: Drupal\ys_core\CoreTwigExtension
-    arguments: ['@config.factory', '@ys_core.media_manager']
+    arguments: ['@config.factory', '@ys_core.media_manager', '@request_stack']
     tags:
       - { name: twig.extension }
   ys_core.media_manager:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSourceManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSourceManager.php
@@ -135,13 +135,13 @@ class EmbedSourceManager extends DefaultPluginManager {
    */
   public function loadPluginById($plugin_id) {
     if (!$this->isValidSourceId($plugin_id)) {
-      return $this->instance[static::BROKEN_ID];
+      return $this->instances[static::BROKEN_ID];
     }
-    if (!empty($this->instance[$plugin_id])) {
-      return $this->instance[$plugin_id];
+    if (!empty($this->instances[$plugin_id])) {
+      return $this->instances[$plugin_id];
     }
-    $this->instance[$plugin_id] = $this->createInstance($plugin_id);
-    return $this->instance[$plugin_id];
+    $this->instances[$plugin_id] = $this->createInstance($plugin_id);
+    return $this->instances[$plugin_id];
   }
 
   /**


### PR DESCRIPTION
## [YALB-520: Links: Dynamically apply link treatments](https://yaleits.atlassian.net/browse/YALB-520)

MultiDev PR: https://github.com/yalesites-org/yalesites-project/pull/467
Component Library PR: https://github.com/yalesites-org/component-library-twig/pull/319
Atomic PR: https://github.com/yalesites-org/atomic/compare/YALB-520-links-dynamically-apply-link-treatments

### Description of work
- Shows off link treatment work completed now in component library twig
- Links decorated:
  - External
  - Downloads
  - Target Blank

### Pages to check link treatments
- [ ] [Testing all of the links](https://pr-467-yalesites-platform.pantheonsite.io/testing-all-of-the-links) - Used content import for this one.  🕺 
- [ ] [Mike V Testing](https://pr-467-yalesites-platform.pantheonsite.io/mike-v-testing)
- [ ] [YALB-520 (Marc's page)](https://pr-467-yalesites-platform.pantheonsite.io/yalb-520)
- [ ] [Testing all of the things](https://pr-467-yalesites-platform.pantheonsite.io/testing-all-of-the-things)

### Functional testing steps:
- [ ] Add a block that has a WYSIWYG editor (Text works great here)
- [ ] Attempt to add different types of links:
  - [ ] Internal link
  - [ ] External link
  - [ ] Download link
  - [ ] Link with a `target="_blank"` defined: Note that I don't think it'll allow you to do this out of the box, but as this is an upcoming feature, we are including the decoration here.
  - [ ] Any other link you can think of that the editor will take
- [ ] Save the block
- [ ] Ensure that the layout builder view decorates each of these with those in our component library styles: https://yalesites-org.github.io/component-library-twig/?path=/story/atoms-controls--text-link
  - [ ] Keep in mind some decisions have been made to create a better flow to these; feedback is appreciated:
    - [ ] links are inline-blocked instead of flex so that they appear inline with the rest of the text
    - [ ] underlines are extended to the icons attached to show that it is 'attached' to that link
    - [ ] in the mailto example in storybook, we copy the text to the left of the copy link, but in this one, we actually copy the URL that was given so that users can have different text, but copy the hidden URL.
    - [ ] for downloads, we append the file type to the link name.  i.e. links to PDFs will have `Name of PDF (PDF) <icon>`
    - [ ] although we do not have a telephone treatment in Storybook, I decided to mimic the email treatment; we can disable this until truly needed, but was simple to implement given the mailto implementation.
- [ ] Save and ensure that the page view decorates each of these with those in our component library styles (linked above)
- [ ] Attempt to add other blocks and ensure that the links in them are not taken over by these styles.  (i.e. buttons are not treated)

### Things to look for when verifying
- [ ] Padding around component links; these were adjusted since the icon is not considered when determining the overall width of the box surrounding them
- [ ] Padding to include the icon in the underline; these have been adjusted since the icon is not included in the link calculations, resulting in the underline not originally extending to the icon.

__Keep in mind scope was change to not include mailto and telephone decorations until more design and feedback is completed.  Anchors are no longer decorated as other decorations handle it (local vs external).__