### PR TITLE
YSP-791: Hotfix: Bump Quick Node Clone to 1.20.0

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -86,7 +86,7 @@
     "drupal/paragraphs": "1.18.0",
     "drupal/paragraphs_features": "2.0.0",
     "drupal/pathauto": "1.13.0",
-    "drupal/quick_node_clone": "1.19.0",
+    "drupal/quick_node_clone": "1.20.0",
     "drupal/recaptcha": "3.4.0",
     "drupal/recaptcha_v3": "2.0.3",
     "drupal/redirect": "1.10.0",

--- a/web/profiles/custom/yalesites_profile/config/sync/cas.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/cas.settings.yml
@@ -48,8 +48,8 @@ error_handling:
   message_prevent_normal_login: 'This account must log in using <a href="[cas:login-url]">CAS</a>.'
   message_restrict_password_management: 'The requested account is associated with CAS and its password cannot be managed from this website.'
 logout:
-  cas_logout: false
-  logout_destination: ''
+  cas_logout: true
+  logout_destination: /
   enable_single_logout: false
   single_logout_session_lifetime: 25
 proxy:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesTitleBreadcrumbBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesTitleBreadcrumbBlock.php
@@ -124,7 +124,7 @@ class YaleSitesTitleBreadcrumbBlock extends BlockBase implements ContainerFactor
         ];
       }
 
-    };
+    }
 
     return [
       '#theme' => 'ys_title_breadcrumb',

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/PowerBI.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/PowerBI.php
@@ -21,12 +21,12 @@ class PowerBI extends EmbedSourceBase implements EmbedSourceInterface {
   /**
    * {@inheritdoc}
    */
-  protected static $pattern = '/^https:\/\/app.powerbi.com\/(?<type>view|reportEmbed)(?<query_params>\?.+)/';
+  protected static $pattern = '/^https:\/\/app.powerbi.com\/(?<type>view|reportEmbed)(?<form_params>\?.+)/';
 
   /**
    * {@inheritdoc}
    */
-  protected static $template = '<iframe class="iframe" title="{{ title }}" src="https://app.powerbi.com/{{ type }}{{ query_params }}" height="100%" width="100%" loading="lazy"></iframe>';
+  protected static $template = '<iframe class="iframe" title="{{ title }}" src="https://app.powerbi.com/{{ type }}{{ form_params }}" height="100%" width="100%" loading="lazy"></iframe>';
 
   /**
    * {@inheritdoc}
@@ -74,8 +74,8 @@ class PowerBI extends EmbedSourceBase implements EmbedSourceInterface {
    */
   public function getUrl(array $params): string {
     $type = $params['type'];
-    $query_params = $params['query_params'];
-    return 'https://app.powerbi.com/' . $type . $query_params;
+    $form_params = $params['form_params'];
+    return 'https://app.powerbi.com/' . $type . $form_params;
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/ys_embed.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/ys_embed.install
@@ -179,3 +179,25 @@ function _copy_embed_file($filename) {
 
   return TRUE;
 }
+
+/**
+ * Updates existing Power BI embeds to add new type parameter.
+ */
+function ys_embed_update_9006() {
+  $media_storage = \Drupal::entityTypeManager()->getStorage('media');
+
+  $power_bi_embeds = $media_storage->loadByProperties([
+    'bundle' => 'embed',
+    'field_media_embed.embed_source' => 'powerbi',
+  ]);
+
+  foreach ($power_bi_embeds as $embed) {
+    /** @var \Drupal\media\Entity\Media $embed */
+    $field_value = $embed->get('field_media_embed')->getValue();
+    if (!isset($field_value[0]['params']['type'])) {
+      $field_value[0]['params']['type'] = 'view';
+      $embed->set('field_media_embed', $field_value);
+      $embed->save();
+    }
+  }
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PageMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PageMetaBlock.php
@@ -91,7 +91,7 @@ class PageMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
     // Get the page title.
     if ($route) {
       $page_title = $this->titleResolver->getTitle($request, $route);
-    };
+    }
 
     return [
       '#theme' => 'ys_page_meta_block',


### PR DESCRIPTION
## [YSP-791: Bump Quick Node Clone to 1.20.0](https://yaleits.atlassian.net/browse/YSP-791)

### Description of work
- Bumps quick node clone to 1.20.0 to continue using patch
- Autofix newly found linting issues on build

### Functional testing steps:
- [ ] Create a node with a paragraphs-based block (i.e. Accordion)
- [ ] Clone the node
- [ ] Verify that paragraphs on the page still are editable and separate from the originally cloned version