### PR TITLE
YSP-417 :: Move from Google Analytics to Google Tag Manager module

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -52,6 +52,7 @@
     "drupal/gin_lb": "1.0.0-rc8",
     "drupal/gin_moderation_sidebar": "1.0.0",
     "drupal/google_analytics": "4.0.2",
+    "drupal/google_tag": "^2.0",
     "drupal/hide_revision_field": "2.5.0",
     "drupal/honeypot": "2.1.4",
     "drupal/imagemagick": "4.0.2",

--- a/web/profiles/custom/yalesites_profile/config/sync/config_ignore.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/config_ignore.settings.yml
@@ -8,6 +8,7 @@ ignored_config_entities:
   - 'field.field.node.post.field_custom_vocab:label'
   - 'field.field.node.profile.field_custom_vocab:label'
   - 'google_analytics.settings:account'
+  - 'google_tag*'
   - 'system.site*'
   - 'taxonomy.vocabulary.custom_vocab:name'
   - 'ys_alert.settings:alert'

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -59,6 +59,7 @@ module:
   gin_moderation_sidebar: 0
   gin_toolbar: 0
   google_analytics: 0
+  google_tag: 0
   help: 0
   honeypot: 0
   image: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/google_tag.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/google_tag.settings.yml
@@ -1,0 +1,4 @@
+_core:
+  default_config_hash: cvh7di-mJogXOBiv_AoDN22DXIg3-OtzE5iLCIFAQ1s
+use_collection: false
+default_google_tag_entity: ''

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -65,6 +65,7 @@ dependencies:
     - contextual
     - editoria11y
     - file
+    - google_tag
     - layout_builder
     - media
     - menu_admin_per_menu
@@ -106,6 +107,7 @@ permissions:
   - 'administer block types'
   - 'administer blocks'
   - 'administer book outlines'
+  - 'administer google_tag_container'
   - 'administer main menu items'
   - 'administer redirects'
   - 'administer users'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -64,6 +64,7 @@ dependencies:
     - contextual
     - editoria11y
     - file
+    - google_tag
     - layout_builder
     - media
     - menu_admin_per_menu
@@ -99,6 +100,7 @@ permissions:
   - 'access webform overview'
   - 'add content to books'
   - 'administer book outlines'
+  - 'administer google_tag_container'
   - 'administer main menu items'
   - 'administer redirects'
   - 'administer users'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -12,6 +12,7 @@ use Drupal\Core\Path\PathValidatorInterface;
 use Drupal\Core\Routing\RequestContext;
 use Drupal\Core\Session\AccountProxy;
 use Drupal\google_analytics\Constants\GoogleAnalyticsPatterns;
+use Drupal\google_tag\Entity\TagContainer;
 use Drupal\path_alias\AliasManagerInterface;
 use Drupal\ys_core\YaleSitesMediaManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -214,11 +215,11 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       '#default_value' => $yaleConfig->get('seo')['google_site_verification'],
     ];
 
