### PR TITLE
fix(remove-exposed-filter-patch): Remove exposed filter patch

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -129,7 +129,6 @@
         "Add reusable option to inline block creation https://www.drupal.org/project/drupal/issues/2999491": "https://git.drupalcode.org/issue/drupal-2999491/-/commit/1330eff91b1234979cf697a66a48e34eb116b441.patch",
         "Update \"Add reusable option to inline block creation\" patch with local changes to save block if it didn't save": "patches/layout_builder/1330eff91b1234979cf697a66a48e34eb116b441-1.patch",
         "Prevent empty block_content info fields from causing php deprecation notices": "https://www.drupal.org/files/issues/2023-07-21/3340159-empty-block-label_0.patch",
-        "Ajax exposed filters not working for multiple instances of the same Views block placed on one page": "https://www.drupal.org/files/issues/2023-05-07/3163299-104-D10.patch",
         "Fix checkboxes not being shown on media filter search https://www.drupal.org/project/drupal/issues/3388913": "https://git.drupalcode.org/project/drupal/-/commit/675d0495e64f20dbde06d78f8023b3c54d1c9401.patch"
       },
       "drupal/entity_redirect": {


### PR DESCRIPTION
## Fix(remove-exposed-filter-patch): Remove exposed filter patch

### Description of work
- Removes "Ajax exposed filters not working for multiple instances of the same Views block placed on one page" patch

### Functional testing steps:
- [ ] Add an image block
- [ ] Ensure when selecting media you can properly filter

### Repercussion test
- [ ] Add two views on a page with similar setups
- [ ] After saving, filter the first view
- [ ] Observe that the 2nd view received the filter the first view selected and the first view has a spinner waiting for it to finish (it never will)

Jakala is looking into a fix for this.  Once we have a fix, we can introduce it.