### PR TITLE
YSP-430: Canvas user need to allow two call to actions in banner

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.cta_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.cta_banner.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.block_content.cta_banner.field_heading_level
     - field.field.block_content.cta_banner.field_instructions
     - field.field.block_content.cta_banner.field_link
+    - field.field.block_content.cta_banner.field_link_two
     - field.field.block_content.cta_banner.field_media
     - field.field.block_content.cta_banner.field_style_color
     - field.field.block_content.cta_banner.field_style_position
@@ -55,6 +56,16 @@ content:
   field_link:
     type: linkit
     weight: 11
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
+    third_party_settings: {  }
+  field_link_two:
+    type: linkit
+    weight: 12
     region: content
     settings:
       placeholder_url: ''

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.grand_hero.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.grand_hero.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.block_content.grand_hero.field_heading_level
     - field.field.block_content.grand_hero.field_instructions
     - field.field.block_content.grand_hero.field_link
+    - field.field.block_content.grand_hero.field_link_two
     - field.field.block_content.grand_hero.field_media
     - field.field.block_content.grand_hero.field_style_position
     - field.field.block_content.grand_hero.field_style_variation
@@ -42,7 +43,7 @@ content:
         maxlength_js_enforce: false
   field_heading_level:
     type: options_select
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -53,6 +54,16 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_link:
+    type: linkit
+    weight: 6
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
+    third_party_settings: {  }
+  field_link_two:
     type: linkit
     weight: 7
     region: content
@@ -75,13 +86,13 @@ content:
         show_edit: '1'
   field_style_position:
     type: options_select
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   field_style_variation:
     type: options_select
-    weight: 6
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.cta_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.cta_banner.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.block_content.cta_banner.field_heading_level
     - field.field.block_content.cta_banner.field_instructions
     - field.field.block_content.cta_banner.field_link
+    - field.field.block_content.cta_banner.field_link_two
     - field.field.block_content.cta_banner.field_media
     - field.field.block_content.cta_banner.field_style_color
     - field.field.block_content.cta_banner.field_style_position
@@ -33,7 +34,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 6
+    weight: 7
     region: content
   field_link:
     type: link_separate
@@ -46,6 +47,18 @@ content:
       target: '0'
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_link_two:
+    type: link_separate
+    label: hidden
+    settings:
+      trim_length: null
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    weight: 4
     region: content
   field_media:
     type: entity_reference_entity_view
@@ -61,14 +74,14 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 4
+    weight: 5
     region: content
   field_style_position:
     type: list_key
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 5
+    weight: 6
     region: content
   field_text:
     type: text_default

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.grand_hero.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.grand_hero.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.block_content.grand_hero.field_heading_level
     - field.field.block_content.grand_hero.field_instructions
     - field.field.block_content.grand_hero.field_link
+    - field.field.block_content.grand_hero.field_link_two
     - field.field.block_content.grand_hero.field_media
     - field.field.block_content.grand_hero.field_style_position
     - field.field.block_content.grand_hero.field_style_variation
@@ -46,6 +47,18 @@ content:
       target: '0'
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_link_two:
+    type: link_separate
+    label: hidden
+    settings:
+      trim_length: null
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    weight: 4
     region: content
   field_media:
     type: entity_reference_entity_view

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_link_two.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_link_two.yml
@@ -1,0 +1,23 @@
+uuid: f7133d77-0df7-4324-95a4-9bbf20ddd47c
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.cta_banner
+    - field.storage.block_content.field_link_two
+  module:
+    - link
+id: block_content.cta_banner.field_link_two
+field_name: field_link_two
+entity_type: block_content
+bundle: cta_banner
+label: 'Call-to-action Two'
+description: 'For more information about linking content, view our resource <a href="https://yalesites.yale.edu/resource-library/linking-content-on-yalesites" target="_blank">Linking Content on YaleSites</a>.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: link

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_link_two.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_link_two.yml
@@ -1,0 +1,23 @@
+uuid: ecbfe710-7aa8-40cc-b4cc-e89127ff77c4
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.grand_hero
+    - field.storage.block_content.field_link_two
+  module:
+    - link
+id: block_content.grand_hero.field_link_two
+field_name: field_link_two
+entity_type: block_content
+bundle: grand_hero
+label: 'Link Two'
+description: 'For more information about linking content, view our resource <a href="https://yalesites.yale.edu/resource-library/linking-content-on-yalesites" target="_blank">Linking Content on YaleSites</a>.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: link

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_link_two.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_link_two.yml
@@ -1,0 +1,19 @@
+uuid: 044745d7-cd7e-4e28-bca0-5f40edd3328d
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - link
+id: block_content.field_link_two
+field_name: field_link_two
+entity_type: block_content
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## [YSP-430: Canvas user need to allow two call to actions in banner](https://yaleits.atlassian.net/browse/YSP-430)

### Description of work
- Adds optional second link field for cta banner and grand hero banner
- Adds a button-group wrapping div to preserve the existing space between elements
- Adds a new `field_link_two` field and re-uses it for each banner - adjusting the label to match the first link's pattern

### Functional Review Steps
- [x] Navigate to test pages: 
  - [x] Action Banner: https://pr-621-yalesites-platform.pantheonsite.io/generic-homepage
  - [x] Grand Hero Banner: https://pr-621-yalesites-platform.pantheonsite.io/fancy-lab 
- [x] Note that each have a second link field and it is not required
  - [x] Action banner:
<img width="2352" alt="Screenshot 2024-04-05 at 12 17 47 PM" src="https://github.com/yalesites-org/yalesites-project/assets/366413/6f7f6e1a-39dc-427d-8888-0680ae8922fd">


  - [x] Grand Hero
<img width="2411" alt="Screenshot 2024-04-05 at 11 59 20 AM" src="https://github.com/yalesites-org/yalesites-project/assets/366413/b7bf060a-0c0b-4baa-b8e8-88cb4ba841c7">

#### Admin screenshots
<img width="2474" alt="Screenshot 2024-04-05 at 11 57 55 AM" src="https://github.com/yalesites-org/yalesites-project/assets/366413/fff4de33-2c91-4a26-b159-773eb9fbff5c">
<img width="2529" alt="Screenshot 2024-04-05 at 11 58 40 AM" src="https://github.com/yalesites-org/yalesites-project/assets/366413/3ec542fc-fb72-45e6-b94a-21890d4d87b8">

