### PR TITLE
IYY-271: HOTFIX Fixes ambiguous nid error on some views

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -459,7 +459,10 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
         $currentNid = $node->id();
         /** @var Drupal\views\Plugin\views\query\Sql $query */
         $query = $view->getQuery();
-        $query->addWhere(0, 'nid', $currentNid, '<>');
+        $baseTableAlias = $query->ensureTable('node_field_data');
+        if ($baseTableAlias) {
+          $query->addWhere(0, "$baseTableAlias.nid", $currentNid, '<>');
+        }
       }
     }
 


### PR DESCRIPTION
## [IYY-271: Add option to hide the current node from the View list](https://app.clickup.com/t/36718269/IYY-271)

### Description of work
- Fixes an issue where with some views, there was a white screen error relating to an ambiguous nid in the query
- Please test with `ys-library-yale-edu`, @dblanken-yale 

### Functional testing steps:
- [ ] Load the previously troublesome view
- [ ] Verify that there are no longer errors
- [ ] Test the functionality of the original feature:
- [ ] Create an event or edit an existing event
- [ ] Add a view of type events
- [ ] Save the block
- [ ] Verify that the current event is not in the view
- [ ] Re-edit the view block and select "Include this content in view"
- [ ] Save the block
- [ ] Verify that the current event is now in the view