### PR TITLE
YSP-987: Auto-Default CAS Protection Based on Private File Storage Setting

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.media.field_media_image.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.media.field_media_image.yml
@@ -17,7 +17,7 @@ settings:
   target_type: file
   display_field: false
   display_default: false
-  uri_scheme: public
+  uri_scheme: private
   default_image:
     uuid: ''
     alt: ''

--- a/web/profiles/custom/yalesites_profile/config/sync/system.file.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/system.file.yml
@@ -1,5 +1,5 @@
 _core:
   default_config_hash: mguGHCYb9Dw5EcpfjwoShGV1Vjkbz3QuPRCLfxiye-g
 allow_insecure_uploads: false
-default_scheme: public
+default_scheme: private
 temporary_maximum_age: 21600

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -255,6 +255,15 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       '#use_favicon_preview' => TRUE,
     ];
 
+    if (ys_core_allow_secret_items($this->currentUser)) {
+      $form['enable_private_files'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Enable private files'),
+        '#default_value' => $yaleConfig->get('enable_private_files') ?? FALSE,
+        '#description' => $this->t('Check this box to enable private file storage. This will allow you to store files that are not publicly accessible except by CAS users, platform admins, and user 1.'),
+      ];
+    }
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -324,6 +333,7 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       ->set('taxonomy.custom_vocab_name', $form_state->getValue('custom_vocab_name'))
       ->set('image_fallback.teaser', $form_state->getValue('teaser_image_fallback'))
       ->set('custom_favicon', $form_state->getValue('favicon'))
