### PR TITLE
YSP-425: Remove link from Reusable Blocks view

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -471,6 +471,18 @@ function ys_core_get_block_type(&$form, &$form_state) {
 }
 
 /**
+ * Implements hook_preprocess_links__dropbutton__operations().
+ */
+function ys_core_preprocess_links__dropbutton__operations(&$variables) {
+  // Remove export link if they don't have permission to export single content.
+  if (isset($variables['links']['export'])) {
+    if (!\Drupal::currentUser()->hasPermission('export single content')) {
+      unset($variables['links']['export']);
+    }
+  }
+}
+
+/**
  * Implements hook_preprocess_html().
  */
 function ys_core_preprocess_html(&$variables) {


### PR DESCRIPTION
## [YSP-425: Remove link from Reusable Blocks view](https://yaleits.atlassian.net/browse/YSP-425)

Remove the export drop down in operations based on whether they have access to export content.  Not just from the Reusable block view, but any view that has operations.

Currently Single Content Sync are ensuring they have access to the node to display this option, but we don't want to just base it on this, but also whether they have the permission access to export content (which only admins have at the moment).  This ensures that we can intercept this before it gets to the user and remove the option to export.

### Description of work
- Adds a hook to remove the export operation if they do not have access to export content.

### Functional testing steps:
- [ ] [Log in](https://pr-607-yalesites-platform.pantheonsite.io/cas)
- [ ] Visit the [reusable blocks view](https://pr-607-yalesites-platform.pantheonsite.io/admin/content/block?menu=main)
- [ ] Verify that the drop downs do not have "Export"

![Screenshot 2024-03-20 at 2 07 20 PM](https://github.com/yalesites-org/yalesites-project/assets/128765777/03d947fb-aa11-4b59-924d-a4844a866811)

#### As an admin
As an admin you should see it--if you can log in as user 1, give it a try:
![Screenshot 2024-03-20 at 2 04 42 PM](https://github.com/yalesites-org/yalesites-project/assets/128765777/2a338d89-3ad2-489e-ad6e-58f82d09133e)
