### PR TITLE
YALB-1574: Branding: Header Variation Backend Front Page Alias Fix

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -155,7 +155,15 @@ function ys_core_preprocess_region(&$variables) {
           'alt' => $focusHeaderImageMedia->get('field_media_image')->first()->get('alt')->getValue(),
         ],
       ];
-      $variables['site_header__background_image'] = (\Drupal::service('path.matcher')->isFrontPage()) ? $focusHeaderImageRender : FALSE;
+
+      $path = \Drupal::service('path.current')->getPath();
+      $alias = \Drupal::service('path_alias.manager')->getAliasByPath($path);
+      $frontPage = \Drupal::config('system.site')->get('page.front');
+
+      $isFrontPage = ($alias == $frontPage || $path == $frontPage || \Drupal::service('path.matcher')->isFrontPage()) ? TRUE : FALSE;
+
+      // See if the path is the front page.
+      $variables['site_header__background_image'] = $isFrontPage ? $focusHeaderImageRender : FALSE;
     }
 
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -160,9 +160,8 @@ function ys_core_preprocess_region(&$variables) {
       $alias = \Drupal::service('path_alias.manager')->getAliasByPath($path);
       $frontPage = \Drupal::config('system.site')->get('page.front');
 
-      $isFrontPage = ($alias == $frontPage || $path == $frontPage || \Drupal::service('path.matcher')->isFrontPage()) ? TRUE : FALSE;
-
       // See if the path is the front page.
+      $isFrontPage = ($alias == $frontPage || $path == $frontPage || \Drupal::service('path.matcher')->isFrontPage());
       $variables['site_header__background_image'] = $isFrontPage ? $focusHeaderImageRender : FALSE;
     }
 


### PR DESCRIPTION
## [YALB-1574: Branding: Header Variation Backend Front Page Alias Fix](https://yaleits.atlassian.net/browse/YALB-1574)

This attempts to fix a bug that was found with the header implementation.  isFrontPage does not seem to take into account aliases.

We get around this by getting the node id of the page, the alias of the page, and the current front page that is set in site settings.  We then determine if it is the front page if the location set in the site settings matches either the node id path or the alias path, or if isFrontPage thinks it's a front page.

### Description of work
- Checks the site settings front page setting against the current page's node and alias to determine whether to display the focus header.

### Functional testing steps:
- [ ] Set the site setting's front page to an alias (do not click what's found or it'll resolve to the node id)
- [ ] Verify that when visiting the home page, it displays the focus header image.
- [ ] Set the site setting's front page to a node (click what's found when typing in an alias--it will resolve to a /node/id url)
- [ ] Verify that when visiting the home page, it displays the focus header image.