### PR TITLE
fix: prevent release.yml from running twice [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,17 @@
 name: Create a release
 on:
-  push:
-    branches: master
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
 env:
   GH_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
   YALESITES_BUILD_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description of work
release.yml currently runs when a push is made to master, but should be changed to when a PR is merged, since semantic-release bumps the yalesites_profile version during the release with an additional commit, which is making the action run twice.