### PR TITLE
fix: remove duplicative dependencies from require-dev stanza

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,15 +36,7 @@
     "yalesites-org/yalesites_profile": "*"
   },
   "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
-    "drupal/coder": "^8.3",
-    "drupal/core-dev": "^10",
-    "drupal/drupal-driver": "^2.1",
-    "drupal/drupal-extension": "^5.0",
-    "mikey179/vfsstream": "^1.6",
-    "phpspec/prophecy-phpunit": "^2",
-    "phpunit/phpunit": "^9.5",
-    "squizlabs/php_codesniffer": "^3.6"
+    "drupal/core-dev": "^10"
   },
   "conflict": {
     "drupal/drupal": "*"


### PR DESCRIPTION
### Description of work
We are running into an issue where`slevomat/coding-standard:dev-master` is being installed instead of the 8.15.0 release version as defined. The root cause is hard to track down, but stripping down our `require-dev` stanza in root composer.json to just contain `drupal/core-dev` fixes the issue.

All dependencies being removed are installed as part of `drupal/core-dev`, except for the below packages, which we are not using:
- `drupal/drupal-driver`
- `drupal/drupal-extension`

### Functional testing steps:
- [ ] Verify that `slevomat/coding-standard:8.15.0` is installed, not `dev-master`
