### PR TITLE
YALB-1169 Links: Enable WYSYWIG tools for anchor links

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,18 @@
     "drupal": {
       "type": "composer",
       "url": "https://packages.drupal.org/8"
+    },
+    "ckeditor5-anchor-drupal": {
+      "type": "package",
+      "package": {
+        "name": "northernco/ckeditor5-anchor-drupal",
+        "version": "0.4.0",
+        "type": "drupal-library",
+        "dist": {
+          "url": "https://registry.npmjs.org/@northernco/ckeditor5-anchor-drupal/-/ckeditor5-anchor-drupal-0.4.0.tgz",
+          "type": "tar"
+        }
+      }
     }
   },
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -10,18 +10,6 @@
     "drupal": {
       "type": "composer",
       "url": "https://packages.drupal.org/8"
-    },
-    "ckeditor5-anchor-drupal": {
-      "type": "package",
-      "package": {
-        "name": "northernco/ckeditor5-anchor-drupal",
-        "version": "0.3.0",
-        "type": "drupal-library",
-        "dist": {
-          "url": "https://registry.npmjs.org/@northernco/ckeditor5-anchor-drupal/-/ckeditor5-anchor-drupal-0.3.0.tgz",
-          "type": "tar"
-        }
-      }
     }
   },
   "require": {
@@ -32,7 +20,6 @@
     "drupal/core-recommended": "10.1.7",
     "drush/drush": "^11 || ^12",
     "oomphinc/composer-installers-extender": "^2.0",
-    "northernco/ckeditor5-anchor-drupal": "^0.3.0",
     "pantheon-systems/drupal-integrations": "^10",
     "yalesites-org/yalesites_profile": "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,18 @@
     "drupal": {
       "type": "composer",
       "url": "https://packages.drupal.org/8"
+    },
+    "ckeditor5-anchor-drupal": {
+      "type": "package",
+      "package": {
+        "name": "northernco/ckeditor5-anchor-drupal",
+        "version": "0.3.0",
+        "type": "drupal-library",
+        "dist": {
+          "url": "https://registry.npmjs.org/@northernco/ckeditor5-anchor-drupal/-/ckeditor5-anchor-drupal-0.3.0.tgz",
+          "type": "tar"
+        }
+      }
     }
   },
   "require": {
@@ -20,6 +32,7 @@
     "drupal/core-recommended": "^10",
     "drush/drush": "^11 || ^12",
     "oomphinc/composer-installers-extender": "^2.0",
+    "northernco/ckeditor5-anchor-drupal": "^0.3.0",
     "pantheon-systems/drupal-integrations": "^10",
     "yalesites-org/yalesites_profile": "*"
   },

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -105,6 +105,7 @@
     "drupal/wingsuit_companion": "2.1",
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.12",
+    "northernco/ckeditor5-anchor-drupal": "^0.3.0",
     "yalesites-org/atomic": "1.21.1",
     "yalesites-org/yale_cas": "1.0.4"
   },

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -10,10 +10,10 @@
       "type": "package",
       "package": {
         "name": "northernco/ckeditor5-anchor-drupal",
-        "version": "0.3.0",
+        "version": "0.4.0",
         "type": "drupal-library",
         "dist": {
-          "url": "https://registry.npmjs.org/@northernco/ckeditor5-anchor-drupal/-/ckeditor5-anchor-drupal-0.3.0.tgz",
+          "url": "https://registry.npmjs.org/@northernco/ckeditor5-anchor-drupal/-/ckeditor5-anchor-drupal-0.4.0.tgz",
           "type": "tar"
         }
       }
@@ -23,7 +23,7 @@
     "drupal/address": "1.12",
     "drupal/admin_toolbar": "3.4.1",
     "drupal/allowed_formats": "3.0",
-    "drupal/anchor_link": "3.0.x-dev@dev",
+    "drupal/anchor_link": "3.0.0-alpha1",
     "drupal/auto_entitylabel": "3.0",
     "drupal/autosave_form": "1.4",
     "drupal/better_exposed_filters": "6.0.3",
@@ -105,7 +105,7 @@
     "drupal/wingsuit_companion": "2.1",
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.12",
-    "northernco/ckeditor5-anchor-drupal": "0.3.0",
+    "northernco/ckeditor5-anchor-drupal": "0.4.0",
     "yalesites-org/atomic": "1.21.1",
     "yalesites-org/yale_cas": "1.0.4"
   },

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -11,6 +11,7 @@
     "drupal/address": "1.12",
     "drupal/admin_toolbar": "3.4.1",
     "drupal/allowed_formats": "3.0",
