### PR TITLE
YSP-613: Bump ai_engine in YaleSites to 1.2.3

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -105,7 +105,7 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.12",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
-    "yalesites-org/ai_engine": "1.2.2",
+    "yalesites-org/ai_engine": "1.2.3",
     "yalesites-org/atomic": "1.33.0",
     "yalesites-org/yale_cas": "1.0.4"
   },


### PR DESCRIPTION
## [YSP-613: Bump ai_engine in YaleSites to 1.2.3](https://yaleits.atlassian.net/browse/YSP-613)

### Description of work
- Bump ai_engine module to 1.2.3

### Functional testing steps:
- [ ] Update a new YaleSites instance to use ai_engine
- [ ] Enable the module
- [ ] Verify that in the Configuration as user 1 you see an AI Engine menu with more than two menu entries
