### PR TITLE
YSP-479 Wrong alignment for Reusable Blocks in Posts, Profiles and Events

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -137,7 +137,6 @@ function ys_themes_preprocess_block(&$variables) {
   // Via: https://drupal.stackexchange.com/questions/266379/how-to-clear-cache-for-config-entity-after-making-changes
   \Drupal::service('renderer')->addCacheableDependency($variables, $config);
 
-
   $block_content_ids = ['inline_block', 'block_content'];
 
   if (!empty($variables['base_plugin_id']) && in_array($variables['base_plugin_id'], $block_content_ids)) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -137,7 +137,10 @@ function ys_themes_preprocess_block(&$variables) {
   // Via: https://drupal.stackexchange.com/questions/266379/how-to-clear-cache-for-config-entity-after-making-changes
   \Drupal::service('renderer')->addCacheableDependency($variables, $config);
 
-  if (!empty($variables['base_plugin_id']) && $variables['base_plugin_id'] == 'inline_block') {
+
+  $block_content_ids = ['inline_block', 'block_content'];
+
+  if (!empty($variables['base_plugin_id']) && in_array($variables['base_plugin_id'], $block_content_ids)) {
 
     $node = \Drupal::routeMatch()->getParameter('node');
     if ($node) {


### PR DESCRIPTION
## [YSP-479: Title](https://yaleits.atlassian.net/browse/YSP-479)

### Description of work
- Adds proper alignment for reusable accordion blocks in posts and events

### Functional testing steps:
- [ ] Add a reusable and non-reusable accordion block to an event or post. Verify that the alignment is the same for both.