### PR TITLE
YSP-769: Add "Pin to Top" visual indicator

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.page.default.yml
@@ -47,6 +47,7 @@ third_party_settings:
     group_publishing_settings:
       children:
         - field_login_required
+        - sticky
       label: 'Publishing Settings'
       region: content
       parent_name: ''
@@ -183,6 +184,13 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 8
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 0
@@ -201,5 +209,4 @@ hidden:
   layout_builder__layout: true
   promote: true
   revision_log: true
-  sticky: true
   uid: true

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -380,6 +380,7 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
 
     // Gets the view mode options based on Ajax callbacks or initial load.
     $sortOptions = $this->viewsBasicManager->sortByList($formSelectors['entity_types']);
+    $sortBy = ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('sort_by', $items[$delta]->params) : NULL;
 
     $form['group_user_selection']['filter_and_sort']['sort_by'] = [
       '#type' => 'select',
@@ -387,11 +388,31 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       '#options' => $sortOptions,
       '#title' => $this->t('Sorting by'),
       '#tree' => TRUE,
-      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('sort_by', $items[$delta]->params) : NULL,
+      '#default_value' => $sortBy,
       '#validated' => 'true',
       '#prefix' => '<div id="edit-sort-by">',
       '#suffix' => '</div>',
       '#states' => ['invisible' => $calendarViewInvisibleState],
+    ];
+
+    $form['group_user_selection']['filter_and_sort']['pinned_to_top'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Display pinned items at the top of the list'),
+      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('pinned_to_top', $items[$delta]->params) : FALSE,
+      '#states' => ['invisible' => $calendarViewInvisibleState],
+    ];
+
+    // If the saved value is NULL, still default it since it's required.
+    $pin_label = (($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('pin_label', $items[$delta]->params) : ViewsBasicManager::DEFAULT_PIN_LABEL) ?? ViewsBasicManager::DEFAULT_PIN_LABEL;
+
+    $form['group_user_selection']['filter_and_sort']['pin_label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('The label to display for pinned items'),
+      '#default_value' => $pin_label,
+      '#states' => [
+        'visible' => [$formSelectors['pinned_to_top_selector'] => ['checked' => TRUE]],
+        'required' => [$formSelectors['pinned_to_top_selector'] => ['checked' => TRUE]],
+      ],
     ];
 
     $form['group_user_selection']['entity_specific']['event_time_period'] = [
@@ -515,6 +536,8 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
         "limit" => (int) $form_state->getValue($formSelectors['limit_array']),
         "offset" => (int) $form_state->getValue($formSelectors['offset_array']),
         "show_current_entity" => $form['group_user_selection']['options']['show_current_entity']['#value'],
+        "pinned_to_top" => $form_state->getValue($formSelectors['pinned_to_top_array']),
+        "pin_label" => $form_state->getValue($formSelectors['pin_label_array']),
       ];
       $value['params'] = json_encode($paramData);
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -384,7 +384,6 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
 
     $form['group_user_selection']['filter_and_sort']['sort_by'] = [
       '#type' => 'select',
-      '#description' => $this->t('Items marked "Pin to the beginning of list" will precede the selected sort.'),
       '#options' => $sortOptions,
       '#title' => $this->t('Sorting by'),
       '#tree' => TRUE,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/sort/ViewsBasicSort.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/sort/ViewsBasicSort.php
@@ -47,7 +47,7 @@ class ViewsBasicSort extends SortPluginBase {
    * Determines if the view should feature a pin to top.
    */
   protected function shouldFeaturePinToTop() {
-    $pinOptions = $this->getPinOptions($this->view->args[9]);
+    $pinOptions = $this->getPinOptions($this->view->args[10]);
     if ($pinOptions && $pinOptions['pinned_to_top']) {
       return TRUE;
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/sort/ViewsBasicSort.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/sort/ViewsBasicSort.php
@@ -34,10 +34,42 @@ class ViewsBasicSort extends SortPluginBase {
         else {
           $field = $sortQueryOptions[0];
         }
-        $query->addOrderBy(NULL, "node_field_data.sticky", 'DESC', 'views_basic_sort');
+
+        if ($this->shouldFeaturePinToTop()) {
+          $query->addOrderBy(NULL, "node_field_data.sticky", 'DESC', 'views_basic_sort');
+        }
         $query->addOrderBy(NULL, "{$field}", $sortQueryOptions[1], 'views_basic_sort');
       }
     }
+  }
+
+  /**
+   * Determines if the view should feature a pin to top.
+   */
+  protected function shouldFeaturePinToTop() {
+    $pinOptions = $this->getPinOptions($this->view->args[9]);
+    if ($pinOptions && $pinOptions['pinned_to_top']) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Decodes the pin option parameters.
+   *
+   * @param string $args
+   *   The arguments passed to the view.
+   *
+   * @return array
+   *   The decoded pin options.
+   */
+  protected function getPinOptions($args) {
+    if ($args) {
+      return json_decode($args, TRUE);
+    }
+
+    return [];
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -154,6 +154,11 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
     ],
   ];
 
+  /**
+   * Default pin label.
+   */
+  const DEFAULT_PIN_LABEL = 'Popular';
+
   /*
    * Define constants for content types.
    */
@@ -255,6 +260,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
           'field' => 'field_event_date_value',
           'group_type' => 'min',
           'order' => $sortDirection[1],
+          'test' => 'hi',
         ],
       ]);
     }
