### PR TITLE
Github Actions: always derive git info from dev environment

### DIFF
--- a/.ci/github/deploy_release_sites
+++ b/.ci/github/deploy_release_sites
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 push_code() {
-  git_path=$(terminus connection:info "$site_with_env" --field=git_url)
+  git_path=$(terminus connection:info "$site_machine_name".dev --field=git_url)
   git remote add "$site_machine_name" "$git_path"
   git fetch "$site_machine_name"
   git push "$site_machine_name" "$RELEASE_BRANCH:$RELEASE_BRANCH" --force


### PR DESCRIPTION
### Description of work
- git connection info was being derived from the included environment, and this would fail for sites that are sourced from `live`. We can hardcode `dev` here to make sure we always get the correct git info.
