### PR TITLE
Hotfix: Update LocalistJson function signature

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -108,7 +108,7 @@
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
     "yalesites-org/ai_engine": "1.2.6",
-    "yalesites-org/atomic": "1.39.1",
+    "yalesites-org/atomic": "1.39.2",
     "yalesites-org/yale_cas": "v1.0.5"
   },
   "minimum-stability": "dev",

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -107,7 +107,7 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
-    "yalesites-org/ai_engine": "1.2.6",
+    "yalesites-org/ai_engine": "1.2.7",
     "yalesites-org/atomic": "1.39.2",
     "yalesites-org/yale_cas": "v1.0.5"
   },

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.default.yml
@@ -4,11 +4,13 @@ status: true
 dependencies:
   config:
     - field.field.media.document.field_media_file
+    - field.field.media.document.field_metatags
     - field.field.media.document.field_tags
     - media.type.document
   module:
     - chosen_field
     - file
+    - metatag
 id: media.document.default
 targetEntityType: media
 bundle: document
@@ -20,6 +22,14 @@ content:
     region: content
     settings:
       progress_indicator: throbber
+    third_party_settings: {  }
+  field_metatags:
+    type: metatag_firehose
+    weight: 3
+    region: content
+    settings:
+      sidebar: true
+      use_details: true
     third_party_settings: {  }
   field_tags:
     type: chosen_select

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.media_library.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.media.document.media_library.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_form_mode.media.media_library
     - field.field.media.document.field_media_file
+    - field.field.media.document.field_metatags
     - field.field.media.document.field_tags
     - media.type.document
   module:
@@ -38,6 +39,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_metatags: true
   path: true
   revision_log_message: true
   status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.media.document.field_media_file
+    - field.field.media.document.field_metatags
     - field.field.media.document.field_tags
     - media.type.document
   module:
@@ -22,6 +23,7 @@ content:
     region: content
 hidden:
   created: true
+  field_metatags: true
   field_tags: true
   name: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.media_library.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.document.media_library.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.media.media_library
     - field.field.media.document.field_media_file
+    - field.field.media.document.field_metatags
     - field.field.media.document.field_tags
     - image.style.media_library
     - media.type.document
@@ -29,6 +30,7 @@ content:
 hidden:
   created: true
   field_media_file: true
+  field_metatags: true
   field_tags: true
   name: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.media.document.field_metatags.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.media.document.field_metatags.yml
@@ -1,0 +1,21 @@
+uuid: 3c7d1cca-b0b1-4ee7-886b-ad6fa0400e92
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_metatags
+    - media.type.document
+  module:
+    - metatag
+id: media.document.field_metatags
+field_name: field_metatags
+entity_type: media
+bundle: document
+label: Metadata
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.media.field_metatags.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.media.field_metatags.yml
@@ -1,0 +1,19 @@
+uuid: 241ba697-d6b1-4a31-88e4-a696c1aee334
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - metatag
+id: media.field_metatags
+field_name: field_metatags
+entity_type: media
+type: metatag
+settings: {  }
+module: metatag
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/metatag.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/metatag.settings.yml
@@ -1,4 +1,7 @@
 entity_type_groups:
+  media:
+    document:
+      ai_engine: ai_engine
   node:
     event:
       basic: basic
@@ -7,12 +10,14 @@ entity_type_groups:
     post:
       basic: basic
       open_graph: open_graph
+separator: ','
 tag_trim_method: beforeValue
+use_maxlength: true
 tag_trim_maxlength:
-  metatag_maxlength_abstract: null
-  metatag_maxlength_description: null
   metatag_maxlength_title: null
-  metatag_maxlength_og_description: null
+  metatag_maxlength_description: null
+  metatag_maxlength_abstract: null
   metatag_maxlength_og_site_name: null
   metatag_maxlength_og_title: null
+  metatag_maxlength_og_description: null
 tag_scroll_max_height: ''

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/Plugin/migrate_plus/data_parser/LocalistJson.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/Plugin/migrate_plus/data_parser/LocalistJson.php
@@ -28,6 +28,9 @@ class LocalistJson extends Json implements ContainerFactoryPluginInterface, Data
    *
    * @param string $url
    *   URL of a JSON feed.
+   * @param string|int $item_selector
+   *   (optional) If the JSON data is nested, this is a selector to the
+   *   specific data. Does nothing here.
    *
    * @throws \GuzzleHttp\Exception\RequestException
    */

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/Plugin/migrate_plus/data_parser/LocalistJson.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/Plugin/migrate_plus/data_parser/LocalistJson.php
@@ -31,7 +31,7 @@ class LocalistJson extends Json implements ContainerFactoryPluginInterface, Data
    *
    * @throws \GuzzleHttp\Exception\RequestException
    */
-  protected function getSourceData(string $url): array {
+  protected function getSourceData(string $url, string|int $item_selector = ''): array {
     $response = $this->getDataFetcherPlugin()->getResponseContent($url);
     // Convert objects to associative arrays.
     $source_data = json_decode($response, TRUE, 512, JSON_THROW_ON_ERROR);


### PR DESCRIPTION
## Update LocalistJson function signature

There was a function signature that had changed, causing our existing LocalistJson parser to fail.  This places the signature in line with the subclass function definition.

References: https://www.drupal.org/project/migrate_plus/issues/3462520

### Description of work
- Updates the function signature to match it's parent class's
- Add `field_metatags` to document media type
- Bump Atomic to 1.39.2
- Bump AI engine to 1.2.7

### Functional testing steps:
- [ ] Visit [Localist Settings](https://pr-805-yalesites-platform.pantheonsite.io/admin/yalesites/localist)
- [ ] Click `Sync now`
- [ ] Ensure no errors occur
- [ ] Check in Content that you see events that would come from Localist