### PR TITLE
YSP-858 :: Taxonomy sub item filter shows multiple instances

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
@@ -861,7 +861,7 @@ display:
         options:
           query_comment: ''
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_tags: {  }
       relationships: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold_events.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold_events.yml
@@ -849,7 +849,7 @@ display:
         options:
           query_comment: ''
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_tags: {  }
       relationships: {  }


### PR DESCRIPTION

## [YSP-858: Taxonomy sub item filter shows multiple instances](https://yaleits.atlassian.net/browse/YSP-858)

### Description of work
- Adds distinct filter to views_basic_scaffold to prevent duplicates 

### Functional testing steps:
- [ ] Add two subcategories to a node in a view, filter by both categories. Verify you only see that node appear once in the view results.