### PR TITLE
Playground: Icon Media Library Type

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/README.md
@@ -1,0 +1,74 @@
+# YaleSites Icons
+
+A Drupal 10 module that provides FontAwesome icon management through the media library with YDS component integration.
+
+## Features
+
+- **Media Library Integration**: Visual icon selection through familiar media library interface
+- **Accessibility**: Built-in ARIA labels and descriptions
+- **YDS Component Integration**: Seamless integration with YDS icon components
+- **Two Field Formatters**: Raw data output for templates or full YDS component rendering
+
+## Installation
+
+1. Enable the module:
+   ```bash
+   drush en ys_icons -y
+   ```
+
+2. Clear cache:
+   ```bash
+   drush cr
+   ```
+
+## Creating Icons
+
+1. Go to `/admin/content/media`
+2. Click "Add media" → "Icon"
+3. Fill in:
+   - **Name**: User-friendly name (e.g., "Home Icon")
+   - **FontAwesome Name**: Technical name (e.g., "home")
+   - **Icon Title**: Accessibility title (e.g., "Home")
+   - **Icon Description**: Detailed description (e.g., "Navigate to homepage")
+
+## Using in Content Types
+
+1. Add an "Entity reference" field to your content type
+2. Configure to reference "Media" entities
+3. Set allowed media types to "Icon" only
+4. Set widget to "Media library"
+5. Choose formatter:
+   - **Icon (Raw Data)**: For template integration (recommended)
+   - **Icon (YDS Component)**: For standalone display
+
+## Template Usage
+
+For facts-and-figures integration:
+
+```twig
+{# Get icon data #}
+{% set icon_data = content.field_icon.0 %}
+{% set has_icon = icon_data['#fontawesome_name'] ? true : false %}
+
+{% embed "@molecules/facts-and-figures/yds-facts-and-figures.twig" with {
+  facts_and_figures__icon_name: icon_data['#fontawesome_name']|default(''),
+  facts_and_figures__has_icon: has_icon ? 'true' : 'false',
+  # ... other variables
+} %}
+{% endembed %}
+```
+
+## Available Raw Data Variables
+
+When using the "Icon (Raw Data)" formatter:
+- `#fontawesome_name`: The FontAwesome icon name
+- `#title`: Accessibility title
+- `#description`: Accessibility description  
+- `#name`: User-friendly display name
+
+## Permissions
+
+Set appropriate permissions at `/admin/people/permissions`:
+- **Create icon media**: Content creators
+- **Edit icon media**: Content editors
+- **Delete icon media**: Content administrators

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/core.entity_form_display.media.icon.default.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/core.entity_form_display.media.icon.default.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.icon.field_fontawesome_name
+    - field.field.media.icon.field_icon_description
+    - field.field.media.icon.field_icon_title
+    - media.type.icon
+id: media.icon.default
+targetEntityType: media
+bundle: icon
+mode: default
+content:
+  field_fontawesome_name:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: 'e.g., home, user, star'
+    third_party_settings: {  }
+  field_icon_description:
+    type: text_textarea
+    weight: 3
+    region: content
+    settings:
+      rows: 4
+      placeholder: 'Detailed description for screen readers'
+    third_party_settings: {  }
+  field_icon_title:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: 'Short accessible title'
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: 'User-friendly name for the icon'
+    third_party_settings: {  }
+hidden:
+  created: true
+  path: true
+  status: true
+  uid: true

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/core.entity_view_display.media.icon.default.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/core.entity_view_display.media.icon.default.yml
@@ -1,0 +1,48 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.icon.field_fontawesome_name
+    - field.field.media.icon.field_icon_description
+    - field.field.media.icon.field_icon_title
+    - media.type.icon
+id: media.icon.default
+targetEntityType: media
+bundle: icon
+mode: default
+content:
+  field_fontawesome_name:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_icon_description:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_icon_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  name:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  thumbnail: true
+  uid: true

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/core.entity_view_display.media.icon.media_library.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/core.entity_view_display.media.icon.media_library.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.icon.field_fontawesome_name
+    - field.field.media.icon.field_icon_description
+    - field.field.media.icon.field_icon_title
+    - media.type.icon
+id: media.icon.media_library
+targetEntityType: media
+bundle: icon
+mode: media_library
+content:
+  field_fontawesome_name:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  name:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_icon_description: true
+  field_icon_title: true
+  thumbnail: true
+  uid: true

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/field.field.media.icon.field_fontawesome_name.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/field.field.media.icon.field_fontawesome_name.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_fontawesome_name
+    - media.type.icon
+id: media.icon.field_fontawesome_name
+field_name: field_fontawesome_name
+entity_type: media
+bundle: icon
+label: 'FontAwesome Name'
+description: 'The FontAwesome icon name (e.g., "home", "user", "star")'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/field.field.media.icon.field_icon_description.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/field.field.media.icon.field_icon_description.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_icon_description
+    - media.type.icon
+  module:
+    - text
+id: media.icon.field_icon_description
+field_name: field_icon_description
+entity_type: media
+bundle: icon
+label: 'Icon Description'
+description: 'Detailed description for accessibility (aria-describedby)'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/field.field.media.icon.field_icon_title.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/field.field.media.icon.field_icon_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_icon_title
+    - media.type.icon
+id: media.icon.field_icon_title
+field_name: field_icon_title
+entity_type: media
+bundle: icon
+label: 'Icon Title'
+description: 'The title for accessibility (aria-label)'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/field.storage.media.field_fontawesome_name.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/field.storage.media.field_fontawesome_name.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_fontawesome_name
+field_name: field_fontawesome_name
+entity_type: media
+type: string
+settings:
+  max_length: 100
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/field.storage.media.field_icon_description.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/field.storage.media.field_icon_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - text
+id: media.field_icon_description
+field_name: field_icon_description
+entity_type: media
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/field.storage.media.field_icon_title.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/field.storage.media.field_icon_title.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_icon_title
+field_name: field_icon_title
+entity_type: media
+type: string
+settings:
+  max_length: 100
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/media.type.icon.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/config/install/media.type.icon.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies: {  }
+id: icon
+label: Icon
+description: 'FontAwesome icon references with accessibility information'
+source: ys_icon_source
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  source_field: field_fontawesome_name

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/css/ys_icons.media_library.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/css/ys_icons.media_library.css
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * Styles for YaleSites Icons in the media library.
+ */
+
+/* Remove padding from icon preview containers only */
+.media-library-item__preview.js-media-library-item-preview:has(.field--name-field-fontawesome-name) {
+  padding: 0;
+}
+
+/* Simple fix: Set icon field to a reasonable height */
+.media-library-item__preview .field--name-field-fontawesome-name {
+  height: 250px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Constrain icon size within the field */
+.field--name-field-fontawesome-name .media-library-icon {
+  max-width: 120px;
+  max-height: 120px;
+  width: 120px;
+  height: 120px;
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/src/Plugin/Field/FieldFormatter/YsIconComponentFormatter.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/src/Plugin/Field/FieldFormatter/YsIconComponentFormatter.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Drupal\ys_icons\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\Plugin\Field\FieldFormatter\EntityReferenceFormatterBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\media\MediaInterface;
+
+/**
+ * Plugin implementation of the 'ys_icon_component' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "ys_icon_component",
+ *   label = @Translation("Icon (YDS Component)"),
+ *   description = @Translation("Display the icon using YDS icon component."),
+ *   field_types = {
+ *     "entity_reference"
+ *   }
+ * )
+ */
+class YsIconComponentFormatter extends EntityReferenceFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'show_title' => TRUE,
+      'additional_classes' => '',
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $elements['show_title'] = [
+      '#title' => $this->t('Show title'),
+      '#type' => 'checkbox',
+      '#default_value' => $this->getSetting('show_title'),
+    ];
+
+    $elements['additional_classes'] = [
+      '#title' => $this->t('Additional CSS classes'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('additional_classes'),
+      '#description' => $this->t('Additional CSS classes to add to the icon element.'),
+    ];
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+
+    if ($this->getSetting('show_title')) {
+      $summary[] = $this->t('Show title');
+    }
+    else {
+      $summary[] = $this->t('Hide title');
+    }
+
+    if ($additional_classes = $this->getSetting('additional_classes')) {
+      $summary[] = $this->t('Additional classes: @classes', ['@classes' => $additional_classes]);
+    }
+
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+
+    foreach ($this->getEntitiesToView($items, $langcode) as $delta => $media) {
+      if ($media instanceof MediaInterface && $media->bundle() === 'icon') {
+        $classes = [];
+        if ($additional_classes = $this->getSetting('additional_classes')) {
+          $classes = explode(' ', trim($additional_classes));
+        }
+
+        $elements[$delta] = [
+          '#type' => 'pattern',
+          '#id' => 'yds_icon',
+          '#fields' => [
+            'icon' => $media->get('field_fontawesome_name')->value,
+            'title' => $media->get('field_icon_title')->value,
+            'description' => $media->get('field_icon_description')->value,
+            'classes' => $classes,
+          ],
+          '#cache' => [
+            'tags' => $media->getCacheTags(),
+          ],
+        ];
+
+        if ($this->getSetting('show_title')) {
+          $elements[$delta]['#fields']['show_title'] = TRUE;
+        }
+      }
+    }
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function isApplicable($field_definition) {
+    // Only show this formatter for entity reference fields targeting media entities.
+    $target_type = $field_definition->getFieldStorageDefinition()->getSetting('target_type');
+    return $target_type === 'media';
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/src/Plugin/Field/FieldFormatter/YsIconRawFormatter.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/src/Plugin/Field/FieldFormatter/YsIconRawFormatter.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\ys_icons\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\Plugin\Field\FieldFormatter\EntityReferenceFormatterBase;
+use Drupal\media\MediaInterface;
+
+/**
+ * Plugin implementation of the 'ys_icon_raw' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "ys_icon_raw",
+ *   label = @Translation("Icon (Raw Data)"),
+ *   description = @Translation("Outputs raw icon data for use in Twig templates."),
+ *   field_types = {
+ *     "entity_reference"
+ *   }
+ * )
+ */
+class YsIconRawFormatter extends EntityReferenceFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+
+    foreach ($this->getEntitiesToView($items, $langcode) as $delta => $media) {
+      if ($media instanceof MediaInterface && $media->bundle() === 'icon') {
+        $elements[$delta] = [
+          '#cache' => [
+            'tags' => $media->getCacheTags(),
+          ],
+          '#fontawesome_name' => $media->get('field_fontawesome_name')->value,
+          '#title' => $media->get('field_icon_title')->value,
+          '#description' => $media->get('field_icon_description')->value,
+          '#name' => $media->label(),
+        ];
+      }
+    }
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function isApplicable($field_definition) {
+    // Only show this formatter for entity reference fields targeting media entities.
+    $target_type = $field_definition->getFieldStorageDefinition()->getSetting('target_type');
+    return $target_type === 'media';
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/src/Plugin/media/Source/IconMediaSource.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/src/Plugin/media/Source/IconMediaSource.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\ys_icons\Plugin\media\Source;
+
+use Drupal\media\MediaSourceBase;
+use Drupal\media\MediaInterface;
+
+/**
+ * Icon media source.
+ *
+ * @MediaSource(
+ *   id = "ys_icon_source",
+ *   label = @Translation("Icon"),
+ *   description = @Translation("Use for FontAwesome icon references."),
+ *   allowed_field_types = {"string"},
+ *   default_thumbnail_filename = "icon.png"
+ * )
+ */
+class IconMediaSource extends MediaSourceBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMetadataAttributes() {
+    return [
+      'fontawesome_name' => $this->t('FontAwesome name'),
+      'icon_title' => $this->t('Icon title'),
+      'icon_description' => $this->t('Icon description'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMetadata(MediaInterface $media, $attribute_name) {
+    switch ($attribute_name) {
+      case 'fontawesome_name':
+        return $media->get('field_fontawesome_name')->value;
+
+      case 'icon_title':
+        return $media->get('field_icon_title')->value;
+
+      case 'icon_description':
+        return $media->get('field_icon_description')->value;
+
+      case 'default_name':
+        return $media->get('field_icon_title')->value ?: $media->get('name')->value;
+
+      case 'thumbnail_uri':
+        // For icons, we don't need a thumbnail file since we render the icon directly
+        return NULL;
+
+      default:
+        return parent::getMetadata($media, $attribute_name);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getSourceFieldName() {
+    return 'field_fontawesome_name';
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/src/Plugin/media/Source/IconMediaSource.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/src/Plugin/media/Source/IconMediaSource.php
@@ -47,7 +47,10 @@ class IconMediaSource extends MediaSourceBase {
         return $media->get('field_icon_title')->value ?: $media->get('name')->value;
 
       case 'thumbnail_uri':
-        // For icons, we don't need a thumbnail file since we render the icon directly
+        $icon_name = $media->get('field_fontawesome_name')->value;
+        if ($icon_name) {
+          return '/themes/contrib/atomic/node_modules/@yalesites-org/component-library-twig/dist/icons.svg#' . $icon_name;
+        }
         return NULL;
 
       default:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/templates/field--media--field-fontawesome-name--icon.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/templates/field--media--field-fontawesome-name--icon.html.twig
@@ -1,0 +1,46 @@
+{#
+/**
+ * @file
+ * Theme override for fontawesome name fields in icon media.
+ */
+#}
+<div{{ attributes.addClass(classes, 'field', 'field--name-' ~ field_name|clean_class, 'field--type-' ~ field_type|clean_class, 'field--label-' ~ label_display|clean_class) }}>
+  {% if label_hidden %}
+    {% if multiple %}
+      <div class="field__items">
+    {% endif %}
+    {% for item in items %}
+      <div class="field__item">
+        {# Render icon instead of just the fontawesome name text #}
+        <div class="media-icon-field-preview">
+          <svg class="icon-field-svg" width="60" height="60" viewBox="0 0 512 512" aria-hidden="true">
+            <use href="/themes/contrib/atomic/node_modules/@yalesites-org/component-library-twig/dist/icons.svg#{{ item.content['#context'].value }}"></use>
+          </svg>
+          <div class="icon-field-name">{{ item.content['#context'].value }}</div>
+        </div>
+      </div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  {% else %}
+    <div class="field__label">{{ label }}</div>
+    {% if multiple %}
+      <div class="field__items">
+    {% endif %}
+    {% for item in items %}
+      <div class="field__item">
+        {# Render icon instead of just the fontawesome name text #}
+        <div class="media-icon-field-preview">
+          <svg class="icon-field-svg" width="60" height="60" viewBox="0 0 512 512" aria-hidden="true">
+            <use href="#{{ item.content['#context'].value }}"></use>
+          </svg>
+          <div class="icon-field-name">{{ item.content['#context'].value }}</div>
+        </div>
+      </div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  {% endif %}
+</div>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/templates/field--media--icon.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/templates/field--media--icon.html.twig
@@ -1,0 +1,59 @@
+{#
+/**
+ * @file
+ * Theme override for icon media fields.
+ * 
+ * This handles when icon media entities are displayed and their fields
+ * need to be rendered (like in form previews).
+ */
+#}
+<div{{ attributes.addClass(classes, 'field', 'field--name-' ~ field_name|clean_class, 'field--type-' ~ field_type|clean_class, 'field--label-' ~ label_display|clean_class) }}>
+  {% if label_hidden %}
+    {% if multiple %}
+      <div class="field__items">
+    {% endif %}
+    {% for item in items %}
+      <div class="field__item">
+        {% if field_name == 'field_fontawesome_name' %}
+          {# Render icon instead of text for fontawesome name field #}
+          <div class="media-icon-field-preview">
+            <svg class="icon-field-svg" width="60" height="60" viewBox="0 0 512 512" aria-hidden="true">
+              <use href="#{{ item.content['#context'].value }}"></use>
+            </svg>
+            <div class="icon-field-name">{{ item.content['#context'].value }}</div>
+          </div>
+        {% else %}
+          {# Normal field rendering for other fields #}
+          {{ item.content }}
+        {% endif %}
+      </div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  {% else %}
+    <div class="field__label">{{ label }}</div>
+    {% if multiple %}
+      <div class="field__items">
+    {% endif %}
+    {% for item in items %}
+      <div class="field__item">
+        {% if field_name == 'field_fontawesome_name' %}
+          {# Render icon instead of text for fontawesome name field #}
+          <div class="media-icon-field-preview">
+            <svg class="icon-field-svg" width="60" height="60" viewBox="0 0 512 512" aria-hidden="true">
+              <use href="#{{ item.content['#context'].value }}"></use>
+            </svg>
+            <div class="icon-field-name">{{ item.content['#context'].value }}</div>
+          </div>
+        {% else %}
+          {# Normal field rendering for other fields #}
+          {{ item.content }}
+        {% endif %}
+      </div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  {% endif %}
+</div>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/templates/media--icon--media-library.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/templates/media--icon--media-library.html.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * @file
+ * Theme override to display an icon media entity in the media library.
+ */
+#}
+<article class="contextual-region media-library-item__preview-wrapper">
+  <div class="media-library-item__preview js-media-library-item-preview">
+    <div class="field field--name-field-fontawesome-name field--type-string field--label-hidden field__item">
+      {# Simple SVG for media library preview - keeps YDS component intact for actual usage #}
+      <svg class="media-library-icon" width="120" height="120" viewBox="0 0 512 512" aria-hidden="true">
+        <use href="/themes/contrib/atomic/node_modules/@yalesites-org/component-library-twig/dist/icons.svg#{{ content.field_fontawesome_name.0['#context'].value }}"></use>
+      </svg>
+    </div>
+  </div>
+  <div class="media-library-item__attributes">
+    <div class="media-library-item__name">
+      {{ content.name }}
+    </div>
+  </div>
+</article>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/ys_icons.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/ys_icons.info.yml
@@ -1,0 +1,7 @@
+name: YaleSites Icons
+type: module
+description: Manages FontAwesome icon references using media entities with YDS component integration
+core_version_requirement: '^9 || ^10'
+package: YaleSites
+dependencies:
+  - drupal:media

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/ys_icons.libraries.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/ys_icons.libraries.yml
@@ -1,0 +1,6 @@
+media_library:
+  css:
+    theme:
+      css/ys_icons.media_library.css: {}
+  dependencies:
+    - core/drupal

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/ys_icons.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/ys_icons.module
@@ -30,6 +30,12 @@ function ys_icons_theme() {
     'media__icon__media_library' => [
       'base hook' => 'media',
     ],
+    'field__media__field_fontawesome_name__icon' => [
+      'base hook' => 'field',
+    ],
+    'field__media__icon' => [
+      'base hook' => 'field',
+    ],
   ];
 }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/ys_icons.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/ys_icons.module
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @file
+ * Contains ys_icons.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function ys_icons_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    case 'help.page.ys_icons':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('The YaleSites Icons module provides a way to manage FontAwesome icon references using media entities with accessibility support and YDS component integration.') . '</p>';
+      return $output;
+
+    default:
+  }
+}
+
+/**
+ * Implements hook_theme().
+ */
+function ys_icons_theme() {
+  return [
+    'media__icon__media_library' => [
+      'base hook' => 'media',
+    ],
+  ];
+}
+
+/**
+ * Implements hook_preprocess_media().
+ */
+function ys_icons_preprocess_media(&$variables) {
+  $media = $variables['media'];
+  
+  // Attach our media library CSS for icon media types
+  if ($media->bundle() === 'icon' && $variables['view_mode'] === 'media_library') {
+    $variables['#attached']['library'][] = 'ys_icons/media_library';
+  }
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/ys_icons.permissions.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_icons/ys_icons.permissions.yml
@@ -1,0 +1,16 @@
+administer icon media:
+  title: 'Administer icon media'
+  description: 'Create, edit, and delete icon media entities'
+  restrict access: true
+
+create icon media:
+  title: 'Create icon media'
+  description: 'Create new icon media entities'
+
+edit icon media:
+  title: 'Edit icon media'
+  description: 'Edit existing icon media entities'
+
+delete icon media:
+  title: 'Delete icon media'
+  description: 'Delete icon media entities'


### PR DESCRIPTION
## Playground: Icon Media Library Type

Description of work

Adds new ys_icons module for managing FontAwesome icon references through the media library
Creates "Icon" media type with fields for FontAwesome name, accessibility title, and description
Implements two field formatters: raw data output for YDS component integration and standalone YDS component rendering
Provides visual icon selection through media library instead of requiring users to remember FontAwesome technical names
Integrates seamlessly with existing YDS icon components and facts-and-figures molecules
Includes proper accessibility features with ARIA labels and descriptions
Fixes media library display sizing to match standard media items
Adds form preview templates so selected icons display properly in paragraph configuration

Functional testing steps:

 Enable the ys_icons module: drush en ys_icons -y
 Verify "Icon" media type exists at /admin/structure/media
 Create test icons at /admin/content/media/add/icon with FontAwesome names like "home", "user", "star"
 Verify icons display properly in media library grid at /admin/content/media with consistent sizing
 Add "Entity reference" field to a paragraph type targeting Media entities with "Icon" bundle allowed
 Set field widget to "Media library" and formatter to "Icon (Raw Data)"
 Create/edit content with that paragraph type and verify media library opens for icon selection
 Verify selected icons display as actual icons (not text) in paragraph form preview
 Verify icons render properly in facts-and-figures component on front-end using raw formatter data
 Test "Icon (YDS Component)" formatter displays standalone icons with accessibility features
 Verify icon field data includes #fontawesome_name, #title, #description for template integration
 Confirm accessibility: icons have proper ARIA labels and descriptions when rendered