### PR TITLE
YSP-730: Revert changes made in #669

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -429,26 +429,6 @@ function ys_core_taxonomy_term_update() {
 }
 
 /**
- * Implements hook_ENTITY_TYPE_insert().
- *
- * This is used to invalidate the render cache so that when selecting media
- * items it correctly corresponds to the image seen in the listing.
- */
-function ys_core_media_insert($entity) {
-  _ys_core_invalidate_media_list();
-}
-
-/**
- * Implements hook_ENTITY_TYPE_delete().
- *
- * This is used to invalidate the render cache so that when selecting media
- * items it correctly corresponds to the image seen in the listing.
- */
-function ys_core_media_delete($entity) {
-  _ys_core_invalidate_media_list();
-}
-
-/**
  * Implements hook_preprocess_page().
  */
 function ys_core_preprocess_page(&$variables) {
@@ -564,16 +544,6 @@ function ys_core_allow_secret_items(AccountProxy $currentUserSession) {
   }
 
   return $allowSecretItems;
-}
-
-/**
- * Invalidate media_list/view on insert/delete.
- *
- * This is used to invalidate the media library pull so that when selecting
- * media items it correctly corresponds to the image seen in the listing.
- */
-function _ys_core_invalidate_media_list() {
-  \Drupal::service('cache.render')->invalidateAll();
 }
 
 /**


### PR DESCRIPTION
## [YSP-566: Revert changes made in #669](https://yaleits.atlassian.net/browse/YSP-566)

Since we are on D10.3 now, this should be fixed and so the invalidation of the cache should no longer be needed.

### Description of work
- Reverts #669 

### Functional testing steps:
#### Adding a new image
- [ ] Add a media image from the media library
- [ ] Go to a page and add an image block
- [ ] When selecting an image, go to a different page than the first, and select an item; make note of the image you clicked on
- [ ] When inserting that image, make sure the image showing up in the block configuration is the same image you selected.

#### Deleting an existing image
- [ ] Delete a media image from the media library
- [ ] Go to a page and add an image block
- [ ] When selecting an image, go to a different page than the first, and select an item; make note of the image you clicked on
- [ ] When inserting that image, make sure the image showing up in the block configuration is the same image you selected.

