### PR TITLE
YSP-324: Deprecation warning in smart_date causes axe to find issue

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -151,7 +151,7 @@
         "Fix multivalued fields throw an error https://www.drupal.org/project/gin_lb/issues/3387157": "https://www.drupal.org/files/issues/2024-01-02/gin_lb-fix-attribute-3387157-5.patch"
       },
       "drupal/media_library_form_element": {
-        "Order Media items https://www.drupal.org/project/media_library_form_element/issues/3168027":"https://www.drupal.org/files/issues/2022-01-22/order_media_items-3168027-8.patch",
+        "Order Media items https://www.drupal.org/project/media_library_form_element/issues/3168027": "https://www.drupal.org/files/issues/2022-01-22/order_media_items-3168027-8.patch",
         "Deprecated function: explode(): Passing null to parameter #2 ($string) of type string is deprecated https://www.drupal.org/project/media_library_form_element/issues/3277273": "https://www.drupal.org/files/issues/2023-01-25/deprecated-explode-3277273-11.patch"
       },
       "drupal/redirect": {
@@ -175,6 +175,9 @@
       },
       "drupal/section_library": {
         "Fix access check issues on add_to_template link: https://www.drupal.org/project/section_library/issues/3241715": "https://www.drupal.org/files/issues/2022-09-21/3241715-6.patch"
+      },
+      "drupal/smart_date": {
+        "Fix deprecation:": "https://git.drupalcode.org/project/smart_date/-/merge_requests/63.diff"
       }
     }
   }


### PR DESCRIPTION
## [YSP-324: Deprecation warning in smart_date causes axe to find issue](https://yaleits.atlassian.net/browse/YSP-324)

This was found while e2e testing locally, and I've experienced this randomly throughout working on different tickets where a deprecation warning is displayed on `dateFormatter`.

While fixed, smart_date 4.0.3 is not released yet, and we don't want to point to dev.  This patch adds a dateFormatter to the class using it instead of relying on the parent class to provide this, causing the deprecation.

Once 4.0.3 is released or we decide to bump to 4.1.x release, we can remove this.

### Description of work
- Add patch to have dateFormatter be on the class in question

### Functional testing steps:

Hard to reproduce, but this was the latest I was able to:

- [ ] Bring down develop locally
- [ ] Change the config to get Mike V's e2e testing site db/files
- [ ] Visit the calendar-list link in the component menu
- [ ] Verify that the deprecation does not display
