### PR TITLE
YSP-814 :: Remove Show Thumbnails in reference card to use with-image

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.info.yml
@@ -1,4 +1,4 @@
-name: YaleSites core
+name: YaleSites Core
 type: module
 description: YaleSites Core Configuation
 core_version_requirement: '^9 || ^10'


### PR DESCRIPTION
[YSP-814: Remove Show Thumbnails in reference card to use with-image](https://yaleits.atlassian.net/browse/YALB-XX)

### Description:
Changes the reference_card__image property (which corresponds to 'withImage' in js files) to be set using the show_thumbnails property from ys_views_basic so that the show_thumbnail is no longer required in the component.
Note: I am not sure if we wanted to change 'show_thumbnail' in ys_views_basic also (which is set with the option 'Show Teaser Image').

Note: The views created by the View block in layout builder work as expected (the images display or are hidden by 'Show Teaser Image'. Images display by default anywhere not in a view (the node, Featured Card block). I'm hoping I haven't missed anything.

### Functional testing steps:
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
