### PR TITLE
YSP-691: YPS: Posts Source Field

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.post.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.post.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -26,6 +27,7 @@ dependencies:
     - metatag
     - path
     - text
+    - workflow_buttons
 third_party_settings:
   field_group:
     group_teaser:
@@ -36,7 +38,7 @@ third_party_settings:
       label: Teaser
       region: content
       parent_name: ''
-      weight: 6
+      weight: 7
       format_type: fieldset
       format_settings:
         classes: ''
@@ -51,7 +53,7 @@ third_party_settings:
       label: 'Publishing Settings'
       region: content
       parent_name: ''
-      weight: 10
+      weight: 11
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -64,10 +66,11 @@ third_party_settings:
     group_external_link:
       children:
         - field_external_source
+        - field_external_source_label
       label: 'External Link'
       region: content
       parent_name: ''
-      weight: 12
+      weight: 13
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -104,6 +107,12 @@ content:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
+  field_external_source_label:
+    type: chosen_select
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_login_required:
     type: boolean_checkbox
     weight: 12
@@ -113,7 +122,7 @@ content:
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 9
+    weight: 10
     region: content
     settings:
       sidebar: true
@@ -127,7 +136,7 @@ content:
     third_party_settings: {  }
   field_tags:
     type: chosen_select
-    weight: 4
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -161,20 +170,27 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  moderation_state:
+    type: workflow_buttons
+    weight: 6
+    region: content
+    settings:
+      show_current_state: false
+    third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   simple_sitemap:
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 11
+    weight: 12
     region: content
     settings:
       display_label: true
@@ -195,7 +211,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.taxonomy_term.sources.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.taxonomy_term.sources.default.yml
@@ -1,0 +1,73 @@
+uuid: 3b7b5b1e-a2e2-4f5e-93a6-375416a4e850
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.sources.field_link
+    - taxonomy.vocabulary.sources
+  module:
+    - hide_revision_field
+    - link
+    - path
+    - text
+id: taxonomy_term.sources.default
+targetEntityType: taxonomy_term
+bundle: sources
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_link:
+    type: link_default
+    weight: 1
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  revision_log_message:
+    type: hide_revision_field_log_widget
+    weight: 5
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+      show: true
+      default: ''
+      permission_based: false
+      allow_user_settings: true
+      hide_revision: false
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.card.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.card.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -84,6 +85,7 @@ content:
     region: content
 hidden:
   field_author: true
+  field_external_source_label: true
   field_login_required: true
   field_metatags: true
   field_publish_date: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.condensed.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.condensed.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -53,6 +54,11 @@ targetEntityType: node
 bundle: post
 mode: condensed
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   field_external_source:
     type: link_separate
     label: hidden
@@ -77,6 +83,7 @@ content:
 hidden:
   field_author: true
   field_category: true
+  field_external_source_label: true
   field_login_required: true
   field_metatags: true
   field_tags: true
@@ -86,3 +93,4 @@ hidden:
   layout_builder__layout: true
   links: true
   search_api_excerpt: true
+  workflow_buttons: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -134,6 +135,14 @@ content:
       target: ''
     third_party_settings: {  }
     weight: 2
+    region: content
+  field_external_source_label:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 3
     region: content
 hidden:
   field_login_required: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.list_item.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.list_item.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -84,6 +85,7 @@ content:
     region: content
 hidden:
   field_author: true
+  field_external_source_label: true
   field_login_required: true
   field_metatags: true
   field_publish_date: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.search_result.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -67,6 +68,7 @@ content:
 hidden:
   field_author: true
   field_category: true
+  field_external_source_label: true
   field_metatags: true
   field_publish_date: true
   field_tags: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.single.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.single.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -52,6 +53,11 @@ targetEntityType: node
 bundle: post
 mode: single
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   field_external_source:
     type: link
     label: hidden
@@ -100,9 +106,11 @@ content:
 hidden:
   field_author: true
   field_category: true
