### PR TITLE
fix(v1.10.0): bump quick node clone to 1.19.0

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -90,7 +90,7 @@
     "drupal/paragraphs_features": "2.0.0",
     "drupal/pathauto": "1.13.0",
     "drupal/publishcontent": "1.6",
-    "drupal/quick_node_clone": "1.18.0",
+    "drupal/quick_node_clone": "1.19.0",
     "drupal/recaptcha": "3.4.0",
     "drupal/recaptcha_v3": "2.0.3",
     "drupal/redirect": "1.10.0",


### PR DESCRIPTION
## fix(v1.10.0): bump quick node clone to 1.19.0

The latest changes to the quick node clone patch we use made it incompatible with 1.18.0.  It does work with 1.19.0.

References: https://www.drupal.org/project/quick_node_clone/issues/3100117

This is a cherry-pick since other vendors are running into issues using develop for work.

### Description of work
- Bumps quick node clone to 1.19.0 so the patch can apply

### Functional testing steps:
- [ ] If the multidev successfully builds, it works