### PR TITLE
YALB-1704: Block names "missing" in Block picker (Hotfix on develop) - DO NOT MERGE

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -57,7 +57,7 @@
     "drupal/imagemagick": "3.4",
     "drupal/improve_line_breaks_filter": "1.5",
     "drupal/inline_entity_form": "2.0.0-rc9",
-    "drupal/layout_builder_browser": "1.x-dev@dev",
+    "drupal/layout_builder_browser": "1.6",
     "drupal/layout_builder_iframe_modal": "1.3",
     "drupal/layout_builder_lock": "1.2",
     "drupal/layout_builder_restrictions": "2.19",


### PR DESCRIPTION
## [YALB-1704: Block names "missing" in Block picker (Hotfix on develop) - DO NOT MERGE](https://yaleits.atlassian.net/browse/YALB-1704)

A new commit was made that broke how Wingsuit is able to decorate links. Since this wasn't truely pinned, we are doing it now which seems to fix this issue.  Checking, it is currently set to the commit before this problematic commit.

Problem commit: https://git.drupalcode.org/project/layout_builder_browser/-/commit/e6575cdbde1f746328b868647f51c6acae41e4d4#d37ca903adbba2f7149c203d859b8d73ba95fa6a_286_291

This was created only to create a multidev showing the change so we all can test easier.

### Description of work
- Pins layout_builder_browser to 1.6

### Functional testing steps:
- [ ] See [the real hotfix](https://github.com/yalesites-org/yalesites-project/pull/550)