### PR TITLE
YSP-478: Bug: Adding Profile Content Block to Post/Events results in error

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
@@ -95,6 +95,7 @@ third_party_settings:
         - System
         - Webform
         - 'YaleSites Core'
+        - 'YaleSites Layouts'
         - 'YaleSites alert'
         - core
     entity_view_mode_restriction_by_region:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
@@ -92,6 +92,7 @@ third_party_settings:
         - System
         - Webform
         - 'YaleSites Core'
+        - 'YaleSites Layouts'
         - 'YaleSites alert'
         - core
     entity_view_mode_restriction_by_region:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/ProfileContactBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/ProfileContactBlock.php
@@ -117,9 +117,9 @@ class ProfileContactBlock extends BlockBase implements ContainerFactoryPluginInt
 
     if ($route && $node) {
       // Profile fields.
-      $email = $node->get('field_email')->getValue()[0]['value'] ?? NULL;
-      $phone = $node->get('field_telephone')->getValue()[0]['value'] ?? NULL;
-      $address = $node->get('field_address')->getValue()[0]['value'] ?? NULL;
+      $email = $this->getValueFor($node, 'field_email');
+      $phone = $this->getValueFor($node, 'field_telephone');
+      $address = $this->getValueFor($node, 'field_address');
     }
 
     return [
@@ -128,6 +128,36 @@ class ProfileContactBlock extends BlockBase implements ContainerFactoryPluginInt
       '#phone' => $phone,
       '#address' => $address,
     ];
+  }
+
+  /**
+   * Get the value for a specific field.
+   *
+   * @param object $node
+   *   The node object.
+   * @param string $name
+   *   The field name.
+   *
+   * @return mixed
+   *   The field value.
+   */
+  protected function getValueFor($node, $name) {
+    try {
+      $fieldObject = $node->get($name);
+    }
+    catch (\Exception $e) {
+      return NULL;
+    }
+
+    $valueObject = $fieldObject->getValue();
+    if ($valueObject) {
+      $firstElement = $valueObject[0];
+      if ($firstElement) {
+        return $firstElement['value'];
+      }
+    }
+
+    return NULL;
   }
 
 }


### PR DESCRIPTION
## [YSP-478: Bug: Adding Profile Content Block to Post/Events results in error](https://yaleits.atlassian.net/browse/YSP-478)

### Description of work
- Adds safety checks for retrieving data in the profile content block
- Restricts YaleSite layout blocks for events and posts

### Functional testing steps:
- [x] Add a post
- [x] Attempt to add a block
- [x] Verify that `Profile Content Block` is not available to add
- [x] Add an event
- [x] Attempt to add a block
- [x] Verify that `Profile Content Block` is not available to add
