### PR TITLE
YALB-1568: FE Bug: Profile page breadcrumb issue

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -457,3 +457,11 @@ function ys_core_get_block_type(&$form, &$form_state) {
 
   return $block_type_name;
 }
+
+/**
+ * Implements hook_preprocess_html().
+ */
+function ys_core_preprocess_html(&$variables) {
+  // Adds the content type in a class to support specific content type styling.
+  $variables['attributes']['class'][] = isset($variables['node_type']) ? "ys-content-type-{$variables['node_type']}" : NULL;
+}


### PR DESCRIPTION
… content type styling

## [YALB-1568: FE Bug: Profile page breadcrumb issue](https://yaleits.atlassian.net/browse/YALB-1568)

### Description of work
- Adds body class with content type for specific content type styling

### Functional testing steps:
- [x] Create two different content types with one of them being a profile
- [x] No need to place anything in layout builder for these tests
- [x] View these pages on the front-end and inspect the page
- [x] Verify that the body class has a class of `ys-content-type-[content-type]`.

![Screenshot 2024-02-06 at 3 08 43 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/a7dc00bb-f4a8-4d6d-be7b-78fd5d5245b4)

- [x] Visit a non-node page such as the search page or an admin page
- [x] Inspect the page and verify that no specific content type body class has been added
- [x] Add the profile page to a menu as a third level deep item (this will ensure breadcrumbs will appear) - do this via `/admin/structure/menu/manage/main`
- [x] Visit the profile page and verify that the breadcrumbs have enough space between the profile meta block and the header.

![Screenshot 2024-02-06 at 3 11 16 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/998500fc-59c5-42f4-9f4d-a7ed070c584a)

