### PR TITLE
Hotfix: YSP-951: Breadcrumbs not showing more than 2 trails levels -- For Multidev Only

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,3 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory..
-


### PR DESCRIPTION
## [Hotfix: YSP-951: Breadcrumbs not showing more than 2 trails levels -- For Multidev Only](https://yaleits.atlassian.net/browse/YSP-951)

### Description of work
- Real work done in
  - [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/524)
  - [Atomic](https://github.com/yalesites-org/atomic/pull/361)

### Functional testing steps:
- [ ] Create a multi-level content collection (3+ deep)
- [ ] Verify that the breadcrumbs completely show the breadcrumb path when you visit one of those deeply nested items