### PR TITLE
Add permissions for wrapped_text_callout content

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.contributor.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.contributor.yml
@@ -35,6 +35,7 @@ dependencies:
     - block_content.type.view
     - block_content.type.webform
     - block_content.type.wrapped_image
+    - block_content.type.wrapped_text_callout
     - core.entity_view_display.node.event.default
     - core.entity_view_display.node.page.default
     - core.entity_view_display.node.post.default
@@ -162,6 +163,7 @@ permissions:
   - 'create view block content'
   - 'create webform block content'
   - 'create wrapped_image block content'
+  - 'create wrapped_text_callout block content'
   - 'delete any accordion block content'
   - 'delete any accordion block content revisions'
   - 'delete any background_video media'
@@ -232,6 +234,8 @@ permissions:
   - 'delete any webform submission'
   - 'delete any wrapped_image block content'
   - 'delete any wrapped_image block content revisions'
+  - 'delete any wrapped_text_callout block content'
+  - 'delete any wrapped_text_callout block content revisions'
   - 'delete own event content'
   - 'delete own page content'
   - 'delete own post content'
@@ -285,6 +289,7 @@ permissions:
   - 'edit any webform block content'
   - 'edit any webform submission'
   - 'edit any wrapped_image block content'
+  - 'edit any wrapped_text_callout block content'
   - 'edit own background_video media'
   - 'edit own document media'
   - 'edit own embed media'
@@ -338,6 +343,7 @@ permissions:
   - 'revert any view block content revisions'
   - 'revert any webform block content revisions'
   - 'revert any wrapped_image block content revisions'
+  - 'revert any wrapped_text_callout block content revisions'
   - 'revert event revisions'
   - 'revert page revisions'
   - 'revert post revisions'
@@ -383,6 +389,7 @@ permissions:
   - 'view any webform block content history'
   - 'view any webform submission'
   - 'view any wrapped_image block content history'
+  - 'view any wrapped_text_callout block content history'
   - 'view editoria11y checker'
   - 'view event revisions'
   - 'view latest version'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.editor.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.editor.yml
@@ -35,6 +35,7 @@ dependencies:
     - block_content.type.view
     - block_content.type.webform
     - block_content.type.wrapped_image
+    - block_content.type.wrapped_text_callout
     - core.entity_view_display.node.event.default
     - core.entity_view_display.node.page.default
     - core.entity_view_display.node.post.default
@@ -164,6 +165,7 @@ permissions:
   - 'create view block content'
   - 'create webform block content'
   - 'create wrapped_image block content'
+  - 'create wrapped_text_callout block content'
   - 'delete any accordion block content'
   - 'delete any accordion block content revisions'
   - 'delete any background_video media'
@@ -239,6 +241,8 @@ permissions:
   - 'delete any webform submission'
   - 'delete any wrapped_image block content'
   - 'delete any wrapped_image block content revisions'
+  - 'delete any wrapped_text_callout block content'
+  - 'delete any wrapped_text_callout block content revisions'
   - 'delete media'
   - 'delete own background_video media'
   - 'delete own document media'
@@ -298,6 +302,7 @@ permissions:
   - 'edit any webform block content'
   - 'edit any webform submission'
   - 'edit any wrapped_image block content'
+  - 'edit any wrapped_text_callout block content'
   - 'edit own background_video media'
   - 'edit own document media'
   - 'edit own embed media'
@@ -351,6 +356,7 @@ permissions:
   - 'revert any view block content revisions'
   - 'revert any webform block content revisions'
   - 'revert any wrapped_image block content revisions'
+  - 'revert any wrapped_text_callout block content revisions'
   - 'revert event revisions'
   - 'revert page revisions'
   - 'revert post revisions'
@@ -404,6 +410,7 @@ permissions:
   - 'view any webform block content history'
   - 'view any webform submission'
   - 'view any wrapped_image block content history'
+  - 'view any wrapped_text_callout block content history'
   - 'view editoria11y checker'
   - 'view event revisions'
   - 'view latest version'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -35,6 +35,7 @@ dependencies:
     - block_content.type.view
     - block_content.type.webform
     - block_content.type.wrapped_image
