### PR TITLE
YSP-920 :: Clean Up User Addition Experience for Non-Platform Admins 

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.action.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.action.yml
@@ -30,3 +30,10 @@ ys_core.link_add_profile:
   title: 'Add profile'
   appears_on:
     - view.manage_profiles.page_1
+
+cas.bulk_add_cas_users:
+  title: 'Add NetId user(s)'
+  route_name: cas.bulk_add_cas_users
+  appears_on:
+    - entity.user.collection
+  weight: 1

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -5,8 +5,12 @@
  * Contains ys_core.module functions.
  */
 
+<<<<<<< HEAD
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+=======
+use Drupal\Core\Block\BlockPluginInterface;
+>>>>>>> a05d0cf61 (ysp-920 updates to local actions, menu items, add user form)
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
@@ -824,6 +828,7 @@ function ys_core_entity_type_alter(array &$entity_types) {
 }
 
 /**
+<<<<<<< HEAD
  * Allowed values callback for Facts and Figures icon field.
  *
  * This function serves as a bridge between Drupal's allowed_values_function
@@ -939,6 +944,8 @@ function ys_core_menu_local_actions_alter(&$local_actions) {
 }
 
 /**
+=======
+>>>>>>> a05d0cf61 (ysp-920 updates to local actions, menu items, add user form)
  * Implements hook_preprocess_menu__toolbar__gin().
  *
  * Hide user creation menu items from the Gin admin toolbar.
@@ -946,24 +953,40 @@ function ys_core_menu_local_actions_alter(&$local_actions) {
 function ys_core_preprocess_menu__toolbar__gin(&$variables) {
   $current_user = \Drupal::currentUser();
 
-  // Skip processing if user is user 1.
-  if ($current_user->id() == 1) {
-    return;
-  }
-
   // Check if current user has the platform_admin role.
   $user_roles = $current_user->getRoles();
-  $has_platform_admin = in_array('platform_admin', $user_roles);
+  $has_platform_admin = in_array('platform_admin', $user_roles) || $current_user->id() == 1;
 
   // If user doesn't have platform_admin role, hide the menu items.
-  if (!$has_platform_admin && isset($variables['items']['entity.user.collection']['below'])) {
-    $restricted_routes = ['user.admin_create', 'cas.bulk_add_cas_users'];
+  if (isset($variables['items']['entity.user.collection']['below'])) {
 
-    foreach ($variables['items']['entity.user.collection']['below'] as $key => $item) {
-      // Check if this sub-item points to a restricted route.
-      if (isset($item['url']) && $item['url']->isRouted() && in_array($item['url']->getRouteName(), $restricted_routes)) {
-        unset($variables['items']['entity.user.collection']['below'][$key]);
+    foreach ($variables['items']['entity.user.collection']['below'] as $key => &$item) {
+      if (isset($item['url']) && $item['url']->isRouted()) {
+        $route_name = $item['url']->getRouteName();
+        if ($route_name === 'cas.bulk_add_cas_users') {
+          // Change the title instead of removing.
+          $item['title'] = t('Add NetID User(s)');
+        }
+        if (!$has_platform_admin && $route_name === 'user.admin_create') {
+          // Still remove the regular user creation if needed.
+          unset($variables['items']['entity.user.collection']['below']['admin_toolbar_tools.extra_links:user.admin_create']);
+        }
       }
     }
   }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() for user_admin_account_form.
+ */
+function ys_core_form_user_register_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $form['ys_core_netid_alert_message'] = [
+    '#type' => 'markup',
+    '#markup' => t('To add users with NetIDs go <a href=":url">here</a>.', [
+      ':url' => Url::fromRoute('cas.bulk_add_cas_users')->toString(),
+    ]),
+    '#prefix' => '<div class="messages messages--warning">',
+    '#suffix' => '</div>',
+    '#weight' => -99,
+  ];
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -904,7 +904,7 @@ function ys_core_menu_local_actions_alter(&$local_actions) {
 
   // Only affect the user admin page where the user creation actions appear.
   if ($route_name === 'entity.user.collection') {
-    // Disable caching for local actions on this page to prevent role-based caching issues.
+    // Disable caching for local actions on this page to prevent aching issues.
     \Drupal::service('plugin.manager.menu.local_action')->useCaches(FALSE);
 
     $current_user = \Drupal::currentUser();

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -825,7 +825,6 @@ function ys_core_entity_type_alter(array &$entity_types) {
 }
 
 /**
-<<<<<<< HEAD
  * Allowed values callback for Facts and Figures icon field.
  *
  * This function serves as a bridge between Drupal's allowed_values_function

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -7,7 +7,6 @@
 
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
-use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -5,12 +5,9 @@
  * Contains ys_core.module functions.
  */
 
-<<<<<<< HEAD
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
-=======
 use Drupal\Core\Block\BlockPluginInterface;
->>>>>>> a05d0cf61 (ysp-920 updates to local actions, menu items, add user form)
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
@@ -944,8 +941,6 @@ function ys_core_menu_local_actions_alter(&$local_actions) {
 }
 
 /**
-=======
->>>>>>> a05d0cf61 (ysp-920 updates to local actions, menu items, add user form)
  * Implements hook_preprocess_menu__toolbar__gin().
  *
  * Hide user creation menu items from the Gin admin toolbar.
@@ -977,7 +972,7 @@ function ys_core_preprocess_menu__toolbar__gin(&$variables) {
 }
 
 /**
- * Implements hook_form_FORM_ID_alter() for user_admin_account_form.
+ * Implements hook_form_FORM_ID_alter().
  */
 function ys_core_form_user_register_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $form['ys_core_netid_alert_message'] = [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -134,6 +134,11 @@ function ys_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {
 
     $delegatable_roles = $delegatable_roles->getAssignableRoles($account);
     $form['roles']['#options'] = $delegatable_roles;
+
+    // Hide the email field since CAS users get email from LDAP.
+    if (isset($form['email_hostname'])) {
+      $form['email_hostname']['#access'] = FALSE;
+    }
   }
 
   // Load custom library.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -953,7 +953,7 @@ function ys_core_preprocess_menu__toolbar__gin(&$variables) {
   // If user doesn't have platform_admin role, hide the menu items.
   if (isset($variables['items']['entity.user.collection']['below'])) {
 
-    foreach ($variables['items']['entity.user.collection']['below'] as $key => &$item) {
+    foreach ($variables['items']['entity.user.collection']['below'] as &$item) {
       if (isset($item['url']) && $item['url']->isRouted()) {
         $route_name = $item['url']->getRouteName();
         if ($route_name === 'cas.bulk_add_cas_users') {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -135,6 +135,11 @@ function ys_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {
     $delegatable_roles = $delegatable_roles->getAssignableRoles($account);
     $form['roles']['#options'] = $delegatable_roles;
 
+    if (isset($form['cas_usernames'])) {
+      $form['cas_usernames']['#title'] = t('NetIDs');
+      $form['cas_usernames']['#description'] = t('Enter one NetID per line.');
+    }
+
     // Hide the email field since CAS users get email from LDAP.
     if (isset($form['email_hostname'])) {
       $form['email_hostname']['#access'] = FALSE;
@@ -923,6 +928,11 @@ function ys_core_menu_local_actions_alter(&$local_actions) {
       // Remove "Add user" action.
       if (isset($local_actions['user_admin_create'])) {
         unset($local_actions['user_admin_create']);
+      }
+
+      // Change the title of the CAS bulk add action.
+      if (isset($local_actions['cas.bulk_add_cas_users'])) {
+        $local_actions['cas.bulk_add_cas_users']['title'] = 'Add NetID Users';
       }
     }
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -403,6 +403,33 @@ function ys_core_preprocess_menu(&$variables) {
       array_unshift($menuItem['below'], $clonedMenuItem);
     }
   }
+  // CAS bulk add menu item title change (global for all menus) and remove Add user for non-platform admins.
+  if (!empty($variables['items'])) {
+    $current_user = \Drupal::currentUser();
+    $user_roles = $current_user->getRoles();
+    $has_platform_admin = in_array('platform_admin', $user_roles) || $current_user->id() == 1;
+    foreach ($variables['items'] as $key => &$item) {
+      // Remove Add user menu item for non-platform admins
+      if (isset($item['url']) && $item['url']->isRouted() && $item['url']->getRouteName() === 'user.admin_create' && !$has_platform_admin) {
+        unset($variables['items'][$key]);
+        continue;
+      }
+      // Also check submenus recursively.
+      if (!empty($item['below'])) {
+        foreach ($item['below'] as $subkey => &$subitem) {
+          if (isset($subitem['url']) && $subitem['url']->isRouted()) {
+            $route_name = $subitem['url']->getRouteName();
+            if ($route_name === 'cas.bulk_add_cas_users') {
+              $subitem['title'] = t('Add NetID User(s)');
+            }
+            if ($route_name === 'user.admin_create' && !$has_platform_admin) {
+              unset($item['below'][$subkey]);
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 /**
@@ -933,37 +960,6 @@ function ys_core_menu_local_actions_alter(&$local_actions) {
       // Change the title of the CAS bulk add action.
       if (isset($local_actions['cas.bulk_add_cas_users'])) {
         $local_actions['cas.bulk_add_cas_users']['title'] = 'Add NetID Users';
-      }
-    }
-  }
-}
-
-/**
- * Implements hook_preprocess_menu__toolbar__gin().
- *
- * Hide user creation menu items from the Gin admin toolbar.
- */
-function ys_core_preprocess_menu__toolbar__gin(&$variables) {
-  $current_user = \Drupal::currentUser();
-
-  // Check if current user has the platform_admin role.
-  $user_roles = $current_user->getRoles();
-  $has_platform_admin = in_array('platform_admin', $user_roles) || $current_user->id() == 1;
-
-  // If user doesn't have platform_admin role, hide the menu items.
-  if (isset($variables['items']['entity.user.collection']['below'])) {
-
-    foreach ($variables['items']['entity.user.collection']['below'] as &$item) {
-      if (isset($item['url']) && $item['url']->isRouted()) {
-        $route_name = $item['url']->getRouteName();
-        if ($route_name === 'cas.bulk_add_cas_users') {
-          // Change the title instead of removing.
-          $item['title'] = t('Add NetID User(s)');
-        }
-        if (!$has_platform_admin && $route_name === 'user.admin_create') {
-          // Still remove the regular user creation if needed.
-          unset($variables['items']['entity.user.collection']['below']['admin_toolbar_tools.extra_links:user.admin_create']);
-        }
       }
     }
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -403,18 +403,14 @@ function ys_core_preprocess_menu(&$variables) {
       array_unshift($menuItem['below'], $clonedMenuItem);
     }
   }
-  // CAS bulk add menu item title change (global for all menus) and remove Add user for non-platform admins.
+  // CAS bulk add menu item title change,
+  // and remove Add user for non-platform admins.
   if (!empty($variables['items'])) {
     $current_user = \Drupal::currentUser();
     $user_roles = $current_user->getRoles();
     $has_platform_admin = in_array('platform_admin', $user_roles) || $current_user->id() == 1;
     foreach ($variables['items'] as $key => &$item) {
-      // Remove Add user menu item for non-platform admins
-      if (isset($item['url']) && $item['url']->isRouted() && $item['url']->getRouteName() === 'user.admin_create' && !$has_platform_admin) {
-        unset($variables['items'][$key]);
-        continue;
-      }
-      // Also check submenus recursively.
+      // These are submenu items.
       if (!empty($item['below'])) {
         foreach ($item['below'] as $subkey => &$subitem) {
           if (isset($subitem['url']) && $subitem['url']->isRouted()) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -887,3 +887,68 @@ function _ys_core_attach_icon_preview(&$form, FormStateInterface $form_state, $f
     }
   }
 }
+
+/**
+ * Implements hook_menu_local_actions_alter().
+ *
+ * Hide 'Add user' action for users without the platform_admin role.
+ */
+function ys_core_menu_local_actions_alter(&$local_actions) {
+  // Get the current route name.
+  $route_name = \Drupal::routeMatch()->getRouteName();
+
+  // Only affect the user admin page where the user creation actions appear.
+  if ($route_name === 'entity.user.collection') {
+    // Disable caching for local actions on this page to prevent role-based caching issues.
+    \Drupal::service('plugin.manager.menu.local_action')->useCaches(FALSE);
+
+    $current_user = \Drupal::currentUser();
+
+    // Skip processing if user is user 1.
+    if ($current_user->id() == 1) {
+      return;
+    }
+
+    // Check if current user has the platform_admin role.
+    $user_roles = $current_user->getRoles();
+    $has_platform_admin = in_array('platform_admin', $user_roles);
+
+    // Hide the actions if user doesn't have platform_admin role.
+    if (!$has_platform_admin) {
+      // Remove "Add user" action.
+      if (isset($local_actions['user_admin_create'])) {
+        unset($local_actions['user_admin_create']);
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_preprocess_menu__toolbar__gin().
+ *
+ * Hide user creation menu items from the Gin admin toolbar.
+ */
+function ys_core_preprocess_menu__toolbar__gin(&$variables) {
+  $current_user = \Drupal::currentUser();
+
+  // Skip processing if user is user 1.
+  if ($current_user->id() == 1) {
+    return;
+  }
+
+  // Check if current user has the platform_admin role.
+  $user_roles = $current_user->getRoles();
+  $has_platform_admin = in_array('platform_admin', $user_roles);
+
+  // If user doesn't have platform_admin role, hide the menu items.
+  if (!$has_platform_admin && isset($variables['items']['entity.user.collection']['below'])) {
+    $restricted_routes = ['user.admin_create', 'cas.bulk_add_cas_users'];
+
+    foreach ($variables['items']['entity.user.collection']['below'] as $key => $item) {
+      // Check if this sub-item points to a restricted route.
+      if (isset($item['url']) && $item['url']->isRouted() && in_array($item['url']->getRouteName(), $restricted_routes)) {
+        unset($variables['items']['entity.user.collection']['below'][$key]);
+      }
+    }
+  }
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -409,7 +409,7 @@ function ys_core_preprocess_menu(&$variables) {
     $current_user = \Drupal::currentUser();
     $user_roles = $current_user->getRoles();
     $has_platform_admin = in_array('platform_admin', $user_roles) || $current_user->id() == 1;
-    foreach ($variables['items'] as $key => &$item) {
+    foreach ($variables['items'] as &$item) {
       // These are submenu items.
       if (!empty($item['below'])) {
         foreach ($item['below'] as $subkey => &$subitem) {


### PR DESCRIPTION
## [YSP-920: Clean Up User Addition Experience for Non-Platform Admins ](https://yaleits.atlassian.net/browse/YSP-920)

### Description of work
- Hide add user action and user menu items for non-platform_admins
- Disable caching for admin items on the user list page to avoid caching between users issues

### Functional testing steps:
- [ ] Verify 'Add user' is removed from the Gin toolbar for non-platorm_admins and 'Add CAS User(s)' is now 'Add NetId User(s)'
- [ ] Verify on the CAS add user(s) form, the email field is hidden for all roles
- [ ] Verify there is an alert on the add users page "To add users with NetIds go here [link]"
