### PR TITLE
Hotfix: v1.13.0: Bump quick node clone to patchable version

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -86,7 +86,7 @@
     "drupal/paragraphs": "1.18.0",
     "drupal/paragraphs_features": "2.0.0",
     "drupal/pathauto": "1.13.0",
-    "drupal/quick_node_clone": "1.20.0",
+    "drupal/quick_node_clone": "1.21.0",
     "drupal/recaptcha": "3.4.0",
     "drupal/recaptcha_v3": "2.0.3",
     "drupal/redirect": "1.10.0",


### PR DESCRIPTION
## Hotfix: v1.13.0: Bump quick node clone to patchable version

### Description of work
- Bumps Quick Node Clone to 1.21.0

### Functional testing steps:
- [ ] Build successfully compiles