### PR TITLE
YSP-1158: RC: Add content moderation to resources

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.resource.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.resource.default.yml
@@ -50,7 +50,7 @@ third_party_settings:
               label_display: ''
               provider: ys_layouts
               context_mapping: {  }
-            weight: 0
+            weight: 1
             additional: {  }
           e0c32219-761e-4d4c-8f33-9ecc8649bc5f:
             uuid: e0c32219-761e-4d4c-8f33-9ecc8649bc5f
@@ -65,27 +65,17 @@ third_party_settings:
                 label: above
                 settings: {  }
                 third_party_settings: {  }
-            weight: 1
+            weight: 2
             additional: {  }
-          421262a0-4266-4e9d-b8ad-d6ee14101e07:
-            uuid: 421262a0-4266-4e9d-b8ad-d6ee14101e07
+          ddf5b173-339f-4717-9d71-bb029713f2ea:
+            uuid: ddf5b173-339f-4717-9d71-bb029713f2ea
             region: content
             configuration:
-              id: 'field_block:node:resource:field_external_source'
+              id: 'extra_field_block:node:resource:content_moderation_control'
               label_display: '0'
               context_mapping:
                 entity: layout_builder.entity
-              formatter:
-                type: link
-                label: above
-                settings:
-                  trim_length: 80
-                  url_only: false
-                  url_plain: false
-                  rel: ''
-                  target: ''
-                third_party_settings: {  }
-            weight: 2
+            weight: 0
             additional: {  }
         third_party_settings:
           layout_builder_lock:
@@ -136,6 +126,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 101
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
     region: content
   field_affiliation:
     type: entity_reference_label
@@ -219,3 +214,4 @@ hidden:
   field_teaser_title: true
   layout_builder__layout: true
   search_api_excerpt: true
+  workflow_buttons: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.resource.search_result.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.resource.search_result.yml
@@ -29,6 +29,11 @@ targetEntityType: node
 bundle: resource
 mode: search_result
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
   field_external_source:
     type: link_separate
     label: hidden
@@ -39,7 +44,7 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 1
+    weight: 3
     region: content
   field_login_required:
     type: boolean
@@ -49,19 +54,19 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 2
+    weight: 4
     region: content
   field_teaser_text:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 2
     region: content
   search_api_excerpt:
     settings: {  }
     third_party_settings: {  }
-    weight: 3
+    weight: 1
     region: content
 hidden:
   addtoany: true

--- a/web/profiles/custom/yalesites_profile/config/sync/workflows.workflow.editorial.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/workflows.workflow.editorial.yml
@@ -6,6 +6,7 @@ dependencies:
     - node.type.page
     - node.type.post
     - node.type.profile
+    - node.type.resource
   module:
     - content_moderation
 id: editorial
@@ -66,4 +67,5 @@ type_settings:
       - page
       - post
       - profile
+      - resource
   default_moderation_state: draft


### PR DESCRIPTION


## [RC: Add content moderation to resources](https://yaleits.atlassian.net/browse/YSP-1158)

### Description of work
- Adds content_moderation_control to resource node displays
- Updates the editorial workflow to include the resource content type
- Adjusts display weights and regions for related fields to support moderation controls

### Functional testing steps:
- [x] Attempt to create a resource
- [x] Verify that you can create a draft
- [x] Verify that you see the content moderation block when new resources are created
- [x] Verify you can publish, archive, etc.
