### PR TITLE
IYY-351: Content Collection Bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory..
+

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
@@ -93,7 +93,7 @@ class ThemeSettingsManager {
     'book_navigation' => [
       'name' => 'Book Navigation theme',
       'prop_type' => 'element',
-      'selector' => '[data-component-theme]',
+      'selector' => '.in-this-section[data-component-theme]',
       'default' => 'one',
       'values' => [
         'one' => [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
@@ -94,7 +94,7 @@ class ThemeSettingsManager {
       'name' => 'Book Navigation theme',
       'prop_type' => 'element',
       'selector' => '.in-this-section[data-component-theme]',
-      'default' => 'one',
+      'default' => 'two',
       'values' => [
         'one' => [
           'label' => 'One',

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ThemeSettingsManager.php
@@ -94,7 +94,7 @@ class ThemeSettingsManager {
       'name' => 'Book Navigation theme',
       'prop_type' => 'element',
       'selector' => '.in-this-section[data-component-theme]',
-      'default' => 'two',
+      'default' => 'one',
       'values' => [
         'one' => [
           'label' => 'One',


### PR DESCRIPTION
### Tickets:

-  [IYY-351: Content Collection Bug: Book navigation theme setting is changing the grand hero overlay](https://fourkitchens.clickup.com/t/36718269/IYY-351)
- [IYY-358: Content Collection Bug: z-index issues](https://fourkitchens.clickup.com/t/36718269/IYY-358)
- [IYY-357: Content Collection Bug: Last item in the Content Collection nav is missing borders](https://fourkitchens.clickup.com/t/36718269/IYY-357)
- [IYY-362: Content Colection Bug: Header/ title spacing](https://fourkitchens.clickup.com/t/36718269/IYY-362)

### Description of work
- Updates selector for `book_navigation` setting.
- Resolve front-end issues related to content collection.

### Functional testing steps:
- [ ] Visit the test site here: https://pr-910-yalesites-platform.pantheonsite.io

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/120c224e-1cb3-48a0-ba8b-a7dfce2290d8" />

- [ ] Create a new page that includes a `Content Collection` and also adds a `Grand Hero` component.
- [ ] Navigate to the node page and click on `Theme Settings`.
- [ ] Verify that the `Book Navigation Theme` only affects the content collection navigation.


### Component Library PR
https://github.com/yalesites-org/component-library-twig/pull/486