### PR TITLE
YSP-672: AI: Add media payloads and pipelines

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,10 @@
           "type": "tar"
         }
       }
+    },
+    "ai_engine": {
+      "type": "vcs",
+      "url": "https://github.com/yalesites-org/ai_engine"
     }
   },
   "require": {

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -1,5 +1,6 @@
 api_version: 1
 # Downstream sites should not change the workflow.
+
 # Specifying Quicksilver workflows in pantheon.upstream.yml is not supported.
 workflows:
   clone_database:

--- a/patches/layout_builder_browser/3408935-and-3409153-9.patch
+++ b/patches/layout_builder_browser/3408935-and-3409153-9.patch
@@ -103,7 +103,7 @@ index 34310e2..fa855a6 100644
 +          if ($config->get('group_reusable_blocks_together')) {
 +
 +            foreach ($block_links as $key => $block_link) {
-+              $changed = date('m/d/Y - H:i', $block_link['#changed']);
++              $changed = date('m/d/Y - H:i', $block_link['link']['#changed']);
 +              $block_links[$key]['link']['#title']['label']['#markup'] = "
 +                <span class='underlined-title'>{$block_link['link']['#title']['label']['#markup']}</span>
 +                <br>

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -115,7 +115,7 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
-    "yalesites-org/ai_engine": "dev-YSP-672-ai-add-media-payloads-and-pipelines",
+    "yalesites-org/ai_engine": "dev-YSP-756-fix-null-request",
     "yalesites-org/atomic": "1.39.0",
     "yalesites-org/yale_cas": "v1.0.5"
   },

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -111,7 +111,6 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
-    "twig/twig": "3.14.0",
     "yalesites-org/ai_engine": "1.2.5",
     "yalesites-org/atomic": "1.39.0",
     "yalesites-org/yale_cas": "v1.0.5"

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -115,6 +115,7 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
+    "yalesites-org/ai_engine": "dev-YSP-672-ai-add-media-payloads-and-pipelines",
     "yalesites-org/atomic": "1.39.0",
     "yalesites-org/yale_cas": "v1.0.5"
   },

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -111,6 +111,7 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
+    "twig/twig": "3.14.0",
     "yalesites-org/ai_engine": "1.2.5",
     "yalesites-org/atomic": "1.39.0",
     "yalesites-org/yale_cas": "v1.0.5"

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -94,7 +94,7 @@
     "drupal/paragraphs_features": "2.0.0",
     "drupal/pathauto": "1.13.0",
     "drupal/publishcontent": "1.6",
-    "drupal/quick_node_clone": "1.18.0",
+    "drupal/quick_node_clone": "1.19.0",
     "drupal/recaptcha": "3.4.0",
     "drupal/recaptcha_v3": "2.0.3",
     "drupal/redirect": "1.10.0",

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -17,6 +17,10 @@
           "type": "tar"
         }
       }
+    },
+    "ai_engine": {
+      "type": "vcs",
+      "url": "https://github.com/yalesites-org/ai_engine"
     }
   },
   "require": {
@@ -111,7 +115,6 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
-    "yalesites-org/ai_engine": "1.2.5",
     "yalesites-org/atomic": "1.39.0",
     "yalesites-org/yale_cas": "v1.0.5"
   },

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -115,7 +115,7 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
-    "yalesites-org/ai_engine": "dev-YSP-756-fix-null-request",
+    "yalesites-org/ai_engine": "1.2.7",
     "yalesites-org/atomic": "1.39.0",
     "yalesites-org/yale_cas": "v1.0.5"
   },

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.default.yml
@@ -4,11 +4,13 @@ status: true
 dependencies:
   config:
     - field.field.media.document.field_media_file
+    - field.field.media.document.field_metatags
     - field.field.media.document.field_tags
     - media.type.document
   module:
     - chosen_field
     - file
+    - metatag
 id: media.document.default
 targetEntityType: media
 bundle: document
@@ -20,6 +22,14 @@ content:
     region: content
     settings:
       progress_indicator: throbber
+    third_party_settings: {  }
+  field_metatags:
+    type: metatag_firehose
+    weight: 3
+    region: content
+    settings:
+      sidebar: true
+      use_details: true
     third_party_settings: {  }
   field_tags:
     type: chosen_select

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.media_library.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.media_library.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_form_mode.media.media_library
     - field.field.media.document.field_media_file
+    - field.field.media.document.field_metatags
     - field.field.media.document.field_tags
     - media.type.document
   module:
@@ -38,6 +39,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_metatags: true
   path: true
   revision_log_message: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.default.yml
@@ -31,6 +31,7 @@ content:
     region: content
 hidden:
   created: true
+  field_metatags: true
   field_tags: true
   name: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.default.yml
@@ -4,10 +4,12 @@ status: true
 dependencies:
   config:
     - field.field.media.document.field_media_file
