### PR TITLE
YSP-560: Localist: Update Event lists + default image updates

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/MetaFieldsManager.php
@@ -148,6 +148,8 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
     $localistImageAlt = $node->field_localist_event_image_alt->first() ? $node->field_localist_event_image_alt->first()->getValue()['value'] : NULL;
     $hasRegister = $node->field_localist_register_enabled->first() ? (bool) $node->field_localist_register_enabled->first()->getValue()['value'] : FALSE;
     $localistUrl = ($node->field_localist_event_url->first()) ? Url::fromUri($node->field_localist_event_url->first()->getValue()['uri'])->toString() : NULL;
+    $streamUrl = ($node->field_stream_url->first()) ? Url::fromUri($node->field_stream_url->first()->getValue()['uri'])->toString() : NULL;
+    $streamEmbedCode = $node->field_stream_embed_code->first() ? $node->field_stream_embed_code->first()->getValue()['value'] : NULL;
 
     // Dates.
     $dates = [];
@@ -253,7 +255,8 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
       'event_topics' => $eventTopics,
       'has_register' => $hasRegister,
       'localist_url' => $localistUrl,
-
+      'stream_url' => $streamUrl,
+      'stream_embed_code' => $streamEmbedCode,
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/EventMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/EventMetaBlock.php
@@ -109,6 +109,8 @@ class EventMetaBlock extends BlockBase implements ContainerFactoryPluginInterfac
       '#teaser_media' => $eventFieldData['teaser_media'],
       '#has_register' => $eventFieldData['has_register'],
       '#localist_url' => $eventFieldData['localist_url'],
+      '#stream_url' => $eventFieldData['stream_url'],
+      '#stream_embed_code' => $eventFieldData['stream_embed_code'],
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.info.yml
@@ -6,3 +6,4 @@ core_version_requirement: '^9 || ^10'
 version: VERSION
 dependencies:
   - calendar_link
+  - ys_localist

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
@@ -33,6 +33,8 @@ function ys_layouts_theme($existing, $type, $theme, $path): array {
         'teaser_media' => [],
         'has_register' => NULL,
         'localist_url' => NULL,
+        'stream_url' => NULL,
+        'stream_embed_code' => NULL,
       ],
     ],
     'ys_page_meta_block' => [


### PR DESCRIPTION
## [YSP-560: Localist: Update Event lists + default image updates ](https://yaleits.atlassian.net/browse/YSP-560)

### Description of work
- Adds `stream_url` and `stream_embed_code` to Events
- Adds contextual styles to allow optional fields to expand/contract as needed
- Adds `reference_heading__prefix` to wire `event_title__prefix` for event reference cards

### Functional testing steps:

#### Testing full event - new stream url fields
- [x] Navigate to: https://pr-674-yalesites-platform.pantheonsite.io/events/katys-event
- [x] Confirm you see `stream_url` and `stream_embed_code` on the page
- [x] Referencing the screeshare below, confirm the following styles are in place: 
- [x] If there is a Cost, Event Website and Event Topic, they will appear `33.33%` and on the same row at desktop resolutions
- [x] If there is a Cost, Event Website, no Event Topic, and Streaming URL, they will appear `33.33%` and on the same row at desktop resolutions
- [x] If there is a Cost, Event Website and Event Topic, they will appear `33.33%` and on the same row at desktop resolutions. If there is _also_ a Streaming URL, it will render 100% wide, under the Cost, Event Website and Event Topic. 

https://github.com/yalesites-org/yalesites-project/assets/366413/69733a39-9ce1-49c3-b088-1119bc87d75e

---
#### Testing Event teasers - Past Event: prefix
- [x] Navigate to: https://pr-674-yalesites-platform.pantheonsite.io/events
- [x] Scroll down the page to Past Events and then All Events
- [x] Note that events with a date in the past will show a title prefix "Past Event:"


https://github.com/yalesites-org/yalesites-project/assets/366413/d22383f8-3e65-4fb5-978d-9690818c1a82


