### PR TITLE
YALB-1644 - Dial: Center-align callout with content-width content

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.callout.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.callout.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - block_content.type.callout
     - field.field.block_content.callout.field_callout
     - field.field.block_content.callout.field_instructions
+    - field.field.block_content.callout.field_style_alignment
     - field.field.block_content.callout.field_style_color
   module:
     - markup
@@ -43,6 +44,12 @@ content:
   field_instructions:
     type: markup
     weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_style_alignment:
+    type: options_select
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.callout.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.callout.default.yml
@@ -26,8 +26,8 @@ content:
     weight: 0
     region: content
   field_style_alignment:
-    type: list_default
-    label: above
+    type: list_key
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     weight: 2

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.callout.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.callout.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - block_content.type.callout
     - field.field.block_content.callout.field_callout
     - field.field.block_content.callout.field_instructions
+    - field.field.block_content.callout.field_style_alignment
     - field.field.block_content.callout.field_style_color
   module:
     - entity_reference_revisions
@@ -23,6 +24,13 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_style_alignment:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
     region: content
   field_style_color:
     type: list_key

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.callout.field_style_alignment.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.callout.field_style_alignment.yml
@@ -13,7 +13,7 @@ entity_type: block_content
 bundle: callout
 label: Alignment
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ys_themes_default_value_function

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.callout.field_style_alignment.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.callout.field_style_alignment.yml
@@ -1,0 +1,21 @@
+uuid: 8f6c0de5-11eb-44b0-92d9-11748df84be8
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.callout
+    - field.storage.block_content.field_style_alignment
+  module:
+    - options
+id: block_content.callout.field_style_alignment
+field_name: field_style_alignment
+entity_type: block_content
+bundle: callout
+label: Alignment
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.callout.field_style_alignment.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.callout.field_style_alignment.yml
@@ -16,6 +16,6 @@ description: ''
 required: false
 translatable: false
 default_value: {  }
-default_value_callback: ''
+default_value_callback: ys_themes_default_value_function
 settings: {  }
 field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_style_alignment.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_style_alignment.yml
@@ -1,0 +1,21 @@
+uuid: 1ec88178-c5cf-4f76-a3d4-05bfd6a8fbbc
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - options
+id: block_content.field_style_alignment
+field_name: field_style_alignment
+entity_type: block_content
+type: list_string
+settings:
+  allowed_values: {}
+  allowed_values_function: ys_themes_allowed_values_function
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {}
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_style_alignment.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_style_alignment.yml
@@ -10,12 +10,12 @@ field_name: field_style_alignment
 entity_type: block_content
 type: list_string
 settings:
-  allowed_values: {}
+  allowed_values: {  }
   allowed_values_function: ys_themes_allowed_values_function
 module: options
 locked: false
 cardinality: 1
 translatable: true
-indexes: {}
+indexes: {  }
 persist_with_no_fields: false
 custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -5,6 +5,11 @@ callout:
       two: Two
       three: Three
     default: one
+  field_style_alignment:
+    values:
+      left: Left
+      center: Center
+    default: Center
 cta_banner:
   field_style_color:
     values:

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -9,7 +9,7 @@ callout:
     values:
       left: Left
       center: Center
-    default: Center
+    default: center
 cta_banner:
   field_style_color:
     values:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
@@ -5,6 +5,11 @@ callout:
       two: Two
       three: Three
     default: one
+  field_style_alignment:
+    values:
+      left: Left
+      center: Center
+    default: Center
 cta_banner:
   field_style_color:
     values:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
@@ -9,7 +9,7 @@ callout:
     values:
       left: Left
       center: Center
-    default: Center
+    default: center
 cta_banner:
   field_style_color:
     values:


### PR DESCRIPTION
## [YALB-1644 - Dial: Center-align callout with content-width content](https://yaleits.atlassian.net/browse/YALB-1644)

### Description of work
- Adds alignment variable for `callout__alignment`
- Adds a default of `center` - existing callouts will render the same
- Adds a `field_style_alignment` field in Drupal, default is `center`
- Wires the `callout__alignment` variable to `field_style_alignment`
- You can choose between `center` and `left`. `center` uses the `site` width. `left` uses `content` width to restrict the callout inner wrapper width.

### Functional testing steps:
- [x] Review this page with two callouts: https://pr-495-yalesites-platform.pantheonsite.io/welcome/customize-with-confidence
- [x] Verify the callout container is left-aligned and the content area of the callouts is limited to the left-aligned content
<img width="1153" alt="Screenshot 2023-11-28 at 11 53 48 AM" src="https://github.com/yalesites-org/yalesites-project/assets/366413/192c4a48-981c-4752-8176-f3dbc83199ae">


- [x] Login and review another test page here - single callout: https://pr-495-yalesites-platform.pantheonsite.io/testing-all-of-the-things 
- [x] Verify it is set to `left` and toggle between `left` and `center` and verify the callout changes.

https://github.com/yalesites-org/yalesites-project/assets/366413/7ffa0d73-fc07-4d37-bb65-814f98585148


