### PR TITLE
YSP-431 Wire/Add/Tweak Call-to-Action button utility nav

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/HeaderSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/HeaderSettingsForm.php
@@ -165,6 +165,18 @@ class HeaderSettingsForm extends ConfigFormBase {
       ],
     ];
 
+    $form['call_to_action_container'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Call to Action'),
+      '#states' => [
+        'disabled' => [
+          ':input[name="header_variation"]' => [
+            'value' => 'focus',
+          ],
+        ],
+      ],
+    ];
+
     $form['site_search_container'] = [
       '#type' => 'details',
       '#title' => $this->t('Site Search'),
@@ -242,6 +254,28 @@ class HeaderSettingsForm extends ConfigFormBase {
       ],
     ];
 
+    $form['call_to_action_container']['cta_text'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Link text'),
+      '#description' => $this->t('Enter the text that should appear in the CTA button.'),
+      '#autocomplete_route_name' => 'linkit.autocomplete',
+      '#autocomplete_route_parameters' => [
+        'linkit_profile_id' => 'default',
+      ],
+      '#default_value' => ($headerConfig->get('cta_text')) ?? NULL,
+    ];
+
+    $form['call_to_action_container']['cta_url'] = [
+      '#type' => 'linkit',
+      '#title' => $this->t('Select link target'),
+      '#description' => $this->t('Start typing to select internal content. You can also enter an external link.'),
+      '#autocomplete_route_name' => 'linkit.autocomplete',
+      '#autocomplete_route_parameters' => [
+        'linkit_profile_id' => 'default',
+      ],
+      '#default_value' => ($headerConfig->get('cta_url')) ?? NULL,
+    ];
+
     $form['site_search_container']['enable_search_form'] = [
       '#type' => 'checkbox',
       '#description' => $this->t('When enabled, a site search form will be displayed in the Utility Menu.'),
@@ -300,6 +334,8 @@ class HeaderSettingsForm extends ConfigFormBase {
     $headerConfig->set('header_variation', $form_state->getValue('header_variation'));
     $headerConfig->set('site_name_image', $form_state->getValue('site_name_image'));
     $headerConfig->set('nav_position', $form_state->getValue('nav_position'));
+    $headerConfig->set('cta_text', $form_state->getValue('cta_text'));
+    $headerConfig->set('cta_url', $form_state->getValue('cta_url'));
     $headerConfig->set('search.enable_search_form', $form_state->getValue('enable_search_form'));
     $headerConfig->set('focus_header_image', $form_state->getValue('focus_header_image'));
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/HeaderSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/HeaderSettingsForm.php
@@ -267,7 +267,7 @@ class HeaderSettingsForm extends ConfigFormBase {
 
     $form['call_to_action_container']['cta_url'] = [
       '#type' => 'linkit',
-      '#title' => $this->t('Select link target'),
+      '#title' => $this->t('Link target'),
       '#description' => $this->t('Start typing to select internal content. You can also enter an external link.'),
       '#autocomplete_route_name' => 'linkit.autocomplete',
       '#autocomplete_route_parameters' => [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/HeaderSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/HeaderSettingsForm.php
@@ -254,7 +254,7 @@ class HeaderSettingsForm extends ConfigFormBase {
       ],
     ];
 
-    $form['call_to_action_container']['cta_text'] = [
+    $form['call_to_action_container']['cta_content'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Link text'),
       '#description' => $this->t('Enter the text that should appear in the CTA button.'),
@@ -262,7 +262,7 @@ class HeaderSettingsForm extends ConfigFormBase {
       '#autocomplete_route_parameters' => [
         'linkit_profile_id' => 'default',
       ],
-      '#default_value' => ($headerConfig->get('cta_text')) ?? NULL,
+      '#default_value' => $headerConfig->get('cta_content') ?? NULL,
     ];
 
     $form['call_to_action_container']['cta_url'] = [
@@ -273,7 +273,7 @@ class HeaderSettingsForm extends ConfigFormBase {
       '#autocomplete_route_parameters' => [
         'linkit_profile_id' => 'default',
       ],
-      '#default_value' => ($headerConfig->get('cta_url')) ?? NULL,
+      '#default_value' => $headerConfig->get('cta_url') ?? NULL,
     ];
 
     $form['site_search_container']['enable_search_form'] = [
@@ -334,7 +334,7 @@ class HeaderSettingsForm extends ConfigFormBase {
     $headerConfig->set('header_variation', $form_state->getValue('header_variation'));
     $headerConfig->set('site_name_image', $form_state->getValue('site_name_image'));
     $headerConfig->set('nav_position', $form_state->getValue('nav_position'));
-    $headerConfig->set('cta_text', $form_state->getValue('cta_text'));
+    $headerConfig->set('cta_content', $form_state->getValue('cta_content'));
     $headerConfig->set('cta_url', $form_state->getValue('cta_url'));
     $headerConfig->set('search.enable_search_form', $form_state->getValue('enable_search_form'));
     $headerConfig->set('focus_header_image', $form_state->getValue('focus_header_image'));

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -172,6 +172,8 @@ function ys_core_preprocess_region(&$variables) {
   $config = \Drupal::config('ys_core.header_settings');
   if ($variables['elements']['#region'] == 'header') {
     $variables['utility_nav__search'] = ($config->get('search')) ? $config->get('search')['enable_search_form'] : NULL;
+    $variables['utility_nav__link__content'] = $config->get('cta_content') ?? NULL;
+    $variables['utility_nav__link__url'] = $config->get('cta_url') ?? NULL;
     // Responsive image render array for focus header image.
     if ($focusHeaderImageId = $config->get('focus_header_image')) {
       // There are cases where the id is really an array of images over one.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/js/levers.js
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/js/levers.js
@@ -1,7 +1,8 @@
 ((Drupal) => {
   Drupal.behaviors.ysLevers = {
-    attach: function (context, settings) { // eslint-disable-line
-      once("ysLevers", ".layout-container", context).forEach((element) => {
+    attach: function (context, settings) {
+      // eslint-disable-line
+      once('ysLevers', '.layout-container', context).forEach((element) => {
         // Update root CSS variables
         function updateRoot(selector, value) {
           const prefix = selector.match(/--([a-z]*[0-9]*)/g);
@@ -17,25 +18,28 @@
           // These convert from element[data-attribute-name] to attributeName
           const dataAttribute = selector.match(/\[(.*?)\]/);
           const convertedAttributeName = dataAttribute[1]
-            .replace("data-", "")
+            .replace('data-', '')
             .replace(/-([a-z]?)/g, (m, g) => g.toUpperCase());
           for (let i = 0; i < elements.length; i++) {
-            elements[i].dataset[convertedAttributeName] = value;
+            // Skip the CTA button in the header
+            if (!elements[i].classList.contains('utility-nav__cta')) {
+              elements[i].dataset[convertedAttributeName] = value;
+            }
           }
         }
 
         function initStyleDrawer() {
           const formItems = context.querySelectorAll(
-            "input.ys-themes--setting"
+            'input.ys-themes--setting'
           );
 
           for (let i = 0; i < formItems.length; i++) {
-            formItems[i].addEventListener("click", (event) => {
+            formItems[i].addEventListener('click', (event) => {
               const { propType, selector } = event.target.dataset;
-              if (propType === "root") {
+              if (propType === 'root') {
                 updateRoot(selector, formItems[i].value);
               }
-              if (propType === "element") {
+              if (propType === 'element') {
                 updateElement(selector, formItems[i].value);
               }
             });
@@ -49,21 +53,23 @@
       });
 
       //
-      // Add Checked (checked = "checked") attribute to clicked radio elements 
+      // Add Checked (checked = "checked") attribute to clicked radio elements
       // to visually identify the active clicked theme option.
       //
 
       // Get all radio inputs in the glogal_theme name group
-      const radioInputs = document.querySelectorAll('input[name="global_theme"]');
+      const radioInputs = document.querySelectorAll(
+        'input[name="global_theme"]'
+      );
 
       // Add event listener to each radio input
-      radioInputs.forEach(input => {
-        input.addEventListener('change', function() {
+      radioInputs.forEach((input) => {
+        input.addEventListener('change', function () {
           if (this.checked) {
             this.setAttribute('checked', 'checked');
 
             // Remove the 'checked' attribute from other radio inputs
-            radioInputs.forEach(otherInput => {
+            radioInputs.forEach((otherInput) => {
               if (otherInput !== this) {
                 otherInput.removeAttribute('checked');
               }
@@ -71,12 +77,16 @@
           }
 
           // Get each component-color span element
-          const targetElements = document.querySelectorAll('span.component-color');
+          const targetElements = document.querySelectorAll(
+            'span.component-color'
+          );
 
           // Read active global theme and capture the number in a variable and
           // update it on radio input paletter selection change.
-          targetElements.forEach(targetElement => {
-            const globalTheme = document.querySelector('div[data-global-theme]');
+          targetElements.forEach((targetElement) => {
+            const globalTheme = document.querySelector(
+              'div[data-global-theme]'
+            );
             const currentTheme = globalTheme.getAttribute('data-global-theme');
             const originalBackground = targetElement.style.background;
 
@@ -84,7 +94,10 @@
             const regexPattern = new RegExp(`--global-themes-(\\w+)-`);
 
             // Replace the --global-themes-${globalTheme}- portion
-            const updatedBackground = originalBackground.replace(regexPattern, `--global-themes-${currentTheme}-`);
+            const updatedBackground = originalBackground.replace(
+              regexPattern,
+              `--global-themes-${currentTheme}-`
+            );
 
             // Update the inline style with the modified background value
             targetElement.style.background = updatedBackground;
@@ -94,18 +107,18 @@
 
       // Function to handle radio input checked behavior based on radio element selection.
       // Note: 'global_theme' is excluded because we're doing the same thing above,
-      // but adding on to it. 
+      // but adding on to it.
       function handleRadioInputs(radioGroup) {
         // Get references to the radio input elements within the specified group
         const radioInputs = document.querySelectorAll(radioGroup);
-      
+
         // Add event listener to each radio input
-        radioInputs.forEach(input => {
-          input.addEventListener('change', function() {
+        radioInputs.forEach((input) => {
+          input.addEventListener('change', function () {
             if (this.checked) {
               this.setAttribute('checked', 'checked');
               // Remove the 'checked' attribute from other radio inputs
-              radioInputs.forEach(otherInput => {
+              radioInputs.forEach((otherInput) => {
                 if (otherInput !== this) {
                   otherInput.removeAttribute('checked');
                 }
@@ -114,9 +127,9 @@
           });
         });
       }
-      
+
       // Store radio input groups in an array
-      const radioGroups = [ 
+      const radioGroups = [
         'input[name="nav_position"]',
         'input[name="nav_type"]',
         'input[name="button_theme"]',
@@ -125,9 +138,9 @@
         'input[name="footer_theme"]',
         'input[name="footer_accent"]',
       ];
-      
+
       // Apply the function to each radio input group
-      radioGroups.forEach(group => {
+      radioGroups.forEach((group) => {
         handleRadioInputs(group);
       });
     },


### PR DESCRIPTION
## [YSP-431: Wire/Add/Tweak Call-to-Action button utility nav](https://yaleits.atlassian.net/browse/YALB-XX)

### Description of work
- Adds the CTA button to the header if the CTA fields are populated in the header form

### Functional testing steps:
- [ ] Go to /admin/yalesites/header, verify there is a new Call To Action section with Link Text (text) and Link Target (linkit) fields
- [ ] Add values for either or both fields
- [ ] Verify if both fields are populated, the Call to Action button appears in the upper right of the navigation as per the designs

Requires https://github.com/yalesites-org/component-library-twig/pull/370