-    $form['google_analytics_id'] = [
+    $form['google_tag_id'] = [
       '#type' => 'textfield',
       '#description' => $this->t('This ID has the form of <code>UA-xxxxx-yy</code>, <code>G-xxxxxxxx</code>, <code>AW-xxxxxxxxx</code>, or <code>DC-xxxxxxxx</code>. To get a Web Property ID, register your site with Google Analytics, or if you already have registered your site, go to your Google Analytics Settings page to see the ID next to every site profile.'),
-      '#title' => $this->t('Google Analytics Web Property ID'),
-      '#default_value' => $yaleConfig->get('seo')['google_analytics_id'],
+      '#title' => $this->t('Google Tag ID'),
+      '#default_value' => $yaleConfig->get('seo')['google_tag_id'],
     ];
 
     $form['custom_vocab_name'] = [
@@ -292,8 +293,8 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
     // Email validations.
     $this->validateEmail($form_state, 'site_mail');
 
-    // Ensure Google Analytics is a valid format.
-    $this->validateGoogleAnalyticsId($form_state, 'google_analytics_id');
+    // Ensure Google Tag ID is a valid format.
+    $this->validateGoogleTagId($form_state, 'google_tag_id');
 
     parent::validateForm($form, $form_state);
   }
@@ -320,13 +321,13 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       ->set('page.posts', $form_state->getValue('site_page_posts'))
       ->set('page.events', $form_state->getValue('site_page_events'))
       ->set('seo.google_site_verification', $form_state->getValue('google_site_verification'))
-      ->set('seo.google_analytics_id', $form_state->getValue('google_analytics_id'))
+      ->set('seo.google_tag_id', $form_state->getValue('google_tag_id'))
       ->set('taxonomy.custom_vocab_name', $form_state->getValue('custom_vocab_name'))
       ->set('image_fallback.teaser', $form_state->getValue('teaser_image_fallback'))
       ->set('custom_favicon', $form_state->getValue('favicon'))
       ->save();
-    $this->configFactory->getEditable('google_analytics.settings')
-      ->set('account', $form_state->getValue('google_analytics_id'))
+    $this->configFactory->getEditable('google_tag.settings')
+      ->set('account', $form_state->getValue('default_google_tag_entity'))
       ->save();
 
     $custom_vocab_name = $this->configFactory->getEditable('taxonomy.vocabulary.custom_vocab')->get('name');
@@ -438,14 +439,14 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
   }
 
   /**
-   * Check that a submitted GA value matches a valid Google Analytics format.
+   * Check that a submitted GA value matches a valid Google Tag format.
    *
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The form state passed by reference.
    * @param string $fieldId
    *   The id of a field on the cnnfig form.
    */
