### PR TITLE
YALB-1696: Hotfix: Can't configure Page title as Site admin

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/js/block-form.js
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/js/block-form.js
@@ -1,59 +1,78 @@
 ((Drupal) => {
   Drupal.behaviors.ysCoreBlockForm = {
-    attach: () => { // eslint-disable-line
+    attach: () => {
+      // eslint-disable-line
 
       /*
-      * Function to validate that all media items contain media.
-      *
-      * @param object blockType
-      *   blockType object.
-      *
-      * @return string
-      *   The error message or empty string.
-      * */
+       * Function to validate that all media items contain media.
+       *
+       * @param object blockType
+       *   blockType object.
+       *
+       * @return string
+       *   The error message or empty string.
+       * */
       function getErrors(blockType) {
         // Get all items of the specified type.
         const items = document.querySelectorAll(blockType.itemSelector);
 
         // Count the number of items present.
         const numberOfItems = items.length;
-        if (numberOfItems < blockType.min || (blockType.max > 0 && numberOfItems > blockType.max)) {
-          let messageText = '';
+        if (
+          numberOfItems < blockType.min ||
+          (blockType.max > 0 && numberOfItems > blockType.max)
+        ) {
+          let messageText = "";
           if (blockType.max > 0) {
             messageText = `Number of ${blockType.type} must be between ${blockType.min} and ${blockType.max}. `;
           } else {
             messageText = `Number of ${blockType.type} must be ${blockType.min} or more. `;
           }
-          return messageText + `Number of ${blockType.type} added: ${numberOfItems}.`;
+          return (
+            messageText + `Number of ${blockType.type} added: ${numberOfItems}.`
+          );
         }
 
         // An empty string signifies no errors and resets validation for the input.
-        return '';
+        return "";
       }
 
       /*
-      * Function to validate a block type.
-      *
-      * @param object blocktype
-      *   Object containing block type information for validation.
-      *
-      * @return void
-      * */
+       * Function to validate a block type.
+       *
+       * @param object blocktype
+       *   Object containing block type information for validation.
+       *
+       * @return void
+       * */
       function validateBlockType(blockType) {
         // Get the layout builder add and update forms.
-        const blockContentForm = document.querySelector('form[id^="block-content"]');
+        const blockContentForm = document.querySelector(
+          'form[id^="block-content"]'
+        );
         // Inputs and submit selectors are different on block content and layout builder forms.
-        const inputSelector = blockContentForm ? blockType.inputSelector : blockType.lbInputSelector;
-        const submitSelector = blockContentForm ? 'edit-submit' : 'edit-actions-submit';
-        const submitButton = document.querySelector(`input[data-drupal-selector=${submitSelector}]`);
+        const inputSelector = blockContentForm
+          ? blockType.inputSelector
+          : blockType.lbInputSelector;
+        const submitSelector = blockContentForm
+          ? "edit-submit"
+          : "edit-actions-submit";
+        const submitButton = document.querySelector(
+          `input[data-drupal-selector=${submitSelector}]`
+        );
 
         if (submitButton) {
           // On click, check for custom errors.
           submitButton.addEventListener("click", () => {
             const input = document.querySelector(inputSelector);
             const errorMsg = getErrors(blockType);
-            // If there are any errors, set custom validity on the chosen input field.
-            input.setCustomValidity(errorMsg);
+            // If there are any errors, set custom validity on the chosen input field if it's visible.
+            if (input.type === "hidden") {
+              submitButton.setCustomValidity(errorMsg);
+              // Otherwise set it on the submit button.
+            } else {
+              input.setCustomValidity(errorMsg);
+            }
           });
         }
       }
@@ -62,40 +81,44 @@
       const blockTypes = [
         {
           // Tabs
-          itemSelector: 'tr.paragraph-type--tab',
+          itemSelector: "tr.paragraph-type--tab",
           inputSelector: 'input[data-drupal-selector^="edit-field-tabs"]',
-          lbInputSelector: 'input[data-drupal-selector^="edit-settings-block-form-field-tabs"]',
+          lbInputSelector:
+            'input[data-drupal-selector^="edit-settings-block-form-field-tabs"]',
           min: 2,
           max: 5,
-          type: 'tabs',
+          type: "tabs",
         },
         {
           // Quick links
-          itemSelector: 'input.ui-autocomplete-input',
+          itemSelector: "input.ui-autocomplete-input",
           inputSelector: 'input[data-drupal-selector^="edit-field-heading"]',
-          lbInputSelector: 'input[data-drupal-selector^="edit-settings-block-form-field-links"]',
+          lbInputSelector:
+            'input[data-drupal-selector^="edit-settings-block-form-field-links"]',
           min: 3,
           max: 9,
-          type: 'links',
+          type: "links",
         },
         {
           // Media Grid
-          itemSelector: '.paragraph-type--media-grid-item',
+          itemSelector: ".paragraph-type--media-grid-item",
           inputSelector: 'input[data-drupal-selector^="edit-field-heading"]',
-          lbInputSelector: 'input[data-drupal-selector^="edit-settings-block-form-field-heading"]',
+          lbInputSelector:
+            'input[data-drupal-selector^="edit-settings-block-form-field-heading"]',
           min: 2,
           max: 0,
-          type: 'media grid items',
+          type: "media grid items",
         },
         {
           // Gallery
-          itemSelector: '.paragraph-type--gallery-item',
+          itemSelector: ".paragraph-type--gallery-item",
           inputSelector: 'input[data-drupal-selector^="edit-field-heading"]',
-          lbInputSelector: 'input[data-drupal-selector^="edit-settings-block-form-field-heading"]',
+          lbInputSelector:
+            'input[data-drupal-selector^="edit-settings-block-form-field-heading"]',
           min: 2,
           max: 0,
-          type: 'gallery items',
-        }
+          type: "gallery items",
+        },
       ];
 
       // Apply the function to each block type.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -137,18 +137,17 @@ function ys_core_form_alter(&$form, $form_state, $form_id) {
     'layout_builder_add_block',
   ];
 
-  // In some cases, block_form will not exist, so we guard against this.
-  // It does seem to exist in the casese we are checking for.
-  if (in_array($form_id, $layout_builder_block_forms) && isset($form['settings']['block_form'])) {
-    // Get the block type from the form.
-    $block = $form['settings']['block_form']['#block'];
+  if (in_array($form_id, $layout_builder_block_forms)) {
+    $inline_block_type_name = $form_state->getBuildInfo()['args'][3];
+    $block_type_name = explode(':', $inline_block_type_name)[-1];
+
     $limited_block_types = [
       'tabs',
       'quick_links',
       'media_grid',
       'gallery',
     ];
-    if (in_array($block->bundle(), $limited_block_types)) {
+    if (in_array($block_type_name, $limited_block_types)) {
       $form['#attached']['library'][] = 'ys_core/block_form';
     }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -438,9 +438,13 @@ function ys_core_get_block_type(&$form, &$form_state) {
   if (strpos($inline_block_type_name, ':') !== FALSE) {
     $block_type_name = explode(':', $inline_block_type_name)[1];
   }
-  // Otherwise, attempt to get it the original way.
-  else {
+  // Otherwise, attempt to get it the original way if it exists.
+  elseif (isset($form['settings']['block_form'])) {
     $block_type_name = $form['settings']['block_form']['#block']->bundle();
+  }
+  // If we can't find it, make it something that will fail any future checks.
+  else {
+    $block_type_name = "unknown";
   }
 
   return $block_type_name;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -138,8 +138,7 @@ function ys_core_form_alter(&$form, $form_state, $form_id) {
   ];
 
   if (in_array($form_id, $layout_builder_block_forms)) {
-    $inline_block_type_name = $form_state->getBuildInfo()['args'][3];
-    $block_type_name = explode(':', $inline_block_type_name)[-1];
+    $block_type_name = ys_core_get_block_type($form, $form_state);
 
     $limited_block_types = [
       'tabs',
@@ -417,4 +416,32 @@ function ys_core_preprocess_page(&$variables) {
   // Via: https://drupal.stackexchange.com/questions/266379/how-to-clear-cache-for-config-entity-after-making-changes
   $config = \Drupal::config('ys_core.header_settings');
   \Drupal::service('renderer')->addCacheableDependency($variables, $config);
+}
+
+/**
+ * Retrieves the block type from a form.
+ *
+ * @param array $form
+ *   The form array.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ *
+ * @return string
+ *   The block type name.
+ */
+function ys_core_get_block_type(&$form, &$form_state) {
+  $block_type_name = "";
+  $inline_block_type_name = $form_state->getBuildInfo()['args'][3];
+
+  // If adding a new element, arg 3 should be of the form:
+  // inline_block:BLOCK_TYPE_NAME.
+  if (strpos($inline_block_type_name, ':') !== FALSE) {
+    $block_type_name = explode(':', $inline_block_type_name)[1];
+  }
+  // Otherwise, attempt to get it the original way.
+  else {
+    $block_type_name = $form['settings']['block_form']['#block']->bundle();
+  }
+
+  return $block_type_name;
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -137,7 +137,9 @@ function ys_core_form_alter(&$form, $form_state, $form_id) {
     'layout_builder_add_block',
   ];
 
-  if (in_array($form_id, $layout_builder_block_forms)) {
+  // In some cases, block_form will not exist, so we guard against this.
+  // It does seem to exist in the casese we are checking for.
+  if (in_array($form_id, $layout_builder_block_forms) && isset($form['settings']['block_form'])) {
     // Get the block type from the form.
     $block = $form['settings']['block_form']['#block'];
     $limited_block_types = [
@@ -151,6 +153,7 @@ function ys_core_form_alter(&$form, $form_state, $form_id) {
     }
 
   }
+
 }
 
 /**


### PR DESCRIPTION
## [YALB-1696: Can't configure Page title as Site admin](https://yaleits.atlassian.net/browse/YALB-1696)

### Description of work
- Add method to have a better attempt to get the block type
- Modified block form JS to revert to providing the error message to the submit button if the input targeted is not visible.

### Functional testing steps:
- [ ] Verify you can modify the page title of a page using the configure button
- [ ] Find or create the following items, ensuring that the functionality in [YALB-959](https://github.com/yalesites-org/yalesites-project/pull/515) is in tact:
  - [ ] Tabs
  - [ ] Quick Links
  - [ ] Image Grid
  - [ ] Media Gallery
- [ ] Attempt to add new elements outside of those to ensure no errors happen

On develop for now so we can test, then will move to master for hotfix inclusion.

[YALB-959]: https://yaleits.atlassian.net/browse/YALB-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