### PR TITLE
YSP-538: Provide a menu link error on Publish

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -146,7 +146,7 @@ module:
   ys_views_basic: 0
   hide_revision_field: 1
   menu_admin_per_menu: 1
-  pathauto: 1
+  pathauto: 2
   selective_better_exposed_filters: 1
   externalauth: 10
   formdazzle: 10

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -133,7 +133,7 @@ module:
   views_ui: 0
   webform: 0
   webform_ui: 0
-  workflow_buttons: 0
+  workflow_buttons: -1
   workflows: 0
   yale_cas: 0
   ys_alert: 0


### PR DESCRIPTION
## [YSP-538: Provide a menu link error on Publish](https://yaleits.atlassian.net/browse/YSP-538)

_Note: Even though the branch is on a hotfix branch, this is no longer a hotfix._

On a published node, adding it to the menu via the sidebar resulted in Pathauto erroring due to the menu-item not being handled correctly.

This is an interaction issue between Pathauto, Token, Content Moderation, and Workflow Buttons.  Adjusting the weights of Pathauto and workflow buttons ensure that the menu item gets saved correctly, and that the alias is properly updated without needing to do a 2nd publish.

### Description of work
- Changes the weights on `pathauto` to occur later
  - This fixes pathauto having to save twice to get the correct parents
- Changes the weights on `workflow_buttons` to occur earlier
  - This fixes the tokens not being able to load the menu item from the `menu_tree` before it exists

### Functional testing steps:
- [x] [CAS login](https://pr-654-yalesites-platform.pantheonsite.io/cas)
- [x] Create a page
- [x] Publish the page
- [x] Edit the new page
- [x] Open menu settings on the right and toggle on "show in menu"
- [x] Fill out other fields for the menu
- [x] Publish the page again
- [x] Verify no error occurs
- [x] Verify that you can see the menu link in the resulting menu on the site
- [x] Verify that the URL alias looks correct and is nested underneath the parent menu path you selected.