### PR TITLE
YSP-470: Media library images slow to load

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.media_library.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.media_library.yml
@@ -1,25 +1,32 @@
-uuid: 7b2b7e9d-436d-45c9-b25f-6fb8985c701b
+uuid: 557918b8-f456-48cc-8230-670ba974bad1
 langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.media.media_library
     - field.field.media.image.field_media_image
+    - image.style.media_library
     - media.type.image
   module:
     - image
-id: media.image.default
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: media.image.media_library
 targetEntityType: media
 bundle: image
-mode: default
+mode: media_library
 content:
   field_media_image:
     type: image
     label: hidden
     settings:
       image_link: ''
-      image_style: ''
+      image_style: media_library
       image_loading:
-        attribute: eager
+        attribute: lazy
     third_party_settings: {  }
     weight: 0
     region: content

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.media_library.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.media_library.yml
@@ -2,19 +2,21 @@ uuid: 4e8a075a-fed8-4da4-bd16-78971503820a
 langcode: en
 status: true
 dependencies:
+  module:
+    - focal_point
   enforced:
     module:
       - media_library
 _core:
   default_config_hash: 7qJqToD1OQLAyeswpmg7M0LRxQlw1URQkJDWUJCnmR8
 name: media_library
-label: 'Media Library thumbnail (220×220)'
+label: 'Media Library thumbnail (350×350)'
 effects:
-  75b076a8-1234-4b42-85db-bf377c4d8d5f:
-    uuid: 75b076a8-1234-4b42-85db-bf377c4d8d5f
-    id: image_scale
-    weight: 0
+  66acf8b4-c9cf-449b-ab95-a1c52c917e6f:
+    uuid: 66acf8b4-c9cf-449b-ab95-a1c52c917e6f
+    id: focal_point_scale_and_crop
+    weight: 2
     data:
-      width: 220
-      height: 220
-      upscale: false
+      width: 350
+      height: 350
+      crop_type: focal_point


### PR DESCRIPTION
## [YALB-470: Media library images slow to load](https://yaleits.atlassian.net/browse/YALB-470)

### Description of work
Pam reported the media library images are very slow to load after a cache flush. After debugging, the media library display mode was not enabled for media library images, so full size images were loading and being scaled down.

This updates the media library thumbnail style to use focal point and increase to 350x350 for clearer previews, and
enables the Media Library display mode for the Image media type.

### Functional testing steps:
- [ ] View the media library on an existing site and open a thumbnail in a new tab and observe that it is the full original image
- [ ] On the PR-generated multidev, open a media library thumbnail image and see that it is now using a scaled down thumbnail
