### PR TITLE
YSP-611: Localist: Views errors after localist enable

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -137,9 +137,21 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
         foreach ($values as $value) {
           /** @var \Drupal\taxonomy\Entity\Term $typeInfo */
           $typeInfo = $this->entityTypeManager->getStorage('taxonomy_term')->load($value['target_id']);
+          $name = $url = "Unknown";
+          $nodeid = $node->id();
+          if ($typeInfo) {
+            $name = $typeInfo->getName();
+            $url = $typeInfo->toUrl()->toString();
+          }
+          else {
+            $this->logger->error('Could not load taxonomy term with ID: @id, NodeID: @nodeid', [
+              '@id' => $value['target_id'],
+              '@nodeid' => $nodeid,
+            ]);
+          }
           $filterValues[] = [
-            'name' => $typeInfo->getName(),
-            'url' => $typeInfo->toUrl()->toString(),
+            'name' => $name,
+            'url' => $url,
           ];
         }
       }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -124,7 +124,7 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
         foreach ($values as $value) {
           /** @var \Drupal\taxonomy\Entity\Term $typeInfo */
           $typeInfo = $this->entityTypeManager->getStorage('taxonomy_term')->load($value['target_id']);
-          $name = $url = "Unknown";
+          $name = $url = "";
           if ($typeInfo) {
             $name = $typeInfo->getName();
             $url = $typeInfo->toUrl()->toString();

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -5,7 +5,6 @@ namespace Drupal\ys_localist;
 use Drupal\calendar_link\Twig\CalendarLinkTwigExtension;
 use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\Entity\EntityTypeManager;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
@@ -45,13 +44,6 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
   protected $localistManager;
 
   /**
-   * Logger channel.
-   *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
-   */
-  protected $logger;
-
-  /**
    * Constructs a new EventMetaBlock instance.
    *
    * @param \Drupal\Core\Datetime\DateFormatter $date_formatter
@@ -60,20 +52,16 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
    *   The entity type manager service.
    * @param \Drupal\ys_localist\LocalistManager $localist_manager
    *   The Localist manager service.
-   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger
-   *   The logger channel.
    */
   public function __construct(
     DateFormatter $date_formatter,
     EntityTypeManager $entity_type_manager,
     LocalistManager $localist_manager,
-    LoggerChannelFactoryInterface $logger,
   ) {
     $this->dateFormatter = $date_formatter;
     $this->entityTypeManager = $entity_type_manager;
     $this->localistManager = $localist_manager;
     $this->calendarLink = new CalendarLinkTwigExtension();
-    $this->logger = $logger->get('ys_localist');
   }
 
   /**
@@ -84,7 +72,6 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
       $container->get('date.formatter'),
       $container->get('entity_type.manager'),
       $container->get('ys_localist.manager'),
-      $container->get('logger.factory'),
     );
   }
 
@@ -138,16 +125,9 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
           /** @var \Drupal\taxonomy\Entity\Term $typeInfo */
           $typeInfo = $this->entityTypeManager->getStorage('taxonomy_term')->load($value['target_id']);
           $name = $url = "Unknown";
-          $nodeid = $node->id();
           if ($typeInfo) {
             $name = $typeInfo->getName();
             $url = $typeInfo->toUrl()->toString();
-          }
-          else {
-            $this->logger->error('Could not load taxonomy term with ID: @id, NodeID: @nodeid', [
-              '@id' => $value['target_id'],
-              '@nodeid' => $nodeid,
-            ]);
           }
           $filterValues[] = [
             'name' => $name,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -5,6 +5,7 @@ namespace Drupal\ys_localist;
 use Drupal\calendar_link\Twig\CalendarLinkTwigExtension;
 use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
@@ -44,6 +45,13 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
   protected $localistManager;
 
   /**
+   * Logger channel.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
    * Constructs a new EventMetaBlock instance.
    *
    * @param \Drupal\Core\Datetime\DateFormatter $date_formatter
@@ -52,16 +60,20 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
    *   The entity type manager service.
    * @param \Drupal\ys_localist\LocalistManager $localist_manager
    *   The Localist manager service.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger
+   *   The logger channel.
    */
   public function __construct(
     DateFormatter $date_formatter,
     EntityTypeManager $entity_type_manager,
     LocalistManager $localist_manager,
+    LoggerChannelFactoryInterface $logger,
   ) {
     $this->dateFormatter = $date_formatter;
     $this->entityTypeManager = $entity_type_manager;
     $this->localistManager = $localist_manager;
     $this->calendarLink = new CalendarLinkTwigExtension();
+    $this->logger = $logger->get('ys_localist');
   }
 
   /**
@@ -72,6 +84,7 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
       $container->get('date.formatter'),
       $container->get('entity_type.manager'),
       $container->get('ys_localist.manager'),
+      $container->get('logger.factory'),
     );
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/ys_localist.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/ys_localist.services.yml
@@ -6,4 +6,4 @@ services:
   # Service for retrieving event field data.
   ys_localist.meta_fields_manager:
     class: Drupal\ys_localist\MetaFieldsManager
-    arguments: ['@date.formatter', '@entity_type.manager', '@ys_localist.manager', '@logger.factory']
+    arguments: ['@date.formatter', '@entity_type.manager', '@ys_localist.manager']

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/ys_localist.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/ys_localist.services.yml
@@ -6,4 +6,4 @@ services:
   # Service for retrieving event field data.
   ys_localist.meta_fields_manager:
     class: Drupal\ys_localist\MetaFieldsManager
-    arguments: ['@date.formatter', '@entity_type.manager', '@ys_localist.manager']
+    arguments: ['@date.formatter', '@entity_type.manager', '@ys_localist.manager', '@logger.factory']


### PR DESCRIPTION
## [YSP-611: Localist: Views errors after localist enable](https://yaleits.atlassian.net/browse/YSP-611)

### Description of work
- If we can't get a taxonomy, make the name an empty string

### Functional testing steps:
- [ ] Create events with event types/experiences of Online or In-person
- [ ] Enable localist and sync
- [ ] Verify that "Online" and "In-person" no longer exist ("In-Person" will exist)
- [ ] Create a page with an events view that includes the events you manually created
- [ ] Load that saved page
- [ ] Verify it loads successfully
- [ ] Visit the logs to verify that either no logs exist from ys_localist