+  field_external_source_label: true
   field_login_required: true
   field_metatags: true
   field_tags: true
   layout_builder__layout: true
   links: true
   search_api_excerpt: true
+  workflow_buttons: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.teaser.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.post.field_author
     - field.field.node.post.field_category
     - field.field.node.post.field_external_source
+    - field.field.node.post.field_external_source_label
     - field.field.node.post.field_login_required
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
@@ -23,6 +24,11 @@ targetEntityType: node
 bundle: post
 mode: teaser
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
@@ -32,6 +38,7 @@ hidden:
   field_author: true
   field_category: true
   field_external_source: true
+  field_external_source_label: true
   field_login_required: true
   field_metatags: true
   field_publish_date: true
@@ -41,3 +48,4 @@ hidden:
   field_teaser_title: true
   layout_builder__layout: true
   search_api_excerpt: true
+  workflow_buttons: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.taxonomy_term.sources.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.taxonomy_term.sources.default.yml
@@ -1,0 +1,36 @@
+uuid: 7220ec28-c9e6-4e99-bc3b-2499f434d0d2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.sources.field_link
+    - taxonomy.vocabulary.sources
+  module:
+    - link
+    - text
+id: taxonomy_term.sources.default
+targetEntityType: taxonomy_term
+bundle: sources
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_link:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_external_source_label.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_external_source_label.yml
@@ -1,0 +1,29 @@
+uuid: a20a36e7-ccc0-40a2-a471-0dfe67a9f5df
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_external_source_label
+    - node.type.post
+    - taxonomy.vocabulary.sources
+id: node.post.field_external_source_label
+field_name: field_external_source_label
+entity_type: node
+bundle: post
+label: 'External Source Label'
+description: 'If an external source is used, you may link it to an overall source to show where it came from.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      sources: sources
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.taxonomy_term.sources.field_link.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.taxonomy_term.sources.field_link.yml
@@ -1,0 +1,23 @@
+uuid: 32eb4c2e-7651-4007-b45b-d25346c1e975
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_link
+    - taxonomy.vocabulary.sources
+  module:
+    - link
+id: taxonomy_term.sources.field_link
+field_name: field_link
+entity_type: taxonomy_term
+bundle: sources
+label: Link
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 0
+  link_type: 16
+field_type: link

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_external_source_label.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_external_source_label.yml
@@ -1,0 +1,20 @@
+uuid: 02fa88d3-c96d-4506-9e93-2cd2b210684e
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_external_source_label
+field_name: field_external_source_label
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.taxonomy_term.field_link.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.taxonomy_term.field_link.yml
@@ -1,0 +1,19 @@
+uuid: 9e46dd61-bf7e-4804-a90b-44fcaa7b183e
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - taxonomy
+id: taxonomy_term.field_link
+field_name: field_link
+entity_type: taxonomy_term
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.sources.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/taxonomy.vocabulary.sources.yml
@@ -1,0 +1,34 @@
+uuid: c2e700fc-632f-414a-8ad1-80f4ce297416
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_redirect
+third_party_settings:
+  entity_redirect:
+    redirect:
+      anonymous:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+      add:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+      edit:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+      delete:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+name: Sources
+vid: sources
+description: 'External source names and URLs'
+weight: 0
+new_revision: false

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
@@ -111,6 +111,13 @@ ys_core.taxonomy_interface_tags:
   title: Tags
   route_parameters:
     taxonomy_vocabulary: "tags"
+ys_core.taxonomy_interface_sources:
+  description: "Manage post sources taxonomy"
+  parent: ys_core.taxonomy_interface
+  route_name: entity.taxonomy_vocabulary.overview_form
+  title: Post Sources
+  route_parameters:
+    taxonomy_vocabulary: "sources"
 # Blocks interface
 ys_core.custom_block_library:
   description: "Manage reusable blocks"

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PostMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PostMetaBlock.php
@@ -81,13 +81,13 @@ class PostMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('current_route_match'),
-      $container->get('title_resolver'),
-      $container->get('request_stack'),
-      $container->get('date.formatter'),
+    $configuration,
+    $plugin_id,
+    $plugin_definition,
+    $container->get('current_route_match'),
+    $container->get('title_resolver'),
+    $container->get('request_stack'),
+    $container->get('date.formatter'),
     );
   }
 
