### PR TITLE
YALB-1654: BUG FIX Reusable Content Prep: Remove or add message to block library

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.background_image_16_9_focus_header.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.background_image_16_9_focus_header.yml
@@ -25,6 +25,8 @@ content:
     settings:
       responsive_image_style: background_image_focus_header
       image_link: ''
+      image_loading:
+        attribute: eager
     third_party_settings: {  }
     weight: 0
     region: content

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -70,6 +70,7 @@ label: 'Site administrator'
 weight: 3
 is_admin: null
 permissions:
+  - 'access block library'
   - 'access content overview'
   - 'access contextual links'
   - 'access files overview'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -241,6 +241,11 @@ function ys_core_help($route_name, RouteMatchInterface $route_match) {
 
       $output = '<p class="replacement-taxonomy-help">' . t('Taxonomy is used to classify website content into groups called vocabularies. Each vocabulary contains a set of terms used to categorize content. For example, an "Event Type" vocabulary contains terms like "Online" and "In-Person". This allows for easy categorization and organization of content on a website.') . '</p>';
       return $output;
+
+      case 'entity.block_content.collection':
+
+      $output = '<p class="replacement-block-help">' . t('Blocks are used for reusable content. Create global blocks here, and they will show up in layout builder at the bottom of the list under a reusable section to place on any page. If the block is updated here, the content will be updated anywhere the block is used.') . '</p>';
+      return $output;
   }
 }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -242,7 +242,7 @@ function ys_core_help($route_name, RouteMatchInterface $route_match) {
       $output = '<p class="replacement-taxonomy-help">' . t('Taxonomy is used to classify website content into groups called vocabularies. Each vocabulary contains a set of terms used to categorize content. For example, an "Event Type" vocabulary contains terms like "Online" and "In-Person". This allows for easy categorization and organization of content on a website.') . '</p>';
       return $output;
 
-      case 'entity.block_content.collection':
+    case 'entity.block_content.collection':
 
       $output = '<p class="replacement-block-help">' . t('Blocks are used for reusable content. Create global blocks here, and they will show up in layout builder at the bottom of the list under a reusable section to place on any page. If the block is updated here, the content will be updated anywhere the block is used.') . '</p>';
       return $output;


### PR DESCRIPTION
## [YALB-1654: Reusable Content Prep: Remove or add message to block library](https://yaleits.atlassian.net/browse/YALB-1654)

### Description of work
- Fixes bug when site admins attempted to add media to blocks.
- Restores access to custom block library to all roles
- Adds help text on top of the custom block library to describe the purpose

### Functional testing steps:
- [x] Login to the site as a site admin role
- [x] Edit an existing page or add a new page to the site and enter layout builder
- [x] Add a component that adds media such as image, wrapped image, grand hero, etc.
- [x] Verify that you can add the media fully

![image](https://github.com/yalesites-org/yalesites-project/assets/107938318/54805b7c-1ccc-40e2-a20e-4712d6a5ee46)

- [x] Visit the block library page at `/admin/content/block` and verify that there is new help text at the top of the page.

![image](https://github.com/yalesites-org/yalesites-project/assets/107938318/bd4ea5e6-6e08-4c14-865e-c95d17643ae7)
