### PR TITLE
fix: run workflow after creating a release to clean up multidevs

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -3,10 +3,13 @@ on:
   pull_request:
     types:
       - synchronize
-      - closed
     branches:
       - v[0-9]+
   workflow_dispatch:
+  workflow_run:
+    workflows: [Create a release]
+    types:
+      - completed
 env:
   YALESITES_BUILD_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
   GH_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
@@ -178,7 +181,7 @@ jobs:
       run: ./.ci/github/deploy_release_sites
 
   clean_up_multidevs:
-    if: ${{ github.event.action == 'closed' }}
+    if: ${{ github.event.action == 'completed' }}
     needs: [setup]
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
### Description of work
b382a15 broke the behavior of release_pr.yml running when a release pull request was closed. This change triggers the workflow to run after running release.yml.
