### PR TITLE
Enable Drupal hook capture in New Relic

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -10,5 +10,3 @@ protected_web_paths:
   - /private/
   - /sites/default/files/private/
   - /sites/default/files/config/
-new_relic:
-  drupal_hooks: true

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -1,6 +1,9 @@
 api_version: 1
 # Downstream sites should not change the workflow.
 
+new_relic:
+  drupal_hooks: true
+
 # Specifying Quicksilver workflows in pantheon.upstream.yml is not supported.
 workflows:
   clone_database:


### PR DESCRIPTION
### Description of work
Adds Drupal hook capture to New Relic reporting:

> As of April 23, 2024, Drupal hooks & modules metrics are not reported by default. To enable this reporting, add the following to your site or upstream pantheon.yml file:
> 
>     new_relic:
>       drupal_hooks: true
> 

Source: https://docs.pantheon.io/guides/new-relic/monitor-new-relic#enable-drupal-hooks--modules-metrics
Source: https://docs.pantheon.io/release-notes/2024/04/new-relic-agent



