### PR TITLE
YSP-440: v1.2.0: Focal point not present in block media add

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.image.media_library.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.image.media_library.yml
@@ -1,0 +1,52 @@
+uuid: fa01d336-c86d-42b9-9a00-9b20e027f868
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.image.field_media_image
+    - image.style.crop_thumbnail
+    - media.type.image
+  module:
+    - focal_point
+    - hide_revision_field
+id: media.image.media_library
+targetEntityType: media
+bundle: image
+mode: media_library
+content:
+  field_media_image:
+    type: image_focal_point
+    weight: 0
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: crop_thumbnail
+      preview_link: true
+      offsets: '50,50'
+      preview_styles:
+        '16_5_640': '16_5_640'
+        '16_9_600': '16_9_600'
+        '1_1_600': '1_1_600'
+        '2_3_640': '2_3_640'
+        '3_1_600': '3_1_600'
+        '3_2_640': '3_2_640'
+    third_party_settings: {  }
+  revision_log_message:
+    type: hide_revision_field_log_widget
+    weight: 80
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+      show: false
+      default: ''
+      permission_based: false
+      allow_user_settings: true
+    third_party_settings: {  }
+hidden:
+  created: true
+  name: true
+  path: true
+  status: true
+  uid: true


### PR DESCRIPTION
## [YSP-440: v1.2.0: Focal point not present in block media add](https://yaleits.atlassian.net/browse/YSP-440)

### Description of work
- Make image media library form display unique

### Functional testing steps:
- [ ] Attempt to add any block that has an image
- [ ] Upload a new image to it
- [ ] Verify that you see the preview link underneath the image as well as the focal point crosshair
