### PR TITLE
YALB-1513: Improve help text for title/heading control fields

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_heading_level.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_heading_level.yml
@@ -12,7 +12,7 @@ field_name: field_heading_level
 entity_type: block_content
 bundle: cta_banner
 label: 'Heading Level'
-description: 'Optionally override heading level for this banner'
+description: 'For more information about conditional banner titles, <a href="https://yalesites.yale.edu/posts/2023-10-17-community-spotlight-yale-united-way-campaign#tips" target="_blank">view our tips and tricks on this topic</a>.'
 required: true
 translatable: false
 default_value:

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_heading_level.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_heading_level.yml
@@ -12,7 +12,7 @@ field_name: field_heading_level
 entity_type: block_content
 bundle: grand_hero
 label: 'Heading Level'
-description: 'Optionally override heading level for this banner'
+description: 'For more information about conditional banner titles, <a href="https://yalesites.yale.edu/posts/2023-10-17-community-spotlight-yale-united-way-campaign#tips" target="_blank">view our tips and tricks on this topic</a>.'
 required: true
 translatable: true
 default_value:

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.text.field_style_variation.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.text.field_style_variation.yml
@@ -11,11 +11,11 @@ id: block_content.text.field_style_variation
 field_name: field_style_variation
 entity_type: block_content
 bundle: text
-label: Text Style Variation
+label: 'Text Style Variation'
 description: ''
 required: true
 translatable: false
-default_value: {}
+default_value: {  }
 default_value_callback: ys_themes_default_value_function
-settings: {}
+settings: {  }
 field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_heading_level.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_heading_level.yml
@@ -13,10 +13,10 @@ settings:
   allowed_values:
     -
       value: '1'
-      label: H1
+      label: 'H1: This page’s title is hidden'
     -
       value: '2'
-      label: H2
+      label: 'H2: This page’s title is displayed or visually hidden'
   allowed_values_function: ''
 module: options
 locked: false

--- a/web/profiles/custom/yalesites_profile/config/sync/system.action.export_content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.action.export_content.yml
@@ -9,5 +9,5 @@ label: 'Export content'
 type: node
 plugin: content_bulk_export
 configuration:
-  assets: '1'
-  translation: '1'
+  assets: true
+  translation: true

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -114,6 +114,6 @@ divider:
 text:
   field_style_variation:
     values:
-      default: 'Default'
-      emphasized: 'Emphasized'
+      default: Default
+      emphasized: Emphasized
     default: default

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesTitleBreadcrumbBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesTitleBreadcrumbBlock.php
@@ -151,7 +151,7 @@ class YaleSitesTitleBreadcrumbBlock extends BlockBase implements ContainerFactor
         'visually-hidden' => $this->t('Visually Hidden: Hide your page title without impacting site accessibility'),
         'hidden' => $this->t('Hide Title: Should only be used when a page’s banner Block title is set to H1'),
       ],
-      '#description' => 'For more information about conditional banner titles, <a href="https://yalesites.yale.edu/posts/2023-10-17-community-spotlight-yale-united-way-campaign#tips" target="_blank">view our tips and tricks on this topic</a>.',
+      '#description' => $this->t('For more information about conditional banner titles, <a href="https://yalesites.yale.edu/posts/2023-10-17-community-spotlight-yale-united-way-campaign#tips" target="_blank">view our tips and tricks on this topic</a>.'),
     ];
 
     return $form;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesTitleBreadcrumbBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesTitleBreadcrumbBlock.php
@@ -147,10 +147,11 @@ class YaleSitesTitleBreadcrumbBlock extends BlockBase implements ContainerFactor
       '#title' => $this->t('Title Display'),
       '#default_value' => $config['page_title_display'] ?? '',
       '#options' => [
-        'visible' => $this->t('Display Title'),
-        'visually-hidden' => $this->t('Visually Hidden'),
-        'hidden' => $this->t('Hide Title'),
+        'visible' => $this->t('Display Title: Your page title is visible and used as the H1'),
+        'visually-hidden' => $this->t('Visually Hidden: Hide your page title without impacting site accessibility'),
+        'hidden' => $this->t('Hide Title: Should only be used when a page’s banner Block title is set to H1'),
       ],
