### PR TITLE
Github Actions: set unique cache for release_pr job

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -59,9 +59,9 @@ jobs:
           /usr/local/bin/terminus
           ~/.terminus
           ~/.ssh
-        key: ${{ runner.os }}-terminus-cache-${{ hashFiles('**/composer.lock') }}
+        key: ${{ github.job }}-setup-cache
         restore-keys: |
-          ${{ runner.os }}-terminus-cache-
+          ${{ github.job }}-setup-cache
 
   get_next_release_version:
     runs-on: ubuntu-latest
@@ -170,9 +170,9 @@ jobs:
           /usr/local/bin/terminus
           ~/.terminus
           ~/.ssh
-        key: ${{ runner.os }}-terminus-cache-${{ hashFiles('**/composer.lock') }}
+        key: ${{ github.job }}-setup-cache
         restore-keys: |
-          ${{ runner.os }}-terminus-cache-
+          ${{ github.job }}-setup-cache
 
     - name: Deploy to environments
       run: ./.ci/github/deploy_release_sites


### PR DESCRIPTION
### Description of work
- Sets unique cache key for `release_pr` job to prevent sharing with other jobs where credentials may be missing