### PR TITLE
YSP-824 Admin Label automatically is the block name

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -154,6 +154,18 @@ function ys_core_form_alter(&$form, $form_state, $form_id) {
     if (in_array($block_type_name, $limited_block_types)) {
       $form['#attached']['library'][] = 'ys_core/block_form';
     }
+
+    // Add default admin label to layout builder blocks.
+    $form_object = $form_state->getFormObject();
+    $component = $form_object->getCurrentComponent();
+    $plugin = $component->getPlugin();
+    if (isset($plugin)) {
+      // Get the default admin label from the block plugin label.
+      $plugin_definition = $plugin->getPluginDefinition();
+      $default_admin_label = $plugin_definition['admin_label'] ?? $plugin->getPluginId();
+      // Add the plugin label as default value.
+      $form['settings']['label']['#default_value'] = $default_admin_label;
+    }
   }
 
   _ys_core_disable_event_fields($form, $form_id);


### PR DESCRIPTION
## [YSP-824: Admin Label automatically is the block name (copy Taxonomy Display Block)](https://yaleits.atlassian.net/browse/YSP-824)

### Description of work
- Gets the admin label from the plugin definition or falls back to the plugin ID and adds it as the default admin label value. This is applied to layout builder block add/update forms.

### Functional testing steps:
- [ ] Add a LB block to any node layout. Verify there is a default admin label (for the text block it'll be "Text", etc.)
