### PR TITLE
YALB-1387: WYSIWYG: Clarity on maxlength

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.accordion.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.accordion.default.yml
@@ -56,7 +56,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 50
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_instructions:
     type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
@@ -39,7 +39,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 80
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_instructions:
     type: markup
@@ -99,7 +99,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 50
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_text:
     type: text_textarea

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.cta_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.cta_banner.default.yml
@@ -38,7 +38,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 50
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_heading_level:
     type: options_select

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.custom_cards.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.custom_cards.default.yml
@@ -56,7 +56,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 50
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_instructions:
     type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.directory.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.directory.default.yml
@@ -29,7 +29,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 50
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_instructions:
     type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.event_list.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.event_list.default.yml
@@ -29,7 +29,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 50
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_instructions:
     type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.gallery.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.gallery.default.yml
@@ -56,7 +56,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 50
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_instructions:
     type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.grand_hero.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.grand_hero.default.yml
@@ -38,7 +38,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 50
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_heading_level:
     type: options_select
@@ -96,7 +96,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 90
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
 hidden:
   info: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.image.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.image.default.yml
@@ -47,7 +47,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 200
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
 hidden:
   info: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.media_grid.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.media_grid.default.yml
@@ -32,7 +32,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 50
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_instructions:
     type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.post_list.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.post_list.default.yml
@@ -29,7 +29,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 50
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_instructions:
     type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.pull_quote.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.pull_quote.default.yml
@@ -31,7 +31,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 90
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_instructions:
     type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.quick_links.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.quick_links.default.yml
@@ -35,7 +35,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 50
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_instructions:
     type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.video.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.video.default.yml
@@ -63,7 +63,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 200
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
 hidden:
   info: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.video.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.video.default.yml
@@ -33,7 +33,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: null
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_instructions:
     type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.view.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.view.default.yml
@@ -31,7 +31,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 50
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_instructions:
     type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.webform.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.webform.default.yml
@@ -39,7 +39,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 80
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_instructions:
     type: markup

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.accordion_item.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.accordion_item.default.yml
@@ -41,7 +41,8 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 80
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: false
 hidden:
   created: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.callout_item.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.callout_item.default.yml
@@ -30,7 +30,8 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 80
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: false
   field_link:
     type: link_default
     weight: 3

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.custom_card.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.custom_card.default.yml
@@ -33,7 +33,8 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 80
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: false
   field_image:
     type: media_library_widget
     weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.gallery_item.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.gallery_item.default.yml
@@ -30,7 +30,8 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 80
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: false
   field_media:
     type: media_library_widget
     weight: 0
@@ -51,7 +52,7 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 200
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
 hidden:
   created: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.tab.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.tab.default.yml
@@ -55,7 +55,8 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 40
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: false
 hidden:
   created: true
   status: true


### PR DESCRIPTION
## [YALB-1387: WYSIWYG: Clarity on maxlength](https://yaleits.atlassian.net/browse/YALB-1387)

### Description of work
- Changes soft limit field maxlength text to read: "Content recommended length set to `@limit` characters, remaining: <strong>`@remaining`</strong>"

### Functional testing steps:
- [ ] Verify that you see the above text in the following blocks that have soft limits:
  - [x] accordion
    - [x] Verify that the accordion item also has the text above for soft limits
  - [x] content spotlight
  - [x] action banner
  - [x] custom cards
    - [x] Verify that the custom card items have the text above for soft limits
  - [x] event list
  - [x] gallery
    - [x] Verify that the gallery items have the text above for soft limits
  - [x] grand hero
  - [x] image
  - [x] media grid
  - [x] post list
  - [x] quote
  - [x] quick links
  - [x] video
  - [x] view
  - [ ] wrapped image
  - [x] webform
  - [x] Tabs - Only the tab heading
  - [x] Callout - Only the items
