### PR TITLE
Hotfix: YSP-791: Bump quick node clone to 1.20.0

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -86,7 +86,7 @@
     "drupal/paragraphs": "1.18.0",
     "drupal/paragraphs_features": "2.0.0",
     "drupal/pathauto": "1.13.0",
-    "drupal/quick_node_clone": "1.19.0",
+    "drupal/quick_node_clone": "1.20.0",
     "drupal/recaptcha": "3.4.0",
     "drupal/recaptcha_v3": "2.0.3",
     "drupal/redirect": "1.10.0",

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesTitleBreadcrumbBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesTitleBreadcrumbBlock.php
@@ -124,7 +124,7 @@ class YaleSitesTitleBreadcrumbBlock extends BlockBase implements ContainerFactor
         ];
       }
 
-    };
+    }
 
     return [
       '#theme' => 'ys_title_breadcrumb',

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PageMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PageMetaBlock.php
@@ -91,7 +91,7 @@ class PageMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
     // Get the page title.
     if ($route) {
       $page_title = $this->titleResolver->getTitle($request, $route);
-    };
+    }
 
     return [
       '#theme' => 'ys_page_meta_block',


### PR DESCRIPTION
## [Hotfix: YSP-791: Bump quick node clone to 1.20.0](https://yaleits.atlassian.net/browse/YSP-791)

### Description of work
- Bumps quick node clone to 1.20.0 to continue using patch
- Autofix newly found linting issues on build

### Functional testing steps:
- [ ] Create a node with a paragraphs-based block (i.e. Accordion)
- [ ] Clone the node
- [ ] Verify that paragraphs on the page still are editable and separate from the originally cloned version