### PR TITLE
YSP-691: YPS: Posts Source Field

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.post.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.post.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -26,6 +27,7 @@ dependencies:
     - metatag
     - path
     - text
+    - workflow_buttons
 third_party_settings:
   field_group:
     group_teaser:
@@ -64,6 +66,7 @@ third_party_settings:
     group_external_link:
       children:
         - field_external_source
+        - field_external_source_label
       label: 'External Link'
       region: content
       parent_name: ''
@@ -103,6 +106,14 @@ content:
     settings:
       placeholder_url: ''
       placeholder_title: ''
+    third_party_settings: {  }
+  field_external_source_label:
+    type: string_textfield
+    weight: 6
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_login_required:
     type: boolean_checkbox
@@ -160,6 +171,13 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  moderation_state:
+    type: workflow_buttons
+    weight: 5
+    region: content
+    settings:
+      show_current_state: false
     third_party_settings: {  }
   path:
     type: path

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.card.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.card.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -84,6 +85,7 @@ content:
     region: content
 hidden:
   field_author: true
+  field_external_source_label: true
   field_login_required: true
   field_metatags: true
   field_publish_date: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.card.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.card.yml
@@ -37,7 +37,7 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 6
+    weight: 7
     region: content
   field_external_source:
     type: link_separate
@@ -51,13 +51,21 @@ content:
     third_party_settings: {  }
     weight: 4
     region: content
+  field_external_source_label:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 5
+    region: content
   field_tags:
     type: entity_reference_label
     label: hidden
     settings:
       link: false
     third_party_settings: {  }
-    weight: 5
+    weight: 6
     region: content
   field_teaser_media:
     type: entity_reference_entity_view
@@ -85,7 +93,6 @@ content:
     region: content
 hidden:
   field_author: true
-  field_external_source_label: true
   field_login_required: true
   field_metatags: true
   field_publish_date: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.condensed.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.condensed.yml
@@ -57,7 +57,7 @@ content:
   content_moderation_control:
     settings: {  }
     third_party_settings: {  }
-    weight: -20
+    weight: 0
     region: content
   field_external_source:
     type: link_separate
@@ -71,6 +71,14 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  field_external_source_label:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
   field_publish_date:
     type: datetime_default
     label: hidden
@@ -78,12 +86,11 @@ content:
       timezone_override: ''
       format_type: medium
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
 hidden:
   field_author: true
   field_category: true
-  field_external_source_label: true
   field_login_required: true
   field_metatags: true
   field_tags: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.condensed.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.condensed.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -53,6 +54,11 @@ targetEntityType: node
 bundle: post
 mode: condensed
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   field_external_source:
     type: link_separate
     label: hidden
@@ -77,6 +83,7 @@ content:
 hidden:
   field_author: true
   field_category: true
+  field_external_source_label: true
   field_login_required: true
   field_metatags: true
   field_tags: true
@@ -86,3 +93,4 @@ hidden:
   layout_builder__layout: true
   links: true
   search_api_excerpt: true
+  workflow_buttons: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
@@ -55,22 +55,6 @@ third_party_settings:
                 entity: layout_builder.entity
             weight: 1
             additional: {  }
-          4c357fc5-0d1f-4568-9927-91cf8b301f51:
-            uuid: 4c357fc5-0d1f-4568-9927-91cf8b301f51
-            region: content
-            configuration:
-              id: 'field_block:node:post:field_external_source_label'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: string
-                label: above
-                settings:
-                  link_to_entity: false
-                third_party_settings: {  }
-            weight: 2
-            additional: {  }
         third_party_settings:
           layout_builder_lock:
             lock:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -53,6 +54,22 @@ third_party_settings:
               context_mapping:
                 entity: layout_builder.entity
             weight: 1
