### PR TITLE
YSP-1064: Add Google Analytics alert for migration to Google Tag Manager

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\ys_core\Form;
 
+use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -207,7 +208,6 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       '#default_value' => $siteConfig->get('page')['404'],
     ];
 
-
     $form['google_site_verification'] = [
       '#type' => 'textfield',
       '#description' => $this->t('Get a verification key from Google Search Console Tools using the "URL Prefix" tool, clicking on the the alternate methods tab, and selecting the HTML Tag option. Use the "content" attribute from the Google tag within this field. Example: <code>&#60;meta name="google-site-verification" content="USE-THIS-CODE" /></code>'),
@@ -216,30 +216,14 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
     ];
 
     $form['google_analytics_migration'] = [
-      '#type' => 'container',
-      '#attributes' => [
-        'class' => ['google-analytics-migration-message'],
-      ],
-      'content' => [
-        '#type' => 'html_tag',
-        '#tag' => 'div',
-        '#attributes' => [
-          'class' => ['google-analytics-migration-content'],
-        ],
-        'text' => [
-          '#type' => 'html_tag',
-          '#tag' => 'p',
-          '#value' => $this->t('Google Analytics will be removed from the platform soon. Please configure Google Tag Manager to migrate your website analytics tracking.'),
-        ],
-        'link' => [
-          '#type' => 'link',
-          '#title' => $this->t('Configure Google Tag Manager'),
-          '#url' => Url::fromRoute('entity.google_tag_container.single_form'),
-          '#attributes' => [
-            'class' => ['button'],
-          ],
-        ],
-      ],
+      '#type' => 'item',
+      '#title' => $this->t('Google Analytics/Tag Manager'),
+      '#description' => $this->t('YaleSites is transitioning from Google Analytics to Google Tag Manager. Configure Google Tag Manager below to maintain your website analytics tracking.'),
+      '#markup' => Link::fromTextAndUrl(
+        $this->t('Configure Google Tag Manager'),
+        Url::fromRoute('entity.google_tag_container.single_form')
+          ->setOptions(['attributes' => ['class' => ['button'], 'style' => 'margin-top: 0; margin-bottom: 0;']])
+      )->toString(),
     ];
 
     $form['custom_vocab_name'] = [


### PR DESCRIPTION
## [YSP-1064: Add Google Analytics alert for migration to Google Tag Manager](https://yaleits.atlassian.net/browse/YSP-1064)

### Description of work
- Adds Google Analytics migration message to Site Settings form
- Provides direct link to Google Tag Manager configuration form

### Functional testing steps:
- [ ] Navigate to Site Settings form
- [ ] Verify migration message appears below Google Site Verification field
- [ ] Verify alert contains message about Google Analytics removal
- [ ] Click "Configure Google Tag Manager" button and verify it navigates to correct form
- [ ] Test message accessibility with screen reader
