### PR TITLE
 IYY-302: Add vertical text alignment to Spotlights

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.block_content.content_spotlight.field_link
     - field.field.block_content.content_spotlight.field_link_two
     - field.field.block_content.content_spotlight.field_media
+    - field.field.block_content.content_spotlight.field_style_alignment
     - field.field.block_content.content_spotlight.field_style_color
     - field.field.block_content.content_spotlight.field_style_position
     - field.field.block_content.content_spotlight.field_style_variation
@@ -89,6 +90,12 @@ content:
     third_party_settings:
       media_library_edit:
         show_edit: '1'
+  field_style_alignment:
+    type: options_select
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_style_color:
     type: options_select
     weight: 8

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight_portrait.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight_portrait.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.block_content.content_spotlight_portrait.field_link
     - field.field.block_content.content_spotlight_portrait.field_link_two
     - field.field.block_content.content_spotlight_portrait.field_media
+    - field.field.block_content.content_spotlight_portrait.field_style_alignment
     - field.field.block_content.content_spotlight_portrait.field_style_color
     - field.field.block_content.content_spotlight_portrait.field_style_position
     - field.field.block_content.content_spotlight_portrait.field_style_variation
@@ -91,6 +92,12 @@ content:
     third_party_settings:
       media_library_edit:
         show_edit: '1'
+  field_style_alignment:
+    type: options_select
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_style_color:
     type: options_select
     weight: 7

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.content_spotlight.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.content_spotlight.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.block_content.content_spotlight.field_link
     - field.field.block_content.content_spotlight.field_link_two
     - field.field.block_content.content_spotlight.field_media
+    - field.field.block_content.content_spotlight.field_style_alignment
     - field.field.block_content.content_spotlight.field_style_color
     - field.field.block_content.content_spotlight.field_style_position
     - field.field.block_content.content_spotlight.field_style_variation
@@ -71,6 +72,13 @@ content:
       link: false
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_style_alignment:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
     region: content
   field_style_color:
     type: list_key

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.content_spotlight_portrait.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.content_spotlight_portrait.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.block_content.content_spotlight_portrait.field_link
     - field.field.block_content.content_spotlight_portrait.field_link_two
     - field.field.block_content.content_spotlight_portrait.field_media
+    - field.field.block_content.content_spotlight_portrait.field_style_alignment
     - field.field.block_content.content_spotlight_portrait.field_style_color
     - field.field.block_content.content_spotlight_portrait.field_style_position
     - field.field.block_content.content_spotlight_portrait.field_style_variation
@@ -70,6 +71,13 @@ content:
       link: false
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_style_alignment:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
     region: content
   field_style_color:
     type: list_key

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_style_alignment.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_style_alignment.yml
@@ -1,0 +1,21 @@
+uuid: b35c43c3-a5be-47f7-9792-9c61606024ec
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.content_spotlight
+    - field.storage.block_content.field_style_alignment
+  module:
+    - options
+id: block_content.content_spotlight.field_style_alignment
+field_name: field_style_alignment
+entity_type: block_content
+bundle: content_spotlight
+label: 'Vertical Alignment'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ys_themes_default_value_function
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight_portrait.field_style_alignment.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight_portrait.field_style_alignment.yml
@@ -1,0 +1,21 @@
+uuid: 911e9ca4-a3b4-424d-bed1-be2051c859bc
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.content_spotlight_portrait
+    - field.storage.block_content.field_style_alignment
+  module:
+    - options
+id: block_content.content_spotlight_portrait.field_style_alignment
+field_name: field_style_alignment
+entity_type: block_content
+bundle: content_spotlight_portrait
+label: 'Vertical Alignment'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ys_themes_default_value_function
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -59,6 +59,12 @@ content_spotlight:
       four: Four
       five: Five
     default: default
+  field_style_alignment:
+    values:
+      top: 'Top'
+      middle: 'Middle'
+      bottom: 'Bottom'
+    default: top
 quick_links:
   field_style_variation:
     values:
@@ -152,6 +158,12 @@ content_spotlight_portrait:
       four: Four
       five: Five
     default: default
+  field_style_alignment:
+    values:
+      top: 'Top'
+      middle: 'Middle'
+      bottom: 'Bottom'
+    default: middle
 text:
   field_style_variation:
     values:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
@@ -59,6 +59,12 @@ content_spotlight:
       four: 'Four'
       five: 'Five'
     default: default
+  field_style_alignment:
+    values:
+      top: 'Top'
+      middle: 'Middle'
+      bottom: 'Bottom'
+    default: top
 quick_links:
   field_style_variation:
     values:
@@ -152,6 +158,12 @@ content_spotlight_portrait:
       four: 'Four'
       five: 'Five'
     default: default
+  field_style_alignment:
+    values:
+      top: 'Top'
+      middle: 'Middle'
+      bottom: 'Bottom'
+    default: middle
 text:
   field_style_variation:
     values:


### PR DESCRIPTION
## [ IYY-302: Add vertical text alignment to Spotlights](https://fourkitchens.clickup.com/t/36718269/IYY-302)

### Description of work
- Adds vertical alignment option to  Spotlight - Landscape and  Spotlight - Portrait
- CL: https://github.com/yalesites-org/component-library-twig/pull/452
- Atomic: https://github.com/yalesites-org/atomic/pull/294

### Functional testing steps:
- [ ] Navigate to: https://pr-838-yalesites-platform.pantheonsite.io/content-spotlights-with-vertical-alignment
- [ ] Verify that the content spotlights on the page have alignment options set
 
<img width="1999" alt="Screenshot 2025-01-06 at 16 43 30" src="https://github.com/user-attachments/assets/77e4d189-9173-4a8b-af22-12cdd961df6e" />


- [ ] New Spotlights will have defaults set: Portrait = `middle` as default, Landscape = `top` as default.
- [ ] If you edit the page, verify you can choose an alignment option and each one is wired to the component library: https://github.com/yalesites-org/component-library-twig/pull/452

<img width="2505" alt="Screenshot 2025-01-07 at 09 57 53" src="https://github.com/user-attachments/assets/2be85591-3a32-4326-aeb2-fe31bcec7fbe" />

