### PR TITLE
YSP-626: New Block are not saving as reusable

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/layout_builder_browser.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/layout_builder_browser.settings.yml
@@ -15,16 +15,21 @@ auto_added_reusable_block_content_bundles:
   divider: divider
   embed: embed
   event_list: event_list
+  facts: facts
   gallery: gallery
   grand_hero: grand_hero
   image: image
+  inline_message: inline_message
+  link_grid: link_grid
   media_grid: media_grid
   post_list: post_list
   pull_quote: pull_quote
   quick_links: quick_links
+  quote_callout: quote_callout
   reference_card: reference_card
   tabs: tabs
   text: text
+  tiles: tiles
   video: video
   view: view
   webform: webform


### PR DESCRIPTION
## [YSP-626: New Block are not saving as reusable](https://yaleits.atlassian.net/browse/YSP-626)

### Description of work
- Adds new blocks to be included in layout builder browser reusable selections

### Functional testing steps:
- [ ] Add one of the new blocks (inline message, facts and figures, tiles, etc.)
- [ ] Make it reusable
- [ ] Attempt to add a new block to show the browser window of available blocks
- [ ] Make sure you see your reusable block
