### PR TITLE
V1.13.0 Feedback/Bug Fixes

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
@@ -92,31 +92,31 @@ content:
         show_edit: '1'
   field_style_alignment:
     type: options_select
-    weight: 3
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   field_style_color:
     type: options_select
-    weight: 8
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   field_style_position:
     type: options_select
-    weight: 9
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   field_style_variation:
     type: options_select
-    weight: 11
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   field_style_width:
     type: options_select
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight_portrait.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight_portrait.default.yml
@@ -48,7 +48,7 @@ content:
         maxlength_js_enforce: false
   field_heading_level:
     type: options_select
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -94,25 +94,25 @@ content:
         show_edit: '1'
   field_style_alignment:
     type: options_select
-    weight: 3
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   field_style_color:
     type: options_select
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   field_style_position:
     type: options_select
-    weight: 8
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   field_style_variation:
     type: options_select
-    weight: 9
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -156,7 +156,7 @@ content:
     third_party_settings: {  }
   revision_log:
     type: hide_revision_field_log_widget
-    weight: 10
+    weight: 13
     region: content
     settings:
       rows: 5
@@ -165,5 +165,6 @@ content:
       default: ''
       permission_based: false
       allow_user_settings: true
+      hide_revision: false
     third_party_settings: {  }
 hidden: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
@@ -84,38 +84,6 @@ third_party_settings:
                 entity: layout_builder.entity
             weight: 1
             additional: {  }
-          85c4af26-efa8-4a5a-8a89-62fd1347a03b:
-            uuid: 85c4af26-efa8-4a5a-8a89-62fd1347a03b
-            region: content
-            configuration:
-              id: 'field_block:node:event:field_audience'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 2
-            additional: {  }
-          0c9e723b-34cf-44b5-9271-7e09d3430ed5:
-            uuid: 0c9e723b-34cf-44b5-9271-7e09d3430ed5
-            region: content
-            configuration:
-              id: 'field_block:node:event:field_custom_vocab'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 3
-            additional: {  }
         third_party_settings:
           layout_builder_lock:
             lock:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.event.default.yml
@@ -110,7 +110,11 @@ third_party_settings:
     allowed_block_categories: {  }
     entity_view_mode_restriction:
       allowed_layouts: {  }
-      denylisted_blocks: {  }
+      denylisted_blocks:
+        'Custom block types':
+          - wrapped_text_callout
+        'Inline blocks':
+          - 'inline_block:wrapped_text_callout'
       allowlisted_blocks:
         'YaleSites Layouts':
           - ys_taxonomy_display_block

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
@@ -43,38 +43,6 @@ third_party_settings:
                 entity: layout_builder.entity
             weight: 0
             additional: {  }
-          4709212c-7270-4b89-8fbd-5b827a18bbd9:
-            uuid: 4709212c-7270-4b89-8fbd-5b827a18bbd9
-            region: content
-            configuration:
-              id: 'field_block:node:page:field_audience'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 1
-            additional: {  }
-          c532011e-458a-42cf-b095-483256cd07eb:
-            uuid: c532011e-458a-42cf-b095-483256cd07eb
-            region: content
-            configuration:
-              id: 'field_block:node:page:field_custom_vocab'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 2
-            additional: {  }
         third_party_settings:
           layout_builder_lock:
             lock:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
@@ -93,7 +93,11 @@ third_party_settings:
       allowed_layouts:
         - layout_onecol
         - ys_layout_two_column
-      denylisted_blocks: {  }
+      denylisted_blocks:
+        'Custom block types':
+          - wrapped_text_callout
+        'Inline blocks':
+          - 'inline_block:wrapped_text_callout'
       allowlisted_blocks: {  }
       restricted_categories:
         - 'YaleSites Core'
@@ -141,15 +145,33 @@ third_party_settings:
               - 'inline_block:tabs'
               - 'inline_block:text'
               - 'inline_block:video'
-            'YaleSites Layouts':
-              - ys_taxonomy_display_block
+            'YaleSites Layouts': {  }
           sidebar:
             'Custom block types':
               - text
             'Inline blocks':
               - 'inline_block:text'
+      denylisted_blocks:
+        layout_onecol:
+          all_regions:
+            'Custom block types':
+              - wrapped_text_callout
+            'Inline blocks':
+              - 'inline_block:wrapped_text_callout'
       restricted_categories:
         ys_layout_two_column:
+          content:
+            - 'Chaos Tools'
+            - 'Content fields'
+            - Forms
+            - Help
+            - 'Lists (Views)'
+            - Menus
+            - System
+            - Webform
+            - 'YaleSites Core'
+            - 'YaleSites alert'
+            - core
           sidebar:
             - 'Chaos Tools'
             - 'Content fields'
@@ -162,18 +184,6 @@ third_party_settings:
             - Webform
             - 'YaleSites Core'
             - 'YaleSites Layouts'
-            - 'YaleSites alert'
-            - core
-          content:
-            - 'Chaos Tools'
-            - 'Content fields'
-            - Forms
-            - Help
-            - 'Lists (Views)'
-            - Menus
-            - System
-            - Webform
-            - 'YaleSites Core'
             - 'YaleSites alert'
             - core
         layout_onecol:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
@@ -56,38 +56,6 @@ third_party_settings:
                 entity: layout_builder.entity
             weight: 1
             additional: {  }
-          7f02e533-466a-4916-8551-97cacf5b1329:
-            uuid: 7f02e533-466a-4916-8551-97cacf5b1329
-            region: content
-            configuration:
-              id: 'field_block:node:post:field_audience'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 2
-            additional: {  }
-          1c9fe26e-5139-4c69-97f0-36dc249676ca:
-            uuid: 1c9fe26e-5139-4c69-97f0-36dc249676ca
-            region: content
-            configuration:
-              id: 'field_block:node:post:field_custom_vocab'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 3
-            additional: {  }
         third_party_settings:
           layout_builder_lock:
             lock:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
@@ -82,7 +82,11 @@ third_party_settings:
     allowed_block_categories: {  }
     entity_view_mode_restriction:
       allowed_layouts: {  }
-      denylisted_blocks: {  }
+      denylisted_blocks:
+        'Custom block types':
+          - wrapped_text_callout
+        'Inline blocks':
+          - 'inline_block:wrapped_text_callout'
       allowlisted_blocks:
         'YaleSites Layouts':
           - ys_taxonomy_display_block

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
@@ -66,38 +66,6 @@ third_party_settings:
               context_mapping: {  }
             weight: 1
             additional: {  }
-          b8465f25-6560-4337-bfc2-7dddbce50ea7:
-            uuid: b8465f25-6560-4337-bfc2-7dddbce50ea7
-            region: content
-            configuration:
-              id: 'field_block:node:profile:field_audience'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 3
-            additional: {  }
-          10965745-2d1e-48b0-b7c0-e6d63ad8b453:
-            uuid: 10965745-2d1e-48b0-b7c0-e6d63ad8b453
-            region: content
-            configuration:
-              id: 'field_block:node:profile:field_custom_vocab'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 4
-            additional: {  }
         third_party_settings:
           layout_builder_lock:
             lock:
@@ -131,6 +99,7 @@ third_party_settings:
       - 'Chaos Tools'
       - 'Content fields'
       - 'Custom block types'
+      - 'Custom blocks'
       - Devel
       - Editoria11y
       - Forms
@@ -157,6 +126,7 @@ third_party_settings:
       restricted_categories:
         - 'Chaos Tools'
         - 'Content fields'
+        - 'Custom blocks'
         - Devel
         - Editoria11y
         - Forms

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
@@ -117,7 +117,11 @@ third_party_settings:
       allowed_layouts:
         - layout_onecol
         - ys_layout_two_column
-      denylisted_blocks: {  }
+      denylisted_blocks:
+        'Custom block types':
+          - wrapped_text_callout
+        'Inline blocks':
+          - 'inline_block:wrapped_text_callout'
       allowlisted_blocks:
         'YaleSites Layouts':
           - profile_contact_block
@@ -172,7 +176,6 @@ third_party_settings:
               - 'inline_block:video'
             'YaleSites Layouts':
               - profile_contact_block
-              - ys_taxonomy_display_block
           sidebar:
             'Custom block types':
               - text
@@ -180,7 +183,13 @@ third_party_settings:
               - 'inline_block:text'
             'YaleSites Layouts':
               - profile_contact_block
-      denylisted_blocks: {  }
+      denylisted_blocks:
+        layout_onecol:
+          all_regions:
+            'Custom block types':
+              - wrapped_text_callout
+            'Inline blocks':
+              - 'inline_block:wrapped_text_callout'
       restricted_categories:
         ys_layout_two_column:
           sidebar:

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -290,5 +290,5 @@ video_banner:
   field_style_width:
     values:
       max: Contained
