### PR TITLE
YSP-351: Allow for more affiliations in Profiles

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.profile.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.profile.default.yml
@@ -157,7 +157,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_affiliation:
-    type: options_select
+    type: chosen_select
     weight: 36
     region: content
     settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_affiliation.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_affiliation.yml
@@ -13,7 +13,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false


### PR DESCRIPTION
## [YSP-351: Allow for more affiliations in Profiles](https://yaleits.atlassian.net/browse/YSP-351)
## [YSP-650: Allow multiple Affiliation/Profile terms to be auto completed like tags](https://yaleits.atlassian.net/browse/YSP-650)

### Description of work
- Changes affiliation from a 1-1 to a 1-many field

### Functional testing steps:
- [ ] Create a new profile
- [ ] Select multiple affiliations for the profile
- [ ] Save
- [ ] Create a view for profiles, making sure to check "add category"
- [ ] Observe all affiliations appear
