### PR TITLE
YSP-373: Front page not updated to node reference

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
@@ -105,6 +105,23 @@ function ys_core_update_9003() {
 }
 
 /**
+ * Implements hook_update().
+ *
+ * This update will convert an alias'd front page to a node based one.
+ */
+function ys_core_update_9004() {
+  $frontPage = \Drupal::config('system.site')->get('page.front');
+
+  if (strpos($frontPage, '/node') === FALSE) {
+    // Path should be already the form we need: /node/<number>.
+    $path = \Drupal::service('path_alias.manager')->getPathByAlias($frontPage);
+    if ($path) {
+      \Drupal::configFactory()->getEditable('system.site')->set('page.front', $path)->save();
+    }
+  }
+}
+
+/**
  * Sanitizes the value of an array object with allowed_tags.
  *
  * @param array $content_array

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
@@ -112,7 +112,7 @@ function ys_core_update_9003() {
 function ys_core_update_9004() {
   $frontPage = \Drupal::config('system.site')->get('page.front');
 
-  if (strpos($frontPage, '/node') === FALSE) {
+  if ($frontPage && strpos($frontPage, '/node') === FALSE) {
     // Path should be already the form we need: /node/<number>.
     $path = \Drupal::service('path_alias.manager')->getPathByAlias($frontPage);
     if ($path) {


### PR DESCRIPTION
## [YSP-373: Front page not updated to node reference](https://yaleits.atlassian.net/browse/YSP-373)

### Description of work
- Adds an update hook to update the front page to a /node/<number> format if it is set to an alias.

### Functional testing steps:
- [ ] Locally bring down a site using this alias currently; see Jira ticket for a specific instance you can reference
- [ ] Run the update hook: `lando drush php-eval '\Drupal::moduleHandler()->loadInclude("ys_core", "install"); echo ys_core_update_9004();'`
- [ ] Visit the site's settings to ensure that it now references the right page
- [ ] Feel free to look in the MySQL database for the blob containing the reference to be `/node/<number>`
  - [ ] `SELECT * FROM pantheon.config where name = 'system.site'`
  - [ ] Then look at the blob as text

#### If you have terminus rights
- [ ] To set the front page to an alias to then run the update hook: `terminus drush yalesites-platform.pr-588 -- php-eval "\Drupal::configFactory()->getEditable('system.site')->set('page.front', '/welcome')->save();"`
- [ ] To run the update hook: `terminus drush yalesites-platform.pr-588 -- php-eval '\Drupal::moduleHandler()->loadInclude("ys_core", "install"); echo ys_core_update_9004();'`
