### PR TITLE
YSP-1072: Admin label change to stop overriding on 'configure'

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -209,16 +209,19 @@ function ys_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {
       $form['#attached']['library'][] = 'ys_core/block_form';
     }
 
-    // Add default admin label to layout builder blocks.
-    $form_object = $form_state->getFormObject();
-    $component = $form_object->getCurrentComponent();
-    $plugin = $component->getPlugin();
-    if (isset($plugin)) {
-      // Get the default admin label from the block plugin label.
-      $plugin_definition = $plugin->getPluginDefinition();
-      $default_admin_label = $plugin_definition['admin_label'] ?? $plugin->getPluginId();
-      // Add the plugin label as default value.
-      $form['settings']['label']['#default_value'] = $default_admin_label;
+    $emptyAdminLabel = $form['settings']['label']['#default_value'] ?? '';
+    if (empty($emptyAdminLabel)) {
+      // Add default admin label to layout builder blocks.
+      $form_object = $form_state->getFormObject();
+      $component = $form_object->getCurrentComponent();
+      $plugin = $component->getPlugin();
+      if (isset($plugin)) {
+        // Get the default admin label from the block plugin label.
+        $plugin_definition = $plugin->getPluginDefinition();
+        $default_admin_label = $plugin_definition['admin_label'] ?? $plugin->getPluginId();
+        // Add the plugin label as default value.
+        $form['settings']['label']['#default_value'] = $default_admin_label;
+      }
     }
   }
 


### PR DESCRIPTION
## [YSP-1072: Admin label change to stop overriding on 'configure'](https://yaleits.atlassian.net/browse/YSP-1072)

Previously, the block plugin admin label was always set as the default value for the layout builder block label. This caused existing labels to be overwritten unintentionally. Now, the default admin label is only set if the current label value is empty, preserving user input.

### Description of work
- Adds conditional around setting to only apply if the field is empty

### Functional testing steps:
- [ ] Add a new block (any kind)
- [ ] Ensure that the administrative label is auto-filled in for you
- [ ] Change that name to something else
- [ ] Save
- [ ] Now edit that block again
- [ ] Ensure that your changed administrator label name is still present
