### PR TITLE
YSP-535: Action Banner Spacing -- MULTIDEV ONLY; DO NOT MERGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The YaleSites platform empowers the Yale community to create digital experiences
 ## Common Scripts
 
 These are the most common npm scripts you may find yourself using:
-(Each is prefixed with `npm run `)
+(Each is prefixed with `npm run`)
 
 ### PR Reviews
 
@@ -41,3 +41,4 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory.
+-

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/banner/banner.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/banner/banner.css
@@ -5,17 +5,3 @@
 .layout--banner .layout__region {
   width: 100%;
 }
-
-/*
- * Content moderation places an empty div which causes
- * items not to become flush with the header. This 
- * attempt to target the item underneat that 
- * div in order to let it not have a margin to but up 
- * to the header.
- */
-.layout--banner
-  .layout__region
-  > div:not([class], [id], [name], [style])
-  + .cta-banner {
-  margin-block-start: 0;
-}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/banner/banner.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/banner/banner.css
@@ -5,3 +5,17 @@
 .layout--banner .layout__region {
   width: 100%;
 }
+
+/*
+ * Content moderation places an empty div which causes
+ * items not to become flush with the header. This 
+ * attempt to target the item underneat that 
+ * div in order to let it not have a margin to but up 
+ * to the header.
+ */
+.layout--banner
+  .layout__region
+  > div:not([class], [id], [name], [style])
+  + .cta-banner {
+  margin-block-start: 0;
+}


### PR DESCRIPTION
## [YSP-535: Action Banner Spacing](https://yaleits.atlassian.net/browse/YSP-535)

[Real work located in Atomic](https://github.com/yalesites-org/atomic/pull/250)

This also fixes the [previous spotlight issues](https://github.com/yalesites-org/component-library-twig/pull/383), so removal of that fix is also included in [component library twig](https://github.com/yalesites-org/component-library-twig/pull/385)

In this specific case, there exists an empty div where the content moderation block renders.  This empty div does not allow the action banner to appear flush with the header.  We overload the content moderation twig to pass on content if it had it (i.e. the form), but display nothing otherwise.

### Description of work
- Overloads the `block--extra-field-block--node--page--content-moderation-control.html.twig` to pass content through if it exists, or nothing

### Functional testing steps:
- [ ] Add a new page
- [ ] Add an action banner to the banner
- [ ] Verify that the action banner is flush with the header line after save and refresh
- [ ] Add a new page
- [ ] Add a spotlight landscape block to the banner top
- [ ] Verify that the spotlight landscape block is flush with the header line after save and refresh
- [ ] Add a new page
- [ ] Add a spotlight portrait block to the banner top
- [ ] Verify that the spotlight portrait block is flush with the header line after save and refresh
