### PR TITLE
AYH-20: Add ai_engine to platform

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -108,6 +108,7 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.12",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
+    "yalesites-org/ai_engine": "1.1.4",
     "yalesites-org/atomic": "1.27.0",
     "yalesites-org/yale_cas": "1.0.4"
   },


### PR DESCRIPTION
## [AYH-20: Add ai_engine to platform](https://github.com/yalesites-org/ask-yale-health/issues/20)

### Description of work
- Adds the ai_engine module to the platform
- The module is not enabled or configured so there are no functional changes

### Functional testing steps:
- Nothing to test. This simply gets us one step closer to bringing all of the AI sites into sync with the main platform.
