### PR TITLE
Enable private media files and security to hinder direct access

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.media.field_media_image.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.media.field_media_image.yml
@@ -17,7 +17,7 @@ settings:
   target_type: file
   display_field: false
   display_default: false
-  uri_scheme: public
+  uri_scheme: private
   default_image:
     uuid: ''
     alt: ''

--- a/web/profiles/custom/yalesites_profile/config/sync/system.file.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.file.yml
@@ -1,5 +1,5 @@
 _core:
   default_config_hash: mguGHCYb9Dw5EcpfjwoShGV1Vjkbz3QuPRCLfxiye-g
 allow_insecure_uploads: false
-default_scheme: public
+default_scheme: private
 temporary_maximum_age: 21600

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -255,6 +255,15 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       '#use_favicon_preview' => TRUE,
     ];
 
+    if (ys_core_allow_secret_items($this->currentUser)) {
+      $form['enable_private_files'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Enable private files'),
+        '#default_value' => $yaleConfig->get('enable_private_files') ?? FALSE,
+        '#description' => $this->t('Check this box to enable private file storage. This will allow you to store files that are not publicly accessible except by CAS users, platform admins, and user 1.'),
+      ];
+    }
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -324,6 +333,7 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       ->set('taxonomy.custom_vocab_name', $form_state->getValue('custom_vocab_name'))
       ->set('image_fallback.teaser', $form_state->getValue('teaser_image_fallback'))
       ->set('custom_favicon', $form_state->getValue('favicon'))
+      ->set('enable_private_files', $form_state->getValue('enable_private_files') ?? FALSE)
       ->save();
     $this->configFactory->getEditable('google_analytics.settings')
       ->set('account', $form_state->getValue('google_analytics_id'))

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -818,6 +818,13 @@ function _ys_core_find_field_in_form($form, $field_name) {
  * Disallow access to private files for non-CAS authenticated users.
  */
 function ys_core_file_download($uri) {
+  // Get the site config for ys_core.
+  $config = \Drupal::config('ys_core.site');
+  if (!$config->get('enable_private_files', FALSE)) {
+    // If private files are not enabled, allow access.
+    return NULL;
+  }
+
   if (!str_starts_with($uri, 'private://')) {
     return NULL;
   }
@@ -839,32 +846,12 @@ function _ys_core_is_cas_authenticated(AccountProxy $account) {
     return FALSE;
   }
 
-  // Method 1: Check if CAS service exists and account has CAS session.
   if (\Drupal::hasService('cas.user_manager')) {
     $cas_user_manager = \Drupal::service('cas.user_manager');
 
     // Check if there's an active CAS session.
     $session = \Drupal::request()->getSession();
     if ($session->has('cas_username')) {
-      return TRUE;
-    }
-  }
-
-  // Method 2: Check user data for CAS authentication marker.
-  $user_data = \Drupal::service('user.data');
-  $cas_username = $user_data->get('cas', $account->id(), 'cas_username');
-
-  if (!empty($cas_username)) {
-    return TRUE;
-  }
-
-  // Method 3: Check if user was created/authenticated by CAS module
-  // Look for CAS-specific patterns in username or authmap.
-  if (\Drupal::hasService('externalauth.authmap')) {
-    $authmap = \Drupal::service('externalauth.authmap');
-    $authname = $authmap->get($account->id(), 'cas');
-
-    if (!empty($authname)) {
       return TRUE;
     }
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -811,3 +811,63 @@ function _ys_core_find_field_in_form($form, $field_name) {
 
   return NULL;
 }
+
+/**
+ * Implements hook_file_download().
+ *
+ * Disallow access to private files for non-CAS authenticated users.
+ */
+function ys_core_file_download($uri) {
+  if (!str_starts_with($uri, 'private://')) {
+    return NULL;
+  }
+
+  $current_user = \Drupal::currentUser();
+  if (!_ys_core_is_cas_authenticated($current_user) && !ys_core_allow_secret_items($current_user)) {
+    \Drupal::logger('mymodule')->notice('Non-CAS user denied private file access: @uri', ['@uri' => $uri]);
+    // Deny access.
+    return -1;
+  }
+}
+
+/**
+ * Checks if the user is CAS authenticated.
+ */
+function _ys_core_is_cas_authenticated(AccountProxy $account) {
+  // Check if account is anonymous.
+  if ($account->isAnonymous()) {
+    return FALSE;
+  }
+
+  // Method 1: Check if CAS service exists and account has CAS session.
+  if (\Drupal::hasService('cas.user_manager')) {
+    $cas_user_manager = \Drupal::service('cas.user_manager');
+
+    // Check if there's an active CAS session.
+    $session = \Drupal::request()->getSession();
+    if ($session->has('cas_username')) {
+      return TRUE;
+    }
+  }
+
+  // Method 2: Check user data for CAS authentication marker.
+  $user_data = \Drupal::service('user.data');
+  $cas_username = $user_data->get('cas', $account->id(), 'cas_username');
+
+  if (!empty($cas_username)) {
+    return TRUE;
+  }
+
+  // Method 3: Check if user was created/authenticated by CAS module
+  // Look for CAS-specific patterns in username or authmap.
+  if (\Drupal::hasService('externalauth.authmap')) {
+    $authmap = \Drupal::service('externalauth.authmap');
+    $authname = $authmap->get($account->id(), 'cas');
+
+    if (!empty($authname)) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}


### PR DESCRIPTION
## Enable private media files and security to hinder direct access

### Description of work
- Adds functionality to switch media image and file storage from public to private scheme
- Adds configurable "Enable private files" checkbox in site settings form (only visible to platform admins and user 1)
- Adds hook_file_download() implementation that checks the private files setting before restricting access
- Restricts private file access to CAS-authenticated users, platform admins, and user 1 when the setting is enabled
- Adds simplified CAS authentication check that validates active CAS session
- Adds logging for denied access attempts for security auditing
- Updates default file scheme configuration from 'public' to 'private' for enhanced security
- Private file restrictions only apply when the "Enable private files" setting is checked

### Functional testing steps:
- [ ] Navigate to site settings and verify the "Enable private files" checkbox is present (only for platform admins/user 1)
- [ ] Verify that non-privileged users cannot see the private files setting
- [ ] Test with private file storage DISABLED (default) - verify all users can access private files normally
- [ ] Enable the "Enable private files" setting and save configuration
- [ ] Verify that new file uploads are stored in the private file system (check file paths contain 'private://')
- [ ] Test that CAS-authenticated users can access private files successfully when setting is enabled
- [ ] Test that platform admin users can access private files successfully when setting is enabled
- [ ] Test that user 1 can access private files successfully when setting is enabled
- [ ] Test that anonymous users are denied access to private files when setting is enabled
- [ ] Test that non-CAS authenticated users are denied access to private files when setting is enabled
- [ ] Verify that access denial attempts are logged properly (check logs for "Non-CAS user denied private file access")
- [ ] Check that existing public files continue to work as expected
- [ ] Test media upload functionality works correctly with new private scheme
- [ ] Test image display and file downloads work properly for authorized users
- [ ] Verify no broken file links exist after switching to private storage
- [ ] Test toggling the private files setting on/off affects access control appropriately
- [ ] Verify that when setting is disabled, the hook_file_download returns NULL (allowing normal access)