### PR TITLE
YALB-1602: Bug: Clone nodes with accordions and callouts wont allow user to edit

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -144,6 +144,9 @@
       },
       "drupal/linkit": {
         "Add phone number matcher https://www.drupal.org/project/linkit/issues/3273630": "https://git.drupalcode.org/project/linkit/-/merge_requests/36.diff"
+      },
+      "drupal/quick_node_clone": {
+        "Fix cloning of inline blocks and paragraphs: https://www.drupal.org/project/quick_node_clone/issues/3100117": "https://www.drupal.org/files/issues/2023-04-25/quick-node-clone--inline-blocks--3100117-32.patch"
       }
     }
   }


### PR DESCRIPTION
## [YALB-1602: Bug: Clone nodes with accordions and callouts wont allow user to edit](https://yaleits.atlassian.net/browse/YALB-1602)

Quick Node Clone does a great job of cloning, however, when it attempts to clone a node with layout builder, it does not correctly clone the inline blocks and paragraph references we use.  This is a more global issue, and a patch has been worked on to fix this.  This patch fixes our issue and sub-items are properly cloned and editable.

References: https://www.drupal.org/project/quick_node_clone/issues/3100117
Patch Reference: https://www.drupal.org/files/issues/2023-04-25/quick-node-clone--inline-blocks--3100117-32.patch

### Description of work
- Add patch to enable inline blocks and paragraphs to be cloned properly through Quick Node Clone

### Functional testing steps:
- [x] Create a new page, adding one of the following items:
  - [x] Accordion
  - [ ] Callout
  - [ ] Custom Card
  - [ ] Gallery
  - [ ] Tab
  - [ ] Media Grid
- [x] Add a few subitems to whichever you decided to make and save the page
- [x] Clone the page
- [x] Visit both pages, ensuring that you can edit the subitem content you added in both; make sure to change the subitems to be unique so you can compare that they are not using the same reference.
