### PR TITLE
YSP-697: Image Banner not respecting focal point

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The YaleSites platform empowers the Yale community to create digital experiences
 ## Common Scripts
 
 These are the most common npm scripts you may find yourself using:
-(Each is prefixed with `npm run `)
+(Each is prefixed with `npm run`)
 
 ### PR Reviews
 
@@ -41,3 +41,4 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory.
+-


### PR DESCRIPTION
## [YSP-697: Image Banner not respecting focal point](https://yaleits.atlassian.net/browse/YSP-697)

_Real work done in :_ [Atomic](https://github.com/yalesites-org/atomic/pull/272)

The div that is inserted for the item seems to be modifying how the image banner behaves, skipping the styling of it to match the grand hero.  By creating this, it allows it to bypass this, picking up the styles similar to the grand hero in Drupal.

### Description of work
- Adds a bypass to the item content so that the extra unsettled div does not get rendered

### Functional testing steps:
- [ ] Create an image banner
- [ ] Create a grand hero banner
- [ ] Observe the placement of the image, the boundaries of it, and make sure they match in image shown
- [ ] In their configuration, modify to the "short" version
- [ ] Observe the placement of the image, the boundaries of it, and make sure they match in image shown
