### PR TITLE
Event Teaser Image: Allow portait images

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
@@ -51,6 +51,7 @@ dependencies:
     - markup
     - maxlength
     - media_library
+    - media_library_edit
     - metatag
     - path
     - smart_date
@@ -492,7 +493,10 @@ content:
     region: content
     settings:
       media_types: {  }
-    third_party_settings: {  }
+    third_party_settings:
+      media_library_edit:
+        show_edit: '1'
+        edit_form_mode: default
   field_teaser_text:
     type: text_textarea
     weight: 13

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -202,13 +202,14 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
     if ($teaserMediaId) {
       /** @var Drupal\media\Entity\Media $teaserMedia */
       if ($teaserMedia = $this->entityTypeManager->getStorage('media')->load($teaserMediaId)) {
-        /** @var Drupal\file\FileStorage $fileEntity */
-        $fileEntity = $this->entityTypeManager->getStorage('file');
-        $teaserImageFileUri = $fileEntity->load($teaserMedia->field_media_image->target_id)->getFileUri();
+        /** @var Drupal\file\FileStorage $fileEntityStorage */
+        $fileEntityStorage = $this->entityTypeManager->getStorage('file');
+        $teaserImageFileUri = $fileEntityStorage->load($teaserMedia->field_media_image->target_id)->getFileUri();
+        $isTeaserImageLandscape = $teaserMedia->get('thumbnail')->width > $teaserMedia->get('thumbnail')->height;
 
         $teaserMediaRender = [
           '#type' => 'responsive_image',
-          '#responsive_image_style_id' => 'card_featured_3_2',
+          '#responsive_image_style_id' => $isTeaserImageLandscape ? 'card_featured_3_2' : 'content_spotlight_portrait',
           '#uri' => $teaserImageFileUri,
           '#attributes' => [
             'alt' => $teaserMedia->get('field_media_image')->first()->get('alt')->getValue(),


### PR DESCRIPTION
## [YALB-XX: Title](https://yaleits.atlassian.net/browse/YALB-XX)

### Description of work
- Auto-detects if an image is portrait or landscape
- Portrait images are rendered using `Content Spotlight Portrait` responsive image style

### Functional testing steps:
- [x] Create an event
- [x] In the Event Teaser Image, add a portrait image
- [x] Save it and confirm it's rendered correctly
- [x] Edit and confirm you can edit the focal point of the image
- [x] Change the focal point and save
- [x] Confirm the focal point is rendering correctly
- [x] Edit the node and add landscape image
- [x] Confirm it's rendered as expected
