### PR TITLE
Update release pull request action

### DIFF
--- a/.ci/github/clean_up_multidevs
+++ b/.ci/github/clean_up_multidevs
@@ -1,0 +1,18 @@
+#!/bin/bash -x
+
+clean_up_multidevs() {
+  site_with_env="$1"
+  site_machine_name="${site_with_env%.*}"
+  terminus multidev:delete "$site_machine_name"."$RELEASE_BRANCH" --delete-branch -y
+}
+
+export -f clean_up_multidevs
+
+# Get sites into array.
+readarray -t release_sites <<< "$(tr -d '\r' <<< "$RELEASE_SITES")"
+
+# Run cleanup with parallel.
+parallel --jobs 0 --keep-order --line-buffer clean_up_multidevs ::: "${release_sites[@]}"
+
+# Reset tracking variable for release site deployment.
+gh variable set RELEASE_SITES_DEPLOYED --body "0"

--- a/.ci/github/create_release_pull_request
+++ b/.ci/github/create_release_pull_request
@@ -2,14 +2,14 @@
 
 set -eo pipefail
 
-# If we aren't updating an existing pull request, create one to merge develop into master.
+# If we aren't updating an existing pull request, create one to merge the release branch into master.
 if [[ -z "$PR_NUMBER" ]]; then
   pull_request_response=$(curl -s -H "Accept: application/vnd.github+json" \
     -H "Authorization: token $ACCESS_TOKEN" \
-    -X POST -d '{"title": "Release", "head": "develop", "base": "master"}' \
+    -X POST -d '{"title": "Release '"$NEXT_VERSION"'", "head": "'"$RELEASE_BRANCH"'", "base": "master"}' \
     "https://api.github.com/repos/$REPO/pulls")
 
-  message=$(echo "$pull_request_response" | jq -r 'if has("errors") then .errors[].message else null end')
+  message=$(echo "$pull_request_response" | jq -r 'if has("errors") then .errors[].message else empty end')
 
   # Check if the pull request creation was successful.
   if [[ -n "$message" ]]; then
@@ -23,12 +23,19 @@ if [[ -z "$PR_NUMBER" ]]; then
   # Extract the pull request number from the response.
   PR_NUMBER=$(echo "$pull_request_response" | jq -r '.number')
 
+  # Set PR_NUMBER for Github Actions.
+  echo PR_NUMBER="$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
 # If there is an existing PR number, get the PR.
 else
   pull_request_response=$(curl --silent -H "Authorization: token $ACCESS_TOKEN" \
     "https://api.github.com/repos/$REPO/pulls/$PR_NUMBER")
 
   pr_url=$(echo "$pull_request_response" | jq -r '.html_url')
+fi
+
+if [[ -z "$RELEASE_PR_URL" ]]; then
+  RELEASE_PR_URL="$pr_url"
 fi
 
 # Page through the /pulls/#/commits endpoint.
@@ -63,7 +70,7 @@ for sha in $commit_shas; do
     "https://api.github.com/repos/$REPO/commits/$sha/pulls" \
     | jq -r 'if type == "object" and has("message") and length > 0 then null else .[].html_url // empty end')
 
-  if [[ -n "$single_pr_url" && "$single_pr_url" != "null" ]]; then
+  if [[ -n "$single_pr_url" && "$single_pr_url" != "null" && "$single_pr_url" != "$RELEASE_PR_URL" ]]; then
     pull_requests+=("$single_pr_url")
   elif [[ "$single_pr_url" == "null" ]]; then
     :

--- a/.ci/github/create_release_pull_request
+++ b/.ci/github/create_release_pull_request
@@ -23,6 +23,9 @@ if [[ -z "$PR_NUMBER" ]]; then
   # Extract the pull request number from the response.
   PR_NUMBER=$(echo "$pull_request_response" | jq -r '.number')
 
+  # Add reviewer to pull request.
+  gh pr edit "$PR_NUMBER" --add-reviewer yalesites-org/yalesites-reviewers
+
   # Set PR_NUMBER for Github Actions.
   echo PR_NUMBER="$PR_NUMBER" >> "$GITHUB_OUTPUT"
 