+    - field.field.media.document.field_metatags
     - field.field.media.document.field_tags
     - media.type.document
   module:
     - file
+    - metatag
 id: media.document.default
 targetEntityType: media
 bundle: document
@@ -19,6 +21,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_metatags:
+    type: metatag_empty_formatter
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
     region: content
 hidden:
   created: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.media_library.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.media_library.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.media.media_library
     - field.field.media.document.field_media_file
+    - field.field.media.document.field_metatags
     - field.field.media.document.field_tags
     - image.style.media_library
     - media.type.document
@@ -29,6 +30,7 @@ content:
 hidden:
   created: true
   field_media_file: true
+  field_metatags: true
   field_tags: true
   name: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.media.document.field_metatags.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.media.document.field_metatags.yml
@@ -1,0 +1,21 @@
+uuid: 04b2e049-3bb3-4f6d-bd72-0d6b20e50142
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_metatags
+    - media.type.document
+  module:
+    - metatag
+id: media.document.field_metatags
+field_name: field_metatags
+entity_type: media
+bundle: document
+label: Metatags
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.media.document.field_metatags.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.media.document.field_metatags.yml
@@ -1,4 +1,4 @@
-uuid: 04b2e049-3bb3-4f6d-bd72-0d6b20e50142
+uuid: 3c7d1cca-b0b1-4ee7-886b-ad6fa0400e92
 langcode: en
 status: true
 dependencies:
@@ -11,7 +11,7 @@ id: media.document.field_metatags
 field_name: field_metatags
 entity_type: media
 bundle: document
-label: Metatags
+label: Metadata
 description: ''
 required: false
 translatable: false

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.media.field_metatags.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.media.field_metatags.yml
@@ -1,0 +1,19 @@
+uuid: c6f18928-63cc-4dc6-910b-5e240d724fb2
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - metatag
+id: media.field_metatags
+field_name: field_metatags
+entity_type: media
+type: metatag
+settings: {  }
+module: metatag
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.media.field_metatags.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.media.field_metatags.yml
@@ -1,4 +1,4 @@
-uuid: c6f18928-63cc-4dc6-910b-5e240d724fb2
+uuid: 241ba697-d6b1-4a31-88e4-a696c1aee334
 langcode: en
 status: true
 dependencies:

--- a/web/profiles/custom/yalesites_profile/config/sync/metatag.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/metatag.settings.yml
@@ -1,18 +1,24 @@
 entity_type_groups:
+  media:
+    document:
+      ai_engine: ai_engine
   node:
     event:
       basic: basic
     page:
       basic: basic
+      ai_engine: ai_engine
     post:
       basic: basic
       open_graph: open_graph
+separator: ','
 tag_trim_method: beforeValue
+use_maxlength: true
 tag_trim_maxlength:
-  metatag_maxlength_abstract: null
-  metatag_maxlength_description: null
   metatag_maxlength_title: null
-  metatag_maxlength_og_description: null
+  metatag_maxlength_description: null
+  metatag_maxlength_abstract: null
   metatag_maxlength_og_site_name: null
   metatag_maxlength_og_title: null
+  metatag_maxlength_og_description: null
 tag_scroll_max_height: ''

--- a/web/profiles/custom/yalesites_profile/config/sync/system.action.disable_ai.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.action.disable_ai.yml
@@ -1,0 +1,11 @@
+uuid: c4c1fe69-3658-4316-a349-fbb29416756e
+langcode: en
+status: true
+dependencies:
+  module:
+    - ai_engine_metadata
+id: disable_ai
+label: 'Disable AI'
+type: node
+plugin: ai_engine_disable_ai
+configuration: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/system.action.enable_ai.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.action.enable_ai.yml
@@ -1,0 +1,11 @@
+uuid: e9915862-ac04-4981-89a0-63858245e47a
+langcode: en
+status: true
+dependencies:
+  module:
+    - ai_engine_metadata
+id: enable_ai
+label: 'Enable AI'
+type: node
+plugin: ai_engine_enable_ai
+configuration: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.content.yml
@@ -80,6 +80,8 @@ display:
           action_title: Action
           include_exclude: include
           selected_actions:
+            - disable_ai
+            - enable_ai
             - node_delete_action
             - pathauto_update_alias_node
             - publish_moderated_content


### PR DESCRIPTION
## [YSP-672: AI: Add media payloads and pipelines](https://yaleits.atlassian.net/browse/YSP-672)

### Description of work
- Adds the ai_engine module PDF feature branch for testing

### Functional testing steps:
- [ ] Log in via CAS
- [ ] Go to `Content->Media->Add Media->Document`
- [ ] Upload a PDF, filling out all of the information
- [ ] Make sure to go into the sidebar metadata and untick `Disable indexing for AI feeds.`
- [ ] Save
- [ ] Verify that the data shows inside of the `askyalemytest` index