-      full: Full Width
+      full: 'Full Width'
     default: max

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -274,6 +274,18 @@ inline_message:
       four: Four
       five: Five
     default: one
+video:
+  field_style_alignment:
+    values:
+      left: Left
+      center: Center
+    default: left
+image_banner:
+  field_style_variation:
+    values:
+      tall: Tall
+      short: Short
+    default: tall
 video_banner:
   field_style_width:
     values:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Menu/CustomTaxonomyMenuLink.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Menu/CustomTaxonomyMenuLink.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\ys_core\Plugin\Menu;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Menu\MenuLinkDefault;
+use Drupal\Core\Menu\StaticMenuLinkOverridesInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Custom Taxonomy Menu Link.
+ */
+class CustomTaxonomyMenuLink extends MenuLinkDefault {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * CustomTaxonomyMenuLink constructor.
+   *
+   * @param array $configuration
+   *   The configuration.
+   * @param string $plugin_id
+   *   The plugin ID.
+   * @param mixed $plugin_definition
+   *   The plugin definition.
+   * @param \Drupal\Core\Menu\StaticMenuLinkOverridesInterface $static_override
+   *   The static override storage.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, StaticMenuLinkOverridesInterface $static_override, ConfigFactoryInterface $config_factory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $static_override);
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('menu_link.static.overrides'),
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getTitle(): string {
+    return $this->configFactory->get('taxonomy.vocabulary.custom_vocab')->get('name') ?? 'Custom Vocab';
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.deploy.php
@@ -14,5 +14,15 @@ function ys_core_deploy_10001() {
   $vocab = \Drupal::configFactory()->getEditable('taxonomy.vocabulary.custom_vocab');
   if ($vocab && $vocab->get('name') === NULL) {
     $vocab->set('name', 'Custom Vocab')->save();
+
+    $content_types = ['event', 'page', 'post', 'profile'];
+
+    foreach ($content_types as $content_type) {
+      \Drupal::configFactory()->getEditable("field.field.node.{$content_type}.field_custom_vocab")
+        ->set('label', 'Custom Vocab')
+        ->save();
+    }
+
+    \Drupal::cache('discovery')->invalidateAll();
   }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.deploy.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for ys_core module.
+ */
+
+/**
+ * Implements hook_deploy_NAME().
+ *
+ * Sets the default taxonomy of custom_vocab if it is NULL.
+ */
+function ys_core_deploy_10001() {
+  $vocab = \Drupal::configFactory()->getEditable('taxonomy.vocabulary.custom_vocab');
+  if ($vocab && $vocab->get('name') === NULL) {
+    $vocab->set('name', 'Custom Vocab')->save();
+  }
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
@@ -5,7 +5,6 @@
  * Install, uninstall and update hooks for ys_core module.
  */
 
-use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\Component\Utility\Xss;
 use Drupal\taxonomy\Entity\Term;
 
@@ -247,18 +246,5 @@ function ys_core_update_10001() {
       ]);
       $term->save();
     }
-  }
-}
-
-/**
- * Implements hook_update().
- *
- * Add default custom_vocab vocabulary name.
- */
-function ys_core_update_10002() {
-  $vocab = Vocabulary::load('custom_vocab');
-  if ($vocab) {
-    $vocab->set('name', 'Custom Vocab');
-    $vocab->save();
   }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
@@ -5,6 +5,7 @@
  * Install, uninstall and update hooks for ys_core module.
  */
 
+use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\Component\Utility\Xss;
 use Drupal\taxonomy\Entity\Term;
 
@@ -246,5 +247,18 @@ function ys_core_update_10001() {
       ]);
       $term->save();
     }
