### PR TITLE
REL-100 Hotfix: add guard clauses to bypass <nolink>

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -249,7 +249,10 @@ function ys_core_preprocess_menu(&$variables) {
       if ($menuItem['url']->isRouted()) {
         $nodeId = $menuItem['url']->getRouteParameters()['node'];
         $node = \Drupal::entityTypeManager()->getStorage('node')->load($nodeId);
-        $clonedMenuItem['node_title'] = $node->getTitle();
+
+        if ($node) {
+          $clonedMenuItem['node_title'] = $node->getTitle();
+        }
       }
 
       // Add cloned item to the beginning of the menu.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -247,11 +247,18 @@ function ys_core_preprocess_menu(&$variables) {
       // If the menu item is associated with a node, replace the node_title
       // with the node's title.
       if ($menuItem['url']->isRouted()) {
-        $nodeId = $menuItem['url']->getRouteParameters()['node'];
-        $node = \Drupal::entityTypeManager()->getStorage('node')->load($nodeId);
+        $routeParameters = $menuItem['url']->getRouteParameters();
 
-        if ($node) {
-          $clonedMenuItem['node_title'] = $node->getTitle();
+        if (array_key_exists('node', $routeParameters)) {
+          $nodeId = $routeParameters['node'];
+
+          if ($nodeId) {
+            $node = \Drupal::entityTypeManager()->getStorage('node')->load($nodeId);
+
+            if ($node) {
+              $clonedMenuItem['node_title'] = $node->getTitle();
+            }
+          }
         }
       }
 


### PR DESCRIPTION
# REL-100 Hotfix: add guard clauses to bypass

There were some sites who had link references in their top level menus, resulting in errors attempting to get a valid node. From what I can tell, having a still results in a menu item showing as "routable", even though a node does not exist on it. This patches this by checking each variable exists and to check that a node param exists on the routable parameters. It should also guard against any other cases where it thinks it's routable but has no node.

### Description of work

- Adds guard checks to node detection

### Functional testing steps:

- [ ] Create a top level menu item with a link to
- [ ] Create a submenu item for that menu
- [ ] Verify that you can load the front page without errors
- [ ] Verify that the first submenu item has the same name as the top level item.