### PR TITLE
YSP-355: External view results don't have external icon

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.search_result.yml
@@ -21,6 +21,18 @@ targetEntityType: node
 bundle: page
 mode: search_result
 content:
+  field_external_source:
+    type: link_separate
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
   field_teaser_text:
     type: text_default
     label: hidden
@@ -34,7 +46,6 @@ content:
     weight: 0
     region: content
 hidden:
-  field_external_source: true
   field_login_required: true
   field_metatags: true
   field_tags: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.search_result.yml
@@ -24,6 +24,18 @@ targetEntityType: node
 bundle: post
 mode: search_result
 content:
+  field_external_source:
+    type: link_separate
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
   field_teaser_text:
     type: text_default
     label: hidden
@@ -39,7 +51,6 @@ content:
 hidden:
   field_author: true
   field_category: true
-  field_external_source: true
   field_login_required: true
   field_metatags: true
   field_publish_date: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.directory.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.directory.yml
@@ -70,6 +70,18 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  field_external_source:
+    type: link_separate
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    weight: 2
+    region: content
   field_media:
     type: entity_reference_entity_view
     label: hidden
@@ -113,7 +125,6 @@ content:
     region: content
 hidden:
   field_address: true
-  field_external_source: true
   field_first_name: true
   field_honorific_prefix: true
   field_last_name: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.search_result.yml
@@ -37,6 +37,18 @@ targetEntityType: node
 bundle: profile
 mode: search_result
 content:
+  field_external_source:
+    type: link_separate
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
   field_teaser_text:
     type: text_default
     label: hidden
@@ -54,7 +66,6 @@ hidden:
   field_affiliation: true
   field_department: true
   field_email: true
-  field_external_source: true
   field_first_name: true
   field_honorific_prefix: true
   field_last_name: true

--- a/web/profiles/custom/yalesites_profile/config/sync/search_api.index.node_index.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/search_api.index.node_index.yml
@@ -42,8 +42,9 @@ field_settings:
           event: default
           page: default
           post: default
+          profile: default
   status:
-    label: null
+    label: status
     datasource_id: 'entity:node'
     property_path: status
     type: boolean
@@ -53,7 +54,7 @@ field_settings:
       module:
         - node
   uid:
-    label: null
+    label: uid
     datasource_id: 'entity:node'
     property_path: uid
     type: integer

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/ProfileContactBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/ProfileContactBlock.php
@@ -117,9 +117,9 @@ class ProfileContactBlock extends BlockBase implements ContainerFactoryPluginInt
 
     if ($route && $node) {
       // Profile fields.
-      $email = ($node->field_email->first()) ? $node->field_email->first()->getValue()['value'] : NULL;
-      $phone = ($node->field_telephone->first()) ? $node->field_telephone->first()->getValue()['value'] : NULL;
-      $address = ($node->field_address->first()) ? $node->field_address->first()->getValue()['value'] : NULL;
+      $email = $node->get('field_email')->getValue()[0]['value'] ?? NULL;
+      $phone = $node->get('field_telephone')->getValue()[0]['value'] ?? NULL;
+      $address = $node->get('field_address')->getValue()[0]['value'] ?? NULL;
     }
 
     return [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/ProfileMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/ProfileMetaBlock.php
@@ -121,10 +121,10 @@ class ProfileMetaBlock extends BlockBase implements ContainerFactoryPluginInterf
     if ($route && $node) {
       // Profile fields.
       $title = $node->getTitle();
-      $position = ($node->field_position->first()) ? $node->field_position->first()->getValue()['value'] : NULL;
-      $subtitle = ($node->field_subtitle->first()) ? $node->field_subtitle->first()->getValue()['value'] : NULL;
-      $department = ($node->field_department->first()) ? $node->field_department->first()->getValue()['value'] : NULL;
-      $mediaId = ($node->field_media->first()) ? $node->field_media->first()->getValue()['target_id'] : NULL;
+      $position = $node->get('field_position')->getValue()[0]['value'] ?? NULL;
+      $subtitle = $node->get('field_subtitle')->getValue()[0]['value'] ?? NULL;
+      $department = $node->get('field_department')->getValue()[0]['value'] ?? NULL;
+      $mediaId = $node->get('field_media')->getValue()[0]['target_id'] ?? NULL;
     }
 
     return [


### PR DESCRIPTION
## [YSP-355: External view results don't have external icon](https://yaleits.atlassian.net/browse/YSP-355)

### Description of work
- Allows views to use external link if available for correct decoration
- Adds field_external_source to profile directory config to pass to twig
- Adds field_external_source to search content types to pass to twig
- Modify search_api to use default rendering of profiles for search
- Fixed backend errors regarding profile data access

### Functional testing steps:
- [ ] Create externally linked nodes for each content type
- [ ] Create a new page to test with
- [ ] Add views for each content type, ensuring you set it up to include your newly created nodes
- [ ] Ensure that when viewing those views, items with externally linked content show the external icon
