### PR TITLE
Bump AI Engine to v1.2.9

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -111,7 +111,7 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
-    "yalesites-org/ai_engine": "1.2.8",
+    "yalesites-org/ai_engine": "1.2.9",
     "yalesites-org/atomic": "1.44.1",
     "yalesites-org/yale_cas": "v1.0.5"
   },


### PR DESCRIPTION
## Bump AI Engine to v1.2.9

### Description of work
- Updated the ai_engine dependency from version 1.2.8 to 1.2.9 in the composer.json file.
- Auto-include AI engine metatags on content types at all times

### Functional testing steps:
- [ ] Verify that AI engine metatags exist when creating or editing a new node