### PR TITLE
YSP-928: Layout Builder Block Tables in Dark Mode Unreadable -- MULTIDEV ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory..
+- 


### PR DESCRIPTION
## [YSP-928: Layout Builder Block Tables in Dark Mode Unreadable -- MULTIDEV ONLY](https://yaleits.atlassian.net/browse/YSP-928)

### Description of work
- Real work done in [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/515)
- Allows layout builder backgrounds to behave while allowing section-based tables to function as intended

### Functional testing steps:
- [ ] Do the following in both dark and light mode:
  - [ ] Create one of the new sections with a background color
  - [ ] Create a text block and add a table with multiple rows
  - [ ] Ensure that on save it looks fine
  - [ ] Create a button block
  - [ ] Ensure that the rows of the links are now readable
  - [ ] Create a few blocks in a section
  - [ ] Now attempt to use the move link in the edit drop down
  - [ ] Ensure that tables there look fine
  - [ ] Ensure that the weight toggle is easily readable
