### PR TITLE
YSP-693: Increase hard limit on spotlights to 650 characters

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
@@ -140,7 +140,7 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: 500
+        maxlength_js: 650
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: true
   info:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
@@ -140,7 +140,7 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: 650
+        maxlength_js: 600
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: true
   info:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight_portrait.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight_portrait.default.yml
@@ -136,7 +136,7 @@ content:
         hide_help: '1'
         hide_guidelines: '1'
       maxlength:
-        maxlength_js: 500
+        maxlength_js: 650
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: true
   info:


### PR DESCRIPTION
## [YSP-693: Increase hard limit on spotlights to 650 characters](https://yaleits.atlassian.net/browse/YSP-693)

### Description of work
- Increase max character limits on portrait spotlights from 500 to 650 characters
- Increase max character limits on landscape spotlights from 500 to 600 characters

### Functional testing steps:
- [ ] Create a new instance of each spotlight
- [ ] Verify that the maximum character limit on the portrait spotlight content is now 650
- [ ] Verify that the maximum character limit on the landscape spotlight content is now 600
- [ ] Create a 650 character version for spotlight portrait, and a 600 character version for spotlight landscape and verify it looks ok, both on desktop and mobile
