### PR TITLE
revert: release action can only run on push event, not pull_request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,13 @@
 name: Create a release
 on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - master
+  push:
+    branches: master
 env:
   GH_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
   YALESITES_BUILD_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
           "assets": [
             "web/profiles/custom/yalesites_profile/yalesites_profile.info.yml"
           ],
-          "message": "chore: bump yalesites_profile to ${nextRelease.version}"
+          "message": "chore: bump yalesites_profile to ${nextRelease.version} [skip ci]"
         }
       ],
       [


### PR DESCRIPTION
Reverts b382a15 since semantic-release can only run on `push` events and we cannot target the source branch, just the target.

Also, since semantic-release makes a commit to bump yalesites_profile version during release, add [skip ci] to the commit so that it does not trigger the release workflow a second time.
