### PR TITLE
YSP-437: v1.2.0: Media preview link contrast issue

### DIFF
--- a/web/themes/custom/ys_admin_theme/css/gin-custom.css
+++ b/web/themes/custom/ys_admin_theme/css/gin-custom.css
@@ -38,6 +38,11 @@
   max-width: 485px;
 }
 
+a.focal-point-preview-link {
+  /* color: var(--gin-color-primary); */
+  background-color: var(--gin-bg-layer2);
+}
+
 /* stylelint-enable */
 
 /*# sourceMappingURL=gin-custom.css.map */

--- a/web/themes/custom/ys_admin_theme/css/gin-custom.css.map
+++ b/web/themes/custom/ys_admin_theme/css/gin-custom.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sourceRoot":"","sources":["../scss/gin-custom.scss"],"names":[],"mappings":"AAAA;AAEA;EACE;EACA;EACA;EACA;EACA;EACA;EACA;;AAEA;AAAA;EAEE;;;AAIJ;EACE;;;AAGF;EACE;;;AAGF;AACA;EACE;;;AAGF;EACE;;;AAGF","file":"gin-custom.css"}
+{"version":3,"sourceRoot":"","sources":["../scss/gin-custom.scss"],"names":[],"mappings":"AAAA;AAEA;EACE;EACA;EACA;EACA;EACA;EACA;EACA;;AAEA;AAAA;EAEE;;;AAIJ;EACE;;;AAGF;EACE;;;AAGF;AACA;EACE;;;AAGF;EACE;;;AAGF;AACA;AACE;;AACA;EAEE;;;AAIJ;AACE;EACA;;;AAGF","file":"gin-custom.css"}

--- a/web/themes/custom/ys_admin_theme/scss/gin-custom.scss
+++ b/web/themes/custom/ys_admin_theme/scss/gin-custom.scss
@@ -41,4 +41,8 @@
   }
 }
 
+a.focal-point-preview-link {
+  background-color: var(--gin-bg-layer2);
+}
+
 /* stylelint-enable */


### PR DESCRIPTION
## [YSP-437: v1.2.0: Media preview link contrast issue](https://yaleits.atlassian.net/browse/YSP-437)

### Description of work
- Changes background color of preview link to use gin in order to pass A11y contrast requirements

### Functional testing steps:
- [ ] Attempt to add an image in media library
- [ ] After selecting the image, where you would enter alternate text, ensure that the Preview link underneath the image passes contrast requirements

![Screenshot 2024-03-25 at 12 52 53 PM](https://github.com/yalesites-org/yalesites-project/assets/128765777/f0f1d91c-2455-4b48-9165-c24a66a9418d)