+      '#description' => 'For more information about conditional banner titles, <a href="https://yalesites.yale.edu/posts/2023-10-17-community-spotlight-yale-united-way-campaign#tips" target="_blank">view our tips and tricks on this topic</a>.',
     ];
 
     return $form;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PageMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PageMetaBlock.php
@@ -117,8 +117,8 @@ class PageMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
         'visually-hidden' => $this->t('Visually Hidden: Hide your page title without impacting site accessibility'),
         'hidden' => $this->t('Hide Title: Should only be used when a page’s banner Block title is set to H1'),
       ],
-      '#description' => 'For more information about conditional banner titles, <a href="https://yalesites.yale.edu/posts/2023-10-17-community-spotlight-yale-united-way-campaign#tips" target="_blank">view our tips and tricks on this topic</a>.',
-    ];
+      '#description' => $this->t('For more information about conditional banner titles, <a href="https://yalesites.yale.edu/posts/2023-10-17-community-spotlight-yale-united-way-campaign#tips" target="_blank">view our tips and tricks on this topic</a>.'),
+      ];
 
     return $form;
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PageMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PageMetaBlock.php
@@ -118,7 +118,7 @@ class PageMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
         'hidden' => $this->t('Hide Title: Should only be used when a page’s banner Block title is set to H1'),
       ],
       '#description' => $this->t('For more information about conditional banner titles, <a href="https://yalesites.yale.edu/posts/2023-10-17-community-spotlight-yale-united-way-campaign#tips" target="_blank">view our tips and tricks on this topic</a>.'),
-      ];
+    ];
 
     return $form;
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PageMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PageMetaBlock.php
@@ -113,10 +113,11 @@ class PageMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
       '#title' => $this->t('Title Display'),
       '#default_value' => $config['page_title_display'] ?? '',
       '#options' => [
-        'visible' => $this->t('Display Title'),
-        'visually-hidden' => $this->t('Visually Hidden'),
-        'hidden' => $this->t('Hide Title'),
+        'visible' => $this->t('Display Title: Your page title is visible and used as the H1'),
+        'visually-hidden' => $this->t('Visually Hidden: Hide your page title without impacting site accessibility'),
+        'hidden' => $this->t('Hide Title: Should only be used when a page’s banner Block title is set to H1'),
       ],
+      '#description' => 'For more information about conditional banner titles, <a href="https://yalesites.yale.edu/posts/2023-10-17-community-spotlight-yale-united-way-campaign#tips" target="_blank">view our tips and tricks on this topic</a>.',
     ];
 
     return $form;


### PR DESCRIPTION
## [YALB-1513: Improve help text for title/heading control fields](https://yaleits.atlassian.net/browse/YALB-1513)

### Description of work
- Adds help text for heading override fields on page title blocks and banner blocks.
- Exports configuration which updates two files with non functional changes.

### Functional testing steps:
- [ ] [Login as as site admin](https://pr-527-yalesites-platform.pantheonsite.io/)
- [ ] Navigate to an [existing page and view the edit layout interface](https://pr-527-yalesites-platform.pantheonsite.io/node/1/layout)
- [ ] 'Configure' the page title block and verify that the new verbose options and help text appear.
![Screen Shot 2024-01-10 at 11 52 25 AM](https://github.com/yalesites-org/yalesites-project/assets/9594124/397c3e84-85a7-469a-aa83-d641f3b7daec)
- [ ] Add a CTA Banner and verify that the new verbose options and help text appear.
![Screen Shot 2024-01-10 at 11 53 55 AM](https://github.com/yalesites-org/yalesites-project/assets/9594124/7d1c2474-bea7-4c2e-9a55-a390dbb292b9)
- [ ] Add a Grand Hero Banner and verify that the new verbose options and help text appear.