### PR TITLE
feat: content on install to environments other than dev

### DIFF
--- a/scripts/shared/content-import.sh
+++ b/scripts/shared/content-import.sh
@@ -22,10 +22,11 @@ if [ "$YALESITES_IS_LOCAL" == "1" ]; then
   homepage_nid=$(lando drush ev "$nid_command")
   lando drush cset system.site page.front "$homepage_nid" -y
 else
-  COMMAND=$(terminus connection:info "$SITE_MACHINE_NAME".dev --field=sftp_command)
+  [ -z "$env" ] && env="dev"
+  COMMAND=$(terminus connection:info "$SITE_MACHINE_NAME"."$env" --field=sftp_command)
   eval "$COMMAND:/files/ <<< 'put $STARTERKIT_FILE'"
-  terminus drush "$SITE_MACHINE_NAME".dev -- content:import ../../files/"$STARTERKIT_FILE"
+  terminus drush "$SITE_MACHINE_NAME"."$env" -- content:import ../../files/"$STARTERKIT_FILE"
   eval "$COMMAND:/files/ <<< 'rm $STARTERKIT_FILE'"
-  homepage_nid=$(echo "$nid_command" | terminus drush "$SITE_MACHINE_NAME".dev -- php-script - 2>/dev/null)
-  terminus drush "$SITE_MACHINE_NAME".dev -- cset system.site page.front "$homepage_nid" -y
+  homepage_nid=$(echo "$nid_command" | terminus drush "$SITE_MACHINE_NAME"."$env" -- php-script - 2>/dev/null)
+  terminus drush "$SITE_MACHINE_NAME"."$env" -- cset system.site page.front "$homepage_nid" -y
 fi


### PR DESCRIPTION
### Description of work
- Changes the content import script to use a variable for the remote environment, and falls back to `dev`. This allows us to set the environment from outside the script if needed.