### PR TITLE
YSP-760: Editing an image popup doesn't show save button

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/ys-themes.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/ys-themes.css
@@ -3,6 +3,10 @@
   display: flex;
 }
 
+#drupal-modal.media-library-edit__modal form [data-drupal-selector^='edit-field-media'][data-drupal-selector$='-remove-button'] {
+  display: none !important;
+}
+
 .ys-layout-builder--drag-drop {
   border: 2px dashed var(--gin-pattern);
   position: absolute;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/ys-themes.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/css/ys-themes.css
@@ -1,3 +1,8 @@
+/* show media save button on ajax modal */
+#drupal-modal.media-library-edit__modal form > .form-actions {
+  display: flex;
+}
+
 .ys-layout-builder--drag-drop {
   border: 2px dashed var(--gin-pattern);
   position: absolute;


### PR DESCRIPTION
## [YSP-760: Editing an image popup doesn't show save button](https://yaleits.atlassian.net/browse/YSP-760)

This displays the save button that is hidden by GinLb.  This makes me wonder the implications or the reason why they chose to do this across all dialogs, but it does work.  My real worry here is that users might not realize when they change the image that it will change the image for that media item--so they're not choosing a new image, they're replacing the current image across the site.

It also does not update the sidebar since it doesn't refresh the page on save.

### Description of work
- Shows the Save button for the media edit within a block edit dialog

### Functional testing steps:
- [ ] Create a new page
- [ ] Add a block that has an image and save it
- [ ] Edit the block
- [ ] Click the pencil icon
- [ ] Verify that there is a `Save` button displayed
- [ ] Make changes to the image
- [ ] Save
- [ ] Save the block
- [ ] Verify you see your changes