--- a/.ci/github/deploy_release_sites
+++ b/.ci/github/deploy_release_sites
@@ -1,0 +1,75 @@
+#!/bin/bash -x
+
+set -eo pipefail
+
+push_code() {
+  git_path=$(terminus connection:info "$site_with_env" --field=git_url)
+  git remote add "$site_machine_name" "$git_path"
+  git fetch "$site_machine_name"
+  git push "$site_machine_name" "$RELEASE_BRANCH:$RELEASE_BRANCH" --force
+  terminus workflow:wait "$site_machine_name"."$RELEASE_BRANCH" --max=420
+}
+
+drush_deploy() {
+  terminus -n env:wake "$site_machine_name"."$RELEASE_BRANCH"
+  echo -e "\nRunning drush deploy...\n"
+  terminus -n drush "$site_machine_name"."$RELEASE_BRANCH" -- deploy -v -y
+}
+    
+process_site() {
+  site_with_env="$1"
+  site_machine_name="${site_with_env%.*}"
+
+  env_status=$(terminus env:info "$site_machine_name"."$RELEASE_BRANCH" --field=initialized 2>/dev/null)
+
+  # If multidev does not exist, create it, otherwise deploy code updates.
+  if [ "$env_status" != 1 ]; then
+    echo -e "\nCreating multidev $site_machine_name.$RELEASE_BRANCH from $site_with_env...\n"
+
+    if [ "$site_machine_name" = "yalesites-platform" ]; then
+      terminus multidev:create "$site_with_env" "$RELEASE_BRANCH" --no-db --no-files
+    else
+      terminus multidev:create "$site_with_env" "$RELEASE_BRANCH"
+    fi
+
+    push_code
+
+    # Do a fresh install on yalesites-platform site.
+    if [ "$site_machine_name" = "yalesites-platform" ]; then
+      echo -e "\nInstalling clean site for $site_machine_name.$RELEASE_BRANCH...\n"
+      terminus -n env:wake "$site_machine_name"."$RELEASE_BRANCH" --delay=20
+      terminus -n drush "$site_machine_name"."$RELEASE_BRANCH" -- si yalesites_profile -y
+      terminus -n drush "$site_machine_name"."$RELEASE_BRANCH" -- cr
+      SITE_MACHINE_NAME="$site_machine_name" env="$RELEASE_BRANCH" ./scripts/shared/content-import.sh
+    fi
+
+    drush_deploy
+
+    # Get site URL and output to file
+    site_url=$(terminus -n domain:list "$site_machine_name"."$RELEASE_BRANCH" --filter='type=platform' --field=id)
+    echo "- https://$site_url" >> output.txt
+  else
+    push_code
+    drush_deploy
+  fi
+}
+
+# Export functions so that GNU Parallel can access them
+export -f push_code process_site drush_deploy
+
+# Install Terminus Build Bools.
+terminus self:plugin:install terminus-build-tools-plugin
+
+# Get release sites and convert to an array.
+readarray -t sites_array <<< "$(tr -d '\r' <<< "$RELEASE_SITES")"
+
+# Process sites with parallel.
+parallel --jobs 0 --keep-order --line-buffer process_site {} ::: "${sites_array[@]}"
+
+echo "Environments ready for review:" | cat - output.txt > temp && mv temp output.txt
+
+# If release sites don't exist, post a comment with URLs and set tracking variable to 1.
+if [ "$RELEASE_SITES_DEPLOYED" == 0 ]; then
+  gh issue comment "$PR_NUMBER" --body-file output.txt
+  gh variable set RELEASE_SITES_DEPLOYED --body "1"
+fi

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -1,21 +1,202 @@
-name: Create/update release pull request
+name: Release pull request
 on:
   pull_request:
+    types:
+      - synchronize
+      - closed
     branches:
       - master
   workflow_dispatch:
+env:
+  YALESITES_BUILD_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
+  GH_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
+  ACCESS_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
+  REPO: ${{ github.repository }}
+  PR_NUMBER: ${{ github.event.number }}
+  RELEASE_PR_URL: ${{ github.event.pull_request._links.html.href }}
+  RELEASE_SITES: ${{ vars.RELEASE_SITES }}
 jobs:
-  create_pull_request:
-    if: github.head_ref == 'develop' ||
-        github.event_name == 'workflow_dispatch'
+  setup:
     runs-on: ubuntu-latest
