### PR TITLE
YALB-1686: Allow rtf file uploads

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.media.document.field_media_file.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.media.document.field_media_file.yml
@@ -21,7 +21,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'txt doc docx pdf xls xlsx'
+  file_extensions: 'txt rtf doc docx pdf xls xlsx'
   max_filesize: ''
   description_field: false
 field_type: file


### PR DESCRIPTION
## [YALB-1686: Allow rtf file uploads](https://yaleits.atlassian.net/browse/YALB-1686)

### Description of work
- Adds rtf files to the list of allowed file types on the document media entity

### Functional testing steps:
- [ ] [Login to as a site admin](https://pr-526-yalesites-platform.pantheonsite.io/)
- [ ] Navigate to the [media library and add a new document entity](https://pr-526-yalesites-platform.pantheonsite.io/media/add/document)
- [ ] Verify that you can upload an rtf file ([example file here](https://file-examples.com/wp-content/storage/2019/09/file-sample_100kB.rtf).)
