### PR TITLE
fix: YALB-959 - revert site admin access block library permission

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -71,6 +71,7 @@ label: 'Site administrator'
 weight: 3
 is_admin: null
 permissions:
+  - 'access block library'
   - 'access content overview'
   - 'access contextual links'
   - 'access files overview'


### PR DESCRIPTION
## Pull requests
- https://github.com/yalesites-org/yalesites-project/pull/541
