### PR TITLE
YALB-1654: Reusable Content Prep: Remove or add message to block library

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -70,7 +70,6 @@ label: 'Site administrator'
 weight: 3
 is_admin: null
 permissions:
-  - 'access block library'
   - 'access content overview'
   - 'access contextual links'
   - 'access files overview'


### PR DESCRIPTION
## [YALB-1654: Reusable Content Prep: Remove or add message to block library](https://yaleits.atlassian.net/browse/YALB-1654)

### Description of work
- Temporarily removes the block library visibility from site admins
- Once reusable content is merged, we can re-enable block library access

### Functional testing steps:
- [x] Login to the site as a site administrator role, not platform admin
- [x] Visit the Media overview page: `/admin/content/media`
- [x] Verify that there is no tab in the tabs area to "Blocks"

<img width="1103" alt="Screenshot 2023-11-30 at 2 27 00 PM" src="https://github.com/yalesites-org/yalesites-project/assets/107938318/234e210f-8a84-440a-b0e9-469ffc9e986e">