+  }
+}
+
+/**
+ * Implements hook_update().
+ *
+ * Add default custom_vocab vocabulary name.
+ */
+function ys_core_update_10002() {
+  $vocab = Vocabulary::load('custom_vocab');
+  if ($vocab) {
+    $vocab->set('name', 'Custom Vocab');
+    $vocab->save();
   }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
@@ -131,7 +131,8 @@ ys_core.taxonomy_interface_custom_vocab:
   description: "Manage custom vocabularoy taxonomy"
   parent: ys_core.taxonomy_interface
   route_name: entity.taxonomy_vocabulary.overview_form
-  title: "Custom vocabulary"
+  title: "Custom Vocab"
+  class: Drupal\ys_core\Plugin\Menu\CustomTaxonomyMenuLink
   route_parameters:
     taxonomy_vocabulary: "custom_vocab"
 # Blocks interface

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
@@ -118,6 +118,22 @@ ys_core.taxonomy_interface_tags:
   title: Tags
   route_parameters:
     taxonomy_vocabulary: "tags"
+# Taxonomy interface - Audience
+ys_core.taxonomy_interface_audience:
+  description: "Manage audience taxonomy"
+  parent: ys_core.taxonomy_interface
+  route_name: entity.taxonomy_vocabulary.overview_form
+  title: Audience
+  route_parameters:
+    taxonomy_vocabulary: "audience"
+# Taxonomy interface - Custom Vocab
+ys_core.taxonomy_interface_custom_vocab:
+  description: "Manage custom vocabularoy taxonomy"
+  parent: ys_core.taxonomy_interface
+  route_name: entity.taxonomy_vocabulary.overview_form
+  title: "Custom vocabulary"
+  route_parameters:
+    taxonomy_vocabulary: "custom_vocab"
 # Blocks interface
 ys_core.custom_block_library:
   description: "Manage reusable blocks"

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/TaxonomyDisplayBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/TaxonomyDisplayBlock.php
@@ -143,7 +143,6 @@ class TaxonomyDisplayBlock extends BlockBase implements ContextAwarePluginInterf
           '#type' => 'select',
           '#title' => $this->t('Theme'),
           '#options' => [
-            'default' => $this->t('Default - No color'),
             'one' => $this->t('One'),
             'two' => $this->t('Two'),
             'three' => $this->t('Three'),

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/TaxonomyDisplayBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/TaxonomyDisplayBlock.php
@@ -197,12 +197,11 @@ class TaxonomyDisplayBlock extends BlockBase implements ContextAwarePluginInterf
               '#url' => $term->toUrl(),
             ];
           }
-          if (!empty($terms)) {
-            $items[$field_name] = [
-              'label' => $field_label,
-              'terms' => $terms,
-            ];
-          }
+
+          $items[$field_name] = [
+            'label' => $field_label,
+            'terms' => $terms,
+          ];
         }
       }
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/sort/ViewsBasicSort.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/sort/ViewsBasicSort.php
@@ -35,41 +35,10 @@ class ViewsBasicSort extends SortPluginBase {
           $field = $sortQueryOptions[0];
         }
 
-        if ($this->shouldFeaturePinToTop()) {
-          $query->addOrderBy(NULL, "node_field_data.sticky", 'DESC', 'views_basic_sort');
-        }
+        $query->addOrderBy(NULL, "node_field_data.sticky", 'DESC', 'views_basic_sort');
         $query->addOrderBy(NULL, "{$field}", $sortQueryOptions[1], 'views_basic_sort');
       }
     }
-  }
-
-  /**
-   * Determines if the view should feature a pin to top.
-   */
-  protected function shouldFeaturePinToTop() {
-    $pinOptions = $this->getPinOptions($this->view->args[10]);
-    if ($pinOptions && $pinOptions['pinned_to_top']) {
-      return TRUE;
-    }
-
-    return FALSE;
-  }
-
-  /**
-   * Decodes the pin option parameters.
-   *
-   * @param string $args
-   *   The arguments passed to the view.
-   *
-   * @return array
-   *   The decoded pin options.
-   */
-  protected function getPinOptions($args) {
-    if ($args) {
-      return json_decode($args, TRUE);
-    }
-
-    return [];
   }
 
 }


### PR DESCRIPTION
## V1.13.0 Feedback/Bug Fixes

### Description of work
- Removed `field_audience` and `field_custom_vocab` blocks from layout builder design
- Set default `custom vocab` name after creation/import
- Add `Audience` and `Custom Vocab` menu items
- Update menu to match custom vocab name
- Revert to always sorting by pin to top in views
- Move `Vertical alignment` down in Spotlight block form
- Removed `wrapped callout text` for now (reintroduce after first release)
- Removed `taxonomy display` from two column sections
- Re-add `video` and `image banner` dials
- #880
- `Show current node` respects its set value on view edit

### Functional testing steps:
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
