### PR TITLE
fix(views-text): Change any/all text to not include category

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -323,8 +323,8 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       '#title' => $this->t('Match Content That Has'),
       // Set operator: "+" is "OR" and "," is "AND".
       '#options' => [
-        '+' => $this->t('Can have any term listed in tags and categories'),
-        ',' => $this->t('Must have all terms listed in tags and categories'),
+        '+' => $this->t('Can have any term listed in include/exclude terms'),
+        ',' => $this->t('Must have all terms listed in include/exclude terms'),
       ],
       '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('operator', $items[$delta]->params) : '+',
       '#attributes' => [


### PR DESCRIPTION
## fix(views-text): Change any/all text to not include category

Because we have muiltiple places where Categories could be used, we don't want to specify that such that it's not misleading that this doesn't apply to the Jakala added filters.

### Description of work
- Changes the text displayed on the "Must include"/"Can include" to remove tags and category reference

### Functional testing steps:
- [ ] Add a view
- [ ] Verify the text has changed