### PR TITLE
YSP-318: Can't clone a profile

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -95,6 +95,7 @@ permissions:
   - 'clone event content'
   - 'clone page content'
   - 'clone post content'
+  - 'clone profile content'
   - 'configure editable event node layout overrides'
   - 'configure editable page node layout overrides'
   - 'configure editable post node layout overrides'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -89,6 +89,7 @@ permissions:
   - 'clone event content'
   - 'clone page content'
   - 'clone post content'
+  - 'clone profile content'
   - 'configure editable event node layout overrides'
   - 'configure editable page node layout overrides'
   - 'configure editable post node layout overrides'


### PR DESCRIPTION
## [YSP-318: Can't clone a profile](https://yaleits.atlassian.net/browse/YSP-318)

### Description of work
- Adds permissions to clone profile for site/platform admins

### Functional testing steps:
- [ ] Visit the content listing and find a profile
- [ ] Use the drop down next to the edit button for that profile and verify that you can clone a node there
- [ ] Click on a profile name in the content listing to go to their profile page
- [ ] From the more actions drop down in the menu, verify that you see and can use the clone tool to clone the profile
