### PR TITLE
Enable drupal hook capture in New Relic

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -10,3 +10,5 @@ protected_web_paths:
   - /private/
   - /sites/default/files/private/
   - /sites/default/files/config/
+new_relic:
+  drupal_hooks: true


### PR DESCRIPTION
### Description of work
Adds Drupal hook capture to New Relic reporting:

> As of April 23, 2024, Drupal hooks & modules metrics are not reported by default. To enable this reporting, add the following to your site or upstream pantheon.yml file:
> 
>     new_relic:
>       drupal_hooks: true
> 

Source: https://docs.pantheon.io/guides/new-relic/monitor-new-relic#enable-drupal-hooks--modules-metrics
Source: https://docs.pantheon.io/release-notes/2024/04/new-relic-agent



