### PR TITLE
YSP-540 give permissions to platform admins to assign roles

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -92,6 +92,8 @@ permissions:
   - 'administer redirects'
   - 'administer users'
   - 'administer utility-navigation menu items'
+  - 'assign contributor role'
+  - 'assign editor role'
   - 'assign platform_admin role'
   - 'assign site_admin role'
   - 'clone event content'


### PR DESCRIPTION
## [YALB-540: Workflow: Allow platform admins to promote/demote to contributor or editor(https://yaleits.atlassian.net/browse/YSP-540)

### Description of work
- Gives permissions to platform admins to assign contributor and editor roles

### Functional testing steps:
- [ ] As a platform admin, edit a user. Verify you can assign the editor and contributor roles.