### PR TITLE
YSP-521 - AX: Hide Revert button on layout builder

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/gin_lb.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/gin_lb.settings.yml
@@ -3,6 +3,6 @@ _core:
 toastify_loading: custom
 enable_preview_regions: false
 hide_discard_button: false
-hide_revert_button: false
+hide_revert_button: true
 save_behavior: default
 safe_behavior: stay


### PR DESCRIPTION
## [YSP-521: AX: Hide 'Revert' button on layout builder](https://fourkitchens.clickup.com/t/86a3ejqyy)

### Description of work
- Hide the 'Revert' button from the layout builder setting.

### Functional testing steps:
- [ ] Edit an existing 'Page' content type and go to the Layout settings: (e.g. https://pr-658-yalesites-platform.pantheonsite.io/node/26/layout). 
- [ ] See the right sidebar, and check that there is no "Discard changes" button below the "Save" button.

**Before:**

![Screen-Shot-2024-05-17-at-5-12-12-PM](https://github.com/yalesites-org/yalesites-project/assets/2343393/2c64bd41-0619-4e3f-b670-b00085985bc4)

**After:**

![Edit-layout-for-Testing-all-of-the-things-🦄-YaleSites](https://github.com/yalesites-org/yalesites-project/assets/2343393/44b01fbf-7ae8-4c71-958b-af9dec5c6b47)