@@ -106,6 +106,8 @@ class PostMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
     $author = NULL;
     $publishDate = NULL;
     $dateFormatted = NULL;
+    $externalSourceLabel = NULL;
+    $externalSourceLabelUrl = NULL;
 
     $route = $this->routeMatch->getRouteObject();
 
@@ -115,6 +117,14 @@ class PostMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
       $author = ($node->field_author->first()) ? $node->field_author->first()->getValue()['value'] : NULL;
       $publishDate = strtotime($node->field_publish_date->first()->getValue()['value']);
       $dateFormatted = $this->dateFormatter->format($publishDate, '', 'c');
+      $taxId = ($node->field_external_source_label->first()) ? $node->field_external_source_label->first()->getValue()['target_id'] : NULL;
+      if ($taxId) {
+        $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($taxId);
+        if ($term) {
+          $externalSourceLabel = $term->getName();
+          $externalSourceLabelUrl = $term->field_link->first()->getValue()['uri'];
+        }
+      }
     }
 
     return [
@@ -122,6 +132,8 @@ class PostMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
       '#label' => $title,
       '#author' => $author,
       '#date_formatted' => $dateFormatted,
+      '#external_source_label' => $externalSourceLabel,
+      '#external_source_label_url' => $externalSourceLabelUrl,
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PostMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PostMetaBlock.php
@@ -122,7 +122,10 @@ class PostMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
         $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($taxId);
         if ($term) {
           $externalSourceLabel = $term->getName();
-          $externalSourceLabelUrl = $term->field_link->first()->getValue()['uri'];
+          $externalSourceLabelUrlField = $term->field_link->first();
+          if ($externalSourceLabelUrlField) {
+            $externalSourceLabelUrl = $term->field_link->first()->getValue()['uri'];
+          }
         }
       }
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PostMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PostMetaBlock.php
@@ -5,6 +5,7 @@ namespace Drupal\ys_layouts\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Controller\TitleResolver;
 use Drupal\Core\Datetime\DateFormatter;
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\node\NodeInterface;
@@ -51,6 +52,13 @@ class PostMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
   protected $dateFormatter;
 
   /**
+   * The taxonomy term storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $taxonomyTermStorage;
+
+  /**
    * Constructs a new PostMetaBlock object.
    *
    * @param array $configuration
@@ -67,13 +75,16 @@ class PostMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
    *   The request stack.
    * @param \Drupal\Core\Datetime\DateFormatter $date_formatter
    *   The date formatter.
+   * @param \Drupal\Core\Entity\EntityStorageInterface $taxonomyTermStorage
+   *   The taxonomy term storage.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, TitleResolver $title_resolver, RequestStack $request_stack, DateFormatter $date_formatter) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, TitleResolver $title_resolver, RequestStack $request_stack, DateFormatter $date_formatter, EntityStorageInterface $taxonomyTermStorage) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->routeMatch = $route_match;
     $this->titleResolver = $title_resolver;
     $this->requestStack = $request_stack;
     $this->dateFormatter = $date_formatter;
+    $this->taxonomyTermStorage = $taxonomyTermStorage;
   }
 
   /**
@@ -88,6 +99,7 @@ class PostMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
     $container->get('title_resolver'),
     $container->get('request_stack'),
     $container->get('date.formatter'),
+    $container->get('entity_type.manager')->getStorage('taxonomy_term'),
     );
   }
 
@@ -119,7 +131,7 @@ class PostMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
       $dateFormatted = $this->dateFormatter->format($publishDate, '', 'c');
       $taxId = ($node->field_external_source_label->first()) ? $node->field_external_source_label->first()->getValue()['target_id'] : NULL;
       if ($taxId) {
-        $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($taxId);
+        $term = $this->taxonomyTermStorage->load($taxId);
         if ($term) {
           $externalSourceLabel = $term->getName();
           $externalSourceLabelUrlField = $term->field_link->first();

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/ys-post-meta-block.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/ys-post-meta-block.html.twig
@@ -4,8 +4,17 @@
   {% endset %}
 {% endif %}
 
+{% if external_source_label %}
+  {% set external_source_link %}
+    {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+        link__content: external_source_label,
+        link__url: external_source_label_url,
+    } %}
+  {% endset %}
+{% endif %}
+
 {% include "@molecules/page-title/yds-page-title.twig" with {
   page_title__heading: label,
-  page_title__meta: author_markup ~ date_formatted|date("l, F j, Y"),
+  page_title__meta: external_source_link ~ '|' ~ author_markup ~ date_formatted|date("l, F j, Y"),
   page_title__width: 'content',
 } %}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/ys-post-meta-block.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/ys-post-meta-block.html.twig
@@ -5,12 +5,18 @@
 {% endif %}
 
 {% if external_source_label %}
-  {% set external_source_link %}
-    {% include "@atoms/controls/text-link/yds-text-link.twig" with {
-        link__content: external_source_label,
-        link__url: external_source_label_url,
-    } %}
-  {% endset %}
+  {% if external_source__label_url %}
+    {% set external_source_link %}
+      {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+          link__content: external_source_label,
+          link__url: external_source_label_url,
+      } %}
+    {% endset %}
+  {% else %}
+    {% set external_source_link %}
+      <span>{{ external_source_label }}</span>
+    {% endset %}
+  {% endif %}
 {% endif %}
 
 {% set formatted_date %}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/ys-post-meta-block.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/ys-post-meta-block.html.twig
@@ -1,6 +1,6 @@
 {% if author %}
   {% set author_markup %}
-    By {{ author }} |
+    <span>By {{ author }}</span>
   {% endset %}
 {% endif %}
 
@@ -13,8 +13,12 @@
   {% endset %}
 {% endif %}
 
+{% set formatted_date %}
+  <span>{{ date_formatted|date("l, F j, Y") }}</span>
+{% endset %}
+
 {% include "@molecules/page-title/yds-page-title.twig" with {
   page_title__heading: label,
-  page_title__meta: external_source_link ~ '|' ~ author_markup ~ date_formatted|date("l, F j, Y"),
+  page_title__meta: external_source_link  ~ author_markup ~ formatted_date,
   page_title__width: 'content',
 } %}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
@@ -49,6 +49,8 @@ function ys_layouts_theme($existing, $type, $theme, $path): array {
         'label' => NULL,
         'author' => NULL,
         'date_formatted' => NULL,
+        'external_source_label' => NULL,
+        'external_source_label_url' => NULL,
       ],
     ],
     'ys_profile_meta_block' => [


### PR DESCRIPTION
## [YSP-691: Posts Source Field](https://yaleits.atlassian.net/browse/YSP-691)

### Description of work
- Adds new `Sources` taxonomy
  - Has a name and a URL
- Makes new taxonomy visible for site admins via the `Taxonomy` menu expansion
- Adds `Post Source` to External link sidebar to define external source
- Show source in rendered Post content

### Functional testing steps:
- [ ] Log in via CAS
- [ ] Go to `Content`->`Taxnomy`->`Post Sources`
- [ ] Add a new post source, adding a URL
- [ ] Add another post source, adding no URL
- [ ] Add a new post
- [ ] In the sidebar of the post under External, expand it and select the taxonomy from the drop down
- [ ] Add another post with the other taxonomy created
- [ ] Verify that on each the source is shown as part of the Meta header with the authors
- [ ] Create a new page
- [ ] Add a post feed and/or different post views via the view block
- [ ] Verify that each post feed with a source is displayed without clickable links
  - [ ] Note that condensed does not have the source since it's condensed
  - [ ] Note that the reason why it's not a clickable link here is due to how we handle card clicking in general
