### PR TITLE
rel-100-hotfix: Submenu Display Fix

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -6,12 +6,10 @@
  */
 
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
-use Drupal\menu_item_extras\Entity\MenuItemExtrasMenuLinkContent;
 
 /**
  * @file
@@ -240,8 +238,19 @@ function ys_core_preprocess_menu(&$variables) {
       // @see component-library-twig/components/02-molecules/menu/_yds-menu-item.twig
       $clonedMenuItem['list__item__is_heading'] = TRUE;
 
-      // Get the CTA text from menu item extras field.
+      // Get the CTA text from menu item extras field. (for mega menu)
       $clonedMenuItem['heading_cta'] = $clonedMenuItem['entity']->get('field_menu_top_level_link_cta')->value ?: t('Explore @title', ['@title' => $clonedMenuItem['title']]);
+
+      // Default the node_title to the menu title.
+      $clonedMenuItem['node_title'] = $clonedMenuItem['title'];
+
+      // If the menu item is associated with a node, replace the node_title
+      // with the node's title.
+      if ($menuItem['url']->isRouted()) {
+        $nodeId = $menuItem['url']->getRouteParameters()['node'];
+        $node = \Drupal::entityTypeManager()->getStorage('node')->load($nodeId);
+        $clonedMenuItem['node_title'] = $node->getTitle();
+      }
 
       // Add cloned item to the beginning of the menu.
       array_unshift($menuItem['below'], $clonedMenuItem);
@@ -396,98 +405,6 @@ function ys_core_preprocess_image_widget(&$variables) {
 function ys_core_taxonomy_term_update() {
   Cache::invalidateTags(['rendered']);
 }
-
-/**
- * The following functions add menu item extras fields to node add/edit forms.
- *
- * @see https://www.drupal.org/project/menu_item_extras/issues/2992096#comment-14140361
- */
-
-/**
- * Implements hook_form_FORM_ID_alter().
- */
-function ys_core_form_node_page_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  ys_core_page_form_alter($form, $form_state);
-}
-
-/**
- * Implements hook_form_FORM_ID_alter().
- */
-function ys_core_form_node_page_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  ys_core_page_form_alter($form, $form_state);
-}
-
-/**
- * Alters the page node forms.
- *
- * @var array $form
- *  The form array.
- * @var Drupal\Core\Form\FormStateInterface $form_state
- *  The current form state.
- */
-function ys_core_page_form_alter(&$form, FormStateInterface $form_state) {
-
-  // Add menu link fields to node form.
-  if ($link = _ys_core_get_link($form_state)) {
-    $form_display = EntityFormDisplay::load('menu_link_content.' . $link->getMenuName() . '.default');
-    assert($form_display instanceof EntityFormDisplay);
-    $form['menu']['link']['extra'] = [
-      '#type' => 'container',
-      '#parents' => ['menu', 'extra'],
-    ];
-    $form_display->buildForm($link, $form['menu']['link']['extra'], $form_state);
-    // Only keep custom fields, other properties already are in the form.
-    foreach (Element::children($form['menu']['link']['extra']) as $key) {
-      if (strpos($key, 'field_') !== 0) {
-        unset($form['menu']['link']['extra'][$key]);
-      }
-    }
-
-    foreach (array_keys($form['actions']) as $action) {
-      if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
-        $form['actions'][$action]['#submit'][] = 'ys_core_save_menu_link_fields';
-      }
-    }
-  }
-}
-
-/**
- * Saves the menu item extras when on the node add/edit pages.
- *
- * @throws \Drupal\Core\Entity\EntityStorageException
- */
-function ys_core_save_menu_link_fields(array $form, FormStateInterface $form_state) {
-  if ($link = _ys_core_get_link($form_state)) {
-    // Only save the menu item extras if there is a menu link with a route.
-    if ($link->getUrlObject()->getRouteName()) {
-      $form_display = EntityFormDisplay::load('menu_link_content.' . $link->getMenuName() . '.default');
-      if ($form_display instanceof EntityFormDisplay) {
-        $form_display->extractFormValues($link, $form['menu']['link']['extra'], $form_state);
-        $link->save();
-      }
-    }
-  }
-}
-
-/**
- * Gets any menu item extras content.
- *
- * @return Drupal\menu_item_extras\Entity\MenuItemExtrasMenuLinkContent
- *   Menu item extras content.
- */
-function _ys_core_get_link(FormStateInterface $form_state) {
-  /** @var Drupal\node\Entity $form_state */
-  $node = $form_state->getFormObject()->getEntity();
-  $defaults = menu_ui_get_menu_link_defaults($node);
-  if ($mlid = $defaults['entity_id']) {
-    return MenuItemExtrasMenuLinkContent::load($mlid);
-  }
-  return MenuItemExtrasMenuLinkContent::create($defaults);
-}
-
-/**
- * End allow menu item extras fields to be included on node add and edit forms.
- */
 
 /**
  * Implements hook_preprocess_page().


### PR DESCRIPTION
## REL-100-Hotfix: Submenu Display Fix

In getting the release ready, the YaleSites portion of the menu fix was not included in the release.  This cherry-picks the commit to be included such that sites will properly display a submenu top level item for basic menus.

### Description of work
- Cherry-picked develop commit to be included in hotfix

### Functional testing steps:
- [ ] Verify that submenu top level basic menu item now displays correctly.