### PR TITLE
YSP-751: Add field_metatags to document media type

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.default.yml
@@ -4,11 +4,13 @@ status: true
 dependencies:
   config:
     - field.field.media.document.field_media_file
+    - field.field.media.document.field_metatags
     - field.field.media.document.field_tags
     - media.type.document
   module:
     - chosen_field
     - file
+    - metatag
 id: media.document.default
 targetEntityType: media
 bundle: document
@@ -20,6 +22,14 @@ content:
     region: content
     settings:
       progress_indicator: throbber
+    third_party_settings: {  }
+  field_metatags:
+    type: metatag_firehose
+    weight: 3
+    region: content
+    settings:
+      sidebar: true
+      use_details: true
     third_party_settings: {  }
   field_tags:
     type: chosen_select

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.media_library.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.media_library.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_form_mode.media.media_library
     - field.field.media.document.field_media_file
+    - field.field.media.document.field_metatags
     - field.field.media.document.field_tags
     - media.type.document
   module:
@@ -38,6 +39,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_metatags: true
   path: true
   revision_log_message: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.media.document.field_media_file
+    - field.field.media.document.field_metatags
     - field.field.media.document.field_tags
     - media.type.document
   module:
@@ -22,6 +23,7 @@ content:
     region: content
 hidden:
   created: true
+  field_metatags: true
   field_tags: true
   name: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.media_library.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.media_library.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.media.media_library
     - field.field.media.document.field_media_file
+    - field.field.media.document.field_metatags
     - field.field.media.document.field_tags
     - image.style.media_library
     - media.type.document
@@ -29,6 +30,7 @@ content:
 hidden:
   created: true
   field_media_file: true
+  field_metatags: true
   field_tags: true
   name: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.media.document.field_metatags.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.media.document.field_metatags.yml
@@ -1,0 +1,21 @@
+uuid: 83050099-3d5e-4a57-8fd7-2de03f19c507
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_metatags
+    - media.type.document
+  module:
+    - metatag
+id: media.document.field_metatags
+field_name: field_metatags
+entity_type: media
+bundle: document
+label: Metadata
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.media.field_metatags.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.media.field_metatags.yml
@@ -1,0 +1,19 @@
+uuid: 4511fa41-c7dd-4923-a83f-46385be53ecc
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - metatag
+id: media.field_metatags
+field_name: field_metatags
+entity_type: media
+type: metatag
+settings: {  }
+module: metatag
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## [YSP-751: Add field_metatags to document media type](https://yaleits.atlassian.net/browse/YSP-751)

This will allow us to use ai_engine on documents as we do with nodes.

### Description of work
- Adds `field_metatags` to the document media type

### Functional testing steps:
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
