### PR TITLE
fix: allow actions/checkout to run on forked repos

### DIFF
--- a/.github/workflows/build_deploy_and_test.yml
+++ b/.github/workflows/build_deploy_and_test.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Set bash_env env var
         run: echo BASH_ENV=${RUNNER_TEMP}/bash_env.txt >> $GITHUB_ENV
@@ -91,6 +92,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Cache composer cache
         uses: actions/cache@v4
@@ -137,6 +139,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           fetch-depth: 0
 
       # Workaround for https://github.com/actions/runner/issues/2033


### PR DESCRIPTION
### Description of work
- Sets `repository` during actions/checkout workflow step to allow runs from forked repos and falls back to the default if not set.

More info: https://github.com/actions/checkout/issues/551#issuecomment-1154421608
