### PR TITLE
Add Redis support

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -2,6 +2,8 @@ api_version: 1
 php_version: 8.3
 database:
   version: 10.6
+object_cache:
+  version: 6.2
 drush_version: 10
 web_docroot: true
 enforce_https: transitional

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -97,6 +97,7 @@
     "drupal/recaptcha": "3.4.0",
     "drupal/recaptcha_v3": "2.0.3",
     "drupal/redirect": "1.10.0",
+    "drupal/redis": "1.10",
     "drupal/role_delegation": "1.2",
     "drupal/search_api": "1.35.0",
     "drupal/search_api_exclude": "2.0.2",

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -56,6 +56,17 @@ $settings['config_sync_directory'] = 'profiles/custom/yalesites_profile/config/s
 $settings['config_exclude_modules'] = ['redis'];
 
 /**
+ * Include the Redis settings file.
+ */
+if (!empty($_ENV['PANTHEON_ENVIRONMENT']) && !empty($_ENV['CACHE_HOST'])) {
+  $redis_settings = __DIR__ . "/settings.redis.php";
+
+  if (file_exists($redis_settings)) {
+    include $redis_settings;
+  }
+}
+
+/**
  * Environment Indicator.
  */
 $env = $_ENV['PANTHEON_ENVIRONMENT'] ?? 'lando';

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -52,6 +52,9 @@ if (isset($_ENV['PANTHEON_SITE_NAME'])) {
 // Set the install profile as the source of site config.
 $settings['config_sync_directory'] = 'profiles/custom/yalesites_profile/config/sync';
 
+// Exclude modules from config sync.
+$settings['config_exclude_modules'] = ['redis'];
+
 /**
  * Environment Indicator.
  */

--- a/web/sites/default/settings.redis.php
+++ b/web/sites/default/settings.redis.php
@@ -1,7 +1,5 @@
 <?php
 
-// phpcs:ignoreFile
-
 /**
  * @file
  * Redis configuration file.

--- a/web/sites/default/settings.redis.php
+++ b/web/sites/default/settings.redis.php
@@ -1,0 +1,94 @@
+<?php
+
+// phpcs:ignoreFile
+
+/**
+ * @file
+ * Redis configuration file.
+ */
+
+if (defined(
+ 'PANTHEON_ENVIRONMENT'
+) && !\Drupal\Core\Installer\InstallerKernel::installationAttempted(
+) && extension_loaded('redis')) {
+ // Set Redis as the default backend for any cache bin not otherwise specified.
+ $settings['cache']['default'] = 'cache.backend.redis';
+
+ //phpredis is built into the Pantheon application container.
+ $settings['redis.connection']['interface'] = 'PhpRedis';
+
+ // These are dynamic variables handled by Pantheon.
+ $settings['redis.connection']['host'] = $_ENV['CACHE_HOST'];
+ $settings['redis.connection']['port'] = $_ENV['CACHE_PORT'];
+ $settings['redis.connection']['password'] = $_ENV['CACHE_PASSWORD'];
+
+ $settings['redis_compress_length'] = 100;
+ $settings['redis_compress_level'] = 1;
+
+ $settings['cache_prefix']['default'] = 'pantheon-redis';
+
+ $settings['cache']['bins']['form'] = 'cache.backend.database'; // Use the database for forms
+
+ // Apply changes to the container configuration to make better use of Redis.
+ // This includes using Redis for the lock and flood control systems, as well
+ // as the cache tag checksum. Alternatively, copy the contents of that file
+ // to your project-specific services.yml file, modify as appropriate, and
+ // remove this line.
+ $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
+
+ // Allow the services to work before the Redis module itself is enabled.
+ $settings['container_yamls'][] = 'modules/contrib/redis/redis.services.yml';
+
+ // Manually add the classloader path, this is required for the container
+ // cache bin definition below.
+ $class_loader->addPsr4('Drupal\\redis\\', 'modules/contrib/redis/src');
+
+ /**
+ * Default TTL for Redis is 1 year.
+ *
+ * Change cache expiration (TTL) for data,default bin - 12 hours.
+ * Change cache expiration (TTL) for entity bin - 48 hours.
+ *
+ * @see \Drupal\redis\Cache\CacheBase::LIFETIME_PERM_DEFAULT
+ */
+
+ $settings['redis.settings']['perm_ttl'] = 2630000; // 30 days
+ $settings['redis.settings']['perm_ttl_config'] = 43200;
+ $settings['redis.settings']['perm_ttl_data'] = 43200;
+ $settings['redis.settings']['perm_ttl_default'] = 43200;
+ $settings['redis.settings']['perm_ttl_entity'] = 172800;
+
+ // Use redis for container cache.
+ // The container cache is used to load the container definition itself, and
+ // thus any configuration stored in the container itself is not available
+ // yet. These lines force the container cache to use Redis rather than the
+ // default SQL cache.
+ $settings['bootstrap_container_definition'] = [
+   'parameters' => [],
+   'services' => [
+     'redis.factory' => [
+       'class' => 'Drupal\redis\ClientFactory',
+     ],
+     'cache.backend.redis' => [
+       'class' => 'Drupal\redis\Cache\CacheBackendFactory',
+       'arguments' => [
+         '@redis.factory',
+         '@cache_tags_provider.container',
+         '@serialization.phpserialize',
+       ],
+     ],
+     'cache.container' => [
+       'class' => '\Drupal\redis\Cache\PhpRedis',
+       'factory' => ['@cache.backend.redis', 'get'],
+       'arguments' => ['container'],
+     ],
+     'cache_tags_provider.container' => [
+       'class' => 'Drupal\redis\Cache\RedisCacheTagsChecksum',
+       'arguments' => ['@redis.factory'],
+     ],
+     'serialization.phpserialize' => [
+       'class' => 'Drupal\Component\Serialization\PhpSerialize',
+     ],
+   ],
+ ];
+}


### PR DESCRIPTION
### Description of work
Some sites will require Redis Object Cache for better performance. This PR:
- Adds `drupal/redis` module
- Conditionally loads the redis configuration file if running on Pantheon and Redis service is enabled
- Excludes Redis module from config tracking so it can be enabled on individual sites without being reverted by config

### Functional testing steps:
- [x] Verify this code works with Redis disabled on Pantheon site plan
- [x] After enabling Redis on Pantheon site plan, enable Redis module
- [x] Verify Redis is working by visiting `/admin/reports/redis`
- [x] Verify that after enabling Redis, running `drush deploy` against environment does not uninstall the Redis module

> [!NOTE]
>  Since lando also sets these same environment vars and spins up redis as part of the pantheon recipe, local environments will also use redis and see better performance.