### PR TITLE
YSP-368: Display Platform Version Number in Dashboard

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Controller/DashboardController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Controller/DashboardController.php
@@ -3,6 +3,8 @@
 namespace Drupal\ys_core\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Extension\InfoParserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Controller for the dashboard page.
@@ -10,12 +12,64 @@ use Drupal\Core\Controller\ControllerBase;
 class DashboardController extends ControllerBase {
 
   /**
+   * The info parser service.
+   *
+   * @var \Drupal\Core\Extension\InfoParserInterface
+   */
+  protected $infoParser;
+
+  /**
+   * Constructs a DashboardController object.
+   *
+   * @param \Drupal\Core\Extension\InfoParserInterface $info_parser
+   *   The info parser service.
+   */
+  public function __construct(InfoParserInterface $info_parser) {
+    $this->infoParser = $info_parser;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('info_parser')
+    );
+  }
+
+  /**
    * Dashboard page contents.
    */
   public function content() {
+    $platform_version = $this->getPlatformVersion();
+
     return [
       '#theme' => 'ys_dashboard',
+      '#platform_version' => $platform_version,
     ];
+  }
+
+  /**
+   * Gets the YaleSites platform version from the profile info file.
+   *
+   * @return string|null
+   *   The platform version string, or NULL if not found.
+   */
+  protected function getPlatformVersion() {
+    $profile_path = DRUPAL_ROOT . '/profiles/custom/yalesites_profile/yalesites_profile.info.yml';
+
+    if (file_exists($profile_path)) {
+      try {
+        $info = $this->infoParser->parse($profile_path);
+        return $info['version'] ?? NULL;
+      }
+      catch (\Exception $e) {
+        // Log error but don't break the dashboard.
+        $this->getLogger('ys_core')->error('Failed to parse YaleSites profile info file: @message', ['@message' => $e->getMessage()]);
+      }
+    }
+
+    return NULL;
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-dashboard.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-dashboard.html.twig
@@ -1,4 +1,11 @@
 <div>
+  {% if platform_version %}
+    <section class="platform-version">
+      <h2>Platform Information</h2>
+      <p><strong>Platform Version:</strong> {{ platform_version }}</p>
+    </section>
+  {% endif %}
+
   Welcome to the YaleSites dashboard.
   {{ drupal_view('content', 'block_1') }}
   <h2>Resources</h2>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -39,7 +39,9 @@ function ys_core_theme($existing, $type, $theme, $path): array {
       ],
     ],
     'ys_dashboard' => [
-      'variables' => [],
+      'variables' => [
+        'platform_version' => NULL,
+      ],
     ],
     'ys_social_links' => [
       'variables' => [


### PR DESCRIPTION
## [YSP-368: Display Platform Version Number in Dashboard](https://yaleits.atlassian.net/browse/YSP-368)

### Description of work
- Add logic to `DashboardController` to read the YaleSites platform version from the profile info file using the `info_parser service`.
- Pass the version to the dashboard theme and render it in the template if present.
- Update theme definition to include the new variable.

### Functional testing steps:
- [ ] Visit the dashboard (Content->Dashboard)
- [ ] As of this version, you should see "Platform Version: 2.9.0"