### PR TITLE
Hotfix: v1130: Remove pass by reference on $display_id

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -121,7 +121,7 @@ function ys_views_basic_views_pre_render(ViewExecutable $view): void {
 /**
  * Implements hook_views_pre_view().
  */
-function ys_views_basic_views_pre_view(ViewExecutable $view, &$display_id, array &$args) {
+function ys_views_basic_views_pre_view(ViewExecutable $view, $display_id, array &$args) {
   _ys_views_basic_invalidate_view_nodes_before_render($view, $args);
 }
 


### PR DESCRIPTION
## Hotfix: v1130: Remove pass by reference on $display_id

### Description of work
- Removes wrong function signature definition so that installs don't complain

### Functional testing steps:
- [ ] If this builds, it is successful