### PR TITLE
YSP-1002: A11y/AI: Fix ARIA Landmark Issue for askYale Chat Widget -- MULTIDEV ONLY

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,10 @@
           "type": "tar"
         }
       }
+    },
+    "yalesites-org/ai_engine": {
+      "type": "vcs",
+      "url": "https://github.com/yalesites-org/ai_engine"
     }
   },
   "require": {

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -16,6 +16,10 @@
           "url": "https://registry.npmjs.org/@northernco/ckeditor5-anchor-drupal/-/ckeditor5-anchor-drupal-0.4.0.tgz",
           "type": "tar"
         }
+      },
+      "yalesites-org/ai_engine": {
+        "type": "vcs",
+        "url": "https://github.com/yalesites-org/ai_engine"
       }
     }
   },
@@ -112,7 +116,7 @@
     "jjj/chosen": "2.2.1",
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
-    "yalesites-org/ai_engine": "1.2.10",
+    "yalesites-org/ai_engine": "dev-YSP-1002-aria-landmark-widget",
     "yalesites-org/atomic": "1.50.0",
     "yalesites-org/yale_cas": "v1.0.5"
   },


### PR DESCRIPTION
## [YSP-1002: A11y/AI: Fix ARIA Landmark Issue for askYale Chat Widget -- MULTIDEV ONLY](https://yaleits.atlassian.net/browse/YSP-1002)

### Description of work
- Updates ai_engine module dependency to include new ARIA accessibility attributes for chat button
- Pulls in changes from YSP-1002-aria-landmark-widget branch that add `role="region"` and `aria-label="AI Chat"` to chat button container
- Enables accessibility testing of chat button landmark functionality
- Actual work done in [ai_engine](https://github.com/yalesites-org/ai_engine/pull/25)

### Functional testing steps:
- [ ] Confirm the AI chat button appears on pages where it should be visible
- [ ] Test with VoiceOver (Cmd+F5) to verify chat button is announced as "AI Chat region"
- [ ] Use VoiceOver rotor (Control+Option+U) to navigate to Landmarks and confirm "AI Chat region" appears in the list
- [ ] Verify chat button functionality remains unchanged (clicking opens chat modal)