### PR TITLE
YALB-1663: User getting error page when clicking "edit layout and content" in top menu

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -166,6 +166,9 @@
       },
       "drupal/quick_node_clone": {
         "Fix cloning of inline blocks and paragraphs: https://www.drupal.org/project/quick_node_clone/issues/3100117": "https://www.drupal.org/files/issues/2023-04-25/quick-node-clone--inline-blocks--3100117-32.patch"
+      },
+      "drupal/section_library": {
+        "Fix access check issues on add_to_template link: https://www.drupal.org/project/section_library/issues/3241715": "https://www.drupal.org/files/issues/2022-09-21/3241715-6.patch"
       }
     }
   }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
@@ -61,7 +61,6 @@ third_party_settings:
               4: 4
               5: 5
               6: 6
-              7: 7
               8: 8
       -
         layout_id: layout_onecol

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
@@ -79,7 +79,10 @@ third_party_settings:
               context_mapping: {  }
             weight: 0
             additional: {  }
-        third_party_settings: {  }
+        third_party_settings:
+          layout_builder_lock:
+            lock:
+              5: 5
   layout_builder_restrictions:
     allowed_block_categories:
       - 'Chaos Tools'

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
@@ -60,7 +60,6 @@ third_party_settings:
               4: 4
               5: 5
               6: 6
-              7: 7
               8: 8
       -
         layout_id: ys_layout_two_column
@@ -79,7 +78,9 @@ third_party_settings:
               context_mapping: {  }
             weight: 0
             additional: {  }
-        third_party_settings: {  }
+        third_party_settings:
+          layout_builder_lock:
+            lock: {  }
   layout_builder_restrictions:
     allowed_block_categories:
       - 'Chaos Tools'

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
@@ -79,10 +79,7 @@ third_party_settings:
               context_mapping: {  }
             weight: 0
             additional: {  }
-        third_party_settings:
-          layout_builder_lock:
-            lock:
-              5: 5
+        third_party_settings: {  }
   layout_builder_restrictions:
     allowed_block_categories:
       - 'Chaos Tools'


### PR DESCRIPTION
## [YALB-1663: User getting error page when clicking "edit layout and content" in top menu](https://yaleits.atlassian.net/browse/YALB-1663)

There was a problem where a user deleted the default content section. Upon saving this, they were unable to go back in to modify the page in layout builder.  This was due to an access check issue in section_library.  This patch fixes this so that the user could edit the page in layout builder again.

### Description of work
- Adds `section_library` patch to allow access check to not throw an exception

### Functional testing steps:
- [ ] Create or edit a page and go into layout builder
- [ ] Delete the "Content Section" section
- [ ] Save layout builder
- [ ] Attempt to go back into layout builder for that page
- [ ] Verify no white screen of death happens
- [ ] Verify you can add sections and blocks without issue
- [ ] Verify that without the default content section, you can still utilize the `Skip to main content` link
- [ ] Perform the above to Profiles as well to verify it will allow removal of "Content Section"

### References

- [Section Library Issue](https://www.drupal.org/project/section_library/issues/3241715)
- [Section Library Patch](https://www.drupal.org/files/issues/2022-09-21/3241715-6.patch)
