### PR TITLE
YSP-892: Design treatment for active Content Collection parent menu items and location move

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,3 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory..
-
-

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/page-meta/layout--page-meta.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/page-meta/layout--page-meta.html.twig
@@ -36,8 +36,8 @@
   <div{{ attributes.addClass(classes) }}>
     <div {{ region_attribute_classes }}>
       {{ drupal_entity('block', 'yalesitesbreadcrumbs', check_access=false) }}
-      {{ content.page_meta }}
       {{ drupal_entity('block', 'atomic_custombooknavigation', check_access=false) }}
+      {{ content.page_meta }}
     </div>
   </div>
 {% endif %}


### PR DESCRIPTION
## [YSP-892: Design treatment for active Content Collect parent menu items](https://yaleits.atlassian.net/browse/YSP-892)
## Moved secondary nav

### Description of work
- A mock of the look and feel if we were to move the content collection above the title near the breadcrumbs
- Work done in:
  - [ ] [Atomic](https://github.com/yalesites-org/atomic/pull/349)
  - [ ] [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/510)

### Functional testing steps:
- [ ] In the multidev
  - [ ] Create a nested content collection item
  - [ ] Navigate to it
  - [ ] See the new location above the title
  - [ ] Ensure that the top level parent in the menu is decorated to show that inside of it is an active link
  - [ ] Create a top level only item (no sub items)
  - [ ] Visit it
  - [ ] Make sure that it is also decorated to show you that link is active