### PR TITLE
YSP-639: Change quotes to soft limit

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.pull_quote.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.pull_quote.default.yml
@@ -58,8 +58,8 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 425
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: false
   info:
     type: string_textfield
     weight: 1

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.quote_callout.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.quote_callout.default.yml
@@ -84,8 +84,8 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 425
-        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
+        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: false
   info:
     type: string_textfield
     weight: 1

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.quote_callout.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.quote_callout.default.yml
@@ -84,8 +84,8 @@ content:
         hide_guidelines: '1'
       maxlength:
         maxlength_js: 425
-        maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: false
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   info:
     type: string_textfield
     weight: 1


### PR DESCRIPTION
## [YSP-639: Change quotes to soft limit](https://yaleits.atlassian.net/browse/YSP-639)

While creating the AI website, there were quotes that were just over the hard limit of 425.  Instead of gradually increasing this, it was decided to remove the hard limit, allowing those that wish to still go over to do so.

### Description of work
- Pull Quote Block now have soft limit enabled

### Functional testing steps:
- [ ] Attempt to create a Pull Quote
- [ ] Verify that the help text underneath states that the length is "recommended"
- [ ] Attempt to go over the recommended limit of 425
- [ ] Save the block
- [ ] Ensure that all of your quote is displayed
