### PR TITLE
fix: only run release_pr.yml workflow against release branch pattern, not master

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -5,7 +5,7 @@ on:
       - synchronize
       - closed
     branches:
-      - master
+      - v[0-9]+
   workflow_dispatch:
 env:
   YALESITES_BUILD_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}


### PR DESCRIPTION
### Description of work
The release_pr.yml workflow is triggered manually using workflow_dispatch, and on pull request synchronize/closed activities. It is running unexpectedly against other pull requests to master, like hotfixes. Since it currently does not need to run automatically against pull requests to master since we create release PRs using workflow_dispatch, this change sets it to only run on pull requests matching the release branch naming pattern.