### PR TITLE
YALB-1685: Bug: Error when going to "Manage Settings" on certain pages

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Database\Database;
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
@@ -415,6 +416,22 @@ function ys_core_form_node_page_edit_form_alter(&$form, FormStateInterface $form
  */
 function ys_core_form_node_page_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   ys_core_page_form_alter($form, $form_state);
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * This renames any menu_link_content with a bundle of menu_link_content to
+ * main so that extra menu items can be properly loaded.
+ */
+function ys_core_cache_flush() {
+  $database = Database::getConnection();
+
+  $query = $database->update('menu_link_content')
+    ->fields(['bundle' => 'main'])
+    ->condition('bundle', 'menu_link_content');
+
+  $query->execute();
 }
 
 /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -6,7 +6,6 @@
  */
 
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Database\Database;
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
@@ -425,13 +424,34 @@ function ys_core_form_node_page_form_alter(&$form, FormStateInterface $form_stat
  * main so that extra menu items can be properly loaded.
  */
 function ys_core_cache_flush() {
-  $database = Database::getConnection();
+  _ys_core_fix_menu_link_content_bundles();
+}
 
-  $query = $database->update('menu_link_content')
-    ->fields(['bundle' => 'main'])
+/**
+ * Changes all menu_link_content bundles to main.
+ *
+ * The reasoning for this is that the menu_link_content bundle does not
+ * actually exist, and as such does not contain the definitions for the menu
+ * item extra fields we have for things like the mega menu CTA text.  This
+ * ensures that on a cache refresh we update them to have the main bundle so
+ * that they do have these defined.
+ */
+function _ys_core_fix_menu_link_content_bundles() {
+  $entityTypeManager = \Drupal::service('entity_type.manager');
+
+  $query = $entityTypeManager->getStorage('menu_link_content')
+    ->getQuery()
+    ->accessCheck(FALSE)
     ->condition('bundle', 'menu_link_content');
 
-  $query->execute();
+  $menuLinkIds = $query->execute();
+
+  $menuLinkEntities = $entityTypeManager->getStorage('menu_link_content')->loadMultiple($menuLinkIds);
+
+  foreach ($menuLinkEntities as $menuLinkEntity) {
+    $menuLinkEntity->bundle = 'main';
+    $menuLinkEntity->save();
+  }
 }
 
 /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -6,12 +6,10 @@
  */
 
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
-use Drupal\menu_item_extras\Entity\MenuItemExtrasMenuLinkContent;
 
 /**
  * @file
@@ -396,135 +394,6 @@ function ys_core_preprocess_image_widget(&$variables) {
 function ys_core_taxonomy_term_update() {
   Cache::invalidateTags(['rendered']);
 }
-
-/**
- * The following functions add menu item extras fields to node add/edit forms.
- *
- * @see https://www.drupal.org/project/menu_item_extras/issues/2992096#comment-14140361
- */
-
-/**
- * Implements hook_form_FORM_ID_alter().
- */
-function ys_core_form_node_page_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  ys_core_page_form_alter($form, $form_state);
-}
-
-/**
- * Implements hook_form_FORM_ID_alter().
- */
-function ys_core_form_node_page_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  ys_core_page_form_alter($form, $form_state);
-}
-
-/**
- * Implements hook_form_FORM_ID_alter().
- *
- * This renames any menu_link_content with a bundle of menu_link_content to
- * main so that extra menu items can be properly loaded.
- */
-function ys_core_cache_flush() {
-  _ys_core_fix_menu_link_content_bundles();
-}
-
-/**
- * Changes all menu_link_content bundles to main.
- *
- * The reasoning for this is that the menu_link_content bundle does not
- * actually exist, and as such does not contain the definitions for the menu
- * item extra fields we have for things like the mega menu CTA text.  This
- * ensures that on a cache refresh we update them to have the main bundle so
- * that they do have these defined.
- */
-function _ys_core_fix_menu_link_content_bundles() {
-  $entityTypeManager = \Drupal::service('entity_type.manager');
-
-  $query = $entityTypeManager->getStorage('menu_link_content')
-    ->getQuery()
-    ->accessCheck(FALSE)
-    ->condition('bundle', 'menu_link_content');
-
-  $menuLinkIds = $query->execute();
-
-  $menuLinkEntities = $entityTypeManager->getStorage('menu_link_content')->loadMultiple($menuLinkIds);
-
-  foreach ($menuLinkEntities as $menuLinkEntity) {
-    $menuLinkEntity->bundle = 'main';
-    $menuLinkEntity->save();
-  }
-}
-
-/**
- * Alters the page node forms.
- *
- * @var array $form
- *  The form array.
- * @var Drupal\Core\Form\FormStateInterface $form_state
- *  The current form state.
- */
-function ys_core_page_form_alter(&$form, FormStateInterface $form_state) {
-
-  // Add menu link fields to node form.
-  if ($link = _ys_core_get_link($form_state)) {
-    $form_display = EntityFormDisplay::load('menu_link_content.' . $link->getMenuName() . '.default');
-    assert($form_display instanceof EntityFormDisplay);
-    $form['menu']['link']['extra'] = [
-      '#type' => 'container',
-      '#parents' => ['menu', 'extra'],
-    ];
-    $form_display->buildForm($link, $form['menu']['link']['extra'], $form_state);
-    // Only keep custom fields, other properties already are in the form.
-    foreach (Element::children($form['menu']['link']['extra']) as $key) {
-      if (strpos($key, 'field_') !== 0) {
-        unset($form['menu']['link']['extra'][$key]);
-      }
-    }
-
-    foreach (array_keys($form['actions']) as $action) {
-      if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
-        $form['actions'][$action]['#submit'][] = 'ys_core_save_menu_link_fields';
-      }
-    }
-  }
-}
-
-/**
- * Saves the menu item extras when on the node add/edit pages.
- *
- * @throws \Drupal\Core\Entity\EntityStorageException
- */
-function ys_core_save_menu_link_fields(array $form, FormStateInterface $form_state) {
-  if ($link = _ys_core_get_link($form_state)) {
-    // Only save the menu item extras if there is a menu link with a route.
-    if ($link->getUrlObject()->getRouteName()) {
-      $form_display = EntityFormDisplay::load('menu_link_content.' . $link->getMenuName() . '.default');
-      if ($form_display instanceof EntityFormDisplay) {
-        $form_display->extractFormValues($link, $form['menu']['link']['extra'], $form_state);
-        $link->save();
-      }
-    }
-  }
-}
-
-/**
- * Gets any menu item extras content.
- *
- * @return Drupal\menu_item_extras\Entity\MenuItemExtrasMenuLinkContent
- *   Menu item extras content.
- */
-function _ys_core_get_link(FormStateInterface $form_state) {
-  /** @var Drupal\node\Entity $form_state */
-  $node = $form_state->getFormObject()->getEntity();
-  $defaults = menu_ui_get_menu_link_defaults($node);
-  if ($mlid = $defaults['entity_id']) {
-    return MenuItemExtrasMenuLinkContent::load($mlid);
-  }
-  return MenuItemExtrasMenuLinkContent::create($defaults);
-}
-
-/**
- * End allow menu item extras fields to be included on node add and edit forms.
- */
 
 /**
  * Implements hook_preprocess_page().

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -238,8 +238,19 @@ function ys_core_preprocess_menu(&$variables) {
       // @see component-library-twig/components/02-molecules/menu/_yds-menu-item.twig
       $clonedMenuItem['list__item__is_heading'] = TRUE;
 
-      // Get the CTA text from menu item extras field.
+      // Get the CTA text from menu item extras field. (for mega menu)
       $clonedMenuItem['heading_cta'] = $clonedMenuItem['entity']->get('field_menu_top_level_link_cta')->value ?: t('Explore @title', ['@title' => $clonedMenuItem['title']]);
+
+      // Default the node_title to the menu title.
+      $clonedMenuItem['node_title'] = $clonedMenuItem['title'];
+
+      // If the menu item is associated with a node, replace the node_title
+      // with the node's title.
+      if ($menuItem['url']->isRouted()) {
+        $nodeId = $menuItem['url']->getRouteParameters()['node'];
+        $node = \Drupal::entityTypeManager()->getStorage('node')->load($nodeId);
+        $clonedMenuItem['node_title'] = $node->getTitle();
+      }
 
       // Add cloned item to the beginning of the menu.
       array_unshift($menuItem['below'], $clonedMenuItem);


### PR DESCRIPTION
## [YALB-1685: Bug: Error when going to "Manage Settings" on certain pages](https://yaleits.atlassian.net/browse/YALB-1685)
## [YALB-1667: Bug: Going back to original basic menu naming capabilities](https://yaleits.atlassian.net/browse/YALB-1667?atlOrigin=eyJpIjoiYmU1NzkzNTM0ZjY3NDBiZWIwNWZlMGRiMmQwMTM5NzkiLCJwIjoiaiJ9)

This will also close [YALB-1633](https://yaleits.atlassian.net/browse/YALB-1633) as the field won't be visible any longer at the location, so including this in the acceptance of this ticket.

[Component Library PR](https://github.com/yalesites-org/component-library-twig/pull/320)

### Description of work
- YALB-1685: Removes the `Mega Menu Top Level Link Text` field from the sidebar menu section of `Manage Settings`
- YALB-1685: You will still be able to access this via the `Manage Main Menu` view
- YALB-1667: In basic menu, allows the parent page title to be the submenu heading in the basic header menu
- YALB-1667: In the event the parent menu item is not linked to a node, it will revert to the parent menu item title

### Functional testing steps:

#### YALB-1685
- [x] Edit a node
- [x] Verify that `Mega Menu Top Level Link Text` is no longer present under the menu section sidebar
- [x] Visit `Content->Manage Main Menu`
- [x] Edit a menu item
- [x] Verify that `Mega Menu Top Level Link Text` field is visible and able to be changed/saved
- [x] To satisfy [YALB-1633](https://yaleits.atlassian.net/browse/YALB-1633), verify that the help text under that field is: `Mega Menu level one links display this link text alongside the Menu link title.  If empty, defaults to "Explore [Menu link title]".`

#### YALB-1667
- [x] Go to Settings->Header Settings and change the header to Basic
- [x] Create a nested menu
- [x] Verify that the top level menu text displayed is that of the menu title defined for that node
- [x] Verify that the first subitem under that menu item when clicked is the top level page title
- [x] Go to Content->Manage Main Menu
- [x] Add a top level menu item that points to an external resource, like Google
- [x] Nest a menu item underneath the external resource you just made
- [x] When you visit the home page, ensure that the top level menu text is what you entered for your external resource, and that it is duplicated underneath as the first subitem.


[YALB-1633]: https://yaleits.atlassian.net/browse/YALB-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[YALB-1633]: https://yaleits.atlassian.net/browse/YALB-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