### PR TITLE
YSP-973 :: YSP-982  YSP-973   Taxonomy: Headings start with H2 on Taxonomy pages

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/README.md
@@ -9,3 +9,5 @@ However, before adding new features or functionality to this module, platform de
 - **Sitewide Elements**: This category covers a wide array of elements including plugins, forms, templates, and various assets used for managing sitewide components such as the site header, footer, and breadcrumbs. These elements may also extend into the styling realm within the Atomic theme and the component library.
 - **Install Configuration**: The module houses default values for YaleSites-specific configuration files used during the creation of new sites on the platform. While technically not mandatory, maintaining these install files is considered a best practice, as they ensure consistency and serve as a reference point for values that should ideally reside in the profile's config/sync directory.
 - **Hooks and Custom Functionality**: It provides a growing list of hooks for adding and altering form elements, tokens, caching rules, and website behavior. These hooks empower developers to customize and fine-tune the platform's behavior to meet specific requirements.
+
+## Test, do not merge


### PR DESCRIPTION
## [YALB-XX: Title](https://yaleits.atlassian.net/browse/YALB-XX)

**Multidev for testing only, do not merge**

### Description of work
- Removes card collection title from taxonomy page (which is h2)
- Adds an h1 title to the page

### Functional testing steps:
- [ ] Go to a taxonomy page that has content
- [ ] Verify the title is h1 and the page looks as expected

Atomic PR: https://github.com/yalesites-org/atomic/pull/369
