### PR TITLE
Fix CAS login under Lando

### DIFF
--- a/web/sites/ys.settings.local.php
+++ b/web/sites/ys.settings.local.php
@@ -73,3 +73,7 @@ if (class_exists('Kint')) {
 // Config split for local environments.
 $config['config_split.config_split.local_config']['status'] = TRUE;
 $config['config_split.config_split.production_config']['status'] = FALSE;
+
+// Override CAS cert settings for local use.
+$config['cas.settings']['server']['verify'] = 0;
+$config['cas.settings']['server']['cert'] = '';


### PR DESCRIPTION
### Description of work
When setting the CAS cert path in #933 to prevent auth errors in Pantheon environments, CAS logins broke under Lando. This PR overrides the CAS cert settings when running locally.