### PR TITLE
YSP-535: Action Banner Spacing

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/banner/banner.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/banner/banner.css
@@ -5,3 +5,17 @@
 .layout--banner .layout__region {
   width: 100%;
 }
+
+/*
+ * Content moderation places an empty div which causes
+ * items not to become flush with the header. This 
+ * attempt to target the item underneat that 
+ * div in order to let it not have a margin to but up 
+ * to the header.
+ */
+.layout--banner
+  .layout__region
+  > div:not([class], [id], [name], [style])
+  + .cta-banner {
+  margin-block-start: 0;
+}


### PR DESCRIPTION
## [YSP-535: Action Banner Spacing](https://yaleits.atlassian.net/browse/YSP-535)

In this specific case, there exists an empty div where the content moderation block renders.  This empty div does not allow the action banner to appear flush with the header.  This specific fix attempts to make the specificity of this win such that any layout--banner's layout--region who first child is a div that contains no class, id, name, or style (essentially empty)'s sibling that is a .cta-banner have no top margin.

### Description of work
- Targets the CTA inside of a banner that is separated by an empty div to allow it to disregard the margin.

### Functional testing steps:
- [ ] Add a new page
- [ ] Add an action banner to the banner
- [ ] Verify that the action banner is flush with the header line
