### PR TITLE
docs(git): document about making atomic a safe directory

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -44,6 +44,14 @@ Repositories used to make the platform:
 While the project can be cloned and run locally without it, one must setup an SSH key on their development machine if they wish to push code on any of the yalesites repositories.
 Luckily, [GitHub has an intuitive guide on how to setup an SSH key on your machine and register it with your GitHub Account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
 
+In some cases, git will complain about ownership issues when building packages.  If this happens to you you can execute the following to mark things like atomic as a safe directory.
+
+```bash
+git config --global --add safe.directory 'web/themes/contrib/atomic'
+```
+
+Keep in mind the above command is a global so it will stay in your `.gitconfig` for future builds.
+
 #### Package Personal Access Token
 
 Each environment that needs to pull @yalesites-org packages from GitHub needs to be authenticated using a "Personal Access Token". This only needs to be done once per-environment.


### PR DESCRIPTION
## docs(git): speak about making atomic a safe directory

In some cases, vendors were receiving strange errors related to the atomic directory already existing.  It turned out the real issue was that git detected strange ownership of it, and would disallow it from being brought down.

While the first fix is to ensure that yalesites-org/* was marked in composer as prefer-dist in the config.json, the next is to add a safe directory to allow this to work again.

### Description of work
- Adds instructions should users run into a safe directory issue