### PR TITLE
YSP-860: Cache not cleared when updating external link in Post

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -116,7 +116,7 @@
     "laminas/laminas-escaper": "2.13.0",
     "northernco/ckeditor5-anchor-drupal": "0.4.0",
     "yalesites-org/ai_engine": "1.2.10",
-    "yalesites-org/atomic": "1.57.0",
+    "yalesites-org/atomic": "1.58.0",
     "yalesites-org/yale_cas": "v1.2.0"
   },
   "minimum-stability": "dev",

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/EventSubscriber/ExternalSourceRedirectSubscriber.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/EventSubscriber/ExternalSourceRedirectSubscriber.php
@@ -47,12 +47,34 @@ class ExternalSourceRedirectSubscriber implements EventSubscriberInterface {
     if ($this->routeMatch->getRouteName() === 'entity.node.canonical') {
       /** @var \Drupal\node\NodeInterface $node */
       $node = $this->routeMatch->getParameter('node');
+
       if (!empty($node) && $node->hasField(self::SOURCE_FIELD)) {
-        if (!empty($node->get(self::SOURCE_FIELD)->first())) {
-          $link = $node->get(self::SOURCE_FIELD)->first()->getValue();
-          if (!empty($link['uri'])) {
-            $response = new TrustedRedirectResponse($link['uri']);
-            $event->setResponse($response);
+        // Reload the node from storage to ensure we have the latest data.
+        // This prevents issues with cached entity data.
+        $fresh_node = \Drupal::entityTypeManager()->getStorage('node')->load($node->id());
+
+        if ($fresh_node && $fresh_node->hasField(self::SOURCE_FIELD)) {
+          $external_source_field = $fresh_node->get(self::SOURCE_FIELD)->first();
+          
+          if ($external_source_field) {
+            $link = $external_source_field->getValue();
+            
+            if (!empty($link['uri'])) {
+              $response = new TrustedRedirectResponse($link['uri']);
+              // Comprehensive cache prevention headers to ensure redirect
+              // changes are immediately reflected.
+              $response->headers->set('Cache-Control', 'no-cache, no-store, must-revalidate, max-age=0');
+              $response->headers->set('Pragma', 'no-cache');
+              $response->headers->set('Expires', '0');
+              // Add Vary header to prevent proxy caching.
+              $response->headers->set('Vary', '*');
+              // Set max-age and s-maxage explicitly to 0.
+              $response->setMaxAge(0);
+              $response->setSharedMaxAge(0);
+              // Mark response as private to prevent shared caching.
+              $response->setPrivate();
+              $event->setResponse($response);
+            }
           }
         }
       }
@@ -74,7 +96,7 @@ class ExternalSourceRedirectSubscriber implements EventSubscriberInterface {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('router.route_provider')
+      $container->get('current_route_match')
     );
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/EventSubscriber/ExternalSourceRedirectSubscriber.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/EventSubscriber/ExternalSourceRedirectSubscriber.php
@@ -55,10 +55,10 @@ class ExternalSourceRedirectSubscriber implements EventSubscriberInterface {
 
         if ($fresh_node && $fresh_node->hasField(self::SOURCE_FIELD)) {
           $external_source_field = $fresh_node->get(self::SOURCE_FIELD)->first();
-          
+
           if ($external_source_field) {
             $link = $external_source_field->getValue();
-            
+
             if (!empty($link['uri'])) {
               $response = new TrustedRedirectResponse($link['uri']);
               // Comprehensive cache prevention headers to ensure redirect

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -587,6 +587,63 @@ function ys_core_taxonomy_term_update() {
 }
 
 /**
+ * Implements hook_ENTITY_update().
+ *
+ * Clears entity and page cache when field_external_source is updated on a node.
+ * This ensures the ExternalSourceRedirectSubscriber sees fresh field data.
+ */
+function ys_core_node_update($node) {
+  // Only process nodes that have the external source field.
+  if (!$node->hasField('field_external_source')) {
+    return;
+  }
+
+  // Check if the external source field was changed.
+  $original_node = $node->original;
+  if (!$original_node || !$original_node->hasField('field_external_source')) {
+    return;
+  }
+
+  // Get current and original field values.
+  // Use first() and getValue() to properly access link field data.
+  $current_field = $node->get('field_external_source')->first();
+  $current_value = $current_field ? $current_field->getValue() : NULL;
+  $current_uri = $current_value['uri'] ?? '';
+
+  $original_field = $original_node->get('field_external_source')->first();
+  $original_value = $original_field ? $original_field->getValue() : NULL;
+  $original_uri = $original_value['uri'] ?? '';
+
+  // If the external source URL has changed, invalidate relevant caches.
+  // This handles all cases: value to empty, empty to value, value to different
+  // value.
+  if ($current_uri !== $original_uri) {
+    // Clear multiple cache layers that could affect the redirect behavior:
+    $cache_tags = [
+      // Node-specific cache.
+      'node:' . $node->id(),
+      // General render cache.
+      'rendered',
+      // Response cache.
+      'response',
+      // Page cache.
+      'page',
+      // HTTP response cache.
+      'http_response',
+    ];
+    Cache::invalidateTags($cache_tags);
+
+    // Clear entity storage cache to ensure fresh data for the event subscriber.
+    \Drupal::entityTypeManager()->getStorage('node')->resetCache([$node->id()]);
+
+    // Clear the dynamic page cache for comprehensive coverage.
+    $dynamic_cache = \Drupal::cache('dynamic_page_cache');
+    $dynamic_cache->invalidateAll();
+  }
+}
+
+
+/**
  * Implements hook_preprocess_page().
  */
 function ys_core_preprocess_page(&$variables) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -642,7 +642,6 @@ function ys_core_node_update($node) {
   }
 }
 
-
 /**
  * Implements hook_preprocess_page().
  */

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.services.yml
@@ -18,7 +18,7 @@ services:
   # Redirect visitors to external source if set on the node.
   ys_core.external_source_redirect_subscriber:
     class: Drupal\ys_core\EventSubscriber\ExternalSourceRedirectSubscriber
-    arguments: ['@current_route_match']
+    arguments: ['@current_route_match', '@entity_type.manager']
     tags:
       - { name: 'event_subscriber' }
   ys_core.moderation_sidebar_controller_alter:


### PR DESCRIPTION
## [YSP-860: Cache not cleared when updating external link in Post](https://yaleits.atlassian.net/browse/YSP-860)

### Description of work
- Reload node entity and add aggressive cache prevention headers in `ExternalSourceRedirectSubscriber` to ensure external source redirects use the latest field data.
- Add `ys_core_node_update()` to invalidate caches when `field_external_source` is updated, preventing stale redirects due to entity or page cache.
- Fix service injection for route match.

### Functional testing steps:
- [x] Create a new page, post, etc.
- [x] Set an external URL for it
- [x] In a private browser, ensure that the redirect occurs
- [x] Edit the external URL to a new URL and save
- [x] In a private browser, ensure that the redirect to the new location occurs
- [x] Edit the external URL to remove the location (make it blank)
- [x] In a private browser, ensure that no redirect occurs

Note:  We can still visit the idea of using the FieldRedirection module, but as this is being seen in current sites, this is a quicker response.
