### PR TITLE
YSP-527: V1.3.0: Reference Card link color contrast -- DO NOT MERGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory.
+


### PR DESCRIPTION
This is to show off changes in the component library for this ticket.

## [YSP-527: V1.3.0: Reference Card link color contrast](https://yaleits.atlassian.net/browse/YSP-527)

### Description of work
- Shows off changes in the [component library twig repo](https://github.com/yalesites-org/component-library-twig/pull/365)

### Functional testing steps:
- [ ] Create a reference card
- [ ] Ensure that link text and hover link text of the item referenced is using `var(--color-card-single-text)` (white)
- [ ] Ensure that contrast passes accessibility standards
- [ ] Try different references to ensure it occurs across all types

[Exiting page with all permutations of usable content types and styles](https://pr-651-yalesites-platform.pantheonsite.io/a-reference-card-to-remember)