### PR TITLE
YSP-1071: Taxonomy page fix -- MULTIDEV ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,3 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory..
-


### PR DESCRIPTION
## [YSP-1071: Taxonomy page fix](https://yaleits.atlassian.net/browse/YSP-1071)

### Description of work
  - Fixes accessibility violation where node titles on taxonomy pages used H3 instead of H2, breaking proper heading hierarchy
  - Fixes visual alignment issue where the H1 page title was misaligned compared to content cards below it
  - Implements template suggestion approach using node--view--taxonomy-term.html.twig for clean separation of taxonomy-specific rendering
  - Replaces manual heading implementation with proper yds-page-title component for consistent layout constraints
  - Real work actually done in https://github.com/yalesites-org/atomic/pull/375

### Functional testing steps:
  - [ ] Navigate to a taxonomy term page (e.g., /taxonomy/term/[id])
  - [ ] Verify the H1 page title is properly aligned with the content cards below it
  - [ ] Use browser developer tools or accessibility inspector to confirm node titles use H2 headings (not H3)
  - [ ] Test with screen reader to verify proper heading hierarchy: H1 (page title) → H2 (content titles)
  - [ ] Verify the fix works for all content types on taxonomy pages (pages, posts, events, profiles)
  - [ ] Confirm other contexts (search results, views, etc.) still use H3 headings appropriately
  - [ ] Test responsive behavior across different screen sizes to ensure alignment is maintained
