### PR TITLE
YSP-426: Placement for the external link icon on footer logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory.
+- 


### PR DESCRIPTION
## [YSP-426: Placement for the external link icon on footer logo](https://yaleits.atlassian.net/browse/YSP-426)

[Component Library: YSP-426](https://github.com/yalesites-org/component-library-twig/pull/343)

### Description of work
- Excludes links with images from being decorated

### Functional testing steps:
- [ ] Change footer to use mega footer
- [ ] Add external links to a footer logo image
- [ ] Ensure the image is not decorated when visiting pages
- [ ] Ensure other blocks look ok
