### PR TITLE
YSP-633: AI: Replace askYale SVG with Yale version - MULTIDEV ONLY

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -17,6 +17,10 @@
           "type": "tar"
         }
       }
+    },
+    "yalesites-org/ai_engine": {
+      "type": "vcs",
+      "url": "https://github.com/yalesites-org/ai_engine"
     }
   },
   "require": {
@@ -105,7 +109,7 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.12",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
-    "yalesites-org/ai_engine": "1.2.3",
+    "yalesites-org/ai_engine": "dev-YSP-633-update-askYale-logo",
     "yalesites-org/atomic": "1.34.1",
     "yalesites-org/yale_cas": "1.0.4"
   },


### PR DESCRIPTION
## [YSP-633: AI: Replace askYale SVG with Yale version - MULTIDEV ONLY](https://yaleits.atlassian.net/browse/YSP-633)

### Description of work
- Adds multidev to test [ai_engine](https://github.com/yalesites-org/ai_engine/pull/14)