### PR TITLE
RC: Make resource media field required

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.resource.field_media.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.resource.field_media.yml
@@ -13,7 +13,7 @@ entity_type: node
 bundle: resource
 label: 'Resource Media'
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
## RC: Make resource media field required

### Description of work
- The 'Resource Media' field on the resource content type is now required.

### Functional testing steps:
- [ ] Attempt to create a resource
- [ ] Ensure you can't without selecting/uploading a media