### PR TITLE
fix(YSP-525): v1.3.0: Bug: Bulk publish/unpublish operations do nothing

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.content.yml
@@ -81,8 +81,6 @@ display:
           include_exclude: include
           selected_actions:
             - node_delete_action
-            - node_publish_action
-            - node_unpublish_action
             - pathauto_update_alias_node
         title:
           id: title

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_events.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_events.yml
@@ -87,8 +87,6 @@ display:
           include_exclude: include
           selected_actions:
             - node_delete_action
-            - node_publish_action
-            - node_unpublish_action
             - pathauto_update_alias_node
         title:
           id: title

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_pages.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_pages.yml
@@ -81,8 +81,6 @@ display:
           include_exclude: include
           selected_actions:
             - node_delete_action
-            - node_publish_action
-            - node_unpublish_action
             - pathauto_update_alias_node
         title_1:
           id: title_1

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_posts.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_posts.yml
@@ -84,8 +84,6 @@ display:
           include_exclude: include
           selected_actions:
             - node_delete_action
-            - node_publish_action
-            - node_unpublish_action
             - pathauto_update_alias_node
         title:
           id: title

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_profiles.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_profiles.yml
@@ -85,8 +85,10 @@ display:
           empty_zero: false
           hide_alter_empty: true
           action_title: Action
-          include_exclude: exclude
-          selected_actions: {  }
+          include_exclude: include
+          selected_actions:
+            - node_delete_action
+            - pathauto_update_alias_node
         title:
           id: title
           table: node_field_data


### PR DESCRIPTION
## [v1.3.0: Bug: Bulk publish/unpublish operations do nothing](https://yaleits.atlassian.net/browse/YSP-525)

Since we are using content moderation, using the existing bulk operations of publish and unpublish result in a warning notifying the user of the use of content moderation, followed by error messages reinforcing the same thing.  Since this is now not able to be done, we remove these options from being selected in the bulk operations drop down.

### Description of work
- Remove `publish` and `unpublish` from possible bulk operations in the following views:
  - Content
  - Manage Events
  - Manage Pages
  - Manage Posts
  - Manage Profiles
    - This originally allowed all bulk operations instead of a subset as the other did.  This also makes Profiles behave like the others by limiting the bulk operations to a subset.  They now all match.

### Functional testing steps:
- [x] Visit each view above
- [x] Select multiple items in bulk
- [x] In the bulk operations dropdown that appears in the bottom, ensure that `publish` and `unpublish` are not available options.
