### PR TITLE
YSP-494 - Allow content spotlight as a banner

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
@@ -103,6 +103,8 @@ third_party_settings:
             'Inline blocks':
               - 'inline_block:cta_banner'
               - 'inline_block:grand_hero'
+              - 'inline_block:content_spotlight'
+              - 'inline_block:content_spotlight_portrait'
         ys_layout_page_meta:
           all_regions:
             'YaleSites Layouts':


### PR DESCRIPTION
## [YSP-494: Allow content spotlight as a banner ](https://fourkitchens.clickup.com/t/86a3kvxdg)

### Description of work
- Allow the blocks Spotlights (Landscape, Portrait) to be added to the 'Banner' section

### Functional testing steps:
- [ ] Create or edit a Page content type (https://pr-670-yalesites-platform.pantheonsite.io/).
- [ ] In the Banner section, click the 'Add Block' button.
- [ ] Check that you can see the blocks:
  - Basic:
    - [ ] Spotlight - Landscape
    - [ ] Spotlight - Portrait
  - Advanced:
    - [ ] Action Banner
    - [ ] Grand Hero

