### PR TITLE
YSP-647: PRESIDENT: Ability to bulk Unpublish

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/system.action.publish_moderated_content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.action.publish_moderated_content.yml
@@ -1,0 +1,12 @@
+uuid: d4a2dbbd-0166-48de-b923-1d2bd9247bf7
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - ys_core
+id: publish_moderated_content
+label: 'Publish content'
+type: node
+plugin: 'entity:publish_moderated_action:node'
+configuration: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/system.action.unpublish_moderated_content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.action.unpublish_moderated_content.yml
@@ -1,0 +1,12 @@
+uuid: 9b6118fe-709b-4b7c-90d5-ae0819d23245
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - ys_core
+id: unpublish_moderated_content
+label: 'Unpublish content'
+type: node
+plugin: 'entity:unpublish_moderated_action:node'
+configuration: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.content.yml
@@ -82,6 +82,8 @@ display:
           selected_actions:
             - node_delete_action
             - pathauto_update_alias_node
+            - publish_moderated_content
+            - unpublish_moderated_content
         title:
           id: title
           table: node_field_data

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_events.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_events.yml
@@ -88,6 +88,8 @@ display:
           selected_actions:
             - node_delete_action
             - pathauto_update_alias_node
+            - publish_moderated_content
+            - unpublish_moderated_content
         title:
           id: title
           table: node_field_data

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_pages.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_pages.yml
@@ -82,6 +82,8 @@ display:
           selected_actions:
             - node_delete_action
             - pathauto_update_alias_node
+            - publish_moderated_content
+            - unpublish_moderated_content
         title_1:
           id: title_1
           table: node_field_data

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_posts.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_posts.yml
@@ -85,6 +85,8 @@ display:
           selected_actions:
             - node_delete_action
             - pathauto_update_alias_node
+            - publish_moderated_content
+            - unpublish_moderated_content
         title:
           id: title
           table: node_field_data

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_profiles.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_profiles.yml
@@ -89,6 +89,8 @@ display:
           selected_actions:
             - node_delete_action
             - pathauto_update_alias_node
+            - publish_moderated_content
+            - unpublish_moderated_content
         title:
           id: title
           table: node_field_data

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedPublish.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedPublish.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\ys_core\Plugin\Action;
+
+use Drupal\Core\Action\Plugin\Action\PublishAction;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Unpublishes an entity.
+ *
+ * @Action(
+ *   id = "entity:publish_moderated_action",
+ *   action_label = @Translation("Publish Moderated"),
+ *   deriver = "Drupal\Core\Action\Plugin\Action\Derivative\EntityPublishedActionDeriver",
+ * )
+ */
+class ModeratedPublish extends PublishAction {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($entity = NULL) {
+    $entity->set('moderation_state', 'published');
+    $entity->setPublished()->save();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    $key = $object->getEntityType()->getKey('published');
+
+    /** @var \Drupal\Core\Entity\EntityInterface $object */
+    $result = $object->access('update', $account, TRUE);
+
+    return $return_as_object ? $result : $result->isAllowed();
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedPublish.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedPublish.php
@@ -28,8 +28,17 @@ class ModeratedPublish extends PublishAction {
    * {@inheritdoc}
    */
   public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    $key = $object->getEntityType()->getKey('published');
+
     /** @var \Drupal\Core\Entity\EntityInterface $object */
-    $result = $object->access('update', $account, TRUE);
+    $result = $object->access('update', $account, TRUE)
+      ->andIf($object->$key->access('edit', $account, TRUE));
+
+    // Allow the action if the entity error is only because of moderation being
+    // enabled.
+    if ($result->getReason() == 'Cannot edit the published field of moderated entities.') {
+      return TRUE;
+    }
 
     return $return_as_object ? $result : $result->isAllowed();
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedPublish.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedPublish.php
@@ -6,7 +6,7 @@ use Drupal\Core\Action\Plugin\Action\PublishAction;
 use Drupal\Core\Session\AccountInterface;
 
 /**
- * Unpublishes an entity.
+ * Publishes an entity.
  *
  * @Action(
  *   id = "entity:publish_moderated_action",
@@ -28,8 +28,6 @@ class ModeratedPublish extends PublishAction {
    * {@inheritdoc}
    */
   public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
-    $key = $object->getEntityType()->getKey('published');
-
     /** @var \Drupal\Core\Entity\EntityInterface $object */
     $result = $object->access('update', $account, TRUE);
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedUnpublish.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedUnpublish.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\ys_core\Plugin\Action;
+
+use Drupal\Core\Action\Plugin\Action\UnpublishAction;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Unpublishes an entity.
+ *
+ * @Action(
+ *   id = "entity:unpublish_moderated_action",
+ *   action_label = @Translation("Unpublish Moderated"),
+ *   deriver = "Drupal\Core\Action\Plugin\Action\Derivative\EntityPublishedActionDeriver",
+ * )
+ */
+class ModeratedUnpublish extends UnpublishAction {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($entity = NULL) {
+    $entity->set('moderation_state', 'archived');
+    $entity->setUnpublished()->save();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    $key = $object->getEntityType()->getKey('published');
+
+    /** @var \Drupal\Core\Entity\EntityInterface $object */
+    $result = $object->access('update', $account, TRUE);
+
+    return $return_as_object ? $result : $result->isAllowed();
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedUnpublish.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedUnpublish.php
@@ -28,8 +28,17 @@ class ModeratedUnpublish extends UnpublishAction {
    * {@inheritdoc}
    */
   public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    $key = $object->getEntityType()->getKey('published');
+
     /** @var \Drupal\Core\Entity\EntityInterface $object */
-    $result = $object->access('update', $account, TRUE);
+    $result = $object->access('update', $account, TRUE)
+      ->andIf($object->$key->access('edit', $account, TRUE));
+
+    // Allow the action if the entity error is only because of moderation being
+    // enabled.
+    if ($result->getReason() == 'Cannot edit the published field of moderated entities.') {
+      return TRUE;
+    }
 
     return $return_as_object ? $result : $result->isAllowed();
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedUnpublish.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedUnpublish.php
@@ -28,8 +28,6 @@ class ModeratedUnpublish extends UnpublishAction {
    * {@inheritdoc}
    */
   public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
-    $key = $object->getEntityType()->getKey('published');
-
     /** @var \Drupal\Core\Entity\EntityInterface $object */
     $result = $object->access('update', $account, TRUE);
 


### PR DESCRIPTION
## [YSP-647: PRESIDENT: Ability to bulk Unpublish](https://yaleits.atlassian.net/browse/YSP-647)

### Description of work
- Adds a bulk unpublish option with content moderation
- Adds a bulk publish option with content moderation

### Functional testing steps:
- [ ] Go to any content list
- [ ] Select multiple items using the check boxes next to them
- [ ] Select "Unpublish content" from the bulk actions menu and submit
- [ ] Ensure no errors exist
- [ ] Try to visit one of those pages as an anonymous user--ensure you cannot
- [ ] Go back into the content list
- [ ] Select the same ones you unpublished
- [ ] Select "Publish content" from the bulk actions menu and submit
- [ ] Ensure no errors exist
- [ ] Try to visit one of the pages again as an anonymous user--ensure you can now
