### PR TITLE
YSP-1070: Icon field move

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.facts_item.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.facts_item.default.yml
@@ -19,7 +19,7 @@ mode: default
 content:
   field_heading:
     type: text_textfield
-    weight: 0
+    weight: 1
     region: content
     settings:
       size: 60
@@ -34,7 +34,7 @@ content:
         maxlength_js_enforce: false
   field_icon:
     type: chosen_select
-    weight: 1
+    weight: 0
     region: content
     settings: {  }
     third_party_settings: {  }


### PR DESCRIPTION
## [YALB-XX: Title](https://yaleits.atlassian.net/browse/YALB-XX)

### Description of work
- Changed the display weights for 'field_icon' and 'field_heading' in the facts_item paragraph form.

### Functional testing steps:
- [ ] Add a facts and figures block
- [ ] Ensure when adding a fact and figure item that the icon is displayed first
- [ ] Ensure that this helps in the dropdown visibility issue that can occur when it drops downward and not being able to see all of the items
