### PR TITLE
YSP-829: Hotfix: v1.13.0: Campus Groups API key support

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -86,7 +86,7 @@
     "drupal/paragraphs": "1.18.0",
     "drupal/paragraphs_features": "2.0.0",
     "drupal/pathauto": "1.13.0",
-    "drupal/quick_node_clone": "1.21.0",
+    "drupal/quick_node_clone": "1.22.0",
     "drupal/recaptcha": "3.4.0",
     "drupal/recaptcha_v3": "2.0.3",
     "drupal/redirect": "1.10.0",

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -86,7 +86,7 @@
     "drupal/paragraphs": "1.18.0",
     "drupal/paragraphs_features": "2.0.0",
     "drupal/pathauto": "1.13.0",
-    "drupal/quick_node_clone": "1.20.0",
+    "drupal/quick_node_clone": "1.21.0",
     "drupal/recaptcha": "3.4.0",
     "drupal/recaptcha_v3": "2.0.3",
     "drupal/redirect": "1.10.0",

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/migrations/campus_groups_events.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/migrations/campus_groups_events.yml
@@ -8,6 +8,8 @@ label: 'Campus Group Events'
 source:
   plugin: campus_groups_url
   data_fetcher_plugin: http
+  headers:
+    Accept: '*/*'
   data_parser_plugin: simple_xml
   track_changes: true
   urls: 'test.xml'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/src/Form/CampusGroupsSettings.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/src/Form/CampusGroupsSettings.php
@@ -59,6 +59,12 @@ class CampusGroupsSettings extends ConfigFormBase {
       '#description' => $this->t('Enter the group ids comma seperated'),
     ];
 
+    $form['campus_groups_api_key'] = [
+      '#type' => 'key_select',
+      '#title' => $this->t('Campus Groups Authentication Credentials'),
+      '#default_value' => $config->get('campus_groups_api_key') ?: '',
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -71,6 +77,7 @@ class CampusGroupsSettings extends ConfigFormBase {
       ->set('enable_campus_groups_sync', $form_state->getValue('enable_campus_groups_sync'))
       ->set('campus_groups_endpoint', rtrim($form_state->getValue('campus_groups_endpoint'), "/"))
       ->set('campus_groups_groupids', $form_state->getValue('campus_groups_groupids'))
+      ->set('campus_groups_api_key', $form_state->getValue('campus_groups_api_key'))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/src/Plugin/migrate/source/CampusGroupUrl.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/src/Plugin/migrate/source/CampusGroupUrl.php
@@ -24,6 +24,7 @@ class CampusGroupUrl extends Url {
     $config = \Drupal::configFactory()->getEditable('ys_campus_groups.settings');
 
     $url = $config->get('campus_groups_endpoint');
+    $api_key_name = $config->get('campus_groups_api_key');
     $groups = $config->get('campus_groups_groupids');
     $days = self::DAYS;
 
@@ -36,9 +37,34 @@ class CampusGroupUrl extends Url {
       $urlObject = UrlObject::fromUri($url, ['query' => $queryParams]);
 
       $configuration['urls'] = $urlObject->toString();
+      $headers = $configuration['headers'] ?? [];
+
+      $api_key = $this->getApiKeyFromKeysModule($api_key_name);
+
+      if ($api_key) {
+        $headers['x-cg-api-secret'] = $api_key;
+        $configuration['headers'] = $headers;
+      }
     }
 
     parent::__construct($configuration, $plugin_id, $plugin_definition, $migration);
+  }
+
+  /**
+   * Retrieves the API key from the keys module.
+   *
+   * @param string $key_name
+   *   The key name.
+   */
+  protected function getApiKeyFromKeysModule($key_name) {
+    $key = \Drupal::service('key.repository')->getKey($key_name);
+
+    if (!$key) {
+      return NULL;
+    }
+
+    $key_value = $key->getKeyValue();
+    return $key_value;
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/ys_campus_groups.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/ys_campus_groups.info.yml
@@ -7,3 +7,4 @@ dependencies:
   - drupal:migrate
   - migrate_plus:migrate_plus
   - migrate_tools:migrate_tools
+  - drupal:key


### PR DESCRIPTION
## [YSP-829: Hotfix: v1.13.0: Campus Groups API key support](https://yaleits.atlassian.net/browse/YSP-829)

### Description of work
- **Add campus groups API key field to settings form**
   - Added a new field `campus_groups_api_key` to the settings form.
   - This field allows users to input Campus Groups Authentication Credentials.
   - Updated the `submitForm` method to save the new API key field value.
- **Make module dependent on keys module**
   - Updated the module to be dependent on the keys module.
- **Add headers and API key support for campus groups**
   - Added `headers` configuration to `campus_groups_events.yml`.
   - Updated `CampusGroupUrl.php` to include API key in headers.
   - Implemented `getApiKeyFromKeysModule` to retrieve API key from keys module.

### Functional testing steps:
- [ ] Turn on campus groups with the settings I will pre-fill with
- [ ] Sync
- [ ] Ensure 2 items were sync'd
- [ ] Ensure `Heidi Test Event 1` exists
