### PR TITLE
YSP-563: Turn off site alerts on starter kits

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/ys_alert.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_alert.settings.yml
@@ -15,7 +15,7 @@ alert:
   id: 1660263375
   headline: 'Optional banner for displaying an announcement or notice'
   message: 'Additional text goes here'
-  status: 1
+  status: 0
   type: announcement
   link_title: ''
   link_url: ''


### PR DESCRIPTION
## [YSP-563: Turn off site alerts on starter kits](https://yaleits.atlassian.net/browse/YSP-563)

### Description of work
- Changed the default 'status' value for alerts from active (1) to inactive (0) in ys_alert.settings.yml. This ensures alerts are not displayed by default until explicitly activated.

### Functional testing steps:
- [x] Visit the multidev
- [x] Verify that you do not see an alert