### PR TITLE
YSP-432: Add version number to yalesites_profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
               "files": [
                 "web/profiles/custom/yalesites_profile/yalesites_profile.info.yml"
               ],
-              "from": "#version:",
+              "from": "#?version:.*",
               "to": "version: ${nextRelease.version}",
               "results": [
                 {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "test": "./scripts/local/test.sh"
   },
   "devDependencies": {
+    "@saithodev/semantic-release-backmerge": "^4.0.1",
+    "@semantic-release/git": "^10.0.1",
     "@yalesites-org/eslint-config-and-other-formatting": "^1.5.0",
     "eslint-config-drupal": "^5.0.2",
     "eslint-plugin-jsx-a11y": "^6.5.1",
@@ -78,6 +80,21 @@
         }
       ],
       "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/git",
+        {
+          "assets": [
+            "web/profiles/custom/yalesites_profile/yalesites_profile.info.yml"
+          ],
+          "message": "chore: bump yalesites_profile to ${nextRelease.version}"
+        }
+      ],
+      [
+        "@saithodev/semantic-release-backmerge",
+        {
+          "backmergeBranches": ["develop"]
+        }
+      ],
       "@semantic-release/github"
     ]
   }


### PR DESCRIPTION
## [YSP-432: Add version number to yalesites_profile](https://yaleits.atlassian.net/browse/YSP-432)

### Description of work
- Add version number to yalesites_profile when new release is created
- Commit the change and backmerge it to `develop` branch