### PR TITLE
YSP-670: Spotlights provide H2 in Banner Section

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - block_content.type.content_spotlight
     - field.field.block_content.content_spotlight.field_heading
+    - field.field.block_content.content_spotlight.field_heading_level
     - field.field.block_content.content_spotlight.field_instructions
     - field.field.block_content.content_spotlight.field_link
     - field.field.block_content.content_spotlight.field_link_two
@@ -43,6 +44,12 @@ content:
         maxlength_js: 80
         maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
+  field_heading_level:
+    type: options_select
+    weight: 8
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_instructions:
     type: markup
     weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight_portrait.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight_portrait.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - block_content.type.content_spotlight_portrait
     - field.field.block_content.content_spotlight_portrait.field_heading
+    - field.field.block_content.content_spotlight_portrait.field_heading_level
     - field.field.block_content.content_spotlight_portrait.field_instructions
     - field.field.block_content.content_spotlight_portrait.field_link
     - field.field.block_content.content_spotlight_portrait.field_link_two
@@ -44,6 +45,12 @@ content:
         maxlength_js: 50
         maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
+  field_heading_level:
+    type: options_select
+    weight: 8
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_instructions:
     type: markup
     weight: 1

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.content_spotlight.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.content_spotlight.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - block_content.type.content_spotlight
     - field.field.block_content.content_spotlight.field_heading
+    - field.field.block_content.content_spotlight.field_heading_level
     - field.field.block_content.content_spotlight.field_instructions
     - field.field.block_content.content_spotlight.field_link
     - field.field.block_content.content_spotlight.field_link_two
@@ -30,6 +31,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_heading_level:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 7
     region: content
   field_link:
     type: link_separate

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.content_spotlight_portrait.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.content_spotlight_portrait.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - block_content.type.content_spotlight_portrait
     - field.field.block_content.content_spotlight_portrait.field_heading
+    - field.field.block_content.content_spotlight_portrait.field_heading_level
     - field.field.block_content.content_spotlight_portrait.field_instructions
     - field.field.block_content.content_spotlight_portrait.field_link
     - field.field.block_content.content_spotlight_portrait.field_link_two
@@ -29,6 +30,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_heading_level:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 7
     region: content
   field_link:
     type: link_separate

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_heading_level.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_heading_level.yml
@@ -1,0 +1,23 @@
+uuid: 215fbd50-3f11-4a5f-bbac-560bd02fe770
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.content_spotlight
+    - field.storage.block_content.field_heading_level
+  module:
+    - options
+id: block_content.content_spotlight.field_heading_level
+field_name: field_heading_level
+entity_type: block_content
+bundle: content_spotlight
+label: 'Heading Level'
+description: 'For more information about conditional banner titles, <a href="https://yalesites.yale.edu/posts/2023-10-17-community-spotlight-yale-united-way-campaign#tips" target="_blank">view our tips and tricks on this topic</a>.'
+required: true
+translatable: false
+default_value:
+  -
+    value: '2'
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight_portrait.field_heading_level.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight_portrait.field_heading_level.yml
@@ -1,0 +1,23 @@
+uuid: 9e7095b2-2145-46ca-947f-ad94eb05fe17
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.content_spotlight_portrait
+    - field.storage.block_content.field_heading_level
+  module:
+    - options
+id: block_content.content_spotlight_portrait.field_heading_level
+field_name: field_heading_level
+entity_type: block_content
+bundle: content_spotlight_portrait
+label: 'Heading Level'
+description: 'For more information about conditional banner titles, <a href="https://yalesites.yale.edu/posts/2023-10-17-community-spotlight-yale-united-way-campaign#tips" target="_blank">view our tips and tricks on this topic</a>.'
+required: true
+translatable: false
+default_value:
+  -
+    value: '2'
+default_value_callback: ''
+settings: {  }
+field_type: list_string


### PR DESCRIPTION
## [YSP-670: Spotlights provide H2 in Banner Section](https://yaleits.atlassian.net/browse/YSP-670)

### Description of work
- Adds `Heading level` to portrait and landscape spotlights now that they are in the banner options
- Wiring done also in [Atomic](https://github.com/yalesites-org/atomic/pull/268) and [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/419) -- please review these as well

### Functional testing steps:
- [ ] Create a spotlight in the banner
- [ ] Set the title to be either visibly hidden or hidden
- [ ] Modify your spotlight to use a heading level of H1
- [ ] Verify it renders correctly with an H1
- [ ] Verify that the first spotlight's `top-margin` is set to `2rem`
- [ ] Verify that other spotlights added that aren't at the top are not set to `2rem`
- [ ] Ensure that other banner blocks placed at the top do not exhibit this spacing
- [ ] Ensure that spotlights added to a banner whose first block was not a spotlight spaces as expected
