### PR TITLE
feat(ys_core): add cas module as dependency to ys_core

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.info.yml
@@ -7,3 +7,4 @@ dependencies:
   - multivalue_form_element
   - media_library_form_element
   - role_delegation
+  - cas


### PR DESCRIPTION
## Add CAS module dependency to ys_core

### Description of work
- Adds the 'cas' module to ys_core.info.yml dependencies to ensure CAS authentication support is available for the ys_core module.  This fixes new local spins from complaining that CasHelper isn't defined in the CAS module.

### Functional testing steps:
- [ ] Spin up a new local
- [ ] Ensure no errors due to CasHelper not being defined

__Note__: Seeing this dependency now made me think it shouldn't be in ys_core; a tech debt ticket has been created for this to fix in the future.