### PR TITLE
YSP-884 :: Site Setting - Create Font Pairing Option with Mallory as Heading Option

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -228,6 +228,17 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       '#default_value' => $yaleConfig->get('taxonomy')['custom_vocab_name'] ?? 'Custom Vocab',
     ];
 
+    $form['font_pairing'] = [
+      '#type' => 'radios',
+      '#options' => [
+        'yalenew' => $this->t('YaleNew (YaleNew for headings, Mallory for paragraph text)'),
+        'mallory' => $this->t('Mallory (Mallory for headings, Mallory for paragraph text)'),
+      ],
+      '#description' => $this->t('This font pairing will apply site-wide and affect all heading levels (h1-h6)'),
+      '#title' => $this->t('Font Pairing'),
+      '#default_value' => $yaleConfig->get('font_pairing') ?? 'yalenew',
+    ];
+
     $form['teaser_image_fallback'] = [
       '#type' => 'media_library',
       '#allowed_bundles' => ['image'],
@@ -324,6 +335,7 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       ->set('taxonomy.custom_vocab_name', $form_state->getValue('custom_vocab_name'))
       ->set('image_fallback.teaser', $form_state->getValue('teaser_image_fallback'))
       ->set('custom_favicon', $form_state->getValue('favicon'))
+      ->set('font_pairing', $form_state->getValue('font_pairing'))
       ->save();
     $this->configFactory->getEditable('google_analytics.settings')
       ->set('account', $form_state->getValue('google_analytics_id'))

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -594,6 +594,11 @@ function ys_core_get_block_type(&$form, &$form_state) {
 function ys_core_preprocess_html(&$variables) {
   // Adds the content type in a class to support specific content type styling.
   $variables['attributes']['class'][] = isset($variables['node_type']) ? "ys-content-type-{$variables['node_type']}" : NULL;
+
+  // Add font pairing data attribute to body tag.
+  $config = \Drupal::config('ys_core.site');
+  $font_pairing = $config->get('font_pairing') ?? 'yalenew';
+  $variables['attributes']['data-font-pairing'] = $font_pairing;
 }
 
 /**


### PR DESCRIPTION

## [YSP-884: Site Setting - Create Font Pairing Option with Mallory as Heading Option](https://yaleits.atlassian.net/browse/YSP-884)

### Description of work
- Adds add setting to site settings
- Adds data-font-pairing attribute to body tag

### Functional testing steps:
- [ ] Verify option exists in site settings to select either YaleNew or Mallory
- [ ] Verify the form input/options meet the requirements
- [ ] Verify a data-font-pairing attribute appears in the body tag for all pages, this will be used for heading font and styles

Note there is FE work needed also which will follow.
