### PR TITLE
IYY-266: Ensure Microsoft BI embeds work

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Controller/EmbedInstructionsController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Controller/EmbedInstructionsController.php
@@ -6,6 +6,7 @@ use Drupal\Component\Utility\Html;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\OpenDialogCommand;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Render\Markup;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\ys_embed\Plugin\EmbedSourceManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -81,14 +82,14 @@ class EmbedInstructionsController extends ControllerBase {
     $sources = [];
     foreach ($this->embedManager->getSources() as $id => $source) {
       $sources[$id]['name'] = $source['label'];
-      $sources[$id]['instructions'] = $source['class']::getInstructions();
+      $sources[$id]['instructions'] = Markup::create($source['class']::getInstructions());
       $sources[$id]['example'] = [
         '#open' => FALSE,
         '#type' => 'details',
         '#title' => 'Example',
       ];
       $sources[$id]['example']['code'] = [
-        '#markup' => Html::escape($source['class']::getExample()),
+        '#markup' => $source['class']::exampleContainsMarkup() ? Markup::create($source['class']::getExample()) : Html::escape($source['class']::getExample()),
       ];
     }
     $content = [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/PowerBI.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/PowerBI.php
@@ -45,7 +45,7 @@ class PowerBI extends EmbedSourceBase implements EmbedSourceInterface {
    */
   protected static $example = '
   <p>
-    <strong>Public:</strong> https://app.powerbi.com/view?r=eyJrIjoiYzhkODFiMDUtZGU3Zi00ZDAzLWJlYTEtZmM1Mjg3MzMzZGE3IiwidCI6ImRkOGNiZWJiLTIxMzktNGRmOC1iNDExLTRlM2U4N2FiZWI1YyIsImMiOjF9
+    <strong>Public:</strong> https://app.powerbi.com/view?r=eyJrIjoiYzQ1ODA0ZjEtZjc5YS00OTgyLWIzOTItNmJmNDY2YmRiODQ2IiwidCI6ImRkOGNiZWJiLTIxMzktNGRmOC1iNDExLTRlM2U4N2FiZWI1YyIsImMiOjF9&pageName=ReportSection2ac2649f17189885d376
   </p>
   <p>
     <strong>Private:</strong> https://app.powerbi.com/reportEmbed?reportId=66e25bd6-5e0a-4db8-ad0c-28bb31b0fd5e&autoAuth=true&ctid=dd8cbebb-2139-4df8-b411-4e3e87abeb5c

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/PowerBI.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/PowerBI.php
@@ -21,12 +21,12 @@ class PowerBI extends EmbedSourceBase implements EmbedSourceInterface {
   /**
    * {@inheritdoc}
    */
-  protected static $pattern = '/^https:\/\/app.powerbi.com\/(?<form_params>.+)/';
+  protected static $pattern = '/^https:\/\/app.powerbi.com\/(?<type>view|reportEmbed)(?<query_params>\?.+)/';
 
   /**
    * {@inheritdoc}
    */
-  protected static $template = '<iframe class="iframe" title="{{ title }}" src="https://app.powerbi.com/{{ form_params }}" height="100%" width="100%" loading="lazy"></iframe>';
+  protected static $template = '<iframe class="iframe" title="{{ title }}" src="https://app.powerbi.com/{{ type }}{{ query_params }}" height="100%" width="100%" loading="lazy"></iframe>';
 
   /**
    * {@inheritdoc}
@@ -36,7 +36,7 @@ class PowerBI extends EmbedSourceBase implements EmbedSourceInterface {
   /**
    * {@inheritdoc}
    */
-  protected static $example = 'https://app.powerbi.com/view?r=eyJrIjoiYzQ1ODA0ZjEtZjc5YS00OTgyLWIzOTItNmJmNDY2YmRiODQ2IiwidCI6ImRkOGNiZWJiLTIxMzktNGRmOC1iNDExLTRlM2U4N2FiZWI1YyIsImMiOjF9&pageName=ReportSection2ac2649f17189885d376';
+  protected static $example = 'https://app.powerbi.com/reportEmbed?reportId=66e25bd6-5e0a-4db8-ad0c-28bb31b0fd5e&autoAuth=true&ctid=dd8cbebb-2139-4df8-b411-4e3e87abeb5c';
 
   /**
    * {@inheritdoc}
@@ -54,8 +54,9 @@ class PowerBI extends EmbedSourceBase implements EmbedSourceInterface {
    * {@inheritdoc}
    */
   public function getUrl(array $params): string {
-    $form_params = $params['form_params'];
-    return 'https://app.powerbi.com/' . $form_params;
+    $type = $params['type'];
+    $query_params = $params['query_params'];
+    return 'https://app.powerbi.com/' . $type . $query_params;
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/PowerBI.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/PowerBI.php
@@ -21,12 +21,12 @@ class PowerBI extends EmbedSourceBase implements EmbedSourceInterface {
   /**
    * {@inheritdoc}
    */
-  protected static $pattern = '/^https:\/\/app.powerbi.com\/view(?<form_params>.+)/';
+  protected static $pattern = '/^https:\/\/app.powerbi.com\/(?<form_params>.+)/';
 
   /**
    * {@inheritdoc}
    */
-  protected static $template = '<iframe class="iframe" title="{{ title }}" src="https://app.powerbi.com/view{{ form_params }}" height="100%" width="100%" loading="lazy"></iframe>';
+  protected static $template = '<iframe class="iframe" title="{{ title }}" src="https://app.powerbi.com/{{ form_params }}" height="100%" width="100%" loading="lazy"></iframe>';
 
   /**
    * {@inheritdoc}
@@ -55,7 +55,7 @@ class PowerBI extends EmbedSourceBase implements EmbedSourceInterface {
    */
   public function getUrl(array $params): string {
     $form_params = $params['form_params'];
-    return 'https://app.powerbi.com/view' . $form_params;
+    return 'https://app.powerbi.com/' . $form_params;
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/PowerBI.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/PowerBI.php
@@ -31,12 +31,31 @@ class PowerBI extends EmbedSourceBase implements EmbedSourceInterface {
   /**
    * {@inheritdoc}
    */
-  protected static $instructions = 'Open a report in the Power BI service. On the File menu, select Embed report > Website or portal. In the Secure embed code dialog, select the value under "Here\'s a link you can use to embed this content."';
+  protected static $instructions = '
+    <p>
+      For a Public Report: Open a report in the Power BI service. On the File menu, select Embed report > Publish to web (public). In the Embed Code dialog, select the value under "Link you can send in email".
+    </p>
+    <p>
+      For a Private (login required) Report: Open a report in the Power BI service. On the File menu, select Embed report > Website or portal. In the Secure embed code dialog, select the value under "Here\'s a link you can use to embed this content."
+    </p>
+    ';
 
   /**
    * {@inheritdoc}
    */
-  protected static $example = 'https://app.powerbi.com/reportEmbed?reportId=66e25bd6-5e0a-4db8-ad0c-28bb31b0fd5e&autoAuth=true&ctid=dd8cbebb-2139-4df8-b411-4e3e87abeb5c';
+  protected static $example = '
+  <p>
+    <strong>Public:</strong> https://app.powerbi.com/view?r=eyJrIjoiYzhkODFiMDUtZGU3Zi00ZDAzLWJlYTEtZmM1Mjg3MzMzZGE3IiwidCI6ImRkOGNiZWJiLTIxMzktNGRmOC1iNDExLTRlM2U4N2FiZWI1YyIsImMiOjF9
+  </p>
+  <p>
+    <strong>Private:</strong> https://app.powerbi.com/reportEmbed?reportId=66e25bd6-5e0a-4db8-ad0c-28bb31b0fd5e&autoAuth=true&ctid=dd8cbebb-2139-4df8-b411-4e3e87abeb5c
+  </p>
+  ';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $exampleContainsMarkup = TRUE;
 
   /**
    * {@inheritdoc}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSourceBase.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSourceBase.php
@@ -59,6 +59,13 @@ abstract class EmbedSourceBase extends PluginBase implements EmbedSourceInterfac
   protected static $example;
 
   /**
+   * Does the example contain markup. Defaults to false.
+   *
+   * @var bool
+   */
+  protected static $exampleContainsMarkup = FALSE;
+
+  /**
    * An array of attributes to add to the template.
    *
    * To support previous implementations, embed_type is set to 'form'.
@@ -143,6 +150,13 @@ abstract class EmbedSourceBase extends PluginBase implements EmbedSourceInterfac
    */
   public static function getExample(): string {
     return static::$example;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function exampleContainsMarkup(): bool {
+    return static::$exampleContainsMarkup;
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSourceInterface.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSourceInterface.php
@@ -56,6 +56,14 @@ interface EmbedSourceInterface extends PluginInspectionInterface {
   public static function getExample(): string;
 
   /**
+   * Does the example contain markup that should not be escaped.
+   *
+   * @return bool
+   *   If the example contains markup.
+   */
+  public static function exampleContainsMarkup(): bool;
+
+  /**
    * Get a render array for an embed code.
    *
    * @param array $params

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/templates/embed-instructions.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/templates/embed-instructions.html.twig
@@ -8,6 +8,6 @@
 
 {% for source in sources %}
   <h2>{{ source.name }}</h2>
-  <p>{{ source.instructions }}</p>
+  {{ source.instructions }}
   {{ source.example }}
 {% endfor %}


### PR DESCRIPTION
## [IYY-266: Ensure Microsoft BI embeds work](https://app.clickup.com/t/36718269/IYY-266)

### Description of work
- Updates the Microsoft Power BI embed to allow for two different kinds of URLs (`/view` and `/reportEmbed`)
- Note - I think it should be fine, but, I would like to test this code on an existing site that has Microsoft Power BI embeds already being used. If anyone knows an existing site, please link it here and I will test that as well.

### Functional testing steps:
- [ ] Login to the site as an admin
- [ ] Add a page, title it, and save to enter layout builder
- [ ] Add a block in the content section
- [ ] Add an Embed block
- [ ] Click "Add media"
- [ ] Under the "Embed Code or URL", click on the "Learn about supported formats and options"
- [ ] Copy the URL from the Microsoft PowerBI example
- [ ] Close the modal
- [ ] Paste the URL into the "Embed Code or URL"

![Screenshot 2024-11-26 at 2 07 31 PM](https://github.com/user-attachments/assets/4d24ba6d-febe-406e-b5fd-d6c410ad6d1f)

- [ ] Click Add
- [ ] Verify that the logo is the Power BI logo and there are no errors in adding the newly formatted URL

![Screenshot 2024-11-26 at 2 07 58 PM](https://github.com/user-attachments/assets/7e99bea5-7fd9-478b-b5dd-eabd47c25735)

- [ ] Title it and then save
- [ ] Click "Insert"
- [ ] Click "Add block"
- [ ] Scroll down on Layout builder and verify that the Power BI block does load, though it will ask you to sign in
- [ ] Repeat the above steps but instead, use the older URL format: `https://app.powerbi.com/view?r=eyJrIjoiYzQ1ODA0ZjEtZjc5YS00OTgyLWIzOTItNmJmNDY2YmRiODQ2IiwidCI6ImRkOGNiZWJiLTIxMzktNGRmOC1iNDExLTRlM2U4N2FiZWI1YyIsImMiOjF9&pageName=ReportSection2ac2649f17189885d376`
- [ ] Verify that it works as well as the new format