### PR TITLE
Semantic release backmerge updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
       [
         "@saithodev/semantic-release-backmerge",
         {
-          "backmergeBranches": ["develop"]
+          "backmergeBranches": ["develop"],
+          "backmergeStrategy": "merge",
         }
       ],
       "@semantic-release/github"


### PR DESCRIPTION
### Description of work
- Semantic Release Backmerge was added in v1.2.0 to keep develop up to date with master after a release, but it failed. This PR switches the merge strategy to `merge` instead of the default `rebase`.
- `develop` is also a protected branch so I'm setting actions/checkout step [per the docs](https://github.com/saitho/semantic-release-backmerge?tab=readme-ov-file#backmerging-into-protected-branches)