### PR TITLE
YSP-487: Add publishcontent back

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -83,6 +83,7 @@
     "drupal/paragraphs": "1.16",
     "drupal/paragraphs_features": "2.0-beta3",
     "drupal/pathauto": "1.12",
+    "drupal/publishcontent": "1.6",
     "drupal/quick_node_clone": "1.16",
     "drupal/recaptcha": "3.2",
     "drupal/recaptcha_v3": "1.9",


### PR DESCRIPTION
## [YSP-487: Add publishcontent back](https://yaleits.atlassian.net/browse/YSP-487)

Builds could not finish due to `publishcontent` being enabled, but the module was removed.  This re-adds it back to the composer file.

### Description of work
- Adds the `publishcontent` module back to the composer.json file

### Functional testing steps:
- [ ] If this build succeeded and you can visit the site, all is well