### PR TITLE
YSP-320: Admin secondary toolbar showing white foreground on white background in light mode

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_toolbar/css/ys_toolbar.theme.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_toolbar/css/ys_toolbar.theme.css
@@ -74,22 +74,3 @@ behind the a.toolbar-icon element. */
 .gin--dark-mode :not(.glb-form-checkboxes):not(td):not(.media-library-item__click-to-select-checkbox):not(.field-content) > .glb-form-type--checkbox input:checked ~ .glb-checkbox-toggle .glb-checkbox-toggle__inner {
   background-color: var(--gin-color-primary) !important;
 }
-
-/* Make the secondary toolbar the same color as the primary toolbar */
-.gin-secondary-toolbar--frontend {
-  background: rgba(255, 255, 255, 1) !important;
-}
-
-.gin--dark-mode .gin-secondary-toolbar--frontend {
-  background: rgba(42, 42, 45, 1) !important;
-}
-
-@supports ((-webkit-backdrop-filter: blur()) or (backdrop-filter: blur())) {
-  .gin-secondary-toolbar--frontend {
-    background: rgba(255, 255, 255, 1) !important;
-  }
-
-  .gin--dark-mode .gin-secondary-toolbar--frontend {
-    background: rgba(42, 42, 45, 1) !important;
-  }
-}


### PR DESCRIPTION
## [YSP-320: Admin secondary toolbar showing white foreground on white background in light mode](https://yaleits.atlassian.net/browse/YSP-320)

We found that on light mode, the secondary toolbar was presenting itself as white on white, making it hard to navigate.  This removes that decoration so that it displays the same in both dark and light mode.

### Description of work
- Removed CSS that forces background color on secondary toolbar

### Functional testing steps:
- [ ] Ensure you are in light mode on your computer
- [ ] Log into the site
- [ ] Visit any page
- [ ] Ensure that the secondary toolbar is visible
- [ ] Change your computer to use dark mode
- [ ] Visit any page
- [ ] Ensure that the secondary toolbar is visible

#### Light Mode
![LightMode](https://github.com/yalesites-org/yalesites-project/assets/128765777/2093fc3f-0dd8-4d63-b6d4-8542dae882f1)

#### Dark Mode
![DarkMode](https://github.com/yalesites-org/yalesites-project/assets/128765777/1fe33464-6ec0-4578-a644-b8a2f39ec2ab)