+      ->set('enable_private_files', $form_state->getValue('enable_private_files') ?? FALSE)
       ->save();
     $this->configFactory->getEditable('google_analytics.settings')
       ->set('account', $form_state->getValue('google_analytics_id'))

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -818,6 +818,13 @@ function _ys_core_find_field_in_form($form, $field_name) {
  * Disallow access to private files for non-CAS authenticated users.
  */
 function ys_core_file_download($uri) {
+  // Get the site config for ys_core.
+  $config = \Drupal::config('ys_core.site');
+  if (!$config->get('enable_private_files', FALSE)) {
+    // If private files are not enabled, allow access.
+    return NULL;
+  }
+
   if (!str_starts_with($uri, 'private://')) {
     return NULL;
   }
@@ -839,32 +846,12 @@ function _ys_core_is_cas_authenticated(AccountProxy $account) {
     return FALSE;
   }
 
-  // Method 1: Check if CAS service exists and account has CAS session.
   if (\Drupal::hasService('cas.user_manager')) {
     $cas_user_manager = \Drupal::service('cas.user_manager');
 
     // Check if there's an active CAS session.
     $session = \Drupal::request()->getSession();
     if ($session->has('cas_username')) {
-      return TRUE;
-    }
-  }
-
-  // Method 2: Check user data for CAS authentication marker.
-  $user_data = \Drupal::service('user.data');
-  $cas_username = $user_data->get('cas', $account->id(), 'cas_username');
-
-  if (!empty($cas_username)) {
-    return TRUE;
-  }
-
-  // Method 3: Check if user was created/authenticated by CAS module
-  // Look for CAS-specific patterns in username or authmap.
-  if (\Drupal::hasService('externalauth.authmap')) {
-    $authmap = \Drupal::service('externalauth.authmap');
-    $authname = $authmap->get($account->id(), 'cas');
-
-    if (!empty($authname)) {
       return TRUE;
     }
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -811,3 +811,63 @@ function _ys_core_find_field_in_form($form, $field_name) {
 
   return NULL;
 }
+
+/**
+ * Implements hook_file_download().
+ *
+ * Disallow access to private files for non-CAS authenticated users.
+ */
+function ys_core_file_download($uri) {
+  if (!str_starts_with($uri, 'private://')) {
+    return NULL;
+  }
+
+  $current_user = \Drupal::currentUser();
+  if (!_ys_core_is_cas_authenticated($current_user) && !ys_core_allow_secret_items($current_user)) {
+    \Drupal::logger('mymodule')->notice('Non-CAS user denied private file access: @uri', ['@uri' => $uri]);
+    // Deny access.
+    return -1;
+  }
+}
+
+/**
+ * Checks if the user is CAS authenticated.
+ */
+function _ys_core_is_cas_authenticated(AccountProxy $account) {
+  // Check if account is anonymous.
+  if ($account->isAnonymous()) {
+    return FALSE;
+  }
+
+  // Method 1: Check if CAS service exists and account has CAS session.
+  if (\Drupal::hasService('cas.user_manager')) {
+    $cas_user_manager = \Drupal::service('cas.user_manager');
+
+    // Check if there's an active CAS session.
+    $session = \Drupal::request()->getSession();
+    if ($session->has('cas_username')) {
+      return TRUE;
+    }
+  }
+
+  // Method 2: Check user data for CAS authentication marker.
+  $user_data = \Drupal::service('user.data');
+  $cas_username = $user_data->get('cas', $account->id(), 'cas_username');
+
+  if (!empty($cas_username)) {
+    return TRUE;
+  }
+
+  // Method 3: Check if user was created/authenticated by CAS module
+  // Look for CAS-specific patterns in username or authmap.
+  if (\Drupal::hasService('externalauth.authmap')) {
+    $authmap = \Drupal::service('externalauth.authmap');
+    $authname = $authmap->get($account->id(), 'cas');
+
+    if (!empty($authname)) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -858,3 +858,29 @@ function _ys_core_is_cas_authenticated(AccountProxy $account) {
 
   return FALSE;
 }
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter() for node_form.
+ */
+function ys_core_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $node = $form_state->getFormObject()->getEntity();
+
+  // Only apply to new nodes.
+  if (!$node->isNew()) {
+    return;
+  }
+
+  // Check if the content type has the field_login_required field.
+  if (!isset($form['field_login_required'])) {
+    return;
+  }
+
+  // Check if private file storage is enabled.
+  $config = \Drupal::config('ys_core.site');
+  $private_files_enabled = $config->get('enable_private_files', FALSE);
+
+  if ($private_files_enabled) {
+    // Set default value to checked (login required)
+    $form['field_login_required']['widget']['value']['#default_value'] = TRUE;
+  }
+}


### PR DESCRIPTION
## [YSP-987: Auto-Default CAS Protection Based on Private File Storage Setting](https://yaleits.atlassian.net/browse/YSP-987)

### Description of work
- Adds private file storage toggle to site settings form (visible only to platform admins and user 1)
- Implements file access control via `hook_file_download()` to restrict private files to CAS-authenticated users, platform admins, and user 1
- Sets default file storage scheme to 'private' for media images and files in configuration
- Adds `hook_form_node_form_alter()` to automatically default the 'login required' field to checked for new nodes when private file storage is enabled
- Includes helper function to check CAS authentication status
- Adds logging for denied private file access attempts for auditing purposes

### Functional testing steps:
- [ ] Verify the private file storage checkbox appears in Site Settings for platform admins and user 1
- [ ] Verify the private file storage checkbox is hidden from non-admin users
- [ ] Test that when private file storage is enabled, private files are accessible to CAS-authenticated users
- [ ] Test that when private file storage is enabled, private files are accessible to platform admins
- [ ] Test that when private file storage is enabled, private files are accessible to user 1
- [ ] Test that when private file storage is enabled, private files are denied to anonymous users
- [ ] Test that when private file storage is enabled, private files are denied to non-CAS authenticated users
- [ ] Verify that new node forms have the 'login required' field defaulted to checked when private file storage is enabled
- [ ] Verify that existing nodes are not affected by the private file storage setting
- [ ] Test that file uploads use the private file scheme when configured
- [ ] Verify that access denied attempts are logged appropriately
- [ ] Test that the CAS authentication check works correctly with the CAS module