### PR TITLE
fix: ysp-445 set css in the head to fix sitewide alert flicker

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/js/anti_flicker.js
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/js/anti_flicker.js
@@ -1,0 +1,30 @@
+/**
+ * @file
+ * Prevents flicker of the toolbar on page load.
+ */
+
+(() => {
+
+    // Function to get all alerts from localstorage.
+    const setHtmlAlertStyle = () => {
+        const alertStyle = document.createElement('style');
+        let styleContent = '';
+        Object.keys(localStorage).forEach((key) => {
+            if (key.substring(0, 12) === 'ys-alert-id-') {
+                if (localStorage.getItem(key) === 'dismissed') {
+                   styleContent += `
+                      .alert[data-alert-id=${key}] {
+                          visibility: hidden;
+                          opacity: 0;
+                          max-height: 0;
+                      }`;
+                }
+            }
+        });
+        alertStyle.textContent = styleContent;
+        document.querySelector('head').appendChild(alertStyle);
+    };
+
+    setHtmlAlertStyle();
+
+})();

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.libraries.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.libraries.yml
@@ -7,3 +7,8 @@ confirm_type_modal:
   dependencies:
     - core/drupal.ajax
     - core/drupal.dialog
+
+anti_flicker:
+  header: true
+  js:
+    js/anti_flicker.js : {}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.module
@@ -37,3 +37,11 @@ function ys_alert_preprocess_page(&$variables) {
   // Also used: https://github.com/yalesites-org/yalesites-project/blob/4cd183c8f568b771d656478adb3b76985501c3a1/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module#LL144C1-L144C1
   \Drupal::service('renderer')->addCacheableDependency($variables, $config);
 }
+
+/**
+ * Implements hook_page_attachments().
+ */
+function ys_alert_page_attachments(array &$page) {
+  // Add anti-flicker JS
+  $page['#attached']['library'][] = 'ys_alert/anti_flicker';
+}


### PR DESCRIPTION
## [YSP-445: Fix alert flicker](https://yaleits.atlassian.net/browse/YSP-445)

### Description of work
- Adds JS in the head which in turn adds CSS in the head if there is an alert which hides the alert if it is dismissed.

### Functional testing steps:
- [ ] Create an alert
- [ ] Dismiss the alert
- [ ] Verify there is no flicker

Notes:
