### PR TITLE
YSP-293: Log out of CAS when logging out of drupal

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/cas.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/cas.settings.yml
@@ -48,8 +48,8 @@ error_handling:
   message_prevent_normal_login: 'This account must log in using <a href="[cas:login-url]">CAS</a>.'
   message_restrict_password_management: 'The requested account is associated with CAS and its password cannot be managed from this website.'
 logout:
-  cas_logout: false
-  logout_destination: ''
+  cas_logout: true
+  logout_destination: /
   enable_single_logout: false
   single_logout_session_lifetime: 25
 proxy:


### PR DESCRIPTION
## [YSP-293: Log out of CAS when logging out of drupal](https://yaleits.atlassian.net/browse/YSP-293)

> When logging out of Drupal, if the home page is CAS-protected, the user is automatically logged back in because they still have a valid CAS session. This causes confusion because the redirection happens quickly and it appears the user is never logged out, even though they are.

### Description of work
- Sets config to log out of CAS when logging out of Drupal
- Returns user back to home page after logout instead of CAS Server default (www.yale.edu)

### Functional testing steps:
- [ ] Log into the site with CAS
- [ ] Log out of Drupal
- [ ] Verify you are taken to the home page
- [ ] Log back into the site and verify you are prompted to re-login to CAS (new session since old CAS session was killed with Drupal logout)
