### PR TITLE
Hotfix: YSP-649: EDT vs EST from Localist causing incorrect time render [skip ci]

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -106,7 +106,7 @@
     "laminas/laminas-escaper": "2.12",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
     "yalesites-org/ai_engine": "1.2.4",
-    "yalesites-org/atomic": "1.34.1",
+    "yalesites-org/atomic": "1.35.0",
     "yalesites-org/yale_cas": "1.0.4"
   },
   "minimum-stability": "dev",

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/README.md
@@ -1,6 +1,7 @@
 # YaleSites Layouts
 
 ## Description
+
 The layouts module organizes work related to YaleSite's implementation of Layout Builder. This includes the definition of custom layouts including the banner, page meta, and two column sections.
 
 ## Meta Fields Manager
@@ -17,6 +18,8 @@ This module includes a service called `MetaFieldsManager` that was specifically 
 * formatted_start_time - Formatted as: 1:30 pm EDT
 * formatted_end_date - Formatted as: Friday, May 3rd, 2024
 * formatted_end_time - Formatted as: 2:30 pm EDT
+* original_start - The unformatted UTC start datetime
+* original_end - The unformatted UTC end datetime
 * is_all_day - Boolean for all day events (i.e. false)
 
 The `ics_url` is auto-calculated if there is an ICS URL provided from Localist, then use it. If not, calculate an ICS URL dynamically from the first date in the series.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/ys-event-meta-block.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/ys-event-meta-block.html.twig
@@ -7,6 +7,8 @@
     formatted_start_time
     formatted_end_date
     formatted_end_time
+    original_start
+    original_end
     is_all_day
   ics_url - Localist ICS includes all dates. Calculated only includes the first date.
   ticket_url - the URL to purchace tickets.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -190,6 +190,8 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
         $dates[$key]['formatted_start_time'] = $this->dateFormatter->format($date['value'], 'event_time_only');
         $dates[$key]['formatted_end_date'] = $this->dateFormatter->format($date['end_value'], 'event_date_only');
         $dates[$key]['formatted_end_time'] = $this->dateFormatter->format($date['end_value'], 'event_time_only');
+        $dates[$key]['original_start'] = $date['value'];
+        $dates[$key]['original_end'] = $date['end_value'];
         $dates[$key]['is_all_day'] = $this->isAllDay($date['value'], $date['end_value']);
         // Remove older dates.
         if ($date['end_value'] < time()) {


### PR DESCRIPTION

## Changes without a pull request:
- e4acea3dbe70b7dcf0c21a74d5cd649947948b4c
- e93e16bfeb6a3ff25daa144351ef834e74b5f373
- bc3172982658487af2d3e4cba2b6d87fadc84ced
