### PR TITLE
Fix deprecation warning on first load

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module
@@ -17,15 +17,13 @@ use Drupal\field\Entity\FieldStorageConfig;
  *   The field definition.
  * @param \Drupal\Core\Entity\ContentEntityInterface|null $entity
  *   The entity being created, if applicable.
- * @param bool $cacheable
- *   Boolean indicating if the results are cache-able.
  *
  * @return array
  *   An array of possible key and value options.
  *
  * @see options_allowed_values()
  */
-function ys_themes_allowed_values_function(FieldStorageConfig $definition, ?ContentEntityInterface $entity = NULL, $cacheable) {
+function ys_themes_allowed_values_function(FieldStorageConfig $definition, ?ContentEntityInterface $entity = NULL) {
   $options = [];
   $config = \Drupal::config('ys_themes.component_overrides');
 


### PR DESCRIPTION
## Fix deprecation warning on first load

We had a $cachable which was not even in the signature of options_allowed_values, yet we were passing something in that then wasn't even being used.  This lets it match the signature found at:

https://api.drupal.org/api/drupal/core%21modules%21options%21options.module/function/options_allowed_values/10

### Description of work
- Adds functionality bullet item
- Fixes this or that bullet item

### Functional testing steps:
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
