### PR TITLE
Accessibility RC fixes

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -116,7 +116,7 @@
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
     "yalesites-org/ai_engine": "1.2.10",
-    "yalesites-org/atomic": "1.53.0",
+    "yalesites-org/atomic": "1.54.0",
     "yalesites-org/yale_cas": "v1.2.0"
   },
   "minimum-stability": "dev",

--- a/web/themes/custom/ys_admin_theme/css/admin-ui.css
+++ b/web/themes/custom/ys_admin_theme/css/admin-ui.css
@@ -12,4 +12,19 @@
   float: none;
 }
 
+.gin--dark-mode .layout-builder-configure-block .fieldset__label.has-error {
+  color: var(--gin-color-info);
+}
+.gin--dark-mode .layout-builder-configure-block .form-boolean.error {
+  border-color: var(--gin-color-info);
+  box-shadow: inset 0 0 0 1px var(--gin-color-info);
+}
+.gin--dark-mode .layout-builder-configure-block .form-boolean--type-checkbox.error:checked {
+  background-color: white;
+}
+.gin--dark-mode .layout-builder-configure-block .form-boolean.error:checked:hover, .gin--dark-mode .layout-builder-configure-block .form-boolean.error:checked:active, .gin--dark-mode .layout-builder-configure-block .form-boolean.error:checked:active:hover {
+  border-color: var(--gin-color-info);
+  color: white;
+}
+
 /*# sourceMappingURL=admin-ui.css.map */

--- a/web/themes/custom/ys_admin_theme/css/admin-ui.css.map
+++ b/web/themes/custom/ys_admin_theme/css/admin-ui.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sourceRoot":"","sources":["../scss/admin-ui.scss"],"names":[],"mappings":"AAAA;EAEE;EACA;;;AAGF;EACE;EACA;;;AAGF;EACE","file":"admin-ui.css"}
+{"version":3,"sourceRoot":"","sources":["../scss/admin-ui.scss"],"names":[],"mappings":"AAAA;EAEE;EACA;;;AAGF;EACE;EACA;;;AAGF;EACE;;;AAOE;EACE;;AAGF;EACE;EACA;;AAGF;EACE;;AAIA;EAGE;EACA","file":"admin-ui.css"}

--- a/web/themes/custom/ys_admin_theme/scss/admin-ui.scss
+++ b/web/themes/custom/ys_admin_theme/scss/admin-ui.scss
@@ -12,3 +12,31 @@
 .toolbar-horizontal .local-tasks-toolbar-tab .toolbar-menu {
   float: none;
 }
+
+// Adjust error state colors for checkboxes and labels in Gin dark mode to
+// improve contrast and visibility on Gin's backgrounds.
+.gin--dark-mode {
+  .layout-builder-configure-block {
+    .fieldset__label.has-error {
+      color: var(--gin-color-info);
+    }
+
+    .form-boolean.error {
+      border-color: var(--gin-color-info);
+      box-shadow: inset 0 0 0 1px var(--gin-color-info);
+    }
+
+    .form-boolean--type-checkbox.error:checked {
+      background-color: white;
+    }
+
+    .form-boolean.error:checked {
+      &:hover,
+      &:active,
+      &:active:hover {
+        border-color: var(--gin-color-info);
+        color: white;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Accessibility RC fixes

### Description of work
- Enhance the visibility and accessibility of error states for checkboxes and labels in Gin dark mode.
- Other work completed in https://github.com/yalesites-org/atomic/pull/382

### Functional testing steps:
#### Taxonomy Block
- [ ] Ensure you're in dark mode
- [ ] Start creating a taxonomy block
- [ ] Make sure not to select a taxonomy in the checkboxes presented
- [ ] Save
- [ ] Ensure that the resulting errors are now passing contrast
- [ ] Test the same in light mode
#### Facts and Figures
- [ ] Ensure you're in dark mode
- [ ] Create a facts and figures block
- [ ] Edit the block
- [ ] Edit the item inside the block
- [ ] Ensure the chosen icon drop down passes contrast
- [ ] Test the same in light mode

<img width="450" height="519" alt="Screenshot 2025-07-24 at 8 56 25 AM" src="https://github.com/user-attachments/assets/dd4d5caf-63c1-4e34-bd69-e7b77a680388" />

<img width="556" height="601" alt="Screenshot 2025-07-24 at 8 57 01 AM" src="https://github.com/user-attachments/assets/5d45cf16-faa7-4640-aebe-f9c2b32dbdcf" />
