### PR TITLE
fix(YSP-528): V1.3.0: Media Library add tag column in view

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.media.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.media.yml
@@ -377,7 +377,7 @@ display:
           click_sort_column: target_id
           type: entity_reference_label
           settings:
-            link: true
+            link: false
           group_column: target_id
           group_columns: {  }
           group_rows: true

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.media.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.media.yml
@@ -2,8 +2,12 @@ uuid: ae64141c-0d51-4f15-967c-e3d7bbedaef8
 langcode: en
 status: true
 dependencies:
+  config:
+    - field.storage.media.field_tags
+    - taxonomy.vocabulary.tags
   module:
     - media
+    - taxonomy
     - user
 _core:
   default_config_hash: mF_CA96Q4unIl78LRoLKR5YPUDGdxn0wbSqyUbvrQjc
@@ -312,6 +316,69 @@ display:
             format_custom_false: Unpublished
             format_custom_true: Published
           group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_tags:
+          id: field_tags
+          table: media__field_tags
+          field: field_tags
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Tags
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -689,6 +756,59 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_tags_target_id:
+          id: field_tags_target_id
+          table: media__field_tags
+          field: field_tags_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: and
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_tags_target_id_op
+            label: Tags
+            description: ''
+            use_operator: false
+            operator: field_tags_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_tags_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              contributor: '0'
+              editor: '0'
+              site_admin: '0'
+              platform_admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: 'Tags (field_tags)'
+            description: null
+            identifier: field_tags_target_id
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1: {  }
+              2: {  }
+              3: {  }
+          reduce_duplicates: false
+          vid: tags
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: true
         langcode:
           id: langcode
           table: media_field_data
@@ -732,6 +852,10 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: table
         options:
@@ -818,7 +942,8 @@ display:
         - url.query_args
         - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.media.field_tags'
   media_page_list:
     id: media_page_list
     display_title: Media
@@ -846,4 +971,5 @@ display:
         - url.query_args
         - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.media.field_tags'


### PR DESCRIPTION
## [YSP-528: V1.3.0: Media Library add tag column in view](https://yaleits.atlassian.net/browse/YSP-528)

While users can add tags, there wasn't a usage for them yet in the system.  This was a way to still convey that entering this can be useful by giving them a chance to filter via the media table by tags and see what tags are assigned to a media.

This adds both a tags filter using Drupal's autocomplete, and a tags column to display tags associated with media.

### Description of work
- Adds tag filter for media table view
- Adds tag column for media table view

### Functional testing steps:
- [ ] Visit the media table view
- [ ] Verify that you can search by tag
- [ ] Verify that you can see a column displaying tags

Note: You might need to add some media or add tags to see this functionality.
