### PR TITLE
Hotfix: YSP-1103: Content Collection Navigation Background Alternative -- MULTIDEV ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory..
+


### PR DESCRIPTION
## [Hotfix: YSP-1103: Content Collection Navigation Background Alternative -- MULTIDEV ONLY](https://yaleits.atlassian.net/browse/YSP-1103)

### Description of work
- Real work done in https://github.com/yalesites-org/component-library-twig/pull/548

### Functional testing steps:
- [ ] Create a content collection
- [ ] Hover over the menu
- [ ] Change themes to verify contrast
- [ ] Compare against implementation done in https://github.com/yalesites-org/yalesites-project/pull/1046
