### PR TITLE
YSP-1137: Image Caption Link Shadow Fix -- MULTIDEV ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ _Notes:_
 - `confim` Imports the current config files to your database.
 - `local:theme-link` Run this script once to establish `npm link`s to all of the frontend-related repositories.
 - `local:cl-dev` Enables a frontend developer to work across all of the repositories (`yalesites-project`, `atomic`, and `component-library-twig`) in an environment configured to support both Storybook development, and have the changes reflected in the Drupal instance. Note: This also wires up the Tokens repo, but if you want to watch for changes there, you'll have to run the `npm run develop` script inside the Tokens directory..
+


### PR DESCRIPTION
## [YSP-1137: Image Caption Link Shadow Fix](https://yaleits.atlassian.net/browse/YSP-1137)

### Description of work
- Real work done in https://github.com/yalesites-org/component-library-twig/pull/561

### Functional testing steps:
- [ ] Create a page
- [ ] Add an image block with a caption--make sure the caption has a link in it
- [ ] Create different sections adding a similar image block with a link in the caption
- [ ] Change section themes and global themes to ensure text shadow issues no longer occur
