### PR TITLE
hotfix: pin drupal 10.1.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
   "require": {
     "composer/installers": "^1.9",
     "cweagans/composer-patches": "^1.7",
-    "drupal/core-composer-scaffold": "^10",
-    "drupal/core-project-message": "^10",
-    "drupal/core-recommended": "^10",
+    "drupal/core-composer-scaffold": "10.1.7",
+    "drupal/core-project-message": "10.1.7",
+    "drupal/core-recommended": "10.1.7",
     "drush/drush": "^11 || ^12",
     "oomphinc/composer-installers-extender": "^2.0",
     "pantheon-systems/drupal-integrations": "^10",


### PR DESCRIPTION
### Description of work
- Drupal 10.2 being installed due to loose version constraint in composer.json which is causing problems on new sites. Pin to Drupal 10.1.7.
