### PR TITLE
YSP-680: PRESIDENT: Add dial to image banner to allow default and large image display

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.image_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.image_banner.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - block_content.type.image_banner
     - field.field.block_content.image_banner.field_media
+    - field.field.block_content.image_banner.field_style_variation
   module:
     - media_library
     - media_library_edit
@@ -22,6 +23,12 @@ content:
     third_party_settings:
       media_library_edit:
         show_edit: '1'
+  field_style_variation:
+    type: options_select
+    weight: 11
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   info:
     type: string_textfield
     weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.image_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.image_banner.default.yml
@@ -19,7 +19,9 @@ content:
     weight: 1
     region: content
     settings:
-      media_types: {  }
+      media_types:
+        - image
+        - background_video
     third_party_settings:
       media_library_edit:
         show_edit: '1'

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.image_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.image_banner.default.yml
@@ -17,7 +17,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: banner_16_5
+      view_mode: default
       link: false
     third_party_settings: {  }
     weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.image_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.image_banner.default.yml
@@ -5,6 +5,9 @@ dependencies:
   config:
     - block_content.type.image_banner
     - field.field.block_content.image_banner.field_media
+    - field.field.block_content.image_banner.field_style_variation
+  module:
+    - options
 id: block_content.image_banner.default
 targetEntityType: block_content
 bundle: image_banner
@@ -18,6 +21,13 @@ content:
       link: false
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_style_variation:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 5
     region: content
 hidden:
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.image_banner.field_media.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.image_banner.field_media.yml
@@ -27,5 +27,5 @@ settings:
       field: _none
       direction: ASC
     auto_create: true
-    auto_create_bundle: background_video
+    auto_create_bundle: image
 field_type: entity_reference

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.image_banner.field_style_variation.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.image_banner.field_style_variation.yml
@@ -1,0 +1,21 @@
+uuid: 746c6e8d-b767-4afe-bc09-8bf928f39ae4
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.image_banner
+    - field.storage.block_content.field_style_variation
+  module:
+    - options
+id: block_content.image_banner.field_style_variation
+field_name: field_style_variation
+entity_type: block_content
+bundle: image_banner
+label: 'Media Size'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ys_themes_default_value_function
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -254,3 +254,9 @@ video:
       left: Left
       center: Center
     default: left
+image_banner:
+  field_style_variation:
+    values:
+      large: Large
+      small: Small
+    default: large

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -257,6 +257,6 @@ video:
 image_banner:
   field_style_variation:
     values:
-      large: Large
-      small: Small
-    default: large
+      tall: Tall
+      short: Short
+    default: tall

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -15,17 +15,17 @@ use Drupal\field\Entity\FieldStorageConfig;
  *
  * @param \Drupal\field\Entity\FieldStorageConfig $definition
  *   The field definition.
- * @param \Drupal\Core\Entity\ContentEntityInterface|null $entity
- *   The entity being created, if applicable.
  * @param bool $cacheable
  *   Boolean indicating if the results are cache-able.
+ * @param \Drupal\Core\Entity\ContentEntityInterface|null $entity
+ *   The entity being created, if applicable.
  *
  * @return array
  *   An array of possible key and value options.
  *
  * @see options_allowed_values()
  */
-function ys_themes_allowed_values_function(FieldStorageConfig $definition, ?ContentEntityInterface $entity = NULL, $cacheable) {
+function ys_themes_allowed_values_function(FieldStorageConfig $definition, $cacheable, ?ContentEntityInterface $entity = NULL) {
   $options = [];
   $config = \Drupal::config('ys_themes.component_overrides');
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -15,17 +15,17 @@ use Drupal\field\Entity\FieldStorageConfig;
  *
  * @param \Drupal\field\Entity\FieldStorageConfig $definition
  *   The field definition.
- * @param bool $cacheable
- *   Boolean indicating if the results are cache-able.
  * @param \Drupal\Core\Entity\ContentEntityInterface|null $entity
  *   The entity being created, if applicable.
+ * @param bool $cacheable
+ *   Boolean indicating if the results are cache-able.
  *
  * @return array
  *   An array of possible key and value options.
  *
  * @see options_allowed_values()
  */
-function ys_themes_allowed_values_function(FieldStorageConfig $definition, $cacheable, ?ContentEntityInterface $entity = NULL) {
+function ys_themes_allowed_values_function(FieldStorageConfig $definition, ?ContentEntityInterface $entity = NULL, $cacheable) {
   $options = [];
   $config = \Drupal::config('ys_themes.component_overrides');
 


### PR DESCRIPTION
## [YSP-680: PRESIDENT: Add dial to image banner to allow default and large image display](https://yaleits.atlassian.net/browse/YSP-680)

### Other work to be reviewed:
- [Atomic](https://github.com/yalesites-org/atomic/pull/270)
- [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/423)

### Description of work
- Adds image banner size dial to image banner (large or small)
- Mimics the grand hero layout and styling to have consistent feel

### Functional testing steps:
- [x] Create an image banner block
- [x] Observe a new field, `Media Size` with options of "Tall" (default) and "Short"
- [x] Add a grand hero as a reference
  - [x] "Tall" mimics "Full", "Short" mimics "Reduced"
- [x] Ensure videos also look good
