### PR TITLE
YSP-414: Deleting used content.school_logo media results in site wide page errors

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesFooterBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesFooterBlock.php
@@ -5,7 +5,9 @@ namespace Drupal\ys_core\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Messenger\Messenger;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Url;
 use Drupal\ys_core\SocialLinksManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -42,6 +44,13 @@ class YaleSitesFooterBlock extends BlockBase implements ContainerFactoryPluginIn
   protected $entityTypeManager;
 
   /**
+   * Drupal messenger.
+   *
+   * @var Drupal\Core\Messenger\Messenger
+   */
+  protected $messenger;
+
+  /**
    * {@inheritdoc}
    */
   public function __construct(
@@ -51,11 +60,13 @@ class YaleSitesFooterBlock extends BlockBase implements ContainerFactoryPluginIn
     SocialLinksManager $social_links_manager,
     ConfigFactoryInterface $config_factory,
     EntityTypeManager $entity_type_manager,
+    Messenger $messenger,
     ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->socialLinks = $social_links_manager;
-    $this->footerSettings = $config_factory->get('ys_core.footer_settings');
+    $this->footerSettings = $config_factory->getEditable('ys_core.footer_settings');
     $this->entityTypeManager = $entity_type_manager;
+    $this->messenger = $messenger;
   }
 
   /**
@@ -69,7 +80,25 @@ class YaleSitesFooterBlock extends BlockBase implements ContainerFactoryPluginIn
       $container->get('ys_core.social_links_manager'),
       $container->get('config.factory'),
       $container->get('entity_type.manager'),
+      $container->get('messenger'),
     );
+  }
+
+  /**
+   * Removes config for a deleted media item if used in the footer.
+   *
+   * @param string $configName
+   *   The configuration key to remove.
+   */
+  protected function clearFooterConfig($configName) {
+    $this->footerSettings->set($configName, NULL);
+    $this->footerSettings->save();
+    $message = $this->t('Note, the image for :config_name has been deleted. You may set a new one in <a href=":footer_settings_path">footer settings form<a>.',
+      [
+        ':config_name' => $configName,
+        ':footer_settings_path' => Url::fromRoute('ys_core.admin_footer_settings')->toString(),
+      ]);
+    $this->messenger->addError($message);
   }
 
   /**
@@ -83,18 +112,28 @@ class YaleSitesFooterBlock extends BlockBase implements ContainerFactoryPluginIn
     if ($footerLogosConfig = $this->footerSettings->get('content.logos')) {
       foreach ($footerLogosConfig as $key => $logoData) {
         if ($logoData['logo']) {
-          $footerLogoMedia = $this->entityTypeManager->getStorage('media')->load($logoData['logo']);
-          if ($footerLogoMedia) {
-            $footerLogoFileUri = $fileEntity->load($footerLogoMedia->field_media_image->target_id)->getFileUri();
-            $footerLogosRender[$key]['url'] = $logoData['logo_url'] ?? NULL;
-            $footerLogosRender[$key]['logo'] = [
-              '#type' => 'responsive_image',
-              '#responsive_image_style_id' => 'image_logos',
-              '#uri' => $footerLogoFileUri,
-              '#attributes' => [
-                'alt' => $footerLogoMedia->get('field_media_image')->first()->get('alt')->getValue(),
-              ],
-            ];
+          // This check is because if a media item is deleted and one added,
+          // it creates an array of ID's which does not work.
+          if (is_numeric($logoData['logo'])) {
+            $footerLogoMedia = $this->entityTypeManager->getStorage('media')->load($logoData['logo']);
+            if ($footerLogoMedia) {
+              $footerLogoFileUri = $fileEntity->load($footerLogoMedia->field_media_image->target_id)->getFileUri();
+              $footerLogosRender[$key]['url'] = $logoData['logo_url'] ?? NULL;
+              $footerLogosRender[$key]['logo'] = [
+                '#type' => 'responsive_image',
+                '#responsive_image_style_id' => 'image_logos',
+                '#uri' => $footerLogoFileUri,
+                '#attributes' => [
+                  'alt' => $footerLogoMedia->get('field_media_image')->first()->get('alt')->getValue(),
+                ],
+              ];
+            }
+            else {
+              $this->clearFooterConfig('content.logos.' . $key);
+            }
+          }
+          else {
+            $this->clearFooterConfig('content.logos.' . $key);
           }
         }
       }
@@ -102,16 +141,27 @@ class YaleSitesFooterBlock extends BlockBase implements ContainerFactoryPluginIn
 
     // Responsive image render array for school logo.
     if ($schoolLogoId = $this->footerSettings->get('content.school_logo')) {
-      $schoolLogoMedia = $this->entityTypeManager->getStorage('media')->load($schoolLogoId);
-      $schoolLogoFileUri = $fileEntity->load($schoolLogoMedia->field_media_image->target_id)->getFileUri();
-      $schoolLogoRender = [
-        '#type' => 'responsive_image',
-        '#responsive_image_style_id' => 'image_horizontal_logos',
-        '#uri' => $schoolLogoFileUri,
-        '#attributes' => [
-          'alt' => $schoolLogoMedia->get('field_media_image')->first()->get('alt')->getValue(),
-        ],
-      ];
+      // This check is because if a media item is deleted and one added,
+      // it creates an array of ID's which does not work.
+      if (is_numeric($schoolLogoId)) {
+        if ($schoolLogoMedia = $this->entityTypeManager->getStorage('media')->load($schoolLogoId)) {
+          $schoolLogoFileUri = $fileEntity->load($schoolLogoMedia->field_media_image->target_id)->getFileUri();
+          $schoolLogoRender = [
+            '#type' => 'responsive_image',
+            '#responsive_image_style_id' => 'image_horizontal_logos',
+            '#uri' => $schoolLogoFileUri,
+            '#attributes' => [
+              'alt' => $schoolLogoMedia->get('field_media_image')->first()->get('alt')->getValue(),
+            ],
+          ];
+        }
+        else {
+          $this->clearFooterConfig('content.school_logo');
+        }
+      }
+      else {
+        $this->clearFooterConfig('content.school_logo');
+      }
     }
 
     $footerBlockRender = [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesFooterBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesFooterBlock.php
@@ -140,11 +140,11 @@ class YaleSitesFooterBlock extends BlockBase implements ContainerFactoryPluginIn
               ];
             }
             else {
-              $this->clearFooterConfig('content.logos.' . $key);
+              $this->clearFooterConfig('content.logos.' . $key . '.logo');
             }
           }
           else {
-            $this->clearFooterConfig('content.logos.' . $key);
+            $this->clearFooterConfig('content.logos.' . $key . '.logo');
           }
         }
       }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesFooterBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesFooterBlock.php
@@ -93,12 +93,23 @@ class YaleSitesFooterBlock extends BlockBase implements ContainerFactoryPluginIn
   protected function clearFooterConfig($configName) {
     $this->footerSettings->set($configName, NULL);
     $this->footerSettings->save();
-    $message = $this->t('Note, the image for :config_name has been deleted. You may set a new one in <a href=":footer_settings_path">footer settings form<a>.',
-      [
-        ':config_name' => $configName,
-        ':footer_settings_path' => Url::fromRoute('ys_core.admin_footer_settings')->toString(),
-      ]);
-    $this->messenger->addError($message);
+    $logoType = NULL;
+
+    if (str_starts_with($configName, 'content.logos')) {
+      $logoType = 'one of the footer logo images';
+    }
+    else {
+      $logoType = 'the school footer logo image';
+    }
+    if ($logoType) {
+      $footerSettingsPath = Url::fromRoute('ys_core.admin_footer_settings')->toString();
+      $message = $this->t('Note, :logo_type has been deleted. You may set a new one in the <a href=":footer_settings_path">footer settings form<a>.',
+        [
+          ':logo_type' => $logoType,
+          ':footer_settings_path' => $footerSettingsPath,
+        ]);
+      $this->messenger->addError($message);
+    }
   }
 
   /**
@@ -111,7 +122,7 @@ class YaleSitesFooterBlock extends BlockBase implements ContainerFactoryPluginIn
     // Responsive image render array for logos.
     if ($footerLogosConfig = $this->footerSettings->get('content.logos')) {
       foreach ($footerLogosConfig as $key => $logoData) {
-        if ($logoData['logo']) {
+        if (isset($logoData['logo'])) {
           // This check is because if a media item is deleted and one added,
           // it creates an array of ID's which does not work.
           if (is_numeric($logoData['logo'])) {


### PR DESCRIPTION
## [YSP-414: Deleting used content.school_logo media results in site wide page errors](https://yaleits.atlassian.net/browse/YSP-414)

### Description of work
- Fixes site wide error if any footer logo media was deleted in media library before being removed from the footer config.

Note: What this code does is actually delete out the missing config ID of the deleted footer media if any was set. Therefore, there is an admin message that gets output at the top of the page that tells the content editor that:

"Note, one of the footer logo images has been deleted. You may set a new one in the footer settings form" with a link to the form.

### Functional testing steps:
- [x] Login to the site and visit the footer settings form here: `/admin/yalesites/footer`
- [x] Switch the footer variation to "Mega"
- [x] Add some images from the media library (or uploaded) to the footer logos. Also add an image into the school logo.
- [x] Save the form.
- [x] Visit the front-end and verify that all logos show appropriately in the footer.
- [x] Visit the media library here: `/admin/content/media-grid`
- [x] Delete one of the images that was used for the footer logos.
- [x] Clear the cache - by default the site will keep the footer logo in place until cache is cleared.
- [x] Visit the front-end and refresh. Verify that the site does not crash and there is an admin message on the top informing that a logo has been deleted.

![Screenshot 2024-03-08 at 12 23 07 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/9467e9a7-11f1-4a82-9797-f34167eab611)

- [x] Also verify that the other logos load just fine.
- [x] Visit the footer settings form again, add an image from the media library (or uploaded) to the one that was deleted previously.
- [x] Save the form
- [x] Verify on the front-end that the logos all load.