### PR TITLE
YALB-1714: Pin gin_lb module to ensure patch applies

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -49,7 +49,7 @@
     "drupal/field_group": "3.4",
     "drupal/formdazzle": "3.0.0",
     "drupal/gin": "3.0-rc6",
-    "drupal/gin_lb": "1.0.x-dev@dev",
+    "drupal/gin_lb": "1.0.0-rc5",
     "drupal/google_analytics": "4.0.2",
     "drupal/hide_revision_field": "2.3",
     "drupal/honeypot": "2.1.3",
@@ -148,7 +148,7 @@
         "update dark mode localstorage https://www.drupal.org/project/gin/issues/3387653": "https://git.drupalcode.org/project/gin/-/merge_requests/304.diff"
       },
       "drupal/gin_lb": {
-        "fix multivalued fields throw an error": "https://www.drupal.org/files/issues/2024-01-02/gin_lb-fix-attribute-3387157-5.patch"
+        "Fix multivalued fields throw an error https://www.drupal.org/project/gin_lb/issues/3387157": "https://www.drupal.org/files/issues/2024-01-02/gin_lb-fix-attribute-3387157-5.patch"
       },
       "drupal/media_library_form_element": {
         "Order Media items https://www.drupal.org/project/media_library_form_element/issues/3168027":"https://www.drupal.org/files/issues/2022-01-22/order_media_items-3168027-8.patch",


### PR DESCRIPTION
## [YALB-1714: Pin gin_lb module to ensure patch applies](https://yaleits.atlassian.net/browse/YALB-1714)

### Description of work
- Pins this module to ensure the patch applies. This was failing (as captured in the JIRA tickets) because we are tracking the latest dev and this module is undergoing a large rewrite.

### Functional testing steps:
- [ ] Inspect the build log. If this builds without composer error, then the bug is resolved.