### PR TITLE
YSP-346: Add pronoun field

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.profile.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.profile.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.profile.field_media
     - field.field.node.profile.field_metatags
     - field.field.node.profile.field_position
+    - field.field.node.profile.field_pronouns
     - field.field.node.profile.field_subtitle
     - field.field.node.profile.field_tags
     - field.field.node.profile.field_teaser_media
@@ -107,6 +108,7 @@ third_party_settings:
         - field_first_name
         - field_last_name
         - field_honorific_prefix
+        - field_pronouns
         - field_position
         - field_subtitle
         - field_department
@@ -164,7 +166,7 @@ content:
     third_party_settings: {  }
   field_department:
     type: string_textfield
-    weight: 33
+    weight: 34
     region: content
     settings:
       size: 60
@@ -236,6 +238,14 @@ content:
     third_party_settings: {  }
   field_position:
     type: string_textfield
+    weight: 32
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_pronouns:
+    type: string_textfield
     weight: 31
     region: content
     settings:
@@ -244,7 +254,7 @@ content:
     third_party_settings: {  }
   field_subtitle:
     type: text_textfield
-    weight: 32
+    weight: 33
     region: content
     settings:
       size: 60

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.card.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.card.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.profile.field_media
     - field.field.node.profile.field_metatags
     - field.field.node.profile.field_position
+    - field.field.node.profile.field_pronouns
     - field.field.node.profile.field_subtitle
     - field.field.node.profile.field_tags
     - field.field.node.profile.field_teaser_media
@@ -128,6 +129,7 @@ hidden:
   field_last_name: true
   field_login_required: true
   field_metatags: true
+  field_pronouns: true
   field_telephone: true
   layout_builder__layout: true
   links: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.condensed.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.condensed.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.profile.field_media
     - field.field.node.profile.field_metatags
     - field.field.node.profile.field_position
+    - field.field.node.profile.field_pronouns
     - field.field.node.profile.field_subtitle
     - field.field.node.profile.field_tags
     - field.field.node.profile.field_teaser_media
@@ -47,6 +48,11 @@ targetEntityType: node
 bundle: profile
 mode: condensed
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   field_external_source:
     type: link_separate
     label: hidden
@@ -78,6 +84,7 @@ hidden:
   field_login_required: true
   field_media: true
   field_metatags: true
+  field_pronouns: true
   field_subtitle: true
   field_tags: true
   field_teaser_media: true
@@ -87,3 +94,4 @@ hidden:
   layout_builder__layout: true
   links: true
   search_api_excerpt: true
+  workflow_buttons: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.profile.field_media
     - field.field.node.profile.field_metatags
     - field.field.node.profile.field_position
+    - field.field.node.profile.field_pronouns
     - field.field.node.profile.field_subtitle
     - field.field.node.profile.field_tags
     - field.field.node.profile.field_teaser_media
@@ -322,6 +323,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 107
+    region: content
+  field_pronouns:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 119
     region: content
   field_subtitle:
     type: text_default

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.directory.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.directory.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.profile.field_media
     - field.field.node.profile.field_metatags
     - field.field.node.profile.field_position
+    - field.field.node.profile.field_pronouns
     - field.field.node.profile.field_subtitle
     - field.field.node.profile.field_tags
     - field.field.node.profile.field_teaser_media
@@ -27,6 +28,7 @@ dependencies:
   module:
     - layout_builder
     - layout_builder_restrictions
+    - link
     - text
     - user
 third_party_settings:
@@ -47,6 +49,11 @@ targetEntityType: node
 bundle: profile
 mode: directory
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   field_affiliation:
     type: entity_reference_label
     label: hidden
@@ -130,9 +137,11 @@ hidden:
   field_last_name: true
   field_login_required: true
   field_metatags: true
+  field_pronouns: true
   field_tags: true
   field_teaser_text: true
   field_teaser_title: true
   layout_builder__layout: true
   links: true
   search_api_excerpt: true
+  workflow_buttons: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.list_item.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.list_item.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.profile.field_media
     - field.field.node.profile.field_metatags
     - field.field.node.profile.field_position
+    - field.field.node.profile.field_pronouns
     - field.field.node.profile.field_subtitle
     - field.field.node.profile.field_tags
     - field.field.node.profile.field_teaser_media
@@ -128,6 +129,7 @@ hidden:
   field_last_name: true
   field_login_required: true
   field_metatags: true
+  field_pronouns: true
   field_telephone: true
   layout_builder__layout: true
   links: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.search_result.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.profile.field_media
     - field.field.node.profile.field_metatags
     - field.field.node.profile.field_position
+    - field.field.node.profile.field_pronouns
     - field.field.node.profile.field_subtitle
     - field.field.node.profile.field_tags
     - field.field.node.profile.field_teaser_media
@@ -26,6 +27,7 @@ dependencies:
     - node.type.profile
   module:
     - layout_builder
+    - link
     - text
     - user
 third_party_settings:
