### PR TITLE
rel-100: Linkit alias patch removal

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -161,8 +161,7 @@
         "Cannot install from existing config https://www.drupal.org/project/google_analytics/issues/3373921": "https://www.drupal.org/files/issues/2023-08-07/google-analytics-issues-3373921-cannot-install-from-existing-config-11.patch"
       },
       "drupal/linkit": {
-        "Add phone number matcher https://www.drupal.org/project/linkit/issues/3273630": "https://git.drupalcode.org/project/linkit/-/merge_requests/36.diff",
-        "Fix linkit autocomplete alias selection https://www.drupal.org/project/linkit/issues/2877535": "https://www.drupal.org/files/issues/2023-10-05/linkit-2877535-64.patch"
+        "Add phone number matcher https://www.drupal.org/project/linkit/issues/3273630": "https://git.drupalcode.org/project/linkit/-/merge_requests/36.diff"
       },
       "drupal/quick_node_clone": {
         "Fix cloning of inline blocks and paragraphs: https://www.drupal.org/project/quick_node_clone/issues/3100117": "https://www.drupal.org/files/issues/2023-04-25/quick-node-clone--inline-blocks--3100117-32.patch"


### PR DESCRIPTION
## rel-100: Linkit alias patch removal

Since I believe we are using the node id to set the home page for content on install, I don't think this patch was needed.

This is causing the home page alias to be used over the node id and somehow resulting in too many redirects in some cases.

### Description of work
- Removes the alias patch to allow node id to be used in Linkit

### Functional testing steps:
- [ ] Attempt to set the home page to a node
- [ ] On save, ensure that it still uses the node id
- [ ] Try Linkit in other cases, like inside CKE blocks to verify all is well.
- [ ] Verify no redirection error when logged out
