### PR TITLE
YSP-633: Bump ai_engine to 1.2.4

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -105,7 +105,7 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.12",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
-    "yalesites-org/ai_engine": "1.2.3",
+    "yalesites-org/ai_engine": "1.2.4",
     "yalesites-org/atomic": "1.34.1",
     "yalesites-org/yale_cas": "1.0.4"
   },


### PR DESCRIPTION
## [YSP-633: Bump ai_engine to 1.2.4](https://yaleits.atlassian.net/browse/YSP-633)

### Description of work
- Bumps the pinned version of ai_engine to 1.2.4

### Functional testing steps:
- [ ] Run the ai chat [from a page](https://pr-740-yalesites-platform.pantheonsite.io/ai-engine-test)
- [ ] Ensure that you no longer see the "askYale" image
- [ ] Ensure that you see a Y with a circle on it after questioning the chat bot
