### PR TITLE
fix(YSP-571): update ai_engine to 1.2.1

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -105,7 +105,7 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.12",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
-    "yalesites-org/ai_engine": "1.1.4",
+    "yalesites-org/ai_engine": "1.2.1",
     "yalesites-org/atomic": "1.32.0",
     "yalesites-org/yale_cas": "1.0.4"
   },


### PR DESCRIPTION
## [YSP-571: v1.4.0: Bump ai_engine module version to 1.2.1](https://yaleits.atlassian.net/browse/YSP-571)

### Description of work
- Bump ai_engine version pin to 1.2.1

### Functional testing steps:
- [ ] Ensure version updated to 1.2.1 on a multidev