### PR TITLE
YSP-738: Hide hamburger menu if no nav items exist -- FOR MULTIDEV ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ _Notes:_
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory..
 
+


### PR DESCRIPTION
## [YSP-738: Hide hamburger menu if no nav items exist -- FOR MULTIDEV ONLY](https://yaleits.atlassian.net/browse/YSP-738)

### Description of work
- Work done in [Atomic](https://github.com/yalesites-org/atomic/pull/360) and [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/522)

### Functional testing steps:
- [x] Ensure that menus either in the primary or utility navigation exist and are enabled
- [x] Ensure that on mobile you see the hamburger menu
- [x] Disable all primary and utility menu items
- [ ] Ensure that now on mobile you do not see the hamburger menu
