### PR TITLE
YSP-904: YPS: Add Image Background to Action Banner and Callout Blocks

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.callout.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.callout.default.yml
@@ -6,10 +6,12 @@ dependencies:
     - block_content.type.callout
     - field.field.block_content.callout.field_callout
     - field.field.block_content.callout.field_instructions
+    - field.field.block_content.callout.field_overlay_background_image
     - field.field.block_content.callout.field_style_alignment
     - field.field.block_content.callout.field_style_color
   module:
     - markup
+    - media_library
     - paragraphs
     - paragraphs_features
 id: block_content.callout.default
@@ -46,6 +48,13 @@ content:
     weight: 0
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_overlay_background_image:
+    type: media_library_widget
+    weight: 7
+    region: content
+    settings:
+      media_types: {  }
     third_party_settings: {  }
   field_style_alignment:
     type: options_select

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.cta_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.cta_banner.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.block_content.cta_banner.field_link
     - field.field.block_content.cta_banner.field_link_two
     - field.field.block_content.cta_banner.field_media
+    - field.field.block_content.cta_banner.field_overlay_background_image
     - field.field.block_content.cta_banner.field_style_color
     - field.field.block_content.cta_banner.field_style_position
     - field.field.block_content.cta_banner.field_text
@@ -19,7 +20,6 @@ dependencies:
     - markup
     - maxlength
     - media_library
-    - media_library_edit
     - text
 id: block_content.cta_banner.default
 targetEntityType: block_content
@@ -55,7 +55,7 @@ content:
     third_party_settings: {  }
   field_link:
     type: linkit
-    weight: 11
+    weight: 9
     region: content
     settings:
       placeholder_url: ''
@@ -65,7 +65,7 @@ content:
     third_party_settings: {  }
   field_link_two:
     type: linkit
-    weight: 12
+    weight: 10
     region: content
     settings:
       placeholder_url: ''
@@ -82,15 +82,22 @@ content:
     third_party_settings:
       media_library_edit:
         show_edit: '1'
+  field_overlay_background_image:
+    type: media_library_widget
+    weight: 7
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
   field_style_color:
     type: options_select
-    weight: 6
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
   field_style_position:
     type: options_select
-    weight: 7
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.callout.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.callout.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - block_content.type.callout
     - field.field.block_content.callout.field_callout
     - field.field.block_content.callout.field_instructions
+    - field.field.block_content.callout.field_overlay_background_image
     - field.field.block_content.callout.field_style_alignment
     - field.field.block_content.callout.field_style_color
   module:
@@ -24,6 +25,15 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_overlay_background_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: full
+      link: false
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_style_alignment:
     type: list_key

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.cta_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.cta_banner.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.block_content.cta_banner.field_link
     - field.field.block_content.cta_banner.field_link_two
     - field.field.block_content.cta_banner.field_media
+    - field.field.block_content.cta_banner.field_overlay_background_image
     - field.field.block_content.cta_banner.field_style_color
     - field.field.block_content.cta_banner.field_style_position
     - field.field.block_content.cta_banner.field_text
@@ -68,6 +69,15 @@ content:
       link: false
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_overlay_background_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: full
+      link: false
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_style_color:
     type: list_key

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.callout.field_overlay_background_image.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.callout.field_overlay_background_image.yml
@@ -1,0 +1,29 @@
+uuid: 24de8b35-266c-485d-b106-c9076033da71
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.callout
+    - field.storage.block_content.field_overlay_background_image
+    - media.type.image
+id: block_content.callout.field_overlay_background_image
+field_name: field_overlay_background_image
+entity_type: block_content
+bundle: callout
+label: 'Overlay background image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_link.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_link.yml
@@ -13,7 +13,7 @@ entity_type: block_content
 bundle: cta_banner
 label: Call-to-action
 description: 'For more information about linking content, view our resource <a href="https://yalesites.yale.edu/resource-library/linking-content-on-yalesites" target="_blank">Linking Content on YaleSites</a>.'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_overlay_background_image.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_overlay_background_image.yml
@@ -1,0 +1,29 @@
+uuid: 4d7120a5-a505-425a-8660-358788f818b3
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.cta_banner
+    - field.storage.block_content.field_overlay_background_image
+    - media.type.image
+id: block_content.cta_banner.field_overlay_background_image
+field_name: field_overlay_background_image
+entity_type: block_content
+bundle: cta_banner
+label: 'Overlay background image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_overlay_background_image.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_overlay_background_image.yml
@@ -1,0 +1,20 @@
+uuid: 8504e50b-4a4c-4659-b2a7-7c8eb4597805
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - media
+id: block_content.field_overlay_background_image
+field_name: field_overlay_background_image
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## [YSP-904: YPS: Add Image Background to Action Banner and Callout Blocks](https://yaleits.atlassian.net/browse/YSP-904)

### Description of work
- Adds `field_overlay_background_image` to the CTA Banner block content type
- Adds `field_overlay_background_image` to the Callout block content type  
- Updates form and view displays to include the new field for both block types
- Configures the field to reference media images using the media library
- Makes the `field_link` field optional for CTA Banner blocks (no longer required)
- Adjusts field weights for improved form layout on both content types
- Ensures proper dependencies and display settings for the new overlay background image field
- Other work completed in:
  - [Atomic](https://github.com/yalesites-org/atomic/pull/367)
  - [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/529)

### Functional testing steps:
- [x] Verify CTA Banner blocks can have an overlay background image field added
- [x] Verify Callout blocks can have an overlay background image field added  
- [ ] Test that the media library integration works for selecting background images
- [x] Confirm the overlay background image displays correctly on both block types
- [ ] Verify that the CTA Banner link field is now optional (can be left empty)
- [x] Test form layout and field ordering to ensure proper weight configuration
- [x] Confirm existing CTA Banner and Callout blocks continue to work without issues
- [ ] Test permissions and access for different user roles when using the new field