### PR TITLE
YSP-671: Unable to Select Media for blocks with images by filtering

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -130,6 +130,7 @@
         "Update \"Add reusable option to inline block creation\" patch with local changes to save block if it didn't save": "patches/layout_builder/1330eff91b1234979cf697a66a48e34eb116b441-1.patch",
         "Prevent empty block_content info fields from causing php deprecation notices": "https://www.drupal.org/files/issues/2023-07-21/3340159-empty-block-label_0.patch",
         "Ajax exposed filters not working for multiple instances of the same Views block placed on one page" : "https://www.drupal.org/files/issues/2023-05-07/3163299-104-D10.patch"
+        "Fix checkboxes not being shown on media filter search https://www.drupal.org/project/drupal/issues/3388913": "https://git.drupalcode.org/project/drupal/-/commit/675d0495e64f20dbde06d78f8023b3c54d1c9401.patch"
       },
       "drupal/entity_redirect": {
         "fix layout route https://www.drupal.org/project/entity_redirect/issues/3352265": "https://git.drupalcode.org/project/entity_redirect/-/merge_requests/6.patch"


### PR DESCRIPTION
## [YSP-671: Unable to Select Media for blocks with images by filtering](https://yaleits.atlassian.net/browse/YSP-671)

While this is a 10.3 fix, it seems to be working locally.  Wanted to get this on a multidev to try.

### Description of work
- Adds a patch for this known issue

### Functional testing steps:
- [ ] Add a block that requires a media item
- [ ] Search for an image, preferably a query that results in one return result
- [ ] Ensure that a checkbox exists for it
- [ ] Try other searches and verify that you can use the checkbox to select (remember to unselect old ones since usually only one can be selected)
