### PR TITLE
fix: filter out merge commits that do not have a PR (actions create PR workflow)

### DIFF
--- a/.ci/github/create_release_pull_request
+++ b/.ci/github/create_release_pull_request
@@ -9,7 +9,7 @@ if [[ -z "$PR_NUMBER" ]]; then
     -X POST -d '{"title": "Release", "head": "develop", "base": "master"}' \
     "https://api.github.com/repos/$REPO/pulls")
 
-  message=$(echo "$pull_request_response" | jq -r 'if has("errors") then .errors[].message else empty end')
+  message=$(echo "$pull_request_response" | jq -r 'if has("errors") then .errors[].message else null end')
 
   # Check if the pull request creation was successful.
   if [ -n "$message" ]; then
@@ -61,7 +61,7 @@ changes_without_pr=()
 for sha in $commit_shas; do
   single_pr_url=$(curl -s -H "Authorization: token $ACCESS_TOKEN" \
     "https://api.github.com/repos/$REPO/commits/$sha/pulls" \
-    | jq -r '.[].html_url')
+    | jq -r 'if type == "object" and has("message") then null else .[].html_url end')
 
   if [[ -n "$single_pr_url" ]]; then
     pull_requests+=("$single_pr_url")


### PR DESCRIPTION
### Description of work
- When updating release PRs, filter out merge commits that caused `jq` parsing errors