### PR TITLE
YSP-966: Drag and Drop is not saving

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/two_column/layout--two-column.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/two_column/layout--two-column.html.twig
@@ -14,15 +14,10 @@
 
 {% set layout__base_class = layout__base_class|default('yds-two-column') %}
 
-{% set layout__attributes = attributes|merge({
-	'class': bem(layout__base_class, layout__modifiers, layout__blockname),
-  'data-component-padding': settings['padding']|default('default'),
-  'data-component-width': layout__width|default('site'),
-	'data-embedded-components': 'true',
-}) %}
+{% set classes = ['yds-two-column'] %}
 
 {% if content %}
-	<div {{ add_attributes(layout__attributes) }}>
+	<div{{ attributes.addClass(classes).setAttribute('data-component-padding', settings['padding']|default('default')).setAttribute('data-component-width', layout__width|default('site')).setAttribute('data-embedded-components', 'true') }}>
 		<div {{ bem('inner', [], layout__base_class)}}>
 			{% if content.content %}
 				<div {{ region_attributes.content.addClass('yds-two-column__primary') }}>


### PR DESCRIPTION
## [YSP-966: Drag and Drop is not saving](https://yaleits.atlassian.net/browse/YSP-966)

### Description of work
- Refactored the two-column layout template to mimic the one column version.  This fixes drag and drop in that it provides the move url to use when dragging and dropping.

### Functional testing steps:
- [x] [Log in via CAS](https://pr-988-yalesites-platform.pantheonsite.io/cas)
- [x] [Create a new page](https://pr-988-yalesites-platform.pantheonsite.io/node/add/page)
- [x] Create a new text block inside the existing one column layout
- [x] Create a 70/30 layout
- [x] In each, add a text block
- [x] Drag the text block from the one column layout to the 70/30 (either side)
- [x] Save
- [x] Edit
- [x] Ensure that it was successfully moved and saved to the 70/30
- [x] Try all other layouts with any other blocks and move them
