### PR TITLE
Fix linting issues on develop preventing multidev creation

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedPublish.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedPublish.php
@@ -27,7 +27,7 @@ class ModeratedPublish extends PublishAction {
   /**
    * {@inheritdoc}
    */
-  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+  public function access($object, ?AccountInterface $account = NULL, $return_as_object = FALSE) {
     $key = $object->getEntityType()->getKey('published');
 
     /** @var \Drupal\Core\Entity\EntityInterface $object */

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedUnpublish.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Action/ModeratedUnpublish.php
@@ -27,7 +27,7 @@ class ModeratedUnpublish extends UnpublishAction {
   /**
    * {@inheritdoc}
    */
-  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+  public function access($object, ?AccountInterface $account = NULL, $return_as_object = FALSE) {
     $key = $object->getEntityType()->getKey('published');
 
     /** @var \Drupal\Core\Entity\EntityInterface $object */

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Service/LayoutUpdater.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Service/LayoutUpdater.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\ys_layouts\Service;
 
-use Drupal\block_content\Entity\BlockContent;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityFieldManager;
@@ -10,6 +9,7 @@ use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\block_content\Entity\BlockContent;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -2,11 +2,11 @@
 
 namespace Drupal\ys_localist;
 
-use Drupal\calendar_link\Twig\CalendarLinkTwigExtension;
 use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
+use Drupal\calendar_link\Twig\CalendarLinkTwigExtension;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/Plugin/migrate_plus/data_parser/LocalistJson.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/Plugin/migrate_plus/data_parser/LocalistJson.php
@@ -49,7 +49,7 @@ class LocalistJson extends Json implements ContainerFactoryPluginInterface, Data
       // If json_decode() has returned NULL, it might be that the data isn't
       // valid utf8 see http://php.net/manual/en/function.json-decode.php#86997.
       if (is_null($source_data)) {
-        $utf8response = utf8_encode($response);
+        $utf8response = mb_convert_encoding($response, 'UTF-8', 'ISO-8859-1');
         $source_data = json_decode($utf8response, TRUE, 512, JSON_THROW_ON_ERROR);
       }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -25,7 +25,7 @@ use Drupal\field\Entity\FieldStorageConfig;
  *
  * @see options_allowed_values()
  */
-function ys_themes_allowed_values_function(FieldStorageConfig $definition, ContentEntityInterface $entity = NULL, $cacheable) {
+function ys_themes_allowed_values_function(FieldStorageConfig $definition, ?ContentEntityInterface $entity = NULL, $cacheable) {
   $options = [];
   $config = \Drupal::config('ys_themes.component_overrides');
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/PostYearFilter.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/PostYearFilter.php
@@ -56,7 +56,7 @@ class PostYearFilter extends InOperator {
   /**
    * {@inheritdoc}
    */
-  public function init(ViewExecutable $view, DisplayPluginBase $display, array &$options = NULL) {
+  public function init(ViewExecutable $view, DisplayPluginBase $display, ?array &$options = NULL) {
     parent::init($view, $display, $options);
 
     $this->valueTitle = $this->t('Post Year Filter');


### PR DESCRIPTION
## Fix linting issues on develop

This adds linting fixes to previous commits that somehow did not find issues, but now does in new multidevs.  This is a way to not have to cherry-pick this commit fix in all other multidevs.

### Description of work
- Adds linting fixes so that multidevs can create

### Functional testing steps:
- [ ] If a multidev creation passes static tests and builds successfully, it worked.