@@ -446,6 +452,18 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
       'hide_add_to_calendar' => (int) !empty($paramsDecoded['event_field_options']['hide_add_to_calendar']),
     ];
 
+    $pinned_to_top = (bool) $paramsDecoded['pinned_to_top'] ?? FALSE;
+    $pin_label = $paramsDecoded['pin_label'] ?? self::DEFAULT_PIN_LABEL;
+
+    if (!$pinned_to_top) {
+      $pin_label = NULL;
+    }
+
+    $pin_options = [
+      'pinned_to_top' => $pinned_to_top,
+      'pin_label' => $pin_label,
+    ];
+
     $view->setArguments(
       [
         'type' => $filterType,
@@ -458,6 +476,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
         'offset' => $paramsDecoded['offset'] ?? 0,
         'field_display_options' => json_encode($field_display_options),
         'event_field_display_options' => json_encode($event_field_display_options),
+        'pin_settings' => json_encode($pin_options),
       ]
     );
 
@@ -880,6 +899,22 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
             'options',
             'offset',
           ],
+          'pinned_to_top' => ($form) ? $form['block_form']['group_user_selection']['filter_and_sort']['pinned_to_top'] : NULL,
+          'pinned_to_top_array' => [
+            'block_form',
+            'group_user_selection',
+            'filter_and_sort',
+            'pinned_to_top',
+          ],
+          'pinned_to_top_selector' => ':input[name="block_form[group_user_selection][filter_and_sort][pinned_to_top]"]',
+          'pin_label' => ($form) ? $form['block_form']['group_user_selection']['filter_and_sort']['pin_label'] : self::DEFAULT_PIN_LABEL,
+          'pin_label_array' => [
+            'settings',
+            'block_form',
+            'group_user_selection',
+            'filter_and_sort',
+            'pin_label',
+          ],
         ];
       }
       else {
@@ -946,6 +981,23 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
             'options',
             'offset',
           ],
+          'pinned_to_top_ajax' => ($form) ? $form['settings']['block_form']['filter_and_sort']['pinned_to_top'] : NULL,
+          'pinned_to_top_array' => [
+            'settings',
+            'block_form',
+            'group_user_selection',
+            'filter_and_sort',
+            'pinned_to_top',
+          ],
+          'pinned_to_top_selector' => ':input[name="settings[block_form][group_user_selection][filter_and_sort][pinned_to_top]"]',
+          'pin_label_ajax' => ($form) ? $form['settings']['block_form']['filter_and_sort']['pin_label'] : self::DEFAULT_PIN_LABEL,
+          'pin_label_array' => [
+            'settings',
+            'block_form',
+            'group_user_selection',
+            'filter_and_sort',
+            'pin_label',
+          ],
         ];
       }
     }
@@ -971,6 +1023,12 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
         'limit_array' => ['limit'],
         'limit_ajax' => ($form) ? $form['group_user_selection']['options']['limit'] : NULL,
         'offset_array' => ['offset'],
+        'pinned_to_top' => ['pinned_to_top'],
+        'pinned_to_top_selector' => ':input[name="settings[block_form][group_user_selection][filter_and_sort][pinned_to_top]"]',
+        'pinned_to_top_array' => ['pinned_to_top'],
+        'pinned_to_top_ajax' => ($form) ? $form['group_user_selection']['filter_and_sort']['pinned_to_top'] : NULL,
+        'pin_label_array' => ['pin_label'],
+        'pin_label_ajax' => ($form) ? $form['settings']['block_form']['filter_and_sort']['pin_label'] : self::DEFAULT_PIN_LABEL,
       ];
     }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -453,7 +453,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
     ];
 
     $pinned_to_top = isset($paramsDecoded['pinned_to_top']) ? (bool) $paramsDecoded['pinned_to_top'] : FALSE;
-    $pin_label = isset($paramsDecoded['pin_label']) ? (bool) $paramsDecoded['pin_label'] : self::DEFAULT_PIN_LABEL;
+    $pin_label = $paramsDecoded['pin_label'] ?? self::DEFAULT_PIN_LABEL;
 
     if (!$pinned_to_top) {
       $pin_label = NULL;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -452,8 +452,8 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
       'hide_add_to_calendar' => (int) !empty($paramsDecoded['event_field_options']['hide_add_to_calendar']),
     ];
 
