### PR TITLE
YALB-1648: Bug: empty footer logo instance causes PHP fatal error

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesFooterBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesFooterBlock.php
@@ -84,16 +84,18 @@ class YaleSitesFooterBlock extends BlockBase implements ContainerFactoryPluginIn
       foreach ($footerLogosConfig as $key => $logoData) {
         if ($logoData['logo']) {
           $footerLogoMedia = $this->entityTypeManager->getStorage('media')->load($logoData['logo']);
-          $footerLogoFileUri = $fileEntity->load($footerLogoMedia->field_media_image->target_id)->getFileUri();
-          $footerLogosRender[$key]['url'] = $logoData['logo_url'] ?? NULL;
-          $footerLogosRender[$key]['logo'] = [
-            '#type' => 'responsive_image',
-            '#responsive_image_style_id' => 'image_logos',
-            '#uri' => $footerLogoFileUri,
-            '#attributes' => [
-              'alt' => $footerLogoMedia->get('field_media_image')->first()->get('alt')->getValue(),
-            ],
-          ];
+          if ($footerLogoMedia) {
+            $footerLogoFileUri = $fileEntity->load($footerLogoMedia->field_media_image->target_id)->getFileUri();
+            $footerLogosRender[$key]['url'] = $logoData['logo_url'] ?? NULL;
+            $footerLogosRender[$key]['logo'] = [
+              '#type' => 'responsive_image',
+              '#responsive_image_style_id' => 'image_logos',
+              '#uri' => $footerLogoFileUri,
+              '#attributes' => [
+                'alt' => $footerLogoMedia->get('field_media_image')->first()->get('alt')->getValue(),
+              ],
+            ];
+          }
         }
       }
     }


### PR DESCRIPTION
## [YALB-1648: Bug: empty footer logo instance causes PHP fatal error](https://yaleits.atlassian.net/browse/YALB-1648)

### Description of work
A user reported an issue with their site throwing fatal errors:
```
Uncaught PHP Exception Error: "Call to a member function getFileUri() on null" at /code/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesFooterBlock.php line 87
```
They had one footer logo uploaded and the other instance of the field was returning as `null`. This checks to make sure an instance of the field is not null.
