### PR TITLE
YSP-983: Implement CAS Service Parameter Hook Override in YaleSites

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,10 @@
           "type": "tar"
         }
       }
+    },
+    "yale_cas_dev": {
+      "type": "vcs",
+      "url": "https://github.com/yalesites-org/yale_cas.git"
     }
   },
   "require": {

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -17,6 +17,10 @@
           "type": "tar"
         }
       }
+    },
+    "yale_cas_dev": {
+      "type": "vcs",
+      "url": "https://github.com/yalesites-org/yale_cas.git"
     }
   },
   "require": {
@@ -114,7 +118,7 @@
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
     "yalesites-org/ai_engine": "1.2.10",
     "yalesites-org/atomic": "1.50.0",
-    "yalesites-org/yale_cas": "v1.0.5"
+    "yalesites-org/yale_cas": "dev-appname-hook"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -255,6 +255,15 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       '#use_favicon_preview' => TRUE,
     ];
 
+    if (ys_core_allow_secret_items_user_1($this->currentUser)) {
+      $form['cas_app_name'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('CAS Application Name'),
+        '#description' => $this->t('The name of the application to be used in CAS login.'),
+        '#default_value' => ($yaleConfig->get('cas_app_name')) ? $yaleConfig->get('cas_app_name') : 'yalesites',
+      ];
+    }
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -324,6 +333,7 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       ->set('taxonomy.custom_vocab_name', $form_state->getValue('custom_vocab_name'))
       ->set('image_fallback.teaser', $form_state->getValue('teaser_image_fallback'))
       ->set('custom_favicon', $form_state->getValue('favicon'))
+      ->set('cas_app_name', $form_state->getValue('cas_app_name') ?? 'yalesites')
       ->save();
     $this->configFactory->getEditable('google_analytics.settings')
       ->set('account', $form_state->getValue('google_analytics_id'))

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -652,6 +652,20 @@ function ys_core_allow_secret_items(AccountProxy $currentUserSession) {
 }
 
 /**
+ * If current user is user 1, allow secret items.
+ *
+ * @return bool
+ *   Returns TRUE if current user is user 1.
+ */
+function ys_core_allow_secret_items_user_1(AccountProxy $currentUserSession) {
+  $allowSecretItems = FALSE;
+  if ($currentUserSession->getAccount()->id() == 1) {
+    $allowSecretItems = TRUE;
+  }
+  return $allowSecretItems;
+}
+
+/**
  * Implements hook_form_FORM_ID_alter() for views_exposed_form.
  */
 function ys_core_form_views_exposed_form_alter(&$form, FormStateInterface $form_state) {
@@ -810,4 +824,22 @@ function _ys_core_find_field_in_form($form, $field_name) {
   }
 
   return NULL;
+}
+
+/**
+ * Implements hook_yale_cas_pre_redirect_service_parameters_alter().
+ *
+ * Allows modules to alter CAS service parameters before redirect
+ * at the pre-redirect event.
+ */
+function ys_core_yale_cas_pre_redirect_service_parameters_alter(
+  array &$service_parameters,
+  $event,
+) {
+  // Retrieve the ys_core config.
+  $config = \Drupal::config('ys_core.site');
+  $app_name = $config->get('cas_app_name') ?: 'yalesites';
+
+  // Set the app parameter to the configured value.
+  $service_parameters['app'] = $app_name;
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -844,6 +844,7 @@ function ys_core_yale_cas_pre_redirect_service_parameters_alter(
   $service_parameters['app'] = $app_name;
 }
 
+/**
  * Implements hook_entity_type_alter().
  */
 function ys_core_entity_type_alter(array &$entity_types) {


### PR DESCRIPTION
## [YSP-983: Implement CAS Service Parameter Hook Override in YaleSites](https://yaleits.atlassian.net/browse/YSP-983)

**REMINDER: Remove the dev reference in composer before merging!**

### Description of work
- Add a `cas app name` field to the site config only for user 1
- Adds a `yale_cas` hook to change the app name to the site config setting

### Functional testing steps:
- [ ] Log in as user 1
- [ ] Access the site settings
- [ ] At the bottom, verify that the CAS App Name is set to `yalesites`
- [ ] Change it to something else
- [ ] Open a new private window and visit the site with CAS
- [ ] Ensure that the ending of that redirect URL is your new name
