### PR TITLE
Hotfix: Sort tree siblings by weight and title

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/src/YsExpandBookManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/src/YsExpandBookManager.php
@@ -213,6 +213,8 @@ class YsExpandBookManager extends ExpandBookManager {
       // Adding the nid to the end of the index ensures that it is unique.
       $new_tree[(50000 + $item['weight']) . ' ' . $item['title'] . ' ' . $item['nid']] = $tree[$key];
     }
+    // Sort siblings in the tree based on the weights and localized titles.
+    ksort($new_tree);
     $tree = $new_tree;
   }
 


### PR DESCRIPTION
## Hotfix: Sort tree siblings by weight and title

### Description of work
- Ensure siblings in the book tree are sorted by their weights and localized titles for consistent ordering.

### Functional testing steps:
- [ ] Create a content collection
- [ ] Please different pages inside (and nest them) such that there are multiple items on the top level nav and sub navigation
- [ ] Ensure that on display of this on the page that it respects the order you have in the CC management

And thanks @vinmassaro for finding the place this issue was happening!!!!
