### PR TITLE
YSP-570: Views: Change limit help text

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/js/views-basic.js
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/js/views-basic.js
@@ -1,6 +1,6 @@
 ((Drupal) => {
   Drupal.behaviors.ysViewsBasic = {
-    attach: function() { // eslint-disable-line
+    attach: function () { // eslint-disable-line
       // Function to handle radio input checked behavior based on radio element selection.
       function handleRadioInputs(radioGroup) {
         // Get references to the radio input elements within the specified group
@@ -42,6 +42,39 @@
       radioGroups.forEach((group) => {
         handleRadioInputs(group);
       });
+
+      // Handle limit display
+      const editLimitWrapperElement = document.querySelector('#edit-limit');
+      const displayElement = document.querySelector('select[name="settings[block_form][group_user_selection][options][display]"');
+
+      // If they're ever gone from the form, don't deal with this.
+      if (editLimitWrapperElement && displayElement) {
+        const limitLabel = editLimitWrapperElement.querySelector('label');
+
+        const updateLimitElement = () => {
+          const value = displayElement.value;
+
+          // First evaluate whether to hide/show the limit
+          const newLimitDisplayValue = value === 'all' ? 'display: none' : '';
+          editLimitWrapperElement.setAttribute('style', newLimitDisplayValue);
+
+          // Change the title
+          switch (value) {
+            case 'all':
+              break;
+            case 'limit':
+              limitLabel.textContent = 'Items';
+              break;
+            case 'pager':
+              limitLabel.textContent = 'Items Per Page';
+            default:
+              break;
+          }
+        }
+
+        displayElement.addEventListener('change', updateLimitElement);
+        updateLimitElement();
+      }
     },
   };
 })(Drupal);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -291,11 +291,13 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       ],
     ];
 
+    $displayValue = ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('display', $items[$delta]->params) : 'all';
+
     $form['group_user_selection']['options']['display'] = [
       '#type' => 'select',
       '#title' => $this
         ->t('Number of Items to Display'),
-      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('display', $items[$delta]->params) : 'all',
+      '#default_value' => $displayValue,
       '#options' => [
         'all' => $this->t('Display all items'),
         'limit' => $this->t('Limit to'),
@@ -303,32 +305,22 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       ],
     ];
 
-    // This section calculates the title for the limit field based on display.
-    $numItemsValue = $formState->getValue(
-      ['group_user_selection', 'options', 'display']
-    );
-
     $limitTitle = $this->t('Items');
 
-    if ($numItemsValue) {
-      if ($numItemsValue == 'pager') {
-        $limitTitle = $this->t('Items per Page');
-      }
+    if ($displayValue && $displayValue == 'pager') {
+      $limitTitle = $this->t('Items per Page');
     }
 
+    /*
+     * Dynamic changes to this is handled in javascript due to issues with
+     * callbacks and #states.
+     */
     $form['group_user_selection']['options']['limit'] = [
       '#title' => $limitTitle,
       '#type' => 'number',
       '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('limit', $items[$delta]->params) : 10,
       '#min' => 1,
       '#required' => TRUE,
-      '#states' => [
-        'invisible' => [
-          $formSelectors['display_ajax'] => [
-            'value' => 'all',
-          ],
-        ],
-      ],
       '#prefix' => '<div id="edit-limit">',
       '#suffix' => '</div>',
     ];


### PR DESCRIPTION
## [YSP-570: Views: Change limit help text](https://yaleits.atlassian.net/browse/YSP-570)

### Description of work
- Move logic from Drupal array to Javascript
- Reinstates original intent
  - Limit hidden only if 'all' display selected
  - Limit label updated depending on display value:
    - 'limit': "Items"
    - 'pager': "Items Per Page"

### Functional testing steps:
- [x] Add a view
- [x] Verify the element underneath "Number of Items to Display" is "Ignore Number of Results"
- [x] Change "Number of Items to Display" from "all" to "Limit to"
- [x] Verify "Items" input appears
- [x] Change "Number of Items to Display" from "Limit to" to "Pagination after"
- [x] Verify "Items Per Page" input appears
- [x] Change "Number of Items to Display" from "Pagination after" to "Display all items"
- [x] Verify that the next element is again "Ignore Number of Results"
- [x] Ensure that you can save in any state and it keeps your values
- [x] Repeat the above on an edit of a view as well