### PR TITLE
YSP-529/530 - Layout builder fixes

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
@@ -43,6 +43,7 @@ third_party_settings:
         third_party_settings:
           layout_builder_lock:
             lock:
+              2: 2
               5: 5
               6: 6
               7: 7

--- a/web/profiles/custom/yalesites_profile/config/sync/layout_builder_browser.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/layout_builder_browser.settings.yml
@@ -22,6 +22,7 @@ auto_added_reusable_block_content_bundles:
   post_list: post_list
   pull_quote: pull_quote
   quick_links: quick_links
+  reference_card: reference_card
   tabs: tabs
   text: text
   video: video


### PR DESCRIPTION
## Layout builder fixes
* [YSP-529: V1.3.0: remove the configure button on moderation placeholder in /layout](https://yaleits.atlassian.net/browse/YSP-529)
* [YSP-530: V1.3.0: Reusable Reference Card doesn't show up in block picker](https://yaleits.atlassian.net/browse/YSP-530)
* Multidev testing: https://pr-652-yalesites-platform.pantheonsite.io/

### Description of work
- Disallows removing of the content moderation block in the banner section
- Adds the reference card reusable block to layout builder browser to pick previously created reference cards

### Functional testing steps (YSP-529):
- [ ] Login to the site as a site administrator, editor, or contributor role
- [ ] Add a new page to the site, title it, and save (publish or draft is fine)
- [ ] In Layout Builder, verify that if you click the "Configure" pencil next to the "Placeholder for the Moderation control field", the remove option no longer exists. Note that this only works for newly added content which is fine as the moderation control field is the same - only newly added content.

![Screenshot 2024-05-14 at 11 55 10 AM](https://github.com/yalesites-org/yalesites-project/assets/107938318/189a0184-d05b-49da-8ab2-934ac024d2f2)

### Functional testing steps (YSP-530):
- [ ] Login to the site as a site administrator, editor, or contributor role
- [ ] Add a new page to the site, title it and save (publish or draft is fine)
- [ ] In Layout Builder, create a new reference card and point to any type of content - make sure this block is set to be reusable.
- [ ] Create a new page, enter layout builder and add a block
- [ ] Verify that at the bottom of the layout builder browser picker, the reusable reference card is now listed

![Screenshot 2024-05-14 at 12 22 16 PM](https://github.com/yalesites-org/yalesites-project/assets/107938318/76313816-15db-4877-a2e3-6694c3a97088)

