### PR TITLE
rel-100-quicklink-format-fix: Re-introduce heading_html format

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.quick_links.field_text.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.quick_links.field_text.yml
@@ -20,5 +20,5 @@ default_value: {  }
 default_value_callback: ''
 settings:
   allowed_formats:
-    - restricted_html
+    - heading_html
 field_type: text_long


### PR DESCRIPTION
## rel-100: Quicklink format fix

In updating develop from master, the allowed_formats were overwritten from before.  This re-establishes this for new quicklink blocks.

### Description of work
- Ensure that new Quicklinks blocks do not allow links

### Functional testing steps:
- [ ] Create a new quick link block
- [ ] Verify that the content section will not allow a link