-    $pinned_to_top = (bool) $paramsDecoded['pinned_to_top'] ?? FALSE;
-    $pin_label = $paramsDecoded['pin_label'] ?? self::DEFAULT_PIN_LABEL;
+    $pinned_to_top = isset($paramsDecoded['pinned_to_top']) ? (bool) $paramsDecoded['pinned_to_top'] : FALSE;
+    $pin_label = isset($paramsDecoded['pin_label']) ? (bool) $paramsDecoded['pin_label'] : self::DEFAULT_PIN_LABEL;
 
     if (!$pinned_to_top) {
       $pin_label = NULL;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -525,6 +525,8 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
             $resultRow['#cache']['keys'][] = $field_display_options['show_tags'];
             $resultRow['#cache']['keys'][] = $field_display_options['show_thumbnail'];
             $resultRow['#cache']['keys'][] = $event_field_display_options['hide_add_to_calendar'];
+            $resultRow['#cache']['keys'][] = $pin_options['pinned_to_top'];
+            $resultRow['#cache']['keys'][] = $pin_options['pin_label'];
           }
         }
         break;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -698,6 +698,12 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
 
       case 'show_current_entity':
         $defaultParam = (empty($paramsDecoded['show_current_entity'])) ? 0 : $paramsDecoded['show_current_entity'];
+      case 'pinned_to_top':
+        $defaultParam = (empty($paramsDecoded['pinned_to_top'])) ? FALSE : (bool) $paramsDecoded['pinned_to_top'];
+        break;
+
+      case 'pin_label':
+        $defaultParam = (empty($paramsDecoded['pin_label'])) ? self::DEFAULT_PIN_LABEL : $paramsDecoded['pin_label'];
         break;
 
       default:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -157,7 +157,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
   /**
    * Default pin label.
    */
-  const DEFAULT_PIN_LABEL = 'Popular';
+  const DEFAULT_PIN_LABEL = 'Pinned';
 
   /*
    * Define constants for content types.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -92,6 +92,11 @@ function ys_views_basic_views_pre_build($view) {
 function ys_views_basic_views_pre_render(ViewExecutable $view): void {
   $view_id = $view->id();
   if (in_array($view_id, ['views_basic_scaffold', 'views_basic_scaffold_events'])) {
+    $pin_options = json_decode($view->args[9]);
+    $pin_label = '';
+    if ($pin_options->pinned_to_top) {
+      $pin_label = $pin_options->pin_label;
+    }
     $field_display_options = json_decode($view->args[8]);
     $event_field_display_options = json_decode($view->args[9]);
     // Loop through each row in the view's results and update the node's
@@ -102,6 +107,11 @@ function ys_views_basic_views_pre_render(ViewExecutable $view): void {
       $row->_entity->show_tags = $field_display_options->show_tags;
       $row->_entity->show_thumbnail = $field_display_options->show_thumbnail;
       $row->_entity->hide_add_to_calendar = $event_field_display_options->hide_add_to_calendar;
+
+      $sticky = (bool) $row->_entity->get('sticky')->value;
+      if ($sticky) {
+        $row->_entity->pin_label = $pin_label;
+      }
     }
   }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -5,7 +5,6 @@
  * Contains ys_views_basic.module functions.
  */
 
-use Drupal\Core\Cache\Cache;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -115,12 +114,4 @@ function ys_views_basic_views_pre_render(ViewExecutable $view): void {
       }
     }
   }
-}
-
-/**
- * Implements hook_save().
- */
-function ys_views_basic_save($node) {
-  // Try just the node in question.
-  Cache::invalidateTags(['node:' . $node->id()]);
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -5,6 +5,7 @@
  * Contains ys_views_basic.module functions.
  */
 
+use Drupal\Core\Cache\Cache;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -92,7 +93,7 @@ function ys_views_basic_views_pre_build($view) {
 function ys_views_basic_views_pre_render(ViewExecutable $view): void {
   $view_id = $view->id();
   if (in_array($view_id, ['views_basic_scaffold', 'views_basic_scaffold_events'])) {
-    $pin_options = json_decode($view->args[9]);
+    $pin_options = json_decode($view->args[10]);
     $pin_label = '';
     if ($pin_options->pinned_to_top) {
       $pin_label = $pin_options->pin_label;
@@ -114,4 +115,12 @@ function ys_views_basic_views_pre_render(ViewExecutable $view): void {
       }
     }
   }
+}
+
+/**
+ * Implements hook_save().
+ */
+function ys_views_basic_save($node) {
+  // Try just the node in question.
+  Cache::invalidateTags(['node:' . $node->id()]);
 }


### PR DESCRIPTION
## [YSP-769: Add "Pin to Top" visual indicator](https://yaleits.atlassian.net/browse/YSP-769)

This work is dependent on the following other PRs--please review these as well:
- [Atomic](https://github.com/yalesites-org/atomic/pull/301)
- [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/462)

### Description of work
- Added checkbox for displaying pinned items at the top of the list.
- Introduced pin label field to customize the label for pinned items.
- Updated form elements and massageFormValues to handle new fields.
- Implemented logic to sort pinned items at the top in ViewsBasicSort.
- Added constants and methods in ViewsBasicManager for pin settings.
- Added pin to top to Page content type

### Functional testing steps:
- [ ] Add a view
- [ ] Scroll down to the sorting section
- [ ] Toggle pin to top on
- [ ] Verify that it asks for a name for the pin to top
- [ ] Verify that the default given was "Popular"
- [ ] Verify when saving that you see your overlay above the images
- [ ] Edit and remove thumbnails
- [ ] Verify you still see the pin to top at the top of the card
