### PR TITLE
v1.10.0: Multiple fixes

### DIFF
--- a/patches/layout_builder_browser/3408935-and-3409153-9.patch
+++ b/patches/layout_builder_browser/3408935-and-3409153-9.patch
@@ -103,7 +103,7 @@ index 34310e2..fa855a6 100644
 +          if ($config->get('group_reusable_blocks_together')) {
 +
 +            foreach ($block_links as $key => $block_link) {
-+              $changed = date('m/d/Y - H:i', $block_link['#changed']);
++              $changed = date('m/d/Y - H:i', $block_link['link']['#changed']);
 +              $block_links[$key]['link']['#title']['label']['#markup'] = "
 +                <span class='underlined-title'>{$block_link['link']['#title']['label']['#markup']}</span>
 +                <br>

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -111,7 +111,6 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
-    "twig/twig": "3.14.0",
     "yalesites-org/ai_engine": "1.2.5",
     "yalesites-org/atomic": "1.39.0",
     "yalesites-org/yale_cas": "v1.0.5"

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -111,6 +111,7 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
+    "twig/twig": "3.14.0",
     "yalesites-org/ai_engine": "1.2.5",
     "yalesites-org/atomic": "1.39.0",
     "yalesites-org/yale_cas": "v1.0.5"

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -112,7 +112,7 @@
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
     "yalesites-org/ai_engine": "1.2.5",
-    "yalesites-org/atomic": "1.39.0",
+    "yalesites-org/atomic": "1.39.1",
     "yalesites-org/yale_cas": "v1.0.5"
   },
   "minimum-stability": "dev",

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -90,7 +90,7 @@
     "drupal/paragraphs_features": "2.0.0",
     "drupal/pathauto": "1.13.0",
     "drupal/publishcontent": "1.6",
-    "drupal/quick_node_clone": "1.18.0",
+    "drupal/quick_node_clone": "1.19.0",
     "drupal/recaptcha": "3.4.0",
     "drupal/recaptcha_v3": "2.0.3",
     "drupal/redirect": "1.10.0",

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -106,6 +106,7 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
 
     $formSelectors = $this->viewsBasicManager->getFormSelectors($formState, NULL, $entityValue);
     $form['#form_selectors'] = $formSelectors;
+    $selectedEntityType = $formSelectors['entity_types'];
 
     $element['group_params'] = [
       '#type' => 'container',
@@ -227,14 +228,22 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
     $fieldOptionValue = ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('field_options', $items[$delta]->params) : [];
     $fieldOptionDefaultValue = $fieldOptionValue ?? ['show_thumbnail' => 'show_thumbnail'];
     $isNewForm = str_contains($formState->getCompleteForm()['#id'], 'layout-builder-add-block');
+
+    // To be consistent in the output render, we name categories affiliation in
+    // the views form if they select profiles.
+    $showCategoriesLabel = $this->t("Show Categories");
+    if ($selectedEntityType === "profile") {
+      $showCategoriesLabel = $this->t("Show Affiliations");
+    }
+
     // Set the default value for 'field_options' to 'show_thumbnail'
     // when creating a new block.
     $form['group_user_selection']['entity_and_view_mode']['field_options'] = [
       '#type' => 'checkboxes',
       '#options' => [
-        'show_categories' => $this->t('Show Categories'),
+        'show_categories' => $showCategoriesLabel,
         'show_tags' => $this->t('Show Tags'),
-        'show_thumbnail' => $this->t('Show Thumbnail'),
+        'show_thumbnail' => $this->t('Show Teaser Image'),
       ],
       '#title' => $this->t('Field Display Options'),
       '#tree' => TRUE,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -264,9 +264,9 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
     $form['group_user_selection']['entity_and_view_mode']['exposed_filter_options'] = [
       '#type' => 'checkboxes',
       '#options' => [
-        'show_search_filter' => $this->t('Show Search Filter'),
-        'show_year_filter' => $this->t('Show Year Filter'),
-        'show_category_filter' => $this->t('Show Category Filter'),
+        'show_search_filter' => $this->t('Show Search'),
+        'show_year_filter' => $this->t('Show Year'),
+        'show_category_filter' => $this->t('Show Category'),
       ],
       '#title' => $this->t('Exposed Filter Options'),
       '#tree' => TRUE,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -288,7 +288,7 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       ],
     ];
 
-    $vocabulary_id = $formSelectors['entity_types'] === 'profile'
+    $vocabulary_id = $selectedEntityType === 'profile'
       ? 'affiliation'
       : $formSelectors['entity_types'] . '_category';
     $form['group_user_selection']['entity_and_view_mode']['category_included_terms'] = [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -370,6 +370,10 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
         'past' => $this->t('Past Events') . '<img src="/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/icons/event-time-past.svg" alt="Past Events icon showing a calendar with a past-pointing arrow to the left.">',
         'all' => $this->t('All Events') . '<img src="/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/icons/event-time-all.svg" alt="All Events icon showing a calendar.">',
       ],
+      '#states' => [
+        'visible' => [$formSelectors['entity_types_ajax'] => ['value' => 'event']],
+        'invisible' => $calendarViewInvisibleState,
+      ],
       '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('event_time_period', $items[$delta]->params) : 'future',
       '#prefix' => '<div id="edit-event-time-period">',
       '#suffix' => '</div>',


### PR DESCRIPTION
## Multiple fixes

Changes also made in [Atomic](https://github.com/yalesites-org/atomic/pull/281); please review that as well.

### Description of work
- Uses correct array attribute to get changed time for sorting and display
- Update quick node clone to 1.19.0 for patch compatibility
- Remove "filter" words from filter list on views block
- Re-add event-based conditional displays on views block

### Functional testing steps:
- [ ] Create a few reusable blocks at different times
- [ ] Ensure that the times are reflected in their block selections when adding blocks
- [ ] Ensure that the times are sorted so that the last made block is first in the block selection
- [ ] Add a view block
  - [ ] Ensure that under the filters it no longer repeats "filter" on each checkbox
  - [ ] Ensure that "Event Time Period" only shows on events except for the calendar event
- [ ] Ensure that you can clone a node successfully
