### PR TITLE
YSP-912: Change default for social media sharing on Post content type

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_hide_sharing_links.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_hide_sharing_links.yml
@@ -13,7 +13,9 @@ label: 'Hide sharing links'
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: 1
 default_value_callback: ''
 settings:
   on_label: 'On'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -76,7 +76,8 @@ function ys_core_theme($existing, $type, $theme, $path): array {
 function ys_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Existing entries would have a NULL entry for field_hide_sharing_links.
   // Upon a new save, they wouldn't realize that it was off by default.
-  // This ensure that in the case where it's null it has the appropriate default.
+  // This ensure that in the case where it's null it has the appropriate
+  // default.
   if ($form_id === 'node_post_edit_form') {
     $node = $form_state->getFormObject()->getEntity();
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -74,6 +74,17 @@ function ys_core_theme($existing, $type, $theme, $path): array {
  * Implements hook_form_alter().
  */
 function ys_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Existing entries would have a NULL entry for field_hide_sharing_links.
+  // Upon a new save, they wouldn't realize that it was off by default.
+  // This ensure that in the case where it's null it has the appropriate default.
+  if ($form_id === 'node_post_edit_form') {
+    $node = $form_state->getFormObject()->getEntity();
+
+    if ($node->get('field_hide_sharing_links')->value === NULL) {
+      $form['field_hide_sharing_links']['widget']['value']['#default_value'] = TRUE;
+    }
+  }
+
   if ($form_id === 'layout_builder_update_block' || $form_id === 'layout_builder_add_block') {
     $block_type = ys_core_get_block_type($form, $form_state);
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PostMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PostMetaBlock.php
@@ -116,7 +116,7 @@ class PostMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
       $publishDate = strtotime($node->field_publish_date->first()->getValue()['value']);
       $dateFormatted = $this->dateFormatter->format($publishDate, '', 'c');
       $showReadTime = ($node->field_show_read_time->first()) ? $node->field_show_read_time->first()->getValue()['value'] : NULL;
-      $hideSharing = ($node->field_hide_sharing_links->first()) ? $node->field_hide_sharing_links->first()->getValue()['value'] : NULL;
+      $hideSharing = ($node->field_hide_sharing_links->first()) ? $node->field_hide_sharing_links->first()->getValue()['value'] : TRUE;
     }
 
     return [


### PR DESCRIPTION
## [YSP-912: Change default for social media sharing on Post content type](https://yaleits.atlassian.net/browse/YSP-912)

### Description of work
- Changes the post config to default `hide_sharing_links` to `TRUE` so new posts will have that value
- Changes the default value of `hide_sharing_links` on render to `TRUE` if no value existed

### Functional testing steps:
- [ ] Find an existing post that was created before this change
- [ ] Ensure that social media links do not show
- [ ] Edit the existing post
- [ ] Expand the Publishing options and ensure that the hide sharing links is enabled
- [ ] Create a new post
- [ ] Ensure that the option to hide is enabled by default
- [ ] Ensure that publishing this does not show the social media links