+            additional: {  }
+          4c357fc5-0d1f-4568-9927-91cf8b301f51:
+            uuid: 4c357fc5-0d1f-4568-9927-91cf8b301f51
+            region: content
+            configuration:
+              id: 'field_block:node:post:field_external_source_label'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              formatter:
+                type: string
+                label: above
+                settings:
+                  link_to_entity: false
+                third_party_settings: {  }
+            weight: 2
             additional: {  }
         third_party_settings:
           layout_builder_lock:
@@ -134,6 +151,14 @@ content:
       target: ''
     third_party_settings: {  }
     weight: 2
+    region: content
+  field_external_source_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
     region: content
 hidden:
   field_login_required: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.list_item.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.list_item.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -84,6 +85,7 @@ content:
     region: content
 hidden:
   field_author: true
+  field_external_source_label: true
   field_login_required: true
   field_metatags: true
   field_publish_date: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.list_item.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.list_item.yml
@@ -37,7 +37,7 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 6
+    weight: 7
     region: content
   field_external_source:
     type: link_separate
@@ -51,13 +51,21 @@ content:
     third_party_settings: {  }
     weight: 4
     region: content
+  field_external_source_label:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 5
+    region: content
   field_tags:
     type: entity_reference_label
     label: hidden
     settings:
       link: false
     third_party_settings: {  }
-    weight: 5
+    weight: 6
     region: content
   field_teaser_media:
     type: entity_reference_entity_view
@@ -85,7 +93,6 @@ content:
     region: content
 hidden:
   field_author: true
-  field_external_source_label: true
   field_login_required: true
   field_metatags: true
   field_publish_date: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.search_result.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -67,6 +68,7 @@ content:
 hidden:
   field_author: true
   field_category: true
+  field_external_source_label: true
   field_metatags: true
   field_publish_date: true
   field_tags: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.single.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.single.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -52,6 +53,11 @@ targetEntityType: node
 bundle: post
 mode: single
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   field_external_source:
     type: link
     label: hidden
@@ -100,9 +106,11 @@ content:
 hidden:
   field_author: true
   field_category: true
+  field_external_source_label: true
   field_login_required: true
   field_metatags: true
   field_tags: true
   layout_builder__layout: true
   links: true
   search_api_excerpt: true
+  workflow_buttons: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.teaser.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -23,6 +24,11 @@ targetEntityType: node
 bundle: post
 mode: teaser
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
@@ -32,6 +38,7 @@ hidden:
   field_author: true
   field_category: true
   field_external_source: true
+  field_external_source_label: true
   field_login_required: true
   field_metatags: true
   field_publish_date: true
@@ -41,3 +48,4 @@ hidden:
   field_teaser_title: true
   layout_builder__layout: true
   search_api_excerpt: true
+  workflow_buttons: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_external_source_label.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_external_source_label.yml
@@ -1,0 +1,19 @@
+uuid: d690a148-c4b3-4b0b-b0f4-6826c29bd6cf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_external_source_label
+    - node.type.post
+id: node.post.field_external_source_label
+field_name: field_external_source_label
+entity_type: node
+bundle: post
+label: 'Post Source'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_external_source_label.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_external_source_label.yml
@@ -1,0 +1,21 @@
+uuid: 2e6aed08-96bf-485a-81e8-bd80018eb87a
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_external_source_label
+field_name: field_external_source_label
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## [YSP-691: YPS: Posts Source Field](https://yaleits.atlassian.net/browse/YSP-691)

### Description of work
- Adds `Post Source` to Post's External Link sidebar
- [Atomic work](https://github.com/yalesites-org/atomic/pull/288)
- [Component Library Twig work](https://github.com/yalesites-org/component-library-twig/pull/444)

### Functional testing steps:
- [ ] [Login via CAS](https://yalesites-platform.lndo.site/cas)
- [ ] [Add a new post](https://yalesites-platform.lndo.site/node/add/post)
- [ ] Expand `External Link` on the right sidebar of the new post
- [ ] Verify that `Post Source` exists
- [ ] Set it to a value
- [ ] Save
- [ ] Edit the post again
- [ ] Ensure it was saved and still appears