+    - block_content.type.wrapped_text_callout
     - core.entity_view_display.node.event.default
     - core.entity_view_display.node.page.default
     - core.entity_view_display.node.post.default
@@ -92,6 +93,7 @@ dependencies:
     - ys_alert
     - ys_campus_groups
     - ys_core
+    - ys_integrations
     - ys_localist
 id: platform_admin
 label: 'Platform administrator'
@@ -186,6 +188,7 @@ permissions:
   - 'create view block content'
   - 'create webform block content'
   - 'create wrapped_image block content'
+  - 'create wrapped_text_callout block content'
   - 'delete any accordion block content'
   - 'delete any accordion block content revisions'
   - 'delete any background_video media'
@@ -261,6 +264,8 @@ permissions:
   - 'delete any webform submission'
   - 'delete any wrapped_image block content'
   - 'delete any wrapped_image block content revisions'
+  - 'delete any wrapped_text_callout block content'
+  - 'delete any wrapped_text_callout block content revisions'
   - 'delete media'
   - 'delete own background_video media'
   - 'delete own document media'
@@ -321,6 +326,7 @@ permissions:
   - 'edit any webform block content'
   - 'edit any webform submission'
   - 'edit any wrapped_image block content'
+  - 'edit any wrapped_text_callout block content'
   - 'edit own background_video media'
   - 'edit own document media'
   - 'edit own embed media'
@@ -385,6 +391,7 @@ permissions:
   - 'revert any view block content revisions'
   - 'revert any webform block content revisions'
   - 'revert any wrapped_image block content revisions'
+  - 'revert any wrapped_text_callout block content revisions'
   - 'revert event revisions'
   - 'revert page revisions'
   - 'revert post revisions'
@@ -438,6 +445,7 @@ permissions:
   - 'view any webform block content history'
   - 'view any webform submission'
   - 'view any wrapped_image block content history'
+  - 'view any wrapped_text_callout block content history'
   - 'view editoria11y checker'
   - 'view event revisions'
   - 'view latest version'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -35,6 +35,7 @@ dependencies:
     - block_content.type.view
     - block_content.type.webform
     - block_content.type.wrapped_image
+    - block_content.type.wrapped_text_callout
     - core.entity_view_display.node.event.default
     - core.entity_view_display.node.page.default
     - core.entity_view_display.node.post.default
@@ -170,6 +171,7 @@ permissions:
   - 'create view block content'
   - 'create webform block content'
   - 'create wrapped_image block content'
+  - 'create wrapped_text_callout block content'
   - 'delete any accordion block content'
   - 'delete any accordion block content revisions'
   - 'delete any background_video media'
@@ -245,6 +247,8 @@ permissions:
   - 'delete any webform submission'
   - 'delete any wrapped_image block content'
   - 'delete any wrapped_image block content revisions'
+  - 'delete any wrapped_text_callout block content'
+  - 'delete any wrapped_text_callout block content revisions'
   - 'delete media'
   - 'delete own background_video media'
   - 'delete own document media'
@@ -305,6 +309,7 @@ permissions:
   - 'edit any webform block content'
   - 'edit any webform submission'
   - 'edit any wrapped_image block content'
+  - 'edit any wrapped_text_callout block content'
   - 'edit own background_video media'
   - 'edit own document media'
   - 'edit own embed media'
@@ -358,6 +363,7 @@ permissions:
   - 'revert any view block content revisions'
   - 'revert any webform block content revisions'
   - 'revert any wrapped_image block content revisions'
+  - 'revert any wrapped_text_callout block content revisions'
   - 'revert event revisions'
   - 'revert page revisions'
   - 'revert post revisions'
@@ -411,6 +417,7 @@ permissions:
   - 'view any webform block content history'
   - 'view any webform submission'
   - 'view any wrapped_image block content history'
+  - 'view any wrapped_text_callout block content history'
   - 'view editoria11y checker'
   - 'view event revisions'
   - 'view latest version'


### PR DESCRIPTION


## Add permissions for wrapped_text_callout content

### Description of work
Added dependencies and permissions for the wrapped_text_callout block content type across contributor, editor, platform_admin, and site_admin roles. This includes create, delete, edit, revert, and view permissions to ensure proper role-based access control.

### Functional testing steps:
Not noticeable change, but more for consistency with how we deal with permissions.