### PR TITLE
YSP-532: Increase grand hero video size maximum

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.media.background_video.field_media_video_file.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.media.background_video.field_media_video_file.yml
@@ -15,13 +15,13 @@ label: 'Video File'
 description: ''
 required: true
 translatable: true
-default_value: {  }
+default_value: {}
 default_value_callback: ''
 settings:
   handler: 'default:file'
-  handler_settings: {  }
+  handler_settings: {}
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: mp4
-  max_filesize: '12 MB'
+  max_filesize: '25 MB'
   description_field: true
 field_type: file


### PR DESCRIPTION
## [YSP-532: Increase grand hero video size maximum](https://yaleits.atlassian.net/browse/YSP-532)

### Description of work
- Increases the max file size of a background video from 12 MB to 25 MB

### Functional testing steps:
- [ ] Attempt to upload a background video
- [ ] Verify that the max allowed says 25 MB
- [ ] Verify that you can upload a MP4 that is within that range
