### PR TITLE
YSP-623: Localist: URL field not getting stored properly, and is not getting updated upon syncing

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/migrations/localist_events.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/migrations/localist_events.yml
@@ -214,7 +214,7 @@ destination:
     - field_stream_url
     - field_stream_embed_code
     - field_localist_register_enabled
-
+    - field_event_cta
 migration_dependencies:
   required:
     - localist_experiences

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/ys_localist.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/ys_localist.module
@@ -5,6 +5,7 @@
  * Primary module hooks for YS Localist module.
  */
 
+use Drupal\Component\Utility\UrlHelper;
 use Drupal\migrate\Plugin\MigrationInterface;
 
 /**
@@ -119,8 +120,7 @@ function ys_localist_migrate_prepare_row($row, $source, $migration) {
  */
 function _ys_localist_create_valid_uri($currentUrl) {
   if (!empty($currentUrl) &&
-    !filter_var($currentUrl,
-      FILTER_VALIDATE_URL) &&
+    !UrlHelper::isValid($currentUrl, TRUE) &&
       strpos($currentUrl, 'http') === FALSE) {
     $currentUrl = 'https://' . $currentUrl;
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/ys_localist.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/ys_localist.module
@@ -90,3 +90,53 @@ function ys_localist_preprocess_node(&$variables) {
     $variables['localist_url'] = $eventFieldData['localist_url'];
   }
 }
+
+/**
+ * Implements hook_migrate_prepare_row().
+ *
+ * For any source that ends with `_url`, it attempts to prepend https:// to the
+ * URL if it doesn't already have a protocol.
+ */
+function ys_localist_migrate_prepare_row($row, $source, $migration) {
+  if ($migration->id() === 'localist_events') {
+    $rowSource = $row->getSource();
+    foreach ($rowSource as $key => $value) {
+      if (_ys_localist_is_url_field($key)) {
+        $row->setSourceProperty($key, _ys_localist_create_valid_uri($value));
+      }
+    }
+  }
+}
+
+/**
+ * Prepends https:// to an invalid URL that has no protocol.
+ *
+ * @param string $currentUrl
+ *   The URL to check.
+ *
+ * @return string
+ *   The corrected URL.
+ */
+function _ys_localist_create_valid_uri($currentUrl) {
+  if (!empty($currentUrl) &&
+    !filter_var($currentUrl,
+      FILTER_VALIDATE_URL) &&
+      strpos($currentUrl, 'http') === FALSE) {
+    $currentUrl = 'https://' . $currentUrl;
+  }
+
+  return $currentUrl;
+}
+
+/**
+ * Determines if the field name given is a URL field.
+ *
+ * @param string $fieldName
+ *   The field name to check.
+ *
+ * @return bool
+ *   TRUE if the field is a URL field, FALSE otherwise.
+ */
+function _ys_localist_is_url_field($fieldName) {
+  return substr($fieldName, -4) === '_url';
+}


### PR DESCRIPTION
## [YSP-623: Localist: URL field not getting stored properly, and is not getting updated upon syncing](https://yaleits.atlassian.net/browse/YSP-623)

### Description of work
- Adds `process_row` hook to help fields ending in `_url` to have a protocol if it was missing
- Allows the `field_event_cta` to be overwritten on localist sync changes

### Functional testing steps:
- [ ] Set up localist to use the Anthropology group
- [ ] Do an initial sync
- [ ] Go into Localist and update one of the anthropology event external_url to be 'anthropology.yale.edu'
- [ ] Tell localist to do another sync in the multidev
- [ ] Ensure that the event that was changed not only changed the `field_event_cta`, but that it prepended the protocol to make it 'https://anthropology.yale.edu'
