### PR TITLE
IYY-263: Show CAS'd content in search results

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.search_result.yml
@@ -51,7 +51,7 @@ content:
   content_moderation_control:
     settings: {  }
     third_party_settings: {  }
-    weight: -20
+    weight: 0
     region: content
   field_external_source:
     type: link_separate
@@ -63,19 +63,29 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 2
+    weight: 3
+    region: content
+  field_login_required:
+    type: boolean
+    label: hidden
+    settings:
+      format: boolean
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 4
     region: content
   field_teaser_text:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   search_api_excerpt:
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
 hidden:
   field_category: true
@@ -100,7 +110,6 @@ hidden:
   field_localist_id: true
   field_localist_info: true
   field_localist_register_enabled: true
-  field_login_required: true
   field_metatags: true
   field_stream_embed_code: true
   field_stream_url: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.search_result.yml
@@ -26,7 +26,7 @@ content:
   content_moderation_control:
     settings: {  }
     third_party_settings: {  }
-    weight: -20
+    weight: 0
     region: content
   field_external_source:
     type: link_separate
@@ -38,23 +38,32 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 2
+    weight: 3
+    region: content
+  field_login_required:
+    type: boolean
+    label: hidden
+    settings:
+      format: true-false
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 4
     region: content
   field_teaser_text:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   search_api_excerpt:
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
 hidden:
   field_category: true
-  field_login_required: true
   field_metatags: true
   field_tags: true
   field_teaser_media: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.search_result.yml
@@ -17,6 +17,7 @@ dependencies:
     - field.field.node.post.layout_builder__layout
     - node.type.post
   module:
+    - link
     - text
     - user
 id: node.post.search_result
@@ -24,6 +25,11 @@ targetEntityType: node
 bundle: post
 mode: search_result
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
   field_external_source:
     type: link_separate
     label: hidden
@@ -34,24 +40,33 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 2
+    weight: 3
+    region: content
+  field_login_required:
+    type: boolean
+    label: above
+    settings:
+      format: boolean
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 4
     region: content
   field_teaser_text:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   search_api_excerpt:
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
 hidden:
   field_author: true
   field_category: true
-  field_login_required: true
   field_metatags: true
   field_publish_date: true
   field_tags: true
@@ -59,3 +74,4 @@ hidden:
   field_teaser_title: true
   layout_builder__layout: true
   links: true
+  workflow_buttons: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.search_result.yml
@@ -42,7 +42,7 @@ content:
   content_moderation_control:
     settings: {  }
     third_party_settings: {  }
-    weight: -20
+    weight: 0
     region: content
   field_external_source:
     type: link_separate
@@ -54,19 +54,29 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 2
+    weight: 3
+    region: content
+  field_login_required:
+    type: boolean
+    label: hidden
+    settings:
+      format: boolean
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 4
     region: content
   field_teaser_text:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   search_api_excerpt:
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
 hidden:
   field_address: true
@@ -76,7 +86,6 @@ hidden:
   field_first_name: true
   field_honorific_prefix: true
   field_last_name: true
-  field_login_required: true
   field_media: true
   field_metatags: true
   field_position: true