-  protected function validateGoogleAnalyticsId(FormStateInterface &$form_state, string $fieldId) {
+  protected function validateGoogleTagId(FormStateInterface &$form_state, string $fieldId) {
     // Exit early if the google_analytics module changed and no longer applies.
     if (!class_exists('Drupal\google_analytics\Constants\GoogleAnalyticsPatterns')) {
       return;
@@ -454,7 +455,7 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       if (!preg_match(GoogleAnalyticsPatterns::GOOGLE_ANALYTICS_GTAG_MATCH, $value)) {
         $form_state->setErrorByName(
           $fieldId,
-          $this->t('A valid Google Analytics Web Property ID is case sensitive and formatted like UA-xxxxx-yy, G-xxxxxxxx, AW-xxxxxxxxx, or DC-xxxxxxxx.')
+          $this->t('A valid Google Tag ID is case sensitive and formatted like UA-xxxxx-yy, G-xxxxxxxx, AW-xxxxxxxxx, or DC-xxxxxxxx.')
         );
       }
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -11,8 +11,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Path\PathValidatorInterface;
 use Drupal\Core\Routing\RequestContext;
 use Drupal\Core\Session\AccountProxy;
-use Drupal\google_analytics\Constants\GoogleAnalyticsPatterns;
-use Drupal\google_tag\Entity\TagContainer;
 use Drupal\path_alias\AliasManagerInterface;
 use Drupal\ys_core\YaleSitesMediaManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -215,13 +213,6 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       '#default_value' => $yaleConfig->get('seo')['google_site_verification'],
     ];
 
-    $form['google_tag_id'] = [
-      '#type' => 'textfield',
-      '#description' => $this->t('This ID has the form of <code>UA-xxxxx-yy</code>, <code>G-xxxxxxxx</code>, <code>AW-xxxxxxxxx</code>, or <code>DC-xxxxxxxx</code>. To get a Web Property ID, register your site with Google Analytics, or if you already have registered your site, go to your Google Analytics Settings page to see the ID next to every site profile.'),
-      '#title' => $this->t('Google Tag ID'),
-      '#default_value' => $yaleConfig->get('seo')['google_tag_id'],
-    ];
-
     $form['custom_vocab_name'] = [
       '#type' => 'textfield',
       '#description' => $this->t('This field will update the name of the custom vocabulary for the site. By default, the name is "Custom Vocab".'),
@@ -293,9 +284,6 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
     // Email validations.
     $this->validateEmail($form_state, 'site_mail');
 
-    // Ensure Google Tag ID is a valid format.
-    $this->validateGoogleTagId($form_state, 'google_tag_id');
-
     parent::validateForm($form, $form_state);
   }
 
@@ -321,13 +309,9 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       ->set('page.posts', $form_state->getValue('site_page_posts'))
       ->set('page.events', $form_state->getValue('site_page_events'))
       ->set('seo.google_site_verification', $form_state->getValue('google_site_verification'))
-      ->set('seo.google_tag_id', $form_state->getValue('google_tag_id'))
       ->set('taxonomy.custom_vocab_name', $form_state->getValue('custom_vocab_name'))
       ->set('image_fallback.teaser', $form_state->getValue('teaser_image_fallback'))
       ->set('custom_favicon', $form_state->getValue('favicon'))
-      ->save();
-    $this->configFactory->getEditable('google_tag.settings')
-      ->set('account', $form_state->getValue('default_google_tag_entity'))
       ->save();
 
     $custom_vocab_name = $this->configFactory->getEditable('taxonomy.vocabulary.custom_vocab')->get('name');
@@ -433,29 +417,6 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       if (strpos($value, '@yale.edu') === FALSE) {
         $form_state->setErrorByName(
           $fieldId, $this->t('Email domain has to be @yale.edu.')
-        );
-      }
-    }
-  }
-
-  /**
-   * Check that a submitted GA value matches a valid Google Tag format.
-   *
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   The form state passed by reference.
-   * @param string $fieldId
-   *   The id of a field on the cnnfig form.
-   */
-  protected function validateGoogleTagId(FormStateInterface &$form_state, string $fieldId) {
-    // Exit early if the google_analytics module changed and no longer applies.
-    if (!class_exists('Drupal\google_analytics\Constants\GoogleAnalyticsPatterns')) {
-      return;
-    }
-    if (($value = $form_state->getValue($fieldId))) {
-      if (!preg_match(GoogleAnalyticsPatterns::GOOGLE_ANALYTICS_GTAG_MATCH, $value)) {
-        $form_state->setErrorByName(
-          $fieldId,
-          $this->t('A valid Google Tag ID is case sensitive and formatted like UA-xxxxx-yy, G-xxxxxxxx, AW-xxxxxxxxx, or DC-xxxxxxxx.')
         );
       }
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
@@ -47,6 +47,13 @@ ys_core.admin_views_settings:
   route_name: ys_core.admin_views_settings
   title: "Views Settings"
   weight: 25
+# Google Tag settings form.
+ys_core.admin_google_tag_settings:
+  description: "Google Tag settings."
+  parent: ys_core.admin_yalesites
+  route_name: entity.google_tag_container.single_form
+  title: "Google Tag Settings"
+  weight: 30
 # Menu interface
 ys_core.menu_interface:
   description: "Manage menus"


### PR DESCRIPTION
## [YSP-417: Move from Google Analytics to Google Tag Manager module](https://yaleits.atlassian.net/browse/YSP-417)

### Description of work
- Adds and configures Google Tag
- Adds permissions for Site Admin and Platform Admin to administer Google Tag
- Adds a menu item in the Settings menu for Google Tag administration
- Adds Google Tag to config ignore

### Functional testing steps:
- [ ] As Site Admin or Platform Admin, verify you see Google Tag Settings in the Settings drop-down menu, verify you can edit the settings

**Note:** The Google Tag module should automatically migrate Google Analytics settings to Google Tag (this happens when Google Tag is enabled). So I think for now we should leave Google Analytics enabled, and when Google Tag is deployed it should be migrated on live sites. Then we can disable and remove Google Analytics. 
