### PR TITLE
YSP-797: Add default display mode selection in views tool

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -26,6 +26,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPluginInterface {
 
+  const DEFAULT_VIEW_MODE = "card";
+
   /**
    * The views basic manager service.
    *
@@ -198,13 +200,20 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
 
     // Gets the view mode options based on Ajax callbacks or initial load.
     $viewModeOptions = $this->viewsBasicManager->viewModeList($formSelectors['entity_types']);
+    $viewMode = ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('view_mode', $items[$delta]->params) : key($viewModeOptions);
+
+    // Set the default if the current view mode does not exist in
+    // the entity type.
+    if (!array_key_exists($viewMode, $viewModeOptions)) {
+      $viewMode = self::DEFAULT_VIEW_MODE;
+    }
 
     $form['group_user_selection']['entity_and_view_mode']['view_mode'] = [
       '#type' => 'radios',
       '#options' => $viewModeOptions,
       '#title' => $this->t('As'),
       '#tree' => TRUE,
-      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('view_mode', $items[$delta]->params) : key($viewModeOptions),
+      '#default_value' => $viewMode,
       '#attributes' => [
         'class' => [
           'views-basic--view-mode',


### PR DESCRIPTION
## [YSP-797: Add default display mode selection in views tool](https://yaleits.atlassian.net/browse/YSP-797)

In a specific cas of a calendar, this view mode does not exist in other content types in the view tool.  Sometimes this results in nothing being selected for a view mode, making the default view be a real render of the page, causing a recursive render of the page if it is included in the list of items in the view.  This ensures that if you go to a content type that no longer has the selected view mode, it defaults to a card, which we will need to make sure is on every content type.  If this ever changes, we'll need a hash to define that for each content type.

### Description of work
- Adds a check that defaults the view mode if it doesn't exist as a possible view mode for a content type

### Functional testing steps:
- [ ] Create an Event-based calendar view
- [ ] Modify this and change it to a Page-based view (do not select a mode)
- [ ] Save
- [ ] Ensure the page loads and that it defaulted to the card based render for each item in the view
