### PR TITLE
YSP-844: Event Meta Block Date Visibility Improvements

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold_events.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold_events.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.storage.node.field_event_date
     - field.storage.node.field_teaser_text
     - field.storage.node.field_teaser_title
     - taxonomy.vocabulary.audience
@@ -11,6 +12,7 @@ dependencies:
     - taxonomy.vocabulary.event_category
   module:
     - node
+    - smart_date
     - taxonomy
     - text
     - user
@@ -214,6 +216,83 @@ display:
           group_column: value
           group_columns: {  }
           group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_event_date:
+          id: field_event_date
+          table: node__field_event_date
+          field: field_event_date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: smartdate_default
+          settings:
+            timezone_override: ''
+            format: default
+            force_chronological: false
+            add_classes: false
+            time_wrapper: true
+            localize: false
+            parts:
+              start: start
+              end: end
+              duration: '0'
+            duration:
+              separator: ' | '
+              unit: ''
+              decimals: 2
+              suffix: h
+          group_column: value
+          group_columns: {  }
+          group_rows: false
           delta_limit: 0
           delta_offset: 0
           delta_reversed: false
@@ -718,7 +797,7 @@ display:
           query_tags: {  }
       relationships: {  }
       use_ajax: true
-      group_by: true
+      group_by: false
       use_more: false
       use_more_always: true
       use_more_text: more
@@ -735,6 +814,7 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.field_event_date'
         - 'config:field.storage.node.field_teaser_text'
         - 'config:field.storage.node.field_teaser_title'
   block_1:
@@ -757,5 +837,6 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.field_event_date'
         - 'config:field.storage.node.field_teaser_text'
         - 'config:field.storage.node.field_teaser_title'

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold_events.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold_events.yml
@@ -300,6 +300,63 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        delta:
+          id: delta
+          table: node__field_event_date
+          field: delta
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ','
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
       pager:
         type: views_basic_full_pager
         options:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/EventMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/EventMetaBlock.php
@@ -113,7 +113,7 @@ class EventMetaBlock extends BlockBase implements ContainerFactoryPluginInterfac
       '#stream_url' => $eventFieldData['stream_url'],
       '#stream_embed_code' => $eventFieldData['stream_embed_code'],
       '#event_source' => $eventFieldData['event_source'],
-      '#event_featured_date' => reset($eventFieldData['dates']),
+      '#event_featured_date' => $eventFieldData['event_featured_date'],
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/EventMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/EventMetaBlock.php
@@ -113,6 +113,7 @@ class EventMetaBlock extends BlockBase implements ContainerFactoryPluginInterfac
       '#stream_url' => $eventFieldData['stream_url'],
       '#stream_embed_code' => $eventFieldData['stream_embed_code'],
       '#event_source' => $eventFieldData['event_source'],
+      '#event_featured_date' => reset($eventFieldData['dates']),
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
@@ -42,6 +42,7 @@ function ys_layouts_theme($existing, $type, $theme, $path): array {
         'stream_embed_code' => NULL,
         'event_source' => NULL,
         'event_id' => NULL,
+        'event_featured_date' => NULL,
       ],
     ],
     'ys_page_meta_block' => [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -342,9 +342,9 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
       }
     }
 
-    // If none were found, use the first element.
+    // If none were found, use the last element.
     if (!$featuredDate) {
-      $featuredDate = reset($dates);
+      $featuredDate = end($dates);
     }
 
     return $featuredDate;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -303,6 +303,7 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
       'stream_url' => $streamUrl,
       'stream_embed_code' => $streamEmbedCode,
       'event_source' => $eventSource,
+      'event_featured_date' => reset($dates),
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -311,7 +311,7 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
         $dates[$key]['original_start'] = $date['value'];
         $dates[$key]['original_end'] = $date['end_value'];
         $dates[$key]['is_all_day'] = $this->isAllDay($date['value'], $date['end_value']);
-        $dates[$key]['is_passed_event'] = $date['end_value'] < time();
+        $dates[$key]['is_past_event'] = $date['end_value'] < time();
       }
       // Sort dates - first date is next upcoming date.
       asort($dates);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -192,24 +192,9 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
     }
 
     // Dates.
