### PR TITLE
YSP-846: Improve Link Contrast and Readability in Inline Message Blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,3 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory..
-


### PR DESCRIPTION
## [YSP-846: Improve Link Contrast and Readability in Inline Message Blocks](https://yaleits.atlassian.net/browse/YSP-846)
## [YSP-930: In-Line Message: Add default bottom padding](https://yaleits.atlassian.net/browse/YSP-930)

### Description of work
- Work completed in [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/523)

### Functional testing steps:
- [x] Create an `in-line message` block
- [x] Add a link to the content portion, as well as a link in the link section.
- [x] Ensure they behave similarly
- [x] Change themes (both component and global) to ensure contrast passes a11y
- [x] Ensure that the in line message now has top and bottom padding resembling the other components
