### PR TITLE
fix(YSP-526): V1.3.0: Reference Card Label Change

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.reference_card.field_content_ref.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.reference_card.field_content_ref.yml
@@ -12,8 +12,8 @@ id: block_content.reference_card.field_content_ref
 field_name: field_content_ref
 entity_type: block_content
 bundle: reference_card
-label: Content
-description: ''
+label: 'Reference source'
+description: 'Type the name of the content you want to refer to in the Reference Source. As you type, an autocomplete feature will suggest matching content from your site.'
 required: true
 translatable: false
 default_value: {  }


### PR DESCRIPTION
## [YSP-526: V1.3.0: Reference Card Label Change](https://yaleits.atlassian.net/browse/YSP-526)

After reviewing the naming of the fields of the reference card, it was determined that Content was not as informative than something like 'Reference source'.  This change renames 'Content' to 'Reference source', and adds help text to help the user know what the use of it is.

### Description of work
- Renames `Content` to `Reference source` for reference card block in Drupal
- Adds help text to the field for `Reference source`

### Functional testing steps:
- [ ] Attempt to add a reference card block
- [ ] Verify that the label of the field shown is not `Content`, but instead `Reference source`
- [ ] Verify that the help text is displayed
- [ ] Verify that you can successfully create a reference card block
