### PR TITLE
YALB-1306: Emphasized text

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.text.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.text.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - block_content.type.text
     - field.field.block_content.text.field_instructions
+    - field.field.block_content.text.field_style_variation
     - field.field.block_content.text.field_text
   module:
     - allowed_formats
@@ -19,6 +20,12 @@ content:
   field_instructions:
     type: markup
     weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_style_variation:
+    type: options_select
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.text.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.text.default.yml
@@ -5,14 +5,23 @@ dependencies:
   config:
     - block_content.type.text
     - field.field.block_content.text.field_instructions
+    - field.field.block_content.text.field_style_variation
     - field.field.block_content.text.field_text
   module:
+    - options
     - text
 id: block_content.text.default
 targetEntityType: block_content
 bundle: text
 mode: default
 content:
+  field_style_variation:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 5
+    region: content
   field_text:
     type: text_default
     label: hidden

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.text.field_style_variation.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.text.field_style_variation.yml
@@ -11,11 +11,11 @@ id: block_content.text.field_style_variation
 field_name: field_style_variation
 entity_type: block_content
 bundle: text
-label: Variation
+label: Text Style Variation
 description: ''
 required: true
 translatable: false
-default_value: {  }
+default_value: {}
 default_value_callback: ys_themes_default_value_function
-settings: {  }
+settings: {}
 field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.text.field_style_variation.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.text.field_style_variation.yml
@@ -1,0 +1,21 @@
+uuid: 423a367c-5159-4a40-a107-031f8c53c99e
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.text
+    - field.storage.block_content.field_style_variation
+  module:
+    - options
+id: block_content.text.field_style_variation
+field_name: field_style_variation
+entity_type: block_content
+bundle: text
+label: Variation
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ys_themes_default_value_function
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -106,3 +106,9 @@ divider:
       50%: 50
       25%: 25
     default: 100%
+text:
+  field_style_variation:
+    values:
+      default: 'Default'
+      emphasized: 'Emphasized'
+    default: default

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
@@ -106,3 +106,9 @@ divider:
       '50%': 50
       '25%': 25
     default: 100%
+text:
+  field_style_variation:
+    values:
+      default: 'Default'
+      emphasized: 'Emphasized'
+    default: default


### PR DESCRIPTION
## [YALB-1306: Emphasized text](https://yaleits.atlassian.net/browse/YALB-1306)

### Description of work
- Adds variation option to the `text` component for `emphasized`
- Themes the emphasized variation to use the body-xl style: https://yalesites-org.github.io/component-library-twig/?path=/story/tokens-typography--body-styles
- Note branched PRs in Atomic and Component library:
- https://github.com/yalesites-org/atomic/pull/191
 - https://github.com/yalesites-org/component-library-twig/pull/315
 
 
### Functional testing steps:
- [ ] View example here: https://pr-508-yalesites-platform.pantheonsite.io/testing-all-of-the-things
- [ ] Verify the introduction text "Introducing chaos" block is now `emphasized`
<img width="1970" alt="Screenshot 2023-12-15 at 12 00 26 PM" src="https://github.com/yalesites-org/yalesites-project/assets/366413/be377505-b848-4095-8608-6bd72d8eb745">


- [ ] Login and add a new text component
- [ ] Verify that, by default, for new text components, the variation is set to `default`

<img width="1429" alt="Screenshot 2023-12-15 at 11 26 13 AM" src="https://github.com/yalesites-org/yalesites-project/assets/366413/aacacc35-e932-4443-9d50-617c49619a69">
