### PR TITLE
YSP-529: V1.3.0: remove the configure button on moderation placeholder in /layout

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
@@ -43,6 +43,7 @@ third_party_settings:
         third_party_settings:
           layout_builder_lock:
             lock:
+              2: 2
               5: 5
               6: 6
               7: 7


### PR DESCRIPTION
## [YSP-529: V1.3.0: remove the configure button on moderation placeholder in /layout](https://yaleits.atlassian.net/browse/YSP-529)

### Description of work
- Content editors can no longer remove default blocks placed in the banner section.

### Functional testing steps:
- [ ] Login to the site as a site administrator, editor, or contributor role
- [ ] Add a new page to the site, title it, and save (publish or draft is fine)
- [ ] In Layout Builder, verify that if you click the "Configure" pencil next to the "Placeholder for the Moderation control field", the remove option no longer exists. Note that this only works for newly added content which is fine as the moderation control field is the same - only newly added content.

![Screenshot 2024-05-14 at 11 55 10 AM](https://github.com/yalesites-org/yalesites-project/assets/107938318/189a0184-d05b-49da-8ab2-934ac024d2f2)

