### PR TITLE
IYY-303: Callout component animations and background image options

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.tiles.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.tiles.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - block_content.type.tiles
+    - field.field.block_content.tiles.field_enable_animation
     - field.field.block_content.tiles.field_instructions
     - field.field.block_content.tiles.field_style_alignment
     - field.field.block_content.tiles.field_style_position
@@ -18,6 +19,13 @@ targetEntityType: block_content
 bundle: tiles
 mode: default
 content:
+  field_enable_animation:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_instructions:
     type: markup
     weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.tiles.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.tiles.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - block_content.type.tiles
+    - field.field.block_content.tiles.field_enable_animation
     - field.field.block_content.tiles.field_instructions
     - field.field.block_content.tiles.field_style_alignment
     - field.field.block_content.tiles.field_style_position
@@ -17,6 +18,16 @@ targetEntityType: block_content
 bundle: tiles
 mode: default
 content:
+  field_enable_animation:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 4
+    region: content
   field_style_alignment:
     type: list_key
     label: hidden

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.tiles.field_enable_animation.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.tiles.field_enable_animation.yml
@@ -1,0 +1,21 @@
+uuid: f913c72a-1e24-4a2e-b0ad-6340284fd907
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.tiles
+    - field.storage.block_content.field_enable_animation
+id: block_content.tiles.field_enable_animation
+field_name: field_enable_animation
+entity_type: block_content
+bundle: tiles
+label: 'Enable Animation'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_enable_animation.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_enable_animation.yml
@@ -1,0 +1,18 @@
+uuid: d623a1ac-6019-49c5-b14a-62f318063432
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_enable_animation
+field_name: field_enable_animation
+entity_type: block_content
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## [IYY-303: Callout component animations and background image options](https://fourkitchens.clickup.com/t/36718269/IYY-303)

### Description of work
- Adds animation option to Tiles component
- Allows animation enabled state to be controlled by the tiles component. That state is passed to each tile-item.
- Atomic: https://github.com/yalesites-org/atomic/pull/306
- Component Library: https://github.com/yalesites-org/component-library-twig/pull/467

### Functional testing steps:
- [ ] Navigate to the test page here: https://pr-868-yalesites-platform.pantheonsite.io/tiles-page
- [ ] Verify the first Tiles entry is not animated.
- [ ] Verify the second Tiles entry _is_ animated.
- [ ] Verify that if you toggle `Prefers Reduced Motion` on in system settings, the animated Tiles _do not animate_.

 

https://github.com/user-attachments/assets/fff06390-7461-4338-8aed-ed7e4f4b2cd7


