### PR TITLE
YSP-716 :: Add "Contained Narrow" Design Option to Grand Hero Block

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -125,6 +125,7 @@ grand_hero:
     values:
       full: Full
       contained: 'Floating Box'
+      contained-narrow: 'Floating Box Narrow'
     default: full
   field_style_variation:
     values:


### PR DESCRIPTION
## [YSP-716: Add "Contained Narrow" Design Option to Grand Hero Block](https://yaleits.atlassian.net/browse/YSP-716)

### Description of work
- Adds option to block: Floating Box Narrow 

Note that the "contained" option has a label of "Floating Box", so I added another with the key "contained-narrow" for which the label is "Floating Box Narrow"

### Functional testing steps:
- [ ] Add a Grand Hero banner to the banner section of a page. There is an example one here: https://pr-922-yalesites-platform.pantheonsite.io/about
- [ ] Choose "Floating Box Narrow" as the Overlay Position option
- [ ] Verify it matches the Figma designs and AC.

PR for the component library is here: https://github.com/yalesites-org/component-library-twig/pull/492
