### PR TITLE
chore: disable unused config_filter module

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -30,7 +30,6 @@ module:
   ckeditor5: 0
   components: 0
   config: 0
-  config_filter: 0
   config_ignore: 0
   config_split: 0
   content_moderation: 0


### PR DESCRIPTION
In working on #950, I noticed config_filter was dropped from config_split in [2.0.0](https://www.drupal.org/project/config_split/releases/2.0.0), but we've had it enabled all along. We will remove this module in a future release.