### PR TITLE
YSP-662: PRESIDENT: allow center or larger view of video block

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.video.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.video.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.block_content.video.field_heading
     - field.field.block_content.video.field_instructions
     - field.field.block_content.video.field_media
+    - field.field.block_content.video.field_style_alignment
     - field.field.block_content.video.field_text
   module:
     - allowed_formats
@@ -50,6 +51,12 @@ content:
     third_party_settings:
       media_library_edit:
         show_edit: '1'
+  field_style_alignment:
+    type: options_select
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_text:
     type: text_textarea
     weight: 3

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.video.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.video.default.yml
@@ -7,8 +7,10 @@ dependencies:
     - field.field.block_content.video.field_heading
     - field.field.block_content.video.field_instructions
     - field.field.block_content.video.field_media
+    - field.field.block_content.video.field_style_alignment
     - field.field.block_content.video.field_text
   module:
+    - options
     - text
 id: block_content.video.default
 targetEntityType: block_content
@@ -28,6 +30,13 @@ content:
     settings:
       view_mode: default
       link: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_style_alignment:
+    type: list_key
+    label: hidden
+    settings: {  }
     third_party_settings: {  }
     weight: 2
     region: content

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.video.field_style_alignment.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.video.field_style_alignment.yml
@@ -1,0 +1,21 @@
+uuid: 93d2b2d9-11a0-4a3e-87a5-e2fbf0e8f0f0
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.video
+    - field.storage.block_content.field_style_alignment
+  module:
+    - options
+id: block_content.video.field_style_alignment
+field_name: field_style_alignment
+entity_type: block_content
+bundle: video
+label: Alignment
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ys_themes_default_value_function
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -222,3 +222,9 @@ inline_message:
       two: Two
       three: Three
     default: one
+video:
+  field_style_alignment:
+    values:
+      left: Left
+      center: Center
+    default: left


### PR DESCRIPTION
## [YSP-662: PRESIDENT: allow center or larger view of video block](https://yaleits.atlassian.net/browse/YSP-622)

Work also done in--please review also:
- [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/414)
- [Atomic](https://github.com/yalesites-org/atomic/pull/266)

### Description of work
- Adds `field_style_alignment` to video block
- Sets component overrides for video block's new dial

### Functional testing steps:
- [ ] Add a new video block
- [ ] Ensure you see the Alignment field
- [ ] Ensure the selectable items in the Alignment field are "Left" and "Center"
- [ ] Select "Center"
- [ ] Save
- [ ] Save the node
- [ ] Ensure that the video is displayed centered
- [ ] Ensure the text underneath the text is still left aligned with the video (both should be centered)
- [ ] Modify the video
- [ ] Select "Left" alignment
- [ ] Save
- [ ] Save node
- [ ] Ensure the video is now left aligned with the site width content

### Bonus Functional testing steps:
- [ ] Find an existing video block if one existed (spoiler: it's on the front page)
- [ ] Ensure it defaulted to the left alignment look
- [ ] When attempting to edit it, ensure that alignment is set to "- Select a value -"
- [ ] **NOTE: DO NOT SAVE** so others can verify this.

See Atomic note, but we are force centering videos on posts and events; I left this unchanged.
