### PR TITLE
YSP-616: Replace Qualtrics render with deprecation message

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/Qualtrics.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/Qualtrics.php
@@ -31,7 +31,7 @@ class Qualtrics extends EmbedSourceBase implements EmbedSourceInterface {
   /**
    * {@inheritdoc}
    */
-  protected static $instructions = 'Visit your Qualtrics form and copy the survey\'s URL. This web address will be used to create an iframe within Drupal.';
+  protected static $instructions = 'Please Note: This is being deprecated.  Please try not to use this.  Visit your Qualtrics form and copy the survey\'s URL. This web address will be used to create an iframe within Drupal.';
 
   /**
    * {@inheritdoc}
@@ -47,7 +47,7 @@ class Qualtrics extends EmbedSourceBase implements EmbedSourceInterface {
     'scrolling' => 'yes',
     'frameborder' => 'no',
     'embedType' => 'form',
-    'isIframe' => TRUE,
+    'isIframe' => FALSE,
   ];
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/Qualtrics.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/Qualtrics.php
@@ -11,7 +11,7 @@ use Drupal\ys_embed\Plugin\EmbedSourceInterface;
  * @EmbedSource(
  *   id = "qualtrics",
  *   label = @Translation("Qualtrics"),
- *   description = @Translation("Qualtrics survey embed source."),
+ *   description = @Translation("Qualtrics survey embed source (deprecated)."),
  *   thumbnail = "qualtrics.png",
  *   active = TRUE,
  * )
@@ -26,7 +26,7 @@ class Qualtrics extends EmbedSourceBase implements EmbedSourceInterface {
   /**
    * {@inheritdoc}
    */
-  protected static $template = '<iframe class="iframe" title="{{ title }}" src="https://yalesurvey.ca1.qualtrics.com/jfe/form/{{ form_id }}" height="100%" width="100%" loading="lazy"></iframe>';
+  protected static $template = '<p>Qualtrics has been removed.  Please recreate your form in Microsoft Forms</p>';
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
## [YSP-616: Replace Qualtrics render with deprecation message](https://yaleits.atlassian.net/browse/YSP-616)

### Description of work
- Replaces rendering of qualtrics embed to be a deprecation message

### Functional testing steps:
- [ ] Add a qualtrics embed
- [ ] Verify that the rendered block does not display the qualtrics form, but instead a message