+    "drupal/anchor_link": "3.0.x-dev@dev",
     "drupal/auto_entitylabel": "3.0",
     "drupal/autosave_form": "1.4",
     "drupal/better_exposed_filters": "6.0.3",

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -105,7 +105,7 @@
     "drupal/wingsuit_companion": "2.1",
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.12",
-    "northernco/ckeditor5-anchor-drupal": "^0.3.0",
+    "northernco/ckeditor5-anchor-drupal": "0.3.0",
     "yalesites-org/atomic": "1.21.1",
     "yalesites-org/yale_cas": "1.0.4"
   },

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -5,6 +5,18 @@
     "drupal": {
       "type": "composer",
       "url": "https://packages.drupal.org/8"
+    },
+    "ckeditor5-anchor-drupal": {
+      "type": "package",
+      "package": {
+        "name": "northernco/ckeditor5-anchor-drupal",
+        "version": "0.3.0",
+        "type": "drupal-library",
+        "dist": {
+          "url": "https://registry.npmjs.org/@northernco/ckeditor5-anchor-drupal/-/ckeditor5-anchor-drupal-0.3.0.tgz",
+          "type": "tar"
+        }
+      }
     }
   },
   "require": {

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -6,6 +6,7 @@ module:
   admin_toolbar: 0
   admin_toolbar_tools: 0
   allowed_formats: 0
+  anchor_link: 0
   auto_entitylabel: 0
   better_exposed_filters: 0
   block: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/editor.editor.basic_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/editor.editor.basic_html.yml
@@ -18,6 +18,8 @@ settings:
       - '|'
       - link
       - '|'
+      - anchor
+      - '|'
       - bulletedList
       - numberedList
       - outdent

--- a/web/profiles/custom/yalesites_profile/config/sync/editor.editor.restricted_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/editor.editor.restricted_html.yml
@@ -15,6 +15,7 @@ settings:
       - italic
       - '|'
       - link
+      - anchor
   plugins:
     linkit_extension:
       linkit_enabled: true

--- a/web/profiles/custom/yalesites_profile/config/sync/filter.format.basic_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/filter.format.basic_html.yml
@@ -17,7 +17,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<br> <p class="text-align-left text-align-center text-align-right text-align-justify"> <h2 id class="text-align-left text-align-center text-align-right text-align-justify"> <h3 id class="text-align-left text-align-center text-align-right text-align-justify"> <h4 id class="text-align-left text-align-center text-align-right text-align-justify"> <h5 id class="text-align-left text-align-center text-align-right text-align-justify"> <h6 id class="text-align-left text-align-center text-align-right text-align-justify"> <cite> <dl> <dt> <dd> <span> <blockquote cite> <ul type> <ol type start> <a hreflang title href data-entity-type data-entity-uuid data-entity-substitution> <strong> <em> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption>'
+      allowed_html: '<a id target rel class="ck-anchor" hreflang title href data-entity-type data-entity-uuid data-entity-substitution> <br> <p class="text-align-left text-align-center text-align-right text-align-justify"> <h2 id class="text-align-left text-align-center text-align-right text-align-justify"> <h3 id class="text-align-left text-align-center text-align-right text-align-justify"> <h4 id class="text-align-left text-align-center text-align-right text-align-justify"> <h5 id class="text-align-left text-align-center text-align-right text-align-justify"> <h6 id class="text-align-left text-align-center text-align-right text-align-justify"> <cite> <dl> <dt> <dd> <span> <blockquote cite> <ul type> <ol type start> <strong> <em> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_align:
@@ -80,14 +80,14 @@ filters:
       smartypants_enabled: '1'
       smartypants_hyphens: '2'
       space_hyphens: '0'
-      wrap_ampersand: '0'
       widont_enabled: '0'
-      space_to_nbsp: '1'
       hyphenate_shy: '0'
-      wrap_abbr: '0'
+      space_to_nbsp: '1'
       wrap_caps: '0'
-      wrap_initial_quotes: '1'
+      wrap_ampersand: '0'
+      wrap_abbr: '0'
       wrap_numbers: '0'
+      wrap_initial_quotes: '1'
       ligatures: 'a:0:{}'
       arrows: 'a:0:{}'
       fractions: 'a:0:{}'

--- a/web/profiles/custom/yalesites_profile/config/sync/filter.format.restricted_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/filter.format.restricted_html.yml
@@ -15,7 +15,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<br> <p> <strong> <em> <a href data-entity-type data-entity-uuid data-entity-substitution>'
+      allowed_html: '<a id target rel class="ck-anchor" href data-entity-type data-entity-uuid data-entity-substitution> <br> <p> <strong> <em>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_autop:


### PR DESCRIPTION
## [YALB-1169 Links: Enable WYSYWIG tools for anchor links](https://yaleits.atlassian.net/browse/YALB-1169)

### Description of work
- Installs and enables `anchor_link` module
- Adds the anchor link button to the `basic_html` and `restricted_html` text formats

### Functional testing steps:
- [x] Login as a site administrator
- [x] Edit the content of a page in the layout builder interface
- [x] Do the following instructions for each block component and its corresponding field
  - [x] Text -> Content
  - [x] Wrapped Image -> Content, Caption
  - [x] Content Spotlight -> Content
  - [x] Image -> Image Caption
  - [x] Quick Links -> Quick Link Content
  - [x] Video -> Video Description
- [x] Verify that the anchor link button is visible in the field's text editor
![image](https://github.com/yalesites-org/yalesites-project/assets/25091784/3e880512-6ffc-44df-8ff0-1ab46769f1c1)
- [x] Add an anchor(s) along with content. Content will help us verify the anchor is functioning properly.
- [x] Verify that anchors added in the component are not visible when the content is published
- [x] Verify that accessing the anchors loads in the correct location
  - e.g. If anchor `anchor1` is set to the bottom of a page `Test Page`, then loading the url `/test-page#anchor1` will load at the bottom of `Test Page`

