### PR TITLE
YSP-652: Views setting Can or Must selection is not selected on configure

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -472,7 +472,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
         break;
 
       case 'operator':
-        $defaultParam = (empty($paramsDecoded['operator'])) ? '+' : (int) $paramsDecoded['operator'];
+        $defaultParam = (empty($paramsDecoded['operator'])) ? '+' : $paramsDecoded['operator'];
         break;
 
       case 'limit':


### PR DESCRIPTION
## [YSP-652: Views setting Can or Must selection is not selected on configure](https://yaleits.atlassian.net/browse/YSP-652)

Passing the integer value of the operator resulted in the item not being properly selected in the form view.  This fixes this.

### Description of work
- Stops passing integer value to the form for the Can/Must selection; send string instead

### Functional testing steps:
- [ ] Create a view, select an option for Can/Must contain the tags
- [ ] Save
- [ ] Modify the view
- [ ] Ensure that the correct Can/Must option that you selected is still selected
- [ ] Ensure that any items you include actually show on the view still by modifying content to match your criteria
