### PR TITLE
YSP-865: Event Content Type: "Basic info" has two 'required' asterisks

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
@@ -148,7 +148,7 @@ third_party_settings:
         id: ''
         formatter: closed
         description: ''
-        required_fields: true
+        required_fields: false
     group_classifications:
       children:
         - field_tags


### PR DESCRIPTION

## [YSP-865: Event Content Type: "Basic info" has two 'required' asterisks](https://yaleits.atlassian.net/browse/YSP-865)

### Description of work
- Set the "required_fields" property for the "group_classifications" field to false in the event content type form display configuration, showing only one asterisk.

### Functional testing steps:
- [ ] Create or edit an event
- [ ] Notice that there is only one asterisk now
