### PR TITLE
YSP-821 :: Fix Table Row Hover Highlighting for Text Block Accessibility -- MULTIDEV ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ _Notes:_
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory..
 
+


### PR DESCRIPTION
## [YSP-821: Fix Table Row Hover Highlighting for Text Block Accessibility](https://yaleits.atlassian.net/browse/YSP-821)

Work actually done in https://github.com/yalesites-org/atomic/pull/341

### Description of work
- Limits gin hover styles to td cells (excludes th)

### Functional testing steps:
- [ ] Create a table that has a thead and th cells, like the second one here: https://development-ys-syllabus-yale-edu.pantheonsite.io/collection-logic-for-syllabi
- [ ] Put the Gin theme into dark mode setting
- [ ] Verify that when you hover over the table, the cells in the body have the hover effect and the header cells do not. This should fix the accessibility issue described in the ticket.
