### PR TITLE
YSP-371: Reusable Blocks created via backend not available in Block Picker

### DIFF
--- a/patches/layout_builder_browser/3408935-and-3409153-8.patch
+++ b/patches/layout_builder_browser/3408935-and-3409153-8.patch
@@ -118,7 +118,7 @@ index 9331cae..376d953 100644
 +            $block_categories['reusable_blocks']['#type'] = 'details';
 +            $block_categories['reusable_blocks']['#attributes']['class'][] = 'js-layout-builder-category';
 +            $block_categories['reusable_blocks']['#open'] = $blockcat->getOpened();
-+            $block_categories['reusable_blocks']['#title'] = $this->t('Global Blocks');
++            $block_categories['reusable_blocks']['#title'] = $this->t('Reusable Blocks');
 +          }
 +          else {
 +            // Only add the information if the category has links.

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -171,7 +171,7 @@
         "Fix cloning of inline blocks and paragraphs: https://www.drupal.org/project/quick_node_clone/issues/3100117": "https://www.drupal.org/files/issues/2023-04-25/quick-node-clone--inline-blocks--3100117-32.patch"
       },
       "drupal/layout_builder_browser": {
-        "Add grouping of reusable blocks (3409153) and add fallback images (3408935) - can't use both patches from d.o would cause merge conflict, combined patch": "patches/layout_builder_browser/3408935-and-3409153-7.patch"
+        "Add grouping of reusable blocks (3409153) and add fallback images (3408935) - can't use both patches from d.o would cause merge conflict, combined patch": "patches/layout_builder_browser/3408935-and-3409153-8.patch"
       },
       "drupal/section_library": {
         "Fix access check issues on add_to_template link: https://www.drupal.org/project/section_library/issues/3241715": "https://www.drupal.org/files/issues/2022-09-21/3241715-6.patch"

--- a/web/profiles/custom/yalesites_profile/config/sync/layout_builder_browser.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/layout_builder_browser.settings.yml
@@ -8,6 +8,7 @@ auto_added_reusable_block_content_bundles:
   button_link: button_link
   callout: callout
   content_spotlight: content_spotlight
+  content_spotlight_portrait: content_spotlight_portrait
   cta_banner: cta_banner
   custom_cards: custom_cards
   directory: directory
@@ -28,5 +29,7 @@ auto_added_reusable_block_content_bundles:
   webform: webform
   wrapped_image: wrapped_image
 group_reusable_blocks_together: true
+reusable_image_fallback: ''
+reusable_image_fallback_alt: ''
 image_fallback: /profiles/custom/yalesites_profile/modules/custom/ys_core/images/preview-icons/fallback-global-block.jpg
 image_fallback_alt: ''


### PR DESCRIPTION
## [YSP-371: Reusable Blocks created via backend not available in Block Picker](https://yaleits.atlassian.net/browse/YSP-371)

### Description of work
- Adds `Spotlight - Portrait` to available reusable blocks for block picker
- Rename `Global Block` to `Reusable Block` in block picker

### Functional testing steps:
- [ ] Add a new reusable block via the Content->Manage Reusable Blocks menu of type `Spotlight - Portrait`
- [ ] Visit a page and attempt to add a block
- [ ] Verify the portrait spotlight you created is available as a selectable item
- [ ] Verify that the section the new spotlight is in is named `Reusable Block`
