### PR TITLE
YSP-299 - Update "term" description in Views block]

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -220,7 +220,7 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
     ];
 
     $form['group_user_selection']['filter_and_sort']['terms_include'] = [
-      '#title' => $this->t('Include content that uses the following terms'),
+      '#title' => $this->t('Include content that uses the following tags or categories'),
       '#type' => 'select',
       '#options' => $this->viewsBasicManager->getAllTags(),
       '#chosen' => TRUE,
@@ -231,7 +231,7 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
     ];
 
     $form['group_user_selection']['filter_and_sort']['terms_exclude'] = [
-      '#title' => $this->t('Exclude content that uses the following terms'),
+      '#title' => $this->t('Exclude content that uses the following tags or categories'),
       '#type' => 'select',
       '#options' => $this->viewsBasicManager->getAllTags(),
       '#multiple' => TRUE,


### PR DESCRIPTION
## [YSP-299: Update "term" description in Views block](https://fourkitchens.clickup.com/t/86a3m6u1j)

### Description of work
-  Replace the word 'terms' with 'tags or categories'.

### Functional testing steps:
- [ ] Create or edit a Page or Event content type. https://pr-670-yalesites-platform.pantheonsite.io/
- [ ] Navigate to layout settings.
- [ ] Add a new block of type "View".
- [ ] Scroll down and check you can see the following fields:
  - [ ] "Include content that uses the following tags or categories" instead of "Include content that uses the following terms".
  - [ ] Exclude content that uses the following tags or categories" instead of "Exclude content that uses the following terms".