@@ -37,6 +39,11 @@ targetEntityType: node
 bundle: profile
 mode: search_result
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   field_external_source:
     type: link_separate
     label: hidden
@@ -73,6 +80,7 @@ hidden:
   field_media: true
   field_metatags: true
   field_position: true
+  field_pronouns: true
   field_subtitle: true
   field_tags: true
   field_teaser_media: true
@@ -80,3 +88,4 @@ hidden:
   field_telephone: true
   layout_builder__layout: true
   links: true
+  workflow_buttons: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.single.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.single.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.profile.field_media
     - field.field.node.profile.field_metatags
     - field.field.node.profile.field_position
+    - field.field.node.profile.field_pronouns
     - field.field.node.profile.field_subtitle
     - field.field.node.profile.field_tags
     - field.field.node.profile.field_teaser_media
@@ -163,6 +164,11 @@ targetEntityType: node
 bundle: profile
 mode: single
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   field_address:
     type: text_default
     label: hidden
@@ -288,7 +294,9 @@ content:
 hidden:
   field_login_required: true
   field_metatags: true
+  field_pronouns: true
   field_tags: true
   layout_builder__layout: true
   links: true
   search_api_excerpt: true
+  workflow_buttons: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.teaser.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.teaser.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.profile.field_media
     - field.field.node.profile.field_metatags
     - field.field.node.profile.field_position
+    - field.field.node.profile.field_pronouns
     - field.field.node.profile.field_subtitle
     - field.field.node.profile.field_tags
     - field.field.node.profile.field_teaser_media
@@ -31,6 +32,11 @@ targetEntityType: node
 bundle: profile
 mode: teaser
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
@@ -49,6 +55,7 @@ hidden:
   field_media: true
   field_metatags: true
   field_position: true
+  field_pronouns: true
   field_subtitle: true
   field_tags: true
   field_teaser_media: true
@@ -57,3 +64,4 @@ hidden:
   field_telephone: true
   layout_builder__layout: true
   search_api_excerpt: true
+  workflow_buttons: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.profile.field_pronouns.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.profile.field_pronouns.yml
@@ -1,0 +1,19 @@
+uuid: 47bd0833-5f70-4c13-a2d9-25b0f01dcfff
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_pronouns
+    - node.type.profile
+id: node.profile.field_pronouns
+field_name: field_pronouns
+entity_type: node
+bundle: profile
+label: Pronouns
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_pronouns.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_pronouns.yml
@@ -1,0 +1,21 @@
+uuid: 78b31208-ff3a-404a-ba52-8fba4c418766
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_pronouns
+field_name: field_pronouns
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/ProfileMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/ProfileMetaBlock.php
@@ -101,6 +101,7 @@ class ProfileMetaBlock extends BlockBase implements ContainerFactoryPluginInterf
     $position = NULL;
     $subtitle = NULL;
     $department = NULL;
+    $pronouns = NULL;
     $mediaId = NULL;
 
     $request = $this->requestStack->getCurrentRequest();
@@ -125,6 +126,7 @@ class ProfileMetaBlock extends BlockBase implements ContainerFactoryPluginInterf
       $position = $node->get('field_position')->getValue()[0]['value'] ?? NULL;
       $subtitle = $node->get('field_subtitle')->getValue()[0]['value'] ?? NULL;
       $department = $node->get('field_department')->getValue()[0]['value'] ?? NULL;
+      $pronouns = $node->get('field_pronouns')->getValue()[0]['value'] ?? NULL;
       $mediaId = $node->get('field_media')->getValue()[0]['target_id'] ?? NULL;
     }
 
@@ -134,10 +136,12 @@ class ProfileMetaBlock extends BlockBase implements ContainerFactoryPluginInterf
       '#profile_meta__title_line' => $position,
       '#profile_meta__subtitle_line' => $subtitle,
       '#profile_meta__department' => $department,
+      '#profile_meta__pronouns' => $pronouns,
       '#media_id' => $mediaId,
       '#profile_meta__image_orientation' => $this->configuration['image_orientation'] ?? 'portrait',
       '#profile_meta__image_style' => $this->configuration['image_style'] ?? 'inline',
       '#profile_meta__image_alignment' => $this->configuration['image_alignment'] ?? 'left',
+
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
@@ -57,6 +57,7 @@ function ys_layouts_theme($existing, $type, $theme, $path): array {
         'profile_meta__title_line' => NULL,
         'profile_meta__subtitle_line' => NULL,
         'profile_meta__department' => NULL,
+        'profile_meta__pronouns' => NULL,
         'media_id' => NULL,
         'profile_meta__image_orientation' => NULL,
         'profile_meta__image_style' => NULL,


### PR DESCRIPTION
## [YSP-346: Add pronoun field](https://yaleits.atlassian.net/browse/YSP-346)

Other work needing review in:
- [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/422)

### Description of work
- Adds pronoun field to profile
- Allows display of this profile field in rendering

### Functional testing steps:
- [ ] Add a profile
- [ ] Observe an input for Pronoun
- [ ] When filling this field out, observe it shows on rendering of the profile
