### PR TITLE
YSP-912: Change default for social media sharing on Post content type

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.post.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.post.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
     - field.field.node.post.field_show_read_time
+    - field.field.node.post.field_show_social_media_sharing
     - field.field.node.post.field_tags
     - field.field.node.post.field_teaser_lead_in
     - field.field.node.post.field_teaser_media
@@ -55,8 +56,8 @@ third_party_settings:
       children:
         - field_login_required
         - sticky
+        - field_show_social_media_sharing
         - field_show_read_time
-        - field_hide_sharing_links
       label: 'Publishing Settings'
       region: content
       parent_name: ''
@@ -125,13 +126,6 @@ content:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-  field_hide_sharing_links:
-    type: boolean_checkbox
-    weight: 14
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
   field_login_required:
     type: boolean_checkbox
     weight: 12
@@ -155,7 +149,14 @@ content:
     third_party_settings: {  }
   field_show_read_time:
     type: boolean_checkbox
-    weight: 14
+    weight: 16
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_show_social_media_sharing:
+    type: boolean_checkbox
+    weight: 15
     region: content
     settings:
       display_label: true
@@ -251,6 +252,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_hide_sharing_links: true
   layout_builder__layout: true
   promote: true
   revision_log: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.card.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.card.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
     - field.field.node.post.field_show_read_time
+    - field.field.node.post.field_show_social_media_sharing
     - field.field.node.post.field_tags
     - field.field.node.post.field_teaser_lead_in
     - field.field.node.post.field_teaser_media
@@ -105,6 +106,7 @@ hidden:
   field_metatags: true
   field_publish_date: true
   field_show_read_time: true
+  field_show_social_media_sharing: true
   layout_builder__layout: true
   links: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.condensed.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.condensed.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
     - field.field.node.post.field_show_read_time
+    - field.field.node.post.field_show_social_media_sharing
     - field.field.node.post.field_tags
     - field.field.node.post.field_teaser_lead_in
     - field.field.node.post.field_teaser_media
@@ -102,6 +103,7 @@ hidden:
   field_login_required: true
   field_metatags: true
   field_show_read_time: true
+  field_show_social_media_sharing: true
   field_tags: true
   field_teaser_media: true
   field_teaser_text: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
     - field.field.node.post.field_show_read_time
+    - field.field.node.post.field_show_social_media_sharing
     - field.field.node.post.field_tags
     - field.field.node.post.field_teaser_lead_in
     - field.field.node.post.field_teaser_media
@@ -224,6 +225,16 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     weight: 5
+    region: content
+  field_show_social_media_sharing:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 6
     region: content
   field_teaser_lead_in:
     type: string

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.list_item.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.list_item.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
     - field.field.node.post.field_show_read_time
+    - field.field.node.post.field_show_social_media_sharing
     - field.field.node.post.field_tags
     - field.field.node.post.field_teaser_lead_in
     - field.field.node.post.field_teaser_media
@@ -105,6 +106,7 @@ hidden:
   field_metatags: true
   field_publish_date: true
   field_show_read_time: true
+  field_show_social_media_sharing: true
   layout_builder__layout: true
   links: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.search_result.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
     - field.field.node.post.field_show_read_time
+    - field.field.node.post.field_show_social_media_sharing
     - field.field.node.post.field_tags
     - field.field.node.post.field_teaser_lead_in
     - field.field.node.post.field_teaser_media
@@ -79,6 +80,7 @@ hidden:
   field_metatags: true
   field_publish_date: true
   field_show_read_time: true
+  field_show_social_media_sharing: true
   field_tags: true
   field_teaser_lead_in: true
   field_teaser_media: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.single.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.single.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
     - field.field.node.post.field_show_read_time
+    - field.field.node.post.field_show_social_media_sharing
     - field.field.node.post.field_tags
     - field.field.node.post.field_teaser_lead_in
     - field.field.node.post.field_teaser_media
@@ -125,6 +126,7 @@ hidden:
   field_login_required: true
   field_metatags: true
   field_show_read_time: true
+  field_show_social_media_sharing: true
   field_tags: true
   layout_builder__layout: true
   links: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.teaser.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.teaser.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.post.field_metatags
     - field.field.node.post.field_publish_date
     - field.field.node.post.field_show_read_time
+    - field.field.node.post.field_show_social_media_sharing
     - field.field.node.post.field_tags
     - field.field.node.post.field_teaser_lead_in
     - field.field.node.post.field_teaser_media
@@ -50,6 +51,7 @@ hidden:
   field_metatags: true
   field_publish_date: true
   field_show_read_time: true
+  field_show_social_media_sharing: true
   field_tags: true
   field_teaser_lead_in: true
   field_teaser_media: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.reference_card.field_show_teaser_lead_in.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.reference_card.field_show_teaser_lead_in.yml
@@ -9,7 +9,7 @@ id: block_content.reference_card.field_show_teaser_lead_in
 field_name: field_show_teaser_lead_in
 entity_type: block_content
 bundle: reference_card