-    $dates = [];
-    if ($dates = $node->field_event_date->getValue()) {
-      foreach ($dates as $key => $date) {
-        $dates[$key]['formatted_start_date'] = $this->dateFormatter->format($date['value'], 'event_date_only');
-        $dates[$key]['formatted_start_time'] = $this->dateFormatter->format($date['value'], 'event_time_only');
-        $dates[$key]['formatted_end_date'] = $this->dateFormatter->format($date['end_value'], 'event_date_only');
-        $dates[$key]['formatted_end_time'] = $this->dateFormatter->format($date['end_value'], 'event_time_only');
-        $dates[$key]['original_start'] = $date['value'];
-        $dates[$key]['original_end'] = $date['end_value'];
-        $dates[$key]['is_all_day'] = $this->isAllDay($date['value'], $date['end_value']);
-        // Remove older dates.
-        if ($date['end_value'] < time()) {
-          unset($dates[$key]);
-        }
-      }
-      // Sort dates - first date is next upcoming date.
-      asort($dates);
-    }
+    $dates = $node->field_event_date->getValue();
+    $this->orderEventDates($dates);
+    $featuredDate = $this->getFeaturedDate($dates);
 
     // Teaser responsive image.
     $teaserMediaRender = [];
@@ -305,6 +290,32 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
       'event_source' => $eventSource,
       'event_featured_date' => reset($dates),
     ];
+  }
+
+  /**
+   * Orders event dates by start date.
+   *
+   * @param array $dates
+   *   An array of dates.
+   *
+   * @return void
+   *   The array is passed by reference.
+   */
+  protected function orderEventDates(&$dates) {
+    if ($dates) {
+      foreach ($dates as $key => $date) {
+        $dates[$key]['formatted_start_date'] = $this->dateFormatter->format($date['value'], 'event_date_only');
+        $dates[$key]['formatted_start_time'] = $this->dateFormatter->format($date['value'], 'event_time_only');
+        $dates[$key]['formatted_end_date'] = $this->dateFormatter->format($date['end_value'], 'event_date_only');
+        $dates[$key]['formatted_end_time'] = $this->dateFormatter->format($date['end_value'], 'event_time_only');
+        $dates[$key]['original_start'] = $date['value'];
+        $dates[$key]['original_end'] = $date['end_value'];
+        $dates[$key]['is_all_day'] = $this->isAllDay($date['value'], $date['end_value']);
+        $dates[$key]['is_passed_event'] = $date['end_value'] < time();
+      }
+      // Sort dates - first date is next upcoming date.
+      asort($dates);
+    }
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -307,4 +307,36 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
     ];
   }
 
+  /**
+   * Get the first upcoming date from the list of dates.
+   *
+   * @param array $dates
+   *   An array of dates.
+   *
+   * @return array|NodeInterface
+   *   The first upcoming date or what was passed.
+   */
+  protected function getFeaturedDate($dates) {
+    $featuredDate = NULL;
+
+    if (!is_array($dates)) {
+      return $dates;
+    }
+
+    // Get the first date that is not in the past.
+    foreach ($dates as $date) {
+      if ($date['end_value'] >= time()) {
+        $featuredDate = $date;
+        break;
+      }
+    }
+
+    // If none were found, use the first element.
+    if (!$featuredDate) {
+      $featuredDate = reset($dates);
+    }
+
+    return $featuredDate;
+  }
+
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -288,7 +288,7 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
       'stream_url' => $streamUrl,
       'stream_embed_code' => $streamEmbedCode,
       'event_source' => $eventSource,
