### PR TITLE
Update drupal core to 10.3.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
   "require": {
     "composer/installers": "^1.9",
     "cweagans/composer-patches": "^1.7",
-    "drupal/core-composer-scaffold": "10.3.8",
-    "drupal/core-project-message": "10.3.8",
-    "drupal/core-recommended": "10.3.8",
+    "drupal/core-composer-scaffold": "10.3.9",
+    "drupal/core-project-message": "10.3.9",
+    "drupal/core-recommended": "10.3.9",
     "drush/drush": "^11 || ^12",
     "oomphinc/composer-installers-extender": "^2.0",
     "pantheon-systems/drupal-integrations": "^10",


### PR DESCRIPTION
### Description of work
- Update Drupal core to [10.3.9](https://www.drupal.org/project/drupal/releases/10.3.9)