### PR TITLE
fix: switch to pull_request_target trigger for forked repo support [skip ci]

### DIFF
--- a/.github/workflows/build_deploy_and_test.yml
+++ b/.github/workflows/build_deploy_and_test.yml
@@ -1,6 +1,6 @@
 name: Build, deploy and test
 on:
-  pull_request:
+  pull_request_target:
     branches-ignore:
       - master
 defaults:


### PR DESCRIPTION
### Description of work
- Switch the build_deploy_and_test workflow to use trigger pull_request_target instead of pull_request for better forked repo support.