### PR TITLE
YSP-517: Tech debt consistent field settings

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/block_content.type.content_spotlight_portrait.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block_content.type.content_spotlight_portrait.yml
@@ -29,5 +29,5 @@ third_party_settings:
         external: ''
 id: content_spotlight_portrait
 label: 'Spotlight - Portrait'
-revision: 0
+revision: 1
 description: 'Spotlight - Portrait allows you to display a portrait 2x3 image adjacent to text. This component has optional content, an image offset option, and different orientations.'

--- a/web/profiles/custom/yalesites_profile/config/sync/block_content.type.directory.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block_content.type.directory.yml
@@ -29,5 +29,5 @@ third_party_settings:
         external: ''
 id: directory
 label: Directory
-revision: 0
+revision: 1
 description: 'Display a list of profiles as a directory list including detailed contact information.'

--- a/web/profiles/custom/yalesites_profile/config/sync/block_content.type.reference_card.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block_content.type.reference_card.yml
@@ -29,5 +29,5 @@ third_party_settings:
         external: ''
 id: reference_card
 label: 'Reference card'
-revision: 0
+revision: 1
 description: 'Select an existing Post, Event, or Profile to display a single card.'

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.callout.field_style_color.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.callout.field_style_color.yml
@@ -11,7 +11,7 @@ id: block_content.callout.field_style_color
 field_name: field_style_color
 entity_type: block_content
 bundle: callout
-label: 'Background Color'
+label: Theme
 description: ''
 required: true
 translatable: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_style_color.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_style_color.yml
@@ -11,7 +11,7 @@ id: block_content.content_spotlight.field_style_color
 field_name: field_style_color
 entity_type: block_content
 bundle: content_spotlight
-label: 'Theme Color'
+label: Theme
 description: ''
 required: true
 translatable: false

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight_portrait.field_style_color.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight_portrait.field_style_color.yml
@@ -11,7 +11,7 @@ id: block_content.content_spotlight_portrait.field_style_color
 field_name: field_style_color
 entity_type: block_content
 bundle: content_spotlight_portrait
-label: 'Theme Color'
+label: Theme
 description: ''
 required: true
 translatable: false

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_style_color.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_style_color.yml
@@ -11,7 +11,7 @@ id: block_content.cta_banner.field_style_color
 field_name: field_style_color
 entity_type: block_content
 bundle: cta_banner
-label: 'Background Color'
+label: Theme
 description: ''
 required: true
 translatable: false


### PR DESCRIPTION
## [YSP-517: TechDebt: Consistent field settings](https://fourkitchens.clickup.com/t/86a3cr6ax)

### Description of work
- Check the option 'Create new revision' for all blocks.
- Use the label 'Theme' in the field field_style_color.

### Functional testing steps:
- [x] Create some custom blocks: https://pr-653-yalesites-platform.pantheonsite.io/block/add
- [x] Check that the following fields are required and have a default value:
  -  Alignment
  - Columns
  - Position
  - Style
  - Theme
- [x] Check that all block has revision.
