### PR TITLE
YSP-893: Bump AI Engine to v1.2.10

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -112,7 +112,7 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
-    "yalesites-org/ai_engine": "1.2.9",
+    "yalesites-org/ai_engine": "1.2.10",
     "yalesites-org/atomic": "1.46.0",
     "yalesites-org/yale_cas": "v1.0.5"
   },


### PR DESCRIPTION
## [YSP-893: Bump AI Engine to v1.2.10](https://yaleits.atlassian.net/browse/YSP-893)

### Description of work
- Bumps ai_engine to 1.2.10 to incorporate accessibility fixes detailed in YSP-893