### PR TITLE
fix: specify path to CA PEM cert to prevent auth errors

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/cas.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/cas.settings.yml
@@ -10,8 +10,8 @@ server:
   hostname: secure.its.yale.edu
   port: 443
   path: /cas
-  verify: 0
-  cert: ''
+  verify: 1
+  cert: /etc/pki/tls/certs/ca-bundle.crt
 gateway:
   enabled: false
   recheck_time: -1


### PR DESCRIPTION
### Description of work
- Sets the "Custom Certificate Authority PEM Certificate" path so the CAS module does not need to autodiscover it, preventing authentication errors.