### PR TITLE
YSP-630: Hotfix: v150: Remove SmartDate $dateFormatter patch

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -164,9 +164,6 @@
       "drupal/layout_builder_browser": {
         "Add grouping of reusable blocks (3409153) and add fallback images (3408935) - can't use both patches from d.o would cause merge conflict, combined patch": "patches/layout_builder_browser/3408935-and-3409153-8.patch"
       },
-      "drupal/smart_date": {
-        "Fix deprecation:": "https://git.drupalcode.org/project/smart_date/-/merge_requests/63.diff"
-      },
       "drupal/migrate_plus": {
         "Allow callback for Url source, and single item Json plugin https://www.drupal.org/project/migrate_plus/issues/3040427": "https://www.drupal.org/files/issues/2023-02-15/3040427-42-migrate_plus_multiple_urls.patch"
       },


### PR DESCRIPTION
## [YSP-630: Hotfix: v150: Remove SmartDate $dateFormatter patch](https://yaleits.atlassian.net/browse/YSP-630)

This patch was used with a previous version of smart_date, which is now fixed in the latest release we are using.  This patch still processed, causing duplicate variables in the class, resulting in errors.

### Description of work
- Removes the smart_date patch adding $dateFormatter a second time now

### Functional testing steps:
- [ ] Ensure pages load and no smart_date errors occur on $dateFormatter duplication