### PR TITLE
Disallow crawling of ?page= parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,10 @@
       "file-mapping": {
         "[project-root]/.editorconfig": false,
         "[project-root]/pantheon.upstream.yml": false,
-        "[project-root]/.gitattributes": false
+        "[project-root]/.gitattributes": false,
+        "[web-root]/robots.txt": {
+          "append": "patches/robots.txt"
+        }
       }
     },
     "installer-types": [

--- a/patches/robots.txt
+++ b/patches/robots.txt
@@ -1,0 +1,2 @@
+# Disallow ?page= params
+Disallow: /*?page=


### PR DESCRIPTION
### Description of work
Pager parameters are causing crawlers to index the same page multiple times, so this PR:
- Adds append logic to composer.json for robots.txt
- Adds `patches/robots.txt` for customizations that get appended to `web/robots.txt` by composer
- Disallows `/*?page=` parameters to prevent duplicate pages in search indexes

### Functional testing steps:
**Pantheon serves its own robots.txt for non-live environments, so this can only be tested locally:**
- [ ] Visit /robots.txt
- [ ] Verify that `Disallow: /*?page=` has been appended to the end of the file
