### PR TITLE
YSP-588: Pagination after first page doesn't comply with ascending/descending dates for events

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold_events.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold_events.yml
@@ -143,20 +143,20 @@ display:
             format: basic_html
           tokenize: false
       sorts:
-        field_event_date_value:
-          id: field_event_date_value
-          table: node__field_event_date
-          field: field_event_date_value
+        views_basic_sort:
+          id: views_basic_sort
+          table: node_field_data
+          field: views_basic_sort
           relationship: none
-          group_type: min
+          group_type: group
           admin_label: ''
-          plugin_id: date
+          entity_type: node
+          plugin_id: views_basic_sort
           order: ASC
           expose:
             label: ''
             field_identifier: ''
           exposed: false
-          granularity: second
       arguments:
         type:
           id: type


### PR DESCRIPTION
While the standard view for the views block was using the proper sorter, the event specific one was not.  This lets it use it to drive the sort operation.

## [YSP-588: Pagination after first page doesn't comply with ascending/descending dates for events](https://yaleits.atlassian.net/browse/YSP-588)

### Description of work
- Makes the event-specific views "view" to use the `basic_views_sorter`

### Functional testing steps:
- [ ] Make lots of events in the past
- [ ] Create a view for past events, ordering by date in descending order
- [ ] Make sure when traversing the view that it respects that decision
