### PR TITLE
hotfix: re-add block_content_permissions module

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -14,6 +14,7 @@
     "drupal/auto_entitylabel": "3.0",
     "drupal/autosave_form": "1.4",
     "drupal/better_exposed_filters": "6.0.3",
+    "drupal/block_content_permissions": "1.11",
     "drupal/bugherd": "1.0",
     "drupal/calendar_link": "3.0.2",
     "drupal/captcha": "1.14",


### PR DESCRIPTION
### Description of work
- Add block_content_permissions module back since having it removed is causing D10 upgrades to throw errors and puts sites into maintenance mode
