### PR TITLE
Hotfix: v1.13.0: Campus groups add to calendar fix

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -108,7 +108,7 @@
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
     "yalesites-org/ai_engine": "1.2.7",
-    "yalesites-org/atomic": "1.42.0",
+    "yalesites-org/atomic": "1.43.0",
     "yalesites-org/yale_cas": "v1.0.5"
   },
   "minimum-stability": "dev",

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/EventMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/EventMetaBlock.php
@@ -112,6 +112,7 @@ class EventMetaBlock extends BlockBase implements ContainerFactoryPluginInterfac
       '#localist_url' => $eventFieldData['localist_url'],
       '#stream_url' => $eventFieldData['stream_url'],
       '#stream_embed_code' => $eventFieldData['stream_embed_code'],
+      '#event_source' => $eventFieldData['event_source'],
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/ys-event-meta-block.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/ys-event-meta-block.html.twig
@@ -26,10 +26,15 @@
   description - a WYSIWYG description
   event_meta__cta_primary__href - An external event URL
   event_meta__cta_primary__content - External event URL text
+  event_meta__with_calendar - Whether the add to calendar link should show
 
 #}
+
+{% set event_meta__with_calendar = TRUE %}
+{% if (event_source == "Campus Groups") %}
+  {% set event_meta__with_calendar = FALSE %}
+{% endif %}
 
 {# All TWIG variables are named appropriately and pass through to this template #}
 {{ attach_library('atomic/event-localist') }}
 {% include '@molecules/meta/event-meta/yds-event-meta-localist.twig' %}
-

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
@@ -36,6 +36,8 @@ function ys_layouts_theme($existing, $type, $theme, $path): array {
         'localist_url' => NULL,
         'stream_url' => NULL,
         'stream_embed_code' => NULL,
+        'event_source' => NULL,
+        'event_id' => NULL,
       ],
     ],
     'ys_page_meta_block' => [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -166,6 +166,15 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
     $streamUrl = ($node->field_stream_url->first()) ? Url::fromUri($node->field_stream_url->first()->getValue()['uri'])->toString() : NULL;
     $streamEmbedCode = $node->field_stream_embed_code->first() ? $node->field_stream_embed_code->first()->getValue()['value'] : NULL;
 
+    // Retrieve the source taxonomy term name.
+    $sourceTaxonomyTermName = '';
+    if ($node->field_event_source->first()) {
+      $termId = $node->field_event_source->first()->getValue()['target_id'];
+      $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($termId);
+      $sourceTaxonomyTermName = $term->getName();
+    }
+    $eventSource = $sourceTaxonomyTermName;
+
     // Localist register ticket changes.
     $localistRegisterTickets = $hasRegister ? $this->localistManager->getTicketInfo($localistId) : NULL;
     if ($localistRegisterTickets) {
@@ -293,6 +302,7 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
       'localist_url' => $localistUrl,
       'stream_url' => $streamUrl,
       'stream_embed_code' => $streamEmbedCode,
+      'event_source' => $eventSource,
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/ys_localist.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/ys_localist.module
@@ -62,6 +62,7 @@ function ys_localist_preprocess_node(&$variables) {
     $variables['has_register'] = $eventFieldData['has_register'];
     $variables['cost_button_text'] = $eventFieldData['cost_button_text'];
     $variables['localist_url'] = $eventFieldData['localist_url'];
+    $variables['event_source'] = $eventFieldData['event_source'];
   }
 }
 


### PR DESCRIPTION
## Hotfix: v1.13.0: Campus groups add to calendar fix

Work also done in [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/481)

### Description of work
- Hides "Add to Calendar" for Campus Group event sources

### Functional testing steps:
- [ ] Import Campus Group events
- [ ] Verify that "Add to Calendar" does not show on event pages