### PR TITLE
YSP-1059: Content Collection: White screen trying to delete items from a content collection

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.module
@@ -7,6 +7,7 @@
  * This module overrides default book module text.
  */
 
+use Drupal\Core\Render\Element;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
@@ -83,7 +84,20 @@ function ys_book_form_alter(&$form, &$form_state, $form_id) {
     '#markup' => t('Content Collections provide a way to create secondary navigation on your webpage. When you organize content into Collections, they become navigation sections. Your content can appear in both the main navigation and Content Collections'),
     '#weight' => -10,
   ];
+}
 
+/**
+ * Implements hook_form_FORM_ID_alter() for book_admin_edit.
+ */
+function ys_book_form_book_admin_edit_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Add required indicator to all title fields in the book admin table.
+  if (isset($form['table'])) {
+    foreach (Element::children($form['table']) as $key) {
+      if (isset($form['table'][$key]['title'])) {
+        $form['table'][$key]['title']['#required'] = TRUE;
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## [YSP-1059: Content Collection: White screen trying to delete items from a content collection](https://yaleits.atlassian.net/browse/YSP-1059)


### Description of work
- Enhanced existing ys_book_form_book_admin_edit_alter() to mark titles as required in collection edit form
  - In Content Collection management interface, JavaScript validation prevents submission and shows error messages for empty title fields
- _Note: this does not allow deletion as that was not ever implemented.  But it does stop the white screen from occurring when users think that deleting the title is removing the item from the content collection._

### Functional testing steps:
- [ ] Navigate to a few individual pages edit form and assign them to a Content Collection
- [ ] Navigate to /admin/structure/book and select a Content Collection to manage
  - [ ] Clear a title field in the management interface and attempt to save the form
  - [ ] Verify JavaScript validation prevents submission and shows error message
  - [ ] Test that form submission works when all title fields have content