### PR TITLE
YALB-1629 Fix node access warning

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.module
@@ -40,6 +40,8 @@ function ys_node_access_node_grants($account, $op) {
  */
 function ys_node_access_node_access_records($node) {
 
+  $private = FALSE;
+
   $nodeAccessManager = new NodeAccessManager();
   // Saving a node, check login required field to set the appropriate grants.
   if ($node->hasField('field_login_required')) {


### PR DESCRIPTION
## [YALB-1629: Bug: Node Access error](https://yaleits.atlassian.net/browse/YALB-1629)

### Description of work
- Define the $private variable at the top of ys_node_access_node_access_records()

### Functional testing steps:
- [ ] Creating a new custom content type. 
- [ ] Create a node using this bundle and verify that this warning does not appear on screen or in the error log on node-save:
`
Warning: Undefined variable $private in ys_node_access_node_access_records() (line 55 of profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.module).`
