### PR TITLE
YSP-927: Show Content Type in LinkIt module

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/linkit.linkit_profile.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/linkit.linkit_profile.default.yml
@@ -15,7 +15,7 @@ matchers:
     id: 'entity:node'
     uuid: 556010a3-e317-48b3-b4ed-854c10f4b950
     settings:
-      metadata: 'by [node:author] | [node:created:medium]'
+      metadata: 'by [node:content-type] | [node:created:medium]'
       bundles: {  }
       group_by_bundle: false
       substitution_type: canonical

--- a/web/profiles/custom/yalesites_profile/config/sync/linkit.linkit_profile.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/linkit.linkit_profile.default.yml
@@ -15,7 +15,7 @@ matchers:
     id: 'entity:node'
     uuid: 556010a3-e317-48b3-b4ed-854c10f4b950
     settings:
-      metadata: 'by [node:content-type] | [node:created:medium]'
+      metadata: '[node:content-type] | [node:created:medium]'
       bundles: {  }
       group_by_bundle: false
       substitution_type: canonical


### PR DESCRIPTION
## [YSP-927: Show Content Type in LinkIt module](https://yaleits.atlassian.net/browse/YSP-927)

### Description of work
- Updated the metadata field in the linkit profile configuration to display the content type instead of the author. This improves the clarity of the metadata displayed for nodes.

![Screenshot 2025-05-06 at 9 55 34 AM](https://github.com/user-attachments/assets/06985de3-6d74-4b01-9c76-8af88fc94da1)

### Functional testing steps:
- [ ] Use a block that has a linkit field
- [ ] Ensure content type shows while searching