-      'event_featured_date' => reset($dates),
+      'event_featured_date' => $featuredDate,
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/pager/ViewsBasicFullPager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/pager/ViewsBasicFullPager.php
@@ -23,23 +23,76 @@ class ViewsBasicFullPager extends Full {
   /**
    * {@inheritdoc}
    */
-  public function query() {
-    if (!isset($this->view->args[5])) {
+  public function query(): void {
+    if (!$this->hasItemsPerPage()) {
       return;
     }
-    $this->setItemsPerPage((int) $this->view->args[5]);
-    $this->setOffset($this->view->args[7]);
+    $this->setItemsPerPage($this->itemsPerPage());
+    $this->setOffset($this->offset());
     $limit = $this->options['items_per_page'];
     $offset = $this->current_page * $this->options['items_per_page'] + $this->options['offset'];
-    if (!empty($this->options['total_pages'])) {
-      if ($this->current_page >= $this->options['total_pages']) {
-        $limit = $this->options['items_per_page'];
-        $offset = $this->options['total_pages'] * $this->options['items_per_page'];
-      }
+    if ($this->hasTotalPages() && $this->pastLastPage()) {
+      // Set them within the bounds of the total pages.
+      $limit = $this->options['items_per_page'];
+      $offset = $this->options['total_pages'] * $this->options['items_per_page'];
     }
 
     $this->view->query->setLimit($limit);
     $this->view->query->setOffset($offset);
+  }
+
+  /**
+   * Checks if the current page is past the last page.
+   *
+   * @return bool
+   *   TRUE if the current page is past the last page, FALSE otherwise.
+   */
+  protected function pastLastPage(): bool {
+    return $this->current_page >= $this->options['total_pages'];
+  }
+
+  /**
+   * Checks if the view has items per page argument.
+   *
+   * @return bool
+   *   TRUE if items per page argument is set, FALSE otherwise.
+   */
+  protected function hasItemsPerPage(): bool {
+    return isset($this->view->args[5]);
+
+  }
+
+  /**
+   * Checks if the total pages option is set.
+   *
+   * @return bool
+   *   TRUE if total pages option is set, FALSE otherwise.
+   */
+  protected function hasTotalPages(): bool {
+    return (!empty($this->options['total_pages']));
+
+  }
+
+  /**
+   * Gets the number of items per page.
+   *
+   * @return int
+   *   The number of items per page.
+   */
+  protected function itemsPerPage(): int {
+    return (int) $this->view->args[5];
+
+  }
+
+  /**
+   * Gets the offset for the query.
+   *
+   * @return int
+   *   The offset for the query.
+   */
+  protected function offset(): int {
+    return (int) $this->view->args[7];
+
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/style/ViewsBasicDynamicStyle.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/style/ViewsBasicDynamicStyle.php
@@ -113,7 +113,13 @@ class ViewsBasicDynamicStyle extends StylePluginBase implements ContainerFactory
     $rows = [];
 
     foreach ($this->view->result as $row) {
-      $rows[] = $this->view->rowPlugin->render($row);
+      $rendered_row = $this->view->rowPlugin->render($row);
+      // If row has node__field_event_date_delta,
+      // inject it into the render array.
+      if (isset($row->node__field_event_date_delta)) {
+        $rendered_row['#delta'] = $row->node__field_event_date_delta;
+      }
+      $rows[] = $rendered_row;
     }
 
     // Map the view mode in Drupal to the type attribute for the component.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -251,22 +251,6 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
   }
 
   /**
-   * Sets a unique pager ID for the given view.
-   *
-   * @param \Drupal\views\ViewExecutable $view
-   *   The view executable object.
-   */
-  public function setUniquePagerId(&$view) {
-    // Get the display for the view.
-    $display = $view->getDisplay();
-
-    // Set the pager id to be unique.
-    $display_options = $display->options;
-    $display_options['pager']['options']['id'] = uniqid();
-    $view->display_handler->overrideOption('pager', $display_options['pager']);
-  }
-
-  /**
    * Sets up the view with the parameters.
    *
    * @param \Drupal\views\ViewExecutable $view
@@ -283,13 +267,6 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
       return;
     }
     $setupRunning = TRUE;
-
-    // Determine if this is an ajax call.
-    $is_ajax = \Drupal::request()->isXmlHttpRequest();
-
-    if (!$is_ajax) {
-      $this->setUniquePagerId($view);
-    }
 
     $paramsDecoded = json_decode($params, TRUE);
     $pinned_to_top = isset($paramsDecoded['pinned_to_top']) ? (bool) $paramsDecoded['pinned_to_top'] : FALSE;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -540,16 +540,6 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
     $view->setArguments($view_args);
     $view->execute();
 
-    // Get all node ids.
-    $node_ids = [];
-    foreach ($view->result as $row) {
-      if (isset($row->_entity) && $row->_entity instanceof NodeInterface) {
-        $node_ids[] = 'node:' . $row->_entity->id();
-      }
-    }
-
-    $this->cacheTagsInvalidator->invalidateTags($node_ids);
-
     // Unset the pager. Needs to be done after view->execute();
     if ($paramsDecoded['display'] != "pager") {
       unset($view->pager);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -232,7 +232,13 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
   }
 
   /**
+   * Initializes the view based on the content type.
    *
+   * @param array $types
+   *   An array of content types.
+   *
+   * @return \Drupal\views\ViewExecutable
+   *   The view object.
    */
   public function initView($types) {
     if (in_array('event', $types)) {
@@ -245,7 +251,15 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
   }
 
   /**
+   * Sets up the view with the parameters.
    *
+   * @param \Drupal\views\ViewExecutable $view
+   *   The view object.
+   * @param string $params
+   *   The JSON encoded string of parameters.
+   *
+   * @return void
+   *   No return value.
    */
   public function setupView(&$view, $params) {
     static $setupRunning;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -251,6 +251,22 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
   }
 
   /**
+   * Sets a unique pager ID for the given view.
+   *
+   * @param \Drupal\views\ViewExecutable $view
+   *   The view executable object.
+   */
+  public function setUniquePagerId(&$view) {
+    // Get the display for the view.
+    $display = $view->getDisplay();
+
+    // Set the pager id to be unique.
+    $display_options = $display->options;
+    $display_options['pager']['options']['id'] = uniqid();
+    $view->display_handler->overrideOption('pager', $display_options['pager']);
+  }
+
+  /**
    * Sets up the view with the parameters.
    *
    * @param \Drupal\views\ViewExecutable $view
@@ -267,6 +283,13 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
       return;
     }
     $setupRunning = TRUE;
+
+    // Determine if this is an ajax call.
+    $is_ajax = \Drupal::request()->isXmlHttpRequest();
+
+    if (!$is_ajax) {
+      $this->setUniquePagerId($view);
+    }
 
     $paramsDecoded = json_decode($params, TRUE);
     $pinned_to_top = isset($paramsDecoded['pinned_to_top']) ? (bool) $paramsDecoded['pinned_to_top'] : FALSE;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -280,7 +280,6 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
         'id' => 'field_event_date_value',
         'table' => "node__field_event_date",
         'field' => 'field_event_date_value',
-        'group_type' => 'min',
         'order' => $sortDirection[1],
       ];
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -5,8 +5,6 @@
  * Contains ys_views_basic.module functions.
  */
 
-use Drupal\node\NodeInterface;
-use Drupal\views\Views;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -124,24 +122,6 @@ function ys_views_basic_views_pre_render(ViewExecutable $view): void {
  * Implements hook_views_pre_view().
  */
 function ys_views_basic_views_pre_view(ViewExecutable $view, $display_id, array &$args) {
-  _ys_views_basic_invalidate_view_nodes_before_render($view, $args);
-}
-
-/**
- * Invalidate the nodes about to be ajax rendered on the views basic views.
- *
- * This helps in custom settings such as hiding add to calendar, and others.
- *
- * @param \Drupal\views\ViewExecutable $view
- *   The view object.
- * @param array $args
- *   The arguments passed to the view.
- *
- * @return void
- *   No return value.
- */
-function _ys_views_basic_invalidate_view_nodes_before_render($view, array &$args) {
-  // Only target specific views.
   if (!in_array($view->id(), ['views_basic_scaffold', 'views_basic_scaffold_events'])) {
     return;
 
@@ -153,31 +133,6 @@ function _ys_views_basic_invalidate_view_nodes_before_render($view, array &$args
     return;
   }
 
-  // Get the next page and items per page.
-  $next_page = \Drupal::service('request_stack')->getCurrentRequest()->query->get('page');
-  $items_per_page = $view->getItemsPerPage();
-
-  // Create a new instance of the view to fetch the next set of results.
-  $view_next = Views::getView($view->id());
-  if ($view_next) {
-    $view_next->setDisplay($view->current_display);
-    $view_next->setItemsPerPage($items_per_page);
-    $view_next->setCurrentPage($next_page);
-    $view_next->args = $view->args;
-    $view_next->exposed_data = $view->exposed_data;
-    $view_next->execute();
-
-    // Collect only the node IDs that will appear in the next page.
-    $node_ids = [];
-    foreach ($view_next->result as $row) {
-      if (isset($row->_entity) && $row->_entity instanceof NodeInterface) {
-        $node_ids[] = 'node:' . $row->_entity->id();
-      }
-    }
-
-    // Invalidate cache **only for the nodes appearing on the next page**.
-    if (!empty($node_ids)) {
-      \Drupal::service('cache_tags.invalidator')->invalidateTags($node_ids);
-    }
-  }
+  $viewsBasicManager = \Drupal::service('ys_views_basic.views_basic_manager');
+  $viewsBasicManager->setupView($view, end($args));
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -5,6 +5,8 @@
  * Contains ys_views_basic.module functions.
  */
 
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\node\NodeInterface;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -135,4 +137,13 @@ function ys_views_basic_views_pre_view(ViewExecutable $view, $display_id, array 
 
   $viewsBasicManager = \Drupal::service('ys_views_basic.views_basic_manager');
   $viewsBasicManager->setupView($view, end($args));
+}
+
+/**
+ * Implements hook_node_view().
+ */
+function ys_views_basic_node_view(array &$build, NodeInterface $node, EntityViewDisplayInterface $display, $view_mode) {
+  if ($node->getType() === 'event' && $view_mode != 'full') {
+    $build['#cache']['max-age'] = 0;
+  }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -143,7 +143,13 @@ function ys_views_basic_views_pre_view(ViewExecutable $view, $display_id, array 
  * Implements hook_node_view().
  */
 function ys_views_basic_node_view(array &$build, NodeInterface $node, EntityViewDisplayInterface $display, $view_mode) {
-  if ($node->getType() === 'event' && $view_mode != 'full') {
+  $view_modes = [
+    "card",
+    "condensed",
+    "list_item",
+  ];
+
+  if (in_array($view_mode, $view_modes)) {
     $build['#cache']['max-age'] = 0;
   }
 }


### PR DESCRIPTION
## [YSP-844: Event Meta Block Date Visibility Improvements](https://yaleits.atlassian.net/browse/YSP-844)
## [YSP-676: Events with multiple dates should show for each instance of the event with the correct event date](https://yaleits.atlassian.net/browse/YSP-676)
## [YSP-839: A11y: Reference card pinned aria-label incorrect](https://yaleits.atlassian.net/browse/YSP-839)

Work also done at:
- [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/485)

### Description of work
- Updated the `MetaFieldsManager` to use the last date in the array if no featured date is found.
- Changed the event featured date handling to use a specific variable instead of the first element of the dates array.
- Refactored event date sorting and added methods to improve code readability and maintainability.
- Added the `event_featured_date` to the event data and related components to ensure it is correctly handled and displayed.
- Passed `delta` of event date into render array to properly display date in views
- Modified event view to not be aggregated for multiple instances of the same node (with different dates) to occur
- Event card views do not generate the following error in logs: `Warning: Array to string conversion in __TwigTemplate_...`

### Functional testing steps:

#### Event Meta Block Date Visibility Improvements
- [x] Create a single date event
- [x] Verify that the date displays
- [x] Create a multi-date event (in the future)
- [x] Verify that the first date is displayed (and all others in the `Show all events` section)
- [x] Create a multi-date event (with some in the past, some in the future)
- [x] Verify that the date displayed is the first upcoming date in the multi-date list
- [x] Verify that past dates under `Show all events` display `Past Event:`
- [x] Create a multi-date event (with all dates in the past)
- [x] Verify that the last past date is displayed
- [x] Verify that past dates under `Show all events` display `Past Event:`

#### Events with multiple dates should show for each instance of the event with the correct event date
- [ ] Create an event view, making sure to include those with multiple dates in the node
- [ ] Ensure that they all display in order and display the correct date
- [ ] Ensure that pagination behaves during this

#### A11y: Reference card pinned aria-label incorrect
- [ ] On the event view you created above, make it a card view, and include pinned items (make sure you have pinned items to show)
- [ ] Inspect the h3 element on the content and verify that the aria-label for pinned has the name you selected for the pin label, along with the title of the event.
  - [ ] For instance, if you named the pin label "Awesome" and the event was titled "Dave", it'd be "Awesome: Dave"
  - [ ] Visit the logs and verify that you no longer get a warning starting with the following text: `Warning: Array to string conversion in __TwigTemplate_...`