### PR TITLE
YSP-631: GaAccount::__construct(): Argument #1 ($account) must be of type string, null given

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -151,7 +151,7 @@
         "update deprecated php for v8.2 https://www.drupal.org/project/typogrify/issues/3398815": "https://git.drupalcode.org/project/typogrify/-/merge_requests/6.diff"
       },
       "drupal/google_analytics": {
-        "Cannot install from existing config https://www.drupal.org/project/google_analytics/issues/3373921": "https://www.drupal.org/files/issues/2023-08-07/google-analytics-issues-3373921-cannot-install-from-existing-config-11.patch"
+        "Guard against null account https://www.drupal.org/project/google_analytics/issues/3275926": "https://git.drupalcode.org/project/google_analytics/-/merge_requests/36.patch"
       },
       "drupal/linkit": {
         "Add phone number matcher https://www.drupal.org/project/linkit/issues/3273630": "https://git.drupalcode.org/project/linkit/-/merge_requests/36.diff",

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -151,6 +151,7 @@
         "update deprecated php for v8.2 https://www.drupal.org/project/typogrify/issues/3398815": "https://git.drupalcode.org/project/typogrify/-/merge_requests/6.diff"
       },
       "drupal/google_analytics": {
+        "Cannot install from existing config https://www.drupal.org/project/google_analytics/issues/3373921": "https://www.drupal.org/files/issues/2023-08-07/google-analytics-issues-3373921-cannot-install-from-existing-config-11.patch",
         "Guard against null account https://www.drupal.org/project/google_analytics/issues/3275926": "https://git.drupalcode.org/project/google_analytics/-/merge_requests/36.patch"
       },
       "drupal/linkit": {


### PR DESCRIPTION
## [YSP-631: GaAccount::__construct(): Argument #1 ($account) must be of type string, null given](https://yaleits.atlassian.net/browse/YSP-631)

### Description of work
- Adds [patch](https://git.drupalcode.org/project/google_analytics/-/merge_requests/36.patch) from [known issue](https://www.drupal.org/project/google_analytics/issues/3275926) to guard against NULL accounts in Google Analytics module

### Functional testing steps:
- [ ] Visit a page to ensure an error is not produced
- [ ] Keep in mind the state of the account must be NULL for this to really test.  I will try to do this beforehand.