-label: 'Show post teaser lead-in'
+label: 'Show teaser lead-in'
 description: 'Currently, only posts are supported to show a lead-in.'
 required: false
 translatable: false

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_show_social_media_sharing.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.post.field_show_social_media_sharing.yml
@@ -1,0 +1,23 @@
+uuid: b72c8d96-30c8-4898-92ab-811d8eff1e2e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_show_social_media_sharing
+    - node.type.post
+id: node.post.field_show_social_media_sharing
+field_name: field_show_social_media_sharing
+entity_type: node
+bundle: post
+label: 'Show Social Media Sharing Links'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_show_social_media_sharing.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_show_social_media_sharing.yml
@@ -1,0 +1,18 @@
+uuid: 33f97779-c39b-4800-9dd4-4d116f967dd6
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_show_social_media_sharing
+field_name: field_show_social_media_sharing
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.deploy.php
@@ -60,3 +60,33 @@ function ys_core_deploy_10002() {
   }
 
 }
+
+/**
+ * Implements hook_update().
+ *
+ * Transforms the values currently in field_hide_sharing_links
+ * to field_show_social_media_sharing for a post node.
+ *
+ * Remember to later remove the field_hide_sharing_links field.
+ */
+function ys_core_deploy_10003() {
+  $ids = \Drupal::entityQuery('node')
+    ->condition('type', 'post')
+    ->accessCheck(FALSE)
+    ->execute();
+
+  $nodes = \Drupal::entityTypeManager()->getStorage('node')->loadMultiple($ids);
+
+  foreach ($nodes as $node) {
+    if (!$node->hasField('field_hide_sharing_links')) {
+      continue;
+    }
+
+    $node->set(
+      'field_show_social_media_sharing',
+      $node->get('field_hide_sharing_links')->value == '0' ? '1' : '0'
+    );
+
+    $node->save();
+  }
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PostMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PostMetaBlock.php
@@ -116,7 +116,7 @@ class PostMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
       $publishDate = strtotime($node->field_publish_date->first()->getValue()['value']);
       $dateFormatted = $this->dateFormatter->format($publishDate, '', 'c');
       $showReadTime = ($node->field_show_read_time->first()) ? $node->field_show_read_time->first()->getValue()['value'] : NULL;
-      $hideSharing = ($node->field_hide_sharing_links->first()) ? $node->field_hide_sharing_links->first()->getValue()['value'] : NULL;
+      $showSocialMediaSharingLinks = ($node->field_show_social_media_sharing->first()) ? $node->field_show_social_media_sharing->first()->getValue()['value'] : NULL;
     }
 
     return [
@@ -125,7 +125,7 @@ class PostMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
       '#author' => $author,
       '#date_formatted' => $dateFormatted,
       '#show_read_time' => $showReadTime,
-      '#hide_sharing' => $hideSharing,
+      '#show_social_media_sharing_links' => $showSocialMediaSharingLinks,
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/ys-post-meta-block.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/ys-post-meta-block.html.twig
@@ -18,7 +18,7 @@
   page_title__heading: label,
   page_title__meta: author_markup ~ date_formatted|date("l, F j, Y"),
   page_title__width: 'content',
-  page_title__show_social_links: hide_sharing ? 'false' : 'true',
+  page_title__show_social_media_sharing_links: show_social_media_sharing_links ? 'false' : 'true',
 } %}
   {% block page_title__meta__extra %}
     {{ read_time }}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/ys-post-meta-block.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/templates/ys-post-meta-block.html.twig
@@ -18,7 +18,7 @@
   page_title__heading: label,
   page_title__meta: author_markup ~ date_formatted|date("l, F j, Y"),
   page_title__width: 'content',
-  page_title__show_social_media_sharing_links: show_social_media_sharing_links ? 'false' : 'true',
+  page_title__show_social_media_sharing_links: show_social_media_sharing_links ? 'true' : 'false',
 } %}
   {% block page_title__meta__extra %}
     {{ read_time }}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
@@ -58,7 +58,7 @@ function ys_layouts_theme($existing, $type, $theme, $path): array {
         'author' => NULL,
         'date_formatted' => NULL,
         'show_read_time' => NULL,
-        'hide_sharing' => NULL,
+        'show_social_media_sharing_links' => NULL,
       ],
     ],
     'ys_profile_meta_block' => [


### PR DESCRIPTION
## [YSP-912: Change default for social media sharing on Post content type](https://yaleits.atlassian.net/browse/YSP-912)

### Description of work
- Changes the setting for Social Media Links on Posts to be an opt-in instead of an opt-out
- Migrates `field_hide_sharing` to `field_show_social_media_sharing` for better naming
  - Posts with none set will be set to `FALSE` (`0`)
  - Posts with `field_hide_sharing` set to `FALSE` will have `field_show_social_media_sharing` set to `TRUE` (`1`)
  - Posts with `field_hide_sharing` set to `TRUE` will have `field_show_social_media_sharing` set to `FALSE` (`0`)
- Modified [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/514) to handle these new changes

### Functional testing steps:
- [x] Find an existing post that was created before this change
- [x] Ensure that social media links do not show
- [x] Edit the existing post
- [x] Expand the Publishing options and ensure that the `Show Social Media Sharing Links` field is set to `FALSE`
- [x] Create a new post
- [x] Ensure that the option to `Show Social Media Sharing Links` is set to `FALSE` (not on) and Save
- [x] Ensure that publishing this does not show the social media links
- [x] Edit the post
- [x] Set the `Show Social Media Sharing Links` to `TRUE` (on)
- [x] Save
- [x] Ensure that the social media links appear for the post now

You can alternatively see each of these states in [Dave's test page](https://pr-971-yalesites-platform.pantheonsite.io/the-3-states-of-social-media-links)