### PR TITLE
YSP-1073: Update Mallory heading typography styling - change weight and reduce size

### DIFF
--- a/web/themes/custom/ys_admin_theme/css/gin-custom.css
+++ b/web/themes/custom/ys_admin_theme/css/gin-custom.css
@@ -1,16 +1,19 @@
 /* stylelint-disable */
 :root {
   --gin-font: Mallory, sans-serif;
-  --gin-font-size-h1: 1.75rem;
-  --gin-font-size-h2: 1.5rem;
-  --gin-font-size-h3: 1.25rem;
+  /* Original sizes: H1: 1.75rem, H2: 1.5rem, H3: 1.25rem */
+  /* Reduced by ~5px: H1: 1.438rem, H2: 1.188rem, H3: 0.938rem */
+  --gin-font-size-h1: 1.438rem;
+  --gin-font-size-h2: 1.188rem;
+  --gin-font-size-h3: 0.938rem;
   --gin-border-m: 0.313rem;
   --jui-dropdown-bg-color: var(--gin-bg-layer);
   --input-fg-color--placeholder: var(--gin-color-text);
 }
 :root h1,
 :root h2 {
-  font-weight: 600;
+  /* Changed from font-weight: 600 to 400 (Book weight) for Mallory headings */
+  font-weight: 400;
 }
 
 .views-bulk-actions__item .button--primary:not(:disabled, .is-disabled) {

--- a/web/themes/custom/ys_admin_theme/scss/gin-custom.scss
+++ b/web/themes/custom/ys_admin_theme/scss/gin-custom.scss
@@ -2,16 +2,19 @@
 
 :root {
   --gin-font: Mallory, sans-serif;
-  --gin-font-size-h1: 1.75rem;
-  --gin-font-size-h2: 1.5rem;
-  --gin-font-size-h3: 1.25rem;
+  // Original sizes: H1: 1.75rem, H2: 1.5rem, H3: 1.25rem
+  // Reduced by ~5px: H1: 1.438rem, H2: 1.188rem, H3: 0.938rem
+  --gin-font-size-h1: 1.438rem;
+  --gin-font-size-h2: 1.188rem;
+  --gin-font-size-h3: 0.938rem;
   --gin-border-m: 0.313rem;
   --jui-dropdown-bg-color: var(--gin-bg-layer);
   --input-fg-color--placeholder: var(--gin-color-text);
 
   h1,
   h2 {
-    font-weight: 600;
+    // Changed from font-weight: 600 to 400 (Book weight) for Mallory headings
+    font-weight: 400;
   }
 }
 


### PR DESCRIPTION
## [YSP-1073: Update Mallory heading typography styling - change weight and reduce size](https://yaleits.atlassian.net/browse/YSP-1073)

Updated admin theme typography to reduce Mallory heading font sizes by approximately 5 pixels and change font weight from 600 to Book weight (400) to align with the main site typography changes.

This ensures consistent Mallory typography treatment between the admin interface and main site, improving visual hierarchy as requested by OPAC.

### Description of work
- Reduced H1 size from 1.75rem to 1.438rem (~5px reduction)
- Reduced H2 size from 1.5rem to 1.188rem (~5px reduction)
- Reduced H3 size from 1.25rem to 0.938rem (~5px reduction)
- Changed H1/H2 font-weight from 600 to 400 (Book weight)
- Updated both SCSS source and compiled CSS files
- Added detailed comments documenting original vs new values

### Functional testing steps:
- [ ] Verify any headings you see has the new reduction
- [ ] Verify that book weights have changed as well for headings
- [ ] Step 3
- [ ] ...
