### PR TITLE
YSP-702: Facts and Figures: add links to items + make "content" optional

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.facts.field_text.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.facts.field_text.yml
@@ -14,7 +14,7 @@ entity_type: block_content
 bundle: facts
 label: Content
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.facts_item.field_text.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.facts_item.field_text.yml
@@ -4,7 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_text
-    - filter.format.heading_html
+    - filter.format.restricted_html
     - paragraphs.paragraphs_type.facts_item
   module:
     - text
@@ -20,5 +20,5 @@ default_value: {  }
 default_value_callback: ''
 settings:
   allowed_formats:
-    - heading_html
+    - restricted_html
 field_type: text_long

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
@@ -303,3 +303,32 @@ function ys_core_update_10003() {
     \Drupal::messenger()->addStatus("Site email not updated as it was set to {$site_mail}.");
   }
 }
+
+/**
+ * Implements hook_update().
+ *
+ * This update will update paragraph Facts and Figure Item block's
+ * field_text format from Heading HTML to Restricted.  Doing so
+ * will allow links to be used.
+ */
+function ys_core_update_10004() {
+
+  $query = \Drupal::entityQuery('paragraph')
+    ->accessCheck(FALSE)
+    ->condition('type', 'facts_item')
+    ->condition('field_text.format', 'heading_html')
+    ->allRevisions();
+
+  $ids = $query->execute();
+  $paragraph_storage = \Drupal::entityTypeManager()->getStorage('paragraph');
+
+  foreach ($ids as $revision_id => $id) {
+    $paragraph = $paragraph_storage->loadRevision($revision_id);
+
+    if ($paragraph && $paragraph->id() == $id) {
+      $new_field_text = ['format' => 'restricted_html', 'value' => $paragraph->field_text->value];
+      $paragraph->set('field_text', $new_field_text);
+      $paragraph->save();
+    }
+  }
+}


### PR DESCRIPTION
## [YSP-702: Facts and Figures: add links to items + make "content" optional](https://yaleits.atlassian.net/browse/YSP-702)

### Description of work
- Makes facts and figure block content field optional
- Converts facts and figure block's paragraph item content format from `heading_html` to `restricted_html`
- Add update hook to convert existing facts and figure paragraph items to utilize the new format

### Functional testing steps:
- [x] Create a new facts and figure
- [x] Ensure that the `Content` field is not required
- [x] Ensure when not entering text there that it does not show
- [x] When adding fact paragraph subitems, ensure that you can now add a link
- [x] Add a link, making sure that it displays properly.
- [ ] If there was previously a facts and figure block (I don't think there is?) it should not prompt you for the format on edit
