### PR TITLE
YALB-1573: Allow admins to manage affiliation terms

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -39,6 +39,7 @@ dependencies:
     - node.type.page
     - node.type.post
     - node.type.profile
+    - taxonomy.vocabulary.affiliation
     - taxonomy.vocabulary.event_category
     - taxonomy.vocabulary.post_category
     - taxonomy.vocabulary.tags
@@ -124,6 +125,7 @@ permissions:
   - 'create pull_quote block content'
   - 'create quick_links block content'
   - 'create tabs block content'
+  - 'create terms in affiliation'
   - 'create terms in event_category'
   - 'create terms in post_category'
   - 'create terms in tags'
@@ -200,6 +202,7 @@ permissions:
   - 'delete own post content'
   - 'delete own profile content'
   - 'delete own video media'
+  - 'delete terms in affiliation'
   - 'delete terms in event_category'
   - 'delete terms in post_category'
   - 'delete terms in tags'
@@ -246,6 +249,7 @@ permissions:
   - 'edit own profile content'
   - 'edit own video media'
   - 'edit own webform submission'
+  - 'edit terms in affiliation'
   - 'edit terms in event_category'
   - 'edit terms in post_category'
   - 'edit terms in tags'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -39,6 +39,7 @@ dependencies:
     - node.type.page
     - node.type.post
     - node.type.profile
+    - taxonomy.vocabulary.affiliation
     - taxonomy.vocabulary.event_category
     - taxonomy.vocabulary.post_category
     - taxonomy.vocabulary.tags
@@ -118,6 +119,7 @@ permissions:
   - 'create pull_quote block content'
   - 'create quick_links block content'
   - 'create tabs block content'
+  - 'create terms in affiliation'
   - 'create terms in event_category'
   - 'create terms in post_category'
   - 'create terms in tags'
@@ -194,6 +196,7 @@ permissions:
   - 'delete own post content'
   - 'delete own profile content'
   - 'delete own video media'
+  - 'delete terms in affiliation'
   - 'delete terms in event_category'
   - 'delete terms in post_category'
   - 'delete terms in tags'
@@ -240,6 +243,7 @@ permissions:
   - 'edit own profile content'
   - 'edit own video media'
   - 'edit own webform submission'
+  - 'edit terms in affiliation'
   - 'edit terms in event_category'
   - 'edit terms in post_category'
   - 'edit terms in tags'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
@@ -73,6 +73,14 @@ ys_core.taxonomy_interface_post_category:
   title: Post Category
   route_parameters:
     taxonomy_vocabulary: "post_category"
+# Taxonomy interface - Profile Affiliation
+ys_core.taxonomy_interface_affiliation:
+  description: "Manage profile affiliation taxonomy"
+  parent: ys_core.taxonomy_interface
+  route_name: entity.taxonomy_vocabulary.overview_form
+  title: Profile Affiliation
+  route_parameters:
+    taxonomy_vocabulary: "affiliation"
 # Taxonomy interface - Tags
 ys_core.taxonomy_interface_tags:
   description: "Manage tags taxonomy"


### PR DESCRIPTION
## [YALB-1573: Allow admins to manage affiliation terms](https://yaleits.atlassian.net/browse/YALB-1573)

### Description of work
- Adds permissions for site admins and platform admins to add/edit/delete affiliation terms.
- Defines a link to manage affilation terms in on the content menu.

### Functional testing steps:
- [x] [Login as a site admin](https://pr-487-yalesites-platform.pantheonsite.io/cas)
- [x] Browse the admin toolbar. Verify that the affiliation taxonomy interface appear in the toolbar under "Content">"Manage Taxonomy">"Profile Affiliation"
  - [x] This link items is new and appears in the list of other vocabs in alphabetic order.
  - [x] The link take the user to this interface admin/structure/taxonomy/manage/affiliation/overview
- [x] Admins can add, edit, and delete terms in the vocabulary.