### PR TITLE
YSP-302 Hide empty exposed filters

### DIFF
--- a/patches/selective_better_exposed_filters/selective_better_exposed_filters-3432551.patch
+++ b/patches/selective_better_exposed_filters/selective_better_exposed_filters-3432551.patch
@@ -1,0 +1,39 @@
+From 30bf569df2f6b17d5ea64da83bf3372165bfa98a Mon Sep 17 00:00:00 2001
+From: Marc Berger <marc@fourkitchens.com>
+Date: Wed, 20 Mar 2024 18:41:32 -0700
+Subject: [PATCH] fix(3432551): If all exposed form elements are set to hide,
+ also hide the form.
+
+---
+ .../filter/SelectiveFilterBase.php               | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/src/Plugin/better_exposed_filters/filter/SelectiveFilterBase.php b/src/Plugin/better_exposed_filters/filter/SelectiveFilterBase.php
+index 9d064a2..c4440b9 100644
+--- a/src/Plugin/better_exposed_filters/filter/SelectiveFilterBase.php
++++ b/src/Plugin/better_exposed_filters/filter/SelectiveFilterBase.php
+@@ -269,6 +269,22 @@ abstract class SelectiveFilterBase {
+               )
+             ) {
+               $element['#access'] = FALSE;
++
++              // Helps with check if all elements are hidden later.
++              $element['#sef_hidden'] = TRUE;
++
++              // If all exposed form elements are hidden, hide the form.
++              $i = 0;
++              foreach ($form['#info'] as $exposedFilter) {
++                if (isset($form[$exposedFilter['value']]['#sef_hidden']) && $form[$exposedFilter['value']]['#sef_hidden']) {
++                  $i++;
++                }
++              }
++
++              if ($i == count($form['#info'])) {
++                $form['#access'] = FALSE;
++              }
++
+             }
+           }
+         }
+--
+GitLab

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -97,7 +97,7 @@
     "drupal/search_api_exclude": "2.0.2",
     "drupal/search_api_html_element_filter": "1.0.4",
     "drupal/section_library": "1.1.1",
-    "drupal/selective_better_exposed_filters": "3.0.0-beta1",
+    "drupal/selective_better_exposed_filters": "3.0.2",
     "drupal/simple_sitemap": "4.1.6",
     "drupal/single_content_sync": "1.4.4",
     "drupal/smart_date": "4.0.3",
@@ -183,6 +183,9 @@
       },
       "drupal/focal_point": {
         "Limit image styles on preview page": "https://www.drupal.org/files/issues/2021-08-13/2830678-29.patch"
+      },
+      "drupal/selective_better_exposed_filters": {
+        "Hide form when no options are available:": "patches/selective_better_exposed_filters/selective_better_exposed_filters-3432551.patch"
       }
     }
   }

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.directory.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.directory.yml
@@ -143,9 +143,10 @@ display:
                     filter_rewrite_values: ''
                   collapsible: false
                   is_secondary: false
-                options_show_only_used: 1
-                options_show_only_used_filtered: 0
-                options_hide_when_empty: 0
+                options_show_only_used: true
+                options_show_only_used_filtered: false
+                options_hide_when_empty: true
+                options_show_items_count: 0
       access:
         type: perm
         options:

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.event_list.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.event_list.yml
@@ -128,9 +128,10 @@ display:
                     filter_rewrite_values: ''
                   collapsible: false
                   is_secondary: false
-                options_show_only_used: 1
-                options_show_only_used_filtered: 0
-                options_hide_when_empty: 0
+                options_show_only_used: true
+                options_show_only_used_filtered: false
+                options_hide_when_empty: true
+                options_show_items_count: 0
       access:
         type: perm
         options:

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.post_list.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.post_list.yml
@@ -128,9 +128,10 @@ display:
                     filter_rewrite_values: ''
                   collapsible: false
                   is_secondary: false
