### PR TITLE
YSP-1094 :: Fix Taxonomy Manager access

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -81,6 +81,7 @@ dependencies:
     - role_delegation
     - system
     - taxonomy
+    - taxonomy_manager
     - toolbar
     - webform
     - ys_alert
@@ -101,6 +102,7 @@ permissions:
   - 'access media overview'
   - 'access printer-friendly version'
   - 'access site in maintenance mode'
+  - 'access taxonomy manager list'
   - 'access taxonomy overview'
   - 'access toolbar'
   - 'access user profiles'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -81,7 +81,6 @@ dependencies:
     - role_delegation
     - system
     - taxonomy
-    - taxonomy_manager
     - toolbar
     - webform
     - ys_alert
@@ -102,7 +101,6 @@ permissions:
   - 'access media overview'
   - 'access printer-friendly version'
   - 'access site in maintenance mode'
-  - 'access taxonomy manager list'
   - 'access taxonomy overview'
   - 'access toolbar'
   - 'access user profiles'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_taxonomy_manager/ys_taxonomy_manager.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_taxonomy_manager/ys_taxonomy_manager.routing.yml
@@ -16,4 +16,4 @@ taxonomy_manager.admin:
     _controller: '\Drupal\ys_taxonomy_manager\Controller\YsTaxonomyManagerMainController::listVocabularies'
     _title: 'Taxonomy Manager'
   requirements:
-    _permission: 'administer taxonomy'
+    _permission: 'access taxonomy manager list'


### PR DESCRIPTION
## [YSP-1094: Fix Taxonomy Manager](https://yaleits.atlassian.net/browse/YSP-1094)

### Description of work
- Fix permission on ys_taxonomy_manger to use the same permission as the parent module, give access to site admin

### Functional testing steps:
- [ ] Log in as Site admin. Verify you can access the taxonomy manger. It is a tab on the normal Manage Taxonomy page.

[Login and then go here](https://pr-1050-yalesites-platform.pantheonsite.io/admin/structure/taxonomy_manager/voc)