--- a/web/profiles/custom/yalesites_profile/config/sync/search_api.index.secure_index.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/search_api.index.secure_index.yml
@@ -1,0 +1,165 @@
+uuid: eaac8aa4-ebe9-48a6-8d40-2aefff92390f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_teaser_text
+    - search_api.server.database_server
+  module:
+    - node
+    - search_api
+    - search_api_exclude
+    - search_api_html_element_filter
+id: secure_index
+name: 'Secure Index'
+description: ''
+read_only: false
+field_settings:
+  field_teaser_text:
+    label: 'Teaser Text'
+    datasource_id: 'entity:node'
+    property_path: field_teaser_text
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_teaser_text
+  rendered_item:
+    label: 'Rendered HTML output'
+    property_path: rendered_item
+    type: text
+    configuration:
+      roles:
+        - authenticated
+      view_mode:
+        'entity:node':
+          event: default
+          page: default
+          post: default
+          profile: default
+  status:
+    label: Published
+    datasource_id: 'entity:node'
+    property_path: status
+    type: boolean
+    dependencies:
+      module:
+        - node
+  type:
+    label: 'Content type'
+    datasource_id: 'entity:node'
+    property_path: type
+    type: string
+    dependencies:
+      module:
+        - node
+  uid:
+    label: 'Authored by'
+    datasource_id: 'entity:node'
+    property_path: uid
+    type: integer
+    dependencies:
+      module:
+        - node
+datasource_settings:
+  'entity:node':
+    bundles:
+      default: true
+      selected: {  }
+    languages:
+      default: true
+      selected: {  }
+processor_settings:
+  add_url: {  }
+  aggregated_field: {  }
+  custom_value: {  }
+  entity_status: {  }
+  entity_type: {  }
+  highlight:
+    weights:
+      postprocess_query: 0
+    prefix: '<strong style="background-color: yellow;">'
+    suffix: '</strong>'
+    excerpt: true
+    excerpt_always: true
+    excerpt_length: 256
+    exclude_fields: {  }
+    highlight: always
+    highlight_partial: false
+  html_element_filter:
+    weights:
+      postprocess_query: -30
+      preprocess_index: -50
+    all_fields: 0
+    fields:
+      - field_teaser_text
+      - rendered_item
+      - type
+    css_selectors: .visually-hidden
+  html_filter:
+    weights:
+      preprocess_index: -49
+      preprocess_query: -48
+    all_fields: false
+    fields:
+      - field_teaser_text
+      - rendered_item
+    title: true
+    alt: true
+    tags:
+      b: 2
+      h1: 5
+      h2: 3
+      h3: 2
+      strong: 2
+  ignorecase:
+    weights:
+      preprocess_index: -48
+      preprocess_query: -47
+    all_fields: true
+    fields:
+      - field_teaser_text
+      - rendered_item
+      - type
+  language_with_fallback: {  }
+  node_exclude: {  }
+  rendered_item: {  }
+  stemmer:
+    weights:
+      preprocess_index: -42
+      preprocess_query: -42
+    all_fields: false
+    fields:
+      - field_teaser_text
+      - rendered_item
+    exceptions:
+      mexican: mexic
+      texan: texa
+  tokenizer:
+    weights:
+      preprocess_index: -45
+      preprocess_query: -44
+    all_fields: false
+    fields:
+      - field_teaser_text
+      - rendered_item
+    spaces: ''
+    ignored: ._-
+    overlap_cjk: 1
+    minimum_word_size: '3'
+  transliteration:
+    weights:
+      preprocess_index: -47
+      preprocess_query: -46
+    all_fields: true
+    fields:
+      - field_teaser_text
+      - rendered_item
+      - type
+tracker_settings:
+  default:
+    indexing_order: fifo
+options:
+  cron_limit: 50
+  index_directly: true
+  track_changes_in_references: true
+server: database_server

--- a/web/profiles/custom/yalesites_profile/config/sync/search_api.index.secure_index.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/search_api.index.secure_index.yml
@@ -11,7 +11,7 @@ dependencies:
     - search_api_exclude
     - search_api_html_element_filter
 id: secure_index
-name: 'Secure Index'
+name: 'Node and CAS Index'
 description: ''
 read_only: false
 field_settings:

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.search_cas.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.search_cas.yml
@@ -11,7 +11,7 @@ dependencies:
 id: search_cas
 label: 'Search CAS'
 module: views
-description: 'Shows CAS-only items (titles only)'
+description: 'Shows all items including CAS items (titles only via twig)'
 tag: ''
 base_table: search_api_index_secure_index
 base_field: search_api_id

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.search_cas.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.search_cas.yml
@@ -1,20 +1,19 @@
-uuid: b4f36218-e053-4754-b5d0-0fccf46965c7
+uuid: 9fc73ca3-3fb4-486a-af60-ebc8213dc241
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_teaser_text
-    - search_api.index.node_index
+    - search_api.index.secure_index
   module:
     - search_api
     - text
-    - user
-id: search
-label: Search
+id: search_cas
+label: 'Search CAS'
 module: views
-description: 'Site search results page.'
+description: 'Shows CAS-only items (titles only)'
 tag: ''
-base_table: search_api_index_node_index
+base_table: search_api_index_secure_index
 base_field: search_api_id
 display:
   default:
@@ -23,11 +22,11 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: Search
+      title: 'Search CAS'
       fields:
         field_teaser_text:
           id: field_teaser_text