-                options_show_only_used: 1
-                options_show_only_used_filtered: 0
-                options_hide_when_empty: 0
+                options_show_only_used: true
+                options_show_only_used_filtered: false
+                options_hide_when_empty: true
+                options_show_items_count: 0
       access:
         type: perm
         options:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -216,7 +216,7 @@ function ys_core_form_user_login_form_alter(&$form, FormStateInterface $form_sta
 }
 
 /**
- * Implements hook_form_alter().
+ * Implements hook_form_FORM_ID_alter().
  */
 function ys_core_form_views_exposed_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
   $view = $form_state->getStorage('view');

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -216,30 +216,6 @@ function ys_core_form_user_login_form_alter(&$form, FormStateInterface $form_sta
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
- */
-function ys_core_form_views_exposed_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
-  $view = $form_state->getStorage('view');
-  // For these blocks, hide the exposed filters if there are no term options.
-  $view_blocks = [
-    // View id => name of taxonomy.
-    'post_list' => 'category',
-    'event_list' => 'category',
-    'directory' => 'affiliation',
-  ];
-  foreach ($view_blocks as $key => $value) {
-    if ($view['view']->id() == $key) {
-      if (isset($form[$value]['#options']) && !empty($form[$value]['#options'])) {
-        // We have to account for the 'any' option.
-        if (count($form[$value]['#options']) < 2) {
-          $form['#attributes']['style'] = 'display: none';
-        }
-      }
-    }
-  }
-}
-
-/**
  * Custom submit handler for the login form.
  */
 function ys_core_user_login_form_submit($form, FormStateInterface $form_state) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -221,18 +221,19 @@ function ys_core_form_user_login_form_alter(&$form, FormStateInterface $form_sta
 function ys_core_form_views_exposed_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
   $view = $form_state->getStorage('view');
   // For these blocks, hide the exposed filters if there are no term options.
-  $view_blocks = ['post_list', 'event_list'];
-  if (in_array($view['view']->id(), $view_blocks)) {
-    if (isset($form['category']['#options']) && !empty($form['category']['#options'])) {
-      if (count($form['category']['#options']) < 2) {
-        $form['#attributes']['style'] = 'display: none';
-      }
-    }
-  }
-  if ($view['view']->id() == 'directory') {
-    if (isset($form['affiliation']['#options']) && !empty($form['affiliation']['#options'])) {
-      if (count($form['affiliation']['#options']) < 2) {
-        $form['#attributes']['style'] = 'display: none';
+  $view_blocks = [
+    // view id => name of taxonomy.
+    'post_list' => 'category',
+    'event_list' => 'category',
+    'directory' => 'affiliation'
+  ];
+  foreach ($view_blocks as $key => $value) {
+    if ($view['view']->id() == $key) {
+      if (isset($form[$value]['#options']) && !empty($form[$value]['#options'])) {
+        // We have to account for the 'any' option.
+        if (count($form[$value]['#options']) < 2) {
+          $form['#attributes']['style'] = 'display: none';
+        }
       }
     }
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -221,11 +221,18 @@ function ys_core_form_user_login_form_alter(&$form, FormStateInterface $form_sta
 function ys_core_form_views_exposed_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
   $view = $form_state->getStorage('view');
   // For these blocks, hide the exposed filters if there are no term options.
-  $view_blocks = ['post_list', 'event_list', 'directory'];
+  $view_blocks = ['post_list', 'event_list'];
   if (in_array($view['view']->id(), $view_blocks)) {
     if (isset($form['category']['#options']) && !empty($form['category']['#options'])) {
       if (count($form['category']['#options']) < 2) {
-        $form['#attributes']['class'][] = 'hide-exposed';
+        $form['#attributes']['style'] = 'display: none';
+      }
+    }
+  }
+  if ($view['view']->id() == 'directory') {
+    if (isset($form['affiliation']['#options']) && !empty($form['affiliation']['#options'])) {
+      if (count($form['affiliation']['#options']) < 2) {
+        $form['#attributes']['style'] = 'display: none';
       }
     }
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -222,10 +222,10 @@ function ys_core_form_views_exposed_form_alter(array &$form, FormStateInterface 
   $view = $form_state->getStorage('view');
   // For these blocks, hide the exposed filters if there are no term options.
   $view_blocks = [
-    // view id => name of taxonomy.
+    // View id => name of taxonomy.
     'post_list' => 'category',
     'event_list' => 'category',
-    'directory' => 'affiliation'
+    'directory' => 'affiliation'.
   ];
   foreach ($view_blocks as $key => $value) {
     if ($view['view']->id() == $key) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -225,7 +225,7 @@ function ys_core_form_views_exposed_form_alter(array &$form, FormStateInterface 
     // View id => name of taxonomy.
     'post_list' => 'category',
     'event_list' => 'category',
-    'directory' => 'affiliation'.
+    'directory' => 'affiliation',
   ];
   foreach ($view_blocks as $key => $value) {
     if ($view['view']->id() == $key) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -216,6 +216,22 @@ function ys_core_form_user_login_form_alter(&$form, FormStateInterface $form_sta
 }
 
 /**
+ * Implements hook_form_alter().
+ */
+function ys_core_form_views_exposed_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+  $view = $form_state->getStorage('view');
+  // For these blocks, hide the exposed filters if there are no term options.
+  $view_blocks = ['post_list', 'event_list', 'directory'];
+  if (in_array($view['view']->id(), $view_blocks)) {
+    if (isset($form['category']['#options']) && !empty($form['category']['#options'])) {
+      if (count($form['category']['#options']) < 2) {
+        $form['#attributes']['class'][] = 'hide-exposed';
+      }
+    }
+  }
+}
+
+/**
  * Custom submit handler for the login form.
  */
 function ys_core_user_login_form_submit($form, FormStateInterface $form_state) {


### PR DESCRIPTION
## [YSP-302: Hide empty exposed filters](https://yaleits.atlassian.net/browse/YSP-302)

### Description of work
- Hides exposed filters if there are no options.

### Functional testing steps:
- [x] Add the following types of blocks: Post list, Calendar list, Profile directory
- [x] Set it up so that there are no filter options (remove taxonomies from posts, eg)
- [x] Verify the exposed filters do not display if there are no options.

### Notes:
I originally wanted to add a class to the form if there are no options and then hide it using CSS but it's Jim's preference that the component library not be involved on this one. So, in-line it is.

I also tried unsetting the options and submit button but that leaves a gap visually because the form is still there, adding its height.