### PR TITLE
Remove unused field blocks on content type displays

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
@@ -84,38 +84,6 @@ third_party_settings:
                 entity: layout_builder.entity
             weight: 1
             additional: {  }
-          85c4af26-efa8-4a5a-8a89-62fd1347a03b:
-            uuid: 85c4af26-efa8-4a5a-8a89-62fd1347a03b
-            region: content
-            configuration:
-              id: 'field_block:node:event:field_audience'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 2
-            additional: {  }
-          0c9e723b-34cf-44b5-9271-7e09d3430ed5:
-            uuid: 0c9e723b-34cf-44b5-9271-7e09d3430ed5
-            region: content
-            configuration:
-              id: 'field_block:node:event:field_custom_vocab'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 3
-            additional: {  }
         third_party_settings:
           layout_builder_lock:
             lock:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
@@ -43,38 +43,6 @@ third_party_settings:
                 entity: layout_builder.entity
             weight: 0
             additional: {  }
-          4709212c-7270-4b89-8fbd-5b827a18bbd9:
-            uuid: 4709212c-7270-4b89-8fbd-5b827a18bbd9
-            region: content
-            configuration:
-              id: 'field_block:node:page:field_audience'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 1
-            additional: {  }
-          c532011e-458a-42cf-b095-483256cd07eb:
-            uuid: c532011e-458a-42cf-b095-483256cd07eb
-            region: content
-            configuration:
-              id: 'field_block:node:page:field_custom_vocab'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 2
-            additional: {  }
         third_party_settings:
           layout_builder_lock:
             lock:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
@@ -56,38 +56,6 @@ third_party_settings:
                 entity: layout_builder.entity
             weight: 1
             additional: {  }
-          7f02e533-466a-4916-8551-97cacf5b1329:
-            uuid: 7f02e533-466a-4916-8551-97cacf5b1329
-            region: content
-            configuration:
-              id: 'field_block:node:post:field_audience'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 2
-            additional: {  }
-          1c9fe26e-5139-4c69-97f0-36dc249676ca:
-            uuid: 1c9fe26e-5139-4c69-97f0-36dc249676ca
-            region: content
-            configuration:
-              id: 'field_block:node:post:field_custom_vocab'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 3
-            additional: {  }
         third_party_settings:
           layout_builder_lock:
             lock:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
@@ -66,38 +66,6 @@ third_party_settings:
               context_mapping: {  }
             weight: 1
             additional: {  }
-          b8465f25-6560-4337-bfc2-7dddbce50ea7:
-            uuid: b8465f25-6560-4337-bfc2-7dddbce50ea7
-            region: content
-            configuration:
-              id: 'field_block:node:profile:field_audience'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 3
-            additional: {  }
-          10965745-2d1e-48b0-b7c0-e6d63ad8b453:
-            uuid: 10965745-2d1e-48b0-b7c0-e6d63ad8b453
-            region: content
-            configuration:
-              id: 'field_block:node:profile:field_custom_vocab'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 4
-            additional: {  }
         third_party_settings:
           layout_builder_lock:
             lock:
@@ -131,6 +99,7 @@ third_party_settings:
       - 'Chaos Tools'
       - 'Content fields'
       - 'Custom block types'
+      - 'Custom blocks'
       - Devel
       - Editoria11y
       - Forms
@@ -157,6 +126,7 @@ third_party_settings:
       restricted_categories:
         - 'Chaos Tools'
         - 'Content fields'
+        - 'Custom blocks'
         - Devel
         - Editoria11y
         - Forms


### PR DESCRIPTION
## Remove unused field blocks on content type displays

Removed unnecessary field blocks from event, page, post, and profile entity view display configurations.

### Description of work
- Removed field_audience and field_custom_vocab blocks.
- Updated third_party_settings to reflect these changes.

### Functional testing steps:
- [ ] Add a page, post, event, and profile
- [ ] Ensure Audience and Custom Vocab does not show