+    steps:
+    - name: Determine Terminus version
+      shell: bash
+      run: |
+        TERMINUS_RELEASE=$(
+          curl --silent \
+            --header 'authorization: Bearer ${{ github.token }}' \
+            "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" \
+            | perl -nle'print $& while m#"tag_name": "\K[^"]*#g'
+        )
+        echo "TERMINUS_RELEASE=$TERMINUS_RELEASE" >> $GITHUB_ENV
+
+    - name: Install Terminus
+      shell: bash
+      run: |
+        mkdir ~/terminus && cd ~/terminus
+        echo "Installing Terminus v$TERMINUS_RELEASE"
+        curl -L https://github.com/pantheon-systems/terminus/releases/download/$TERMINUS_RELEASE/terminus.phar -o /usr/local/bin/terminus
+        chmod +x /usr/local/bin/terminus
+
+    - name: Authenticate to Terminus
+      env:
+        TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
+      run: |
+        terminus auth:login --machine-token="${TERMINUS_TOKEN}"
+
+    - name: Install SSH key
+      uses: shimataro/ssh-key-action@v2
+      with:
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        known_hosts: unnecessary
+        config: ${{ secrets.SSH_CONFIG }}
+
+    - name: Cache terminus
+      uses: actions/cache@v4
+      id: terminus-cache
+      with:
+        path: |
+          /usr/local/bin/terminus
+          ~/.terminus
+          ~/.ssh
+        key: ${{ runner.os }}-terminus-cache-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-terminus-cache-
+
+  get_next_release_version:
+    runs-on: ubuntu-latest
+    needs: [setup]
+    if: ${{ github.event.action != 'synchronize' && github.event.action != 'closed' }}
+    outputs:
+      NEXT_VERSION: ${{ steps.get_release_number.outputs.next_version }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: master
+        fetch-depth: 0
+
+    - name: Setup node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Git setup
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+
+    - name: Get next release number
+      id: get_release_number
+      run: |
+        if [[ "$PR_NUMBER" ]]; then
+          release_branch=$(gh pr view "$PR_NUMBER" --json headRefName --jq '.[]')
+        else
+          git merge origin/develop --no-edit -X theirs
+          npm install --force
+          unset GITHUB_ACTIONS
+          unset GITHUB_EVENT_NAME
+          semantic_release=$(npx --no-install semantic-release --no-ci --dry-run 2>/dev/null)
+          next_version=$(echo "$semantic_release" | sed -nE 's/.*The next release version is ([0-9]+\.[0-9]+\.[0-9]+).*/v\1/p')
+          
+          if [ -z "$next_version" ]; then
+            exit 1
+          else
+            release_branch="${next_version//.}"
+          fi
+        fi
+        echo next_version="$next_version" >> "$GITHUB_OUTPUT"
+
+        # Set release branch as a variable for access.
+        gh variable set RELEASE_BRANCH --body "$release_branch"
+
+    - name: Create release branch
+      if: ${{ github.event.number == '' }}
+      env:
+        RELEASE_BRANCH: ${{ vars.RELEASE_BRANCH }}
+      run: |
+        echo "The release branch is: $RELEASE_BRANCH" 
+        git checkout -b "$RELEASE_BRANCH"
+        git push origin "$RELEASE_BRANCH"
+
+  create_pull_request:
+    needs: [setup, get_next_release_version]
+    if: ${{ always() && github.event.action != 'closed' }}
+    outputs:
+      PR_NUMBER: ${{ steps.create_pull_request.outputs.PR_NUMBER }}
     env:
-      ACCESS_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
-      REPO: ${{ github.repository }}
-      PR_NUMBER: ${{ github.event.number }}
+      RELEASE_BRANCH: ${{ vars.RELEASE_BRANCH }}
+      NEXT_VERSION: ${{ needs.get_next_release_version.outputs.NEXT_VERSION }}
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
     - name: Create pull request
+      id: create_pull_request
       run: ./.ci/github/create_release_pull_request
+
+  release_sites:
+    needs: [setup, create_pull_request]
+    runs-on: ubuntu-latest
+    if: ${{ always() && github.event.action != 'closed' }}
+    env:
+      RELEASE_BRANCH: ${{ vars.RELEASE_BRANCH }}
+      PR_NUMBER: ${{ needs.create_pull_request.outputs.PR_NUMBER }}
+      RELEASE_SITES_DEPLOYED: ${{ vars.RELEASE_SITES_DEPLOYED }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ env.RELEASE_BRANCH }}
+        fetch-depth: 0
+
+    - name: Git setup
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+
+    - name: Restore cache
+      uses: actions/cache@v4
+      id: terminus-cache
+      with:
+        path: |
+          /usr/local/bin/terminus
+          ~/.terminus
+          ~/.ssh
+        key: ${{ runner.os }}-terminus-cache-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-terminus-cache-
+
+    - name: Deploy to environments
+      run: ./.ci/github/deploy_release_sites
+
+  clean_up_multidevs:
+    if: ${{ github.event.action == 'closed' }}
+    needs: [setup]
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_BRANCH: ${{ vars.RELEASE_BRANCH }}
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+        
+    - name: Restore cache
+      uses: actions/cache@v4
+      id: terminus-cache
+      with:
+        path: |
+          /usr/local/bin/terminus
+          ~/.terminus
+          ~/.ssh
+        key: ${{ runner.os }}-terminus-cache-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-terminus-cache-
+
+    - name: Clean up
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: ./.ci/github/clean_up_multidevs

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
     "test": "./scripts/local/test.sh"
   },
   "devDependencies": {
-    "@semantic-release/git": "^10.0.1",
     "@yalesites-org/eslint-config-and-other-formatting": "^1.5.0",
     "eslint-config-drupal": "^5.0.2",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-yml": "^0.14.0",
+    "semantic-release": "^23.0.0",
     "semantic-release-replace-plugin": "^1.2.7",
     "shelljs": "^0.8.5"
   },


### PR DESCRIPTION
### Description of work
This PR updates the automation of pull request creation for releases. Highlights:

- Updates to use latest version of [semantic-release](https://github.com/semantic-release/semantic-release)
- Runs on `workflow_dispatch` to allow for creation of a "release pull request"
- The next release number is derived from the changes in `develop` and a release branch with this name is created
- Pull request is created with summary of all changes in the release branch
- Testing multidevs are created and release branch is pushed to them
- A comment is posted with environments for review
- yalesites-reviewers team is added as reviewer
- Runs automatically on specific `pull_request` events:
  - `synchronize` for any new pushed changes
  - `close` to clean up generated environments and reset repo tracking variables
- When PR is merged, testing multidev environments are deleted automatically
- Adds repo variables to track release branch, sites, site deployment status