-          table: search_api_index_node_index
+          table: search_api_index_secure_index
           field: field_teaser_text
           relationship: none
           group_type: group
@@ -129,9 +128,8 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: perm
-        options:
-          perm: 'access content'
+        type: none
+        options: {  }
       cache:
         type: search_api_tag
         options: {  }
@@ -152,7 +150,7 @@ display:
       sorts:
         search_api_relevance:
           id: search_api_relevance
-          table: search_api_index_node_index
+          table: search_api_index_secure_index
           field: search_api_relevance
           relationship: none
           group_type: group
@@ -166,7 +164,7 @@ display:
       arguments:
         search_api_fulltext:
           id: search_api_fulltext
-          table: search_api_index_node_index
+          table: search_api_index_secure_index
           field: search_api_fulltext
           relationship: none
           group_type: group
@@ -199,10 +197,10 @@ display:
           parse_mode: terms
           conjunction: AND
           fields: {  }
-        type:
-          id: type
-          table: search_api_index_node_index
-          field: type
+        search_api_datasource:
+          id: search_api_datasource
+          table: search_api_index_secure_index
+          field: search_api_datasource
           relationship: none
           group_type: group
           admin_label: ''
@@ -234,6 +232,10 @@ display:
       filters: {  }
       style:
         type: default
+        options:
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
       row:
         type: search_api
         options:
@@ -246,8 +248,8 @@ display:
       query:
         type: search_api_query
         options:
-          bypass_access: false
-          skip_access: false
+          bypass_access: true
+          skip_access: true
           preserve_facet_query_args: false
           query_tags: {  }
       relationships: {  }
@@ -265,7 +267,10 @@ display:
           content_plural: '<div class="search-results--summary">@total search results</div>'
           plural_count_token: '@total'
       footer: {  }
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
     cache_metadata:
       max-age: -1
       contexts:
@@ -274,8 +279,7 @@ display:
         - url
         - url.query_args
         - 'user.node_grants:view'
-        - user.permissions
       tags:
         - 'config:field.storage.node.field_teaser_text'
-        - 'config:search_api.index.node_index'
-        - 'search_api_list:node_index'
+        - 'config:search_api.index.secure_index'
+        - 'search_api_list:secure_index'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/install/ys_core.header_settings.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/install/ys_core.header_settings.yml
@@ -4,3 +4,4 @@ focus_header_image: ''
 site_name_image: ''
 search:
   enable_search_form: 1
+  enable_cas_search: 0

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Controller/SearchController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Controller/SearchController.php
@@ -27,7 +27,9 @@ class SearchController extends ControllerBase {
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory service.
    */
-  public function __construct(ConfigFactoryInterface $config_factory) {
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+  ) {
     $this->configFactory = $config_factory;
   }
 
@@ -36,33 +38,30 @@ class SearchController extends ControllerBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('config.factory')
+      $container->get('config.factory'),
     );
   }
 
   /**
    * Dynamic search page to show CAS titles or not.
+   *
+   * @param Symfony\Component\HttpFoundation\Request $request
+   *   The Drupal request.
    */
   public function searchPage(Request $request) {
-    // Check your configuration value to decide which view to render.
+    // Only show CAS titles if it is enabled.
     $config = $this->configFactory->get('ys_core.header_settings');
-    $view_name = $config->get('search.enable_cas_search') ? 'search_cas' : 'search';
+    $view_name = $config->get('search.enable_cas_search') && $config->get('search.enable_search_form') ? 'search_cas' : 'search';
 
     $view = Views::getView($view_name);
     if ($view) {
-      // Set the display (e.g., 'default' display or a custom display).
       $view->setDisplay('default');
 
       // Retrieve the 'keywords' parameter from the request, if it exists.
       $keywords = $request->query->get('keywords');
       if ($keywords) {
-        // If your view has a contextual filter for keywords, pass it here.
+        // Pass keywords to contextual filter.
         $view->setArguments([$keywords]);
-        $keywords_markup = Markup::create('<em>' . $this->t('@keywords', ['@keywords' => $keywords]) . '</em>');
-        $title = $this->t('Search results: @keywords', ['@keywords' => $keywords_markup]);
-      }
-      else {
-        $title = $this->t('Search');
       }
 
       // Execute the view and render it.
@@ -70,7 +69,7 @@ class SearchController extends ControllerBase {
       $view->execute();
 
       return [
-        '#title' => $title,
+        '#title' => $this->getTitle($request, TRUE),
         'view' => $view->render(),
         '#cache' => [
           'contexts' => ['url.query_args:keywords'],
@@ -79,8 +78,34 @@ class SearchController extends ControllerBase {
     }
 
     return [
-      '#markup' => $this->t('No view available.'),
+      '#markup' => $this->t('No search view available.'),
     ];
+  }
+
+  /**
+   * Title callback to set <title> tag and H1 page title.
+   *
+   * @param Symfony\Component\HttpFoundation\Request $request
+   *   The Drupal request.
+   * @param bool $withMarkup
+   *   If set, outputs the title with formatting for use with H1 tag.
+   *
+   * @return Drupal\Core\StringTranslation\TranslatableMarkup
+   *   Drupal's translatable markup for the title.
+   */
+  public function getTitle(Request $request, $withMarkup = FALSE) {
+    $keywords = $request->query->get('keywords');
+
+    if (!$keywords) {
+      return $this->t('Search');
+    }
+
+    if ($withMarkup) {
+      $keywords = Markup::create('<em>' . $this->t('@keywords', ['@keywords' => $keywords]) . '</em>');
+    }
+    $title = $this->t('Search results: @keywords', ['@keywords' => $keywords]);
+
+    return $title;
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Controller/SearchController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Controller/SearchController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\ys_core\Controller;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Render\Markup;
+use Drupal\views\Views;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Controller for the search page.
+ */
+class SearchController extends ControllerBase {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a SearchController object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * Dynamic search page to show CAS titles or not.
+   */
+  public function searchPage(Request $request) {
+    // Check your configuration value to decide which view to render.
+    $config = $this->configFactory->get('ys_core.header_settings');
+    $view_name = $config->get('search.enable_cas_search') ? 'search_cas' : 'search';
+
+    $view = Views::getView($view_name);
+    if ($view) {
+      // Set the display (e.g., 'default' display or a custom display).
+      $view->setDisplay('default');
+
+      // Retrieve the 'keywords' parameter from the request, if it exists.
+      $keywords = $request->query->get('keywords');
+      if ($keywords) {
+        // If your view has a contextual filter for keywords, pass it here.
+        $view->setArguments([$keywords]);
+        $keywords_markup = Markup::create('<em>' . $this->t('@keywords', ['@keywords' => $keywords]) . '</em>');
+        $title = $this->t('Search results: @keywords', ['@keywords' => $keywords_markup]);
+      }
+      else {
+        $title = $this->t('Search');
+      }
+
+      // Execute the view and render it.
+      $view->preExecute();
+      $view->execute();
+
+      return [
+        '#title' => $title,
+        'view' => $view->render(),
+        '#cache' => [
+          'contexts' => ['url.query_args:keywords'],
+        ],
+      ];
+    }
+
+    return [
+      '#markup' => $this->t('No view available.'),
+    ];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/HeaderSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/HeaderSettingsForm.php
@@ -314,6 +314,18 @@ class HeaderSettingsForm extends ConfigFormBase {
       ],
     ];
 
+    $form['site_search_container']['enable_cas_search'] = [
+      '#type' => 'checkbox',
+      '#description' => $this->t('When enabled, anonymous users can see titles only of CAS-only content in search.'),
+      '#title' => $this->t('Enable CAS search'),
+      '#default_value' => $headerConfig->get('search.enable_cas_search'),
+      '#states' => [
+        'invisible' => [
+          ':input[name="enable_search_form"]' => ['checked' => FALSE],
+        ],
+      ],
+    ];
+
     $form['full_screen_homepage_image_container']['focus_header_image'] = [
       '#type' => 'media_library',
       '#allowed_bundles' => ['image'],
@@ -365,6 +377,7 @@ class HeaderSettingsForm extends ConfigFormBase {
     $headerConfig->set('cta_content', $form_state->getValue('cta_content'));
     $headerConfig->set('cta_url', $form_state->getValue('cta_url'));
     $headerConfig->set('search.enable_search_form', $form_state->getValue('enable_search_form'));
+    $headerConfig->set('search.enable_cas_search', $form_state->getValue('enable_cas_search'));
     $headerConfig->set('focus_header_image', $form_state->getValue('focus_header_image'));
 
     $headerConfig->save();

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/HeaderSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/HeaderSettingsForm.php
@@ -377,7 +377,12 @@ class HeaderSettingsForm extends ConfigFormBase {
     $headerConfig->set('cta_content', $form_state->getValue('cta_content'));
     $headerConfig->set('cta_url', $form_state->getValue('cta_url'));
     $headerConfig->set('search.enable_search_form', $form_state->getValue('enable_search_form'));
-    $headerConfig->set('search.enable_cas_search', $form_state->getValue('enable_cas_search'));
+    if ($form_state->getValue('enable_search_form') && $form_state->getValue('enable_cas_search')) {
+      $headerConfig->set('search.enable_cas_search', $form_state->getValue('enable_cas_search'));
+    }
+    else {
+      $headerConfig->set('search.enable_cas_search', 0);
+    }
     $headerConfig->set('focus_header_image', $form_state->getValue('focus_header_image'));
 
     $headerConfig->save();

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.routing.yml
@@ -50,6 +50,7 @@ ys_core.admin_views_settings:
 ys_core.search_page:
   path: '/search'
   defaults:
+    _title_callback: '\Drupal\ys_core\Controller\SearchController::getTitle'
     _controller: '\Drupal\ys_core\Controller\SearchController::searchPage'
   requirements:
-    _permission: 'TRUE'
+    _access: 'TRUE'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.routing.yml
@@ -46,3 +46,10 @@ ys_core.admin_views_settings:
     _title: 'Views Settings'
   requirements:
     _permission: 'yalesites manage settings'
+# Dynamic search page.
+ys_core.search_page:
+  path: '/search'
+  defaults:
+    _controller: '\Drupal\ys_core\Controller\SearchController::searchPage'
+  requirements:
+    _permission: 'TRUE'


### PR DESCRIPTION
## [IYY-263: Show CAS'd content in search results](https://app.clickup.com/t/36718269/IYY-263)

### Description of work
- Adds a new Search API index that searches CAS content by indexing the content as viewed by an authenticated user
- Adds a new view for showing CAS content
- Updates the header settings form to add a new option to show CAS titles only when searching. Default is off.
- Removes the `/search` path from the existing Search view
- Replaced with a custom route and controller to handle the `/search` path and only shows CAS content if set in the header settings form.
- Note: This requires Atomic [PR-284](https://github.com/yalesites-org/atomic/pull/284) as that is where the logic is to disable the rendering of the teaser and content preview of CAS nodes.
- A second FED part of this ticket will add a lock icon next to the CAS-only titles.

### Security Implications 
- All CAS content (rendered HTML default display) is still indexed in a new index (Node and CAS Index, machine name `secure_index`) but only the titles show (via TWIG).
- This is important because people can still search for all content inside a CAS page and get results for CAS-only content, but only see titles. We added a safety via the header settings form so sites will need to opt into this new feature but we want to be sure Yale ITS approves of this change before merge.

### Functional testing steps:
- [ ] Login to the site and add a few pages/posts/events/profiles with some content you can use to test searching. Content can go into layout builder and/or the teaser text.
- [ ] Use the search form and verify you can find your content.
- [ ] Edit one of the pages and change it to CAS Login Required and save the page.

![Screenshot 2024-11-19 at 4 56 56 PM](https://github.com/user-attachments/assets/3d5988ee-c517-41b8-9588-5eaba1838c87)

- [ ] Perform the search again and verify that the CAS-only content does not show up in the results.

![Screenshot 2024-11-19 at 4 54 43 PM](https://github.com/user-attachments/assets/2b7669db-c78f-4e2d-94ee-be1c48da17c3)

- [ ] Visit the Header Settings form at `/admin/yalesites/header`
- [ ] Verify there is a new setting under "Site Search" for "Enable CAS search". Note, this only shows up when "Enable search form" is enabled.

![Screenshot 2024-11-19 at 4 58 49 PM](https://github.com/user-attachments/assets/e6459be0-51f2-4598-a553-af983fbd716d)

- [ ] Enable CAS search and then perform the same search again and verify that search results now include CAS-only nodes, but that those results only show a title

![Screenshot 2024-11-19 at 5 00 09 PM](https://github.com/user-attachments/assets/ae4ea5a1-1f05-491e-90c5-c57e5594fdf1)

- [ ] Verify that clicking on the CAS-only title will prompt you to login
