### PR TITLE
IYY-300: Add option to hide "Add to Calendar" on events listing

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -261,6 +261,23 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       ],
     ];
 
+    $eventFieldOptionValue = ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('event_field_options', $items[$delta]->params) : [];
+    $eventFieldOptionDefaultValue = $eventFieldOptionValue ?? [];
+
+    $form['group_user_selection']['entity_and_view_mode']['event_field_options'] = [
+      '#type' => 'checkboxes',
+      '#options' => [
+        'hide_add_to_calendar' => $this->t('Hide Add to Calendar link'),
+      ],
+      '#title' => $this->t('Event Field Display Options'),
+      '#tree' => TRUE,
+      '#default_value' => ($isNewForm && empty($eventFieldOptionValue)) ? [] : $eventFieldOptionDefaultValue,
+      '#states' => [
+        'visible' => [$formSelectors['entity_types_ajax'] => ['value' => 'event']],
+        'invisible' => $calendarViewInvisibleState,
+      ],
+    ];
+
     $form['group_user_selection']['entity_and_view_mode']['exposed_filter_options'] = [
       '#type' => 'checkboxes',
       '#options' => [
@@ -467,6 +484,7 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
           "event_time_period" => $form['group_user_selection']['entity_specific']['event_time_period']['#value'],
         ],
         "field_options" => $form['group_user_selection']['entity_and_view_mode']['field_options']['#value'],
+        "event_field_options" => $form['group_user_selection']['entity_and_view_mode']['event_field_options']['#value'],
         "exposed_filter_options" => $form['group_user_selection']['entity_and_view_mode']['exposed_filter_options']['#value'],
         "category_filter_label" => $form['group_user_selection']['entity_and_view_mode']['category_filter_label']['#value'],
         "category_included_terms" => $form['group_user_selection']['entity_and_view_mode']['category_included_terms']['#value'],

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -414,6 +414,10 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
       'show_thumbnail' => (int) $no_field_display_options_saved || !empty($paramsDecoded['field_options']['show_thumbnail']),
     ];
 
+    $event_field_display_options = [
+      'hide_add_to_calendar' => (int) !empty($paramsDecoded['event_field_options']['hide_add_to_calendar']),
+    ];
+
     $view->setArguments(
       [
         'type' => $filterType,
@@ -425,6 +429,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
         'event_time_period' => str_contains($filterType, 'event') ? $eventTimePeriod : NULL,
         'offset' => $paramsDecoded['offset'] ?? 0,
         'field_display_options' => json_encode($field_display_options),
+        'event_field_display_options' => json_encode($event_field_display_options),
       ]
     );
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -456,6 +456,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
             $resultRow['#cache']['keys'][] = $field_display_options['show_categories'];
             $resultRow['#cache']['keys'][] = $field_display_options['show_tags'];
             $resultRow['#cache']['keys'][] = $field_display_options['show_thumbnail'];
+            $resultRow['#cache']['keys'][] = $event_field_display_options['hide_add_to_calendar'];
           }
         }
         break;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -607,6 +607,26 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
         $defaultParam = (empty($paramsDecoded['filters']['event_time_period'])) ? 'future' : $paramsDecoded['filters']['event_time_period'];
         break;
 
+      case 'field_options':
+        $defaultParam = (empty($paramsDecoded['field_options'])) ? ['show_thumbnail' => 'show_thumbnail'] : $paramsDecoded['field_options'];
+        break;
+
+      case 'event_field_options':
+        $defaultParam = (empty($paramsDecoded['event_field_options'])) ? [] : $paramsDecoded['event_field_options'];
+        break;
+
+      case 'exposed_filter_options':
+        $defaultParam = (empty($paramsDecoded['exposed_filter_options'])) ? [] : $paramsDecoded['exposed_filter_options'];
+        break;
+
+      case 'category_filter_label':
+        $defaultParam = (empty($paramsDecoded['category_filter_label'])) ? NULL : $paramsDecoded['category_filter_label'];
+        break;
+
+      case 'category_included_terms':
+        $defaultParam = (empty($paramsDecoded['category_included_terms'])) ? NULL : $paramsDecoded['category_included_terms'];
+        break;
+
       default:
         $defaultParam = $paramsDecoded[$type];
         break;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -93,6 +93,7 @@ function ys_views_basic_views_pre_render(ViewExecutable $view): void {
   $view_id = $view->id();
   if (in_array($view_id, ['views_basic_scaffold', 'views_basic_scaffold_events'])) {
     $field_display_options = json_decode($view->args[8]);
+    $event_field_display_options = json_decode($view->args[9]);
     // Loop through each row in the view's results and update the node's
     // properties based on show_categories, show_tags and show_thumbnail
     // configuration.
@@ -100,6 +101,7 @@ function ys_views_basic_views_pre_render(ViewExecutable $view): void {
       $row->_entity->show_categories = $field_display_options->show_categories;
       $row->_entity->show_tags = $field_display_options->show_tags;
       $row->_entity->show_thumbnail = $field_display_options->show_thumbnail;
+      $row->_entity->hide_add_to_calendar = $event_field_display_options->hide_add_to_calendar;
     }
   }
 }


### PR DESCRIPTION
## [IYY-300: Add option to hide "Add to Calendar" on events listing](https://app.clickup.com/t/36718269/IYY-300)

### Description of work
- Adds an option in the views tool to hide the "Add to calendar" links for events on card and list views
- Requires Atomic PR-297 - https://github.com/yalesites-org/atomic/pull/297

### Functional testing steps:
- [ ] Login to the site
- [ ] Edit an existing page that has a view block that shows events or create a new page and add a view block that shows events
- [ ] Verify that when "Event" is selected, there is a new area called "Event Field Display Options" and a new option called "Hide Add to Calendar link".

![Screenshot 2025-01-15 at 12 56 53 PM](https://github.com/user-attachments/assets/f03275a7-83d3-4a3d-97b9-9b15f14cfba3)

- [ ] Select this new option and make sure the view mode is Event Card Grid
- [ ] Save the view block
- [ ] Verify that the view updates to no longer show the "Add to Calendar" button

![Screenshot 2025-01-15 at 1 08 05 PM](https://github.com/user-attachments/assets/75ff54f1-7692-4f97-bc8d-f5a15616a4fb)

- [ ] Test for the other view mode - Event Card List