### PR TITLE
YSP-1129: Remove siteimprove code from authoring experience pages

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -478,9 +478,9 @@ function ys_core_help($route_name, RouteMatchInterface $route_match) {
  * Implements hook_page_attachments().
  */
 function ys_core_page_attachments(array &$page) {
-  // Add Siteimprove Javascript only on production.
+  // Add Siteimprove Javascript only on production and front-facing pages.
   $config = \Drupal::config('config_split.config_split.production_config');
-  if ($config->get('status')) {
+  if ($config->get('status') && _ys_core_should_load_siteimprove()) {
     $page['#attached']['library'][] = 'ys_core/siteimprove';
   }
 
@@ -489,6 +489,129 @@ function ys_core_page_attachments(array &$page) {
   foreach ($favicons as $name => $favicon) {
     $page['#attached']['html_head'][] = [$favicon, $name];
   }
+}
+
+/**
+ * Helper function to determine if SiteImprove should load on the current page.
+ *
+ * @return bool
+ *   TRUE if SiteImprove should load, FALSE otherwise.
+ */
+function _ys_core_should_load_siteimprove() {
+  $route_match = \Drupal::routeMatch();
+  $route_name = $route_match->getRouteName();
+  $current_path = \Drupal::service('path.current')->getPath();
+
+  // Administrative routes to exclude.
+  $excluded_routes = [
+    // Admin pages.
+    'system.admin',
+    'system.admin_content',
+    'system.admin_structure',
+    'system.admin_config',
+    'system.admin_reports',
+    'system.admin_help',
+    'system.modules_list',
+    'system.themes_page',
+
+    // Content editing.
+    'entity.node.edit_form',
+    'node.add',
+    'entity.node.delete_form',
+    'entity.node.revision',
+    'entity.node.version_history',
+    'quickedit.field_form',
+    'entity.node.content_translation_overview',
+
+    // Layout Builder.
+    'layout_builder.overrides.node.view',
+    'layout_builder.overrides.node.save',
+    'layout_builder.overrides.node.cancel',
+    'layout_builder.overrides.node.revert',
+    'layout_builder.move_block',
+    'layout_builder.configure_block',
+    'layout_builder.add_block',
+    'layout_builder.remove_block',
+    'layout_builder.configure_section',
+    'layout_builder.add_section',
+    'layout_builder.remove_section',
+
+    // User management (keep public profiles).
+    'entity.user.edit_form',
+    'user.register',
+    'user.pass',
+    'user.login',
+    'user.logout',
+    'entity.user.delete_form',
+    'user.admin_create',
+    'user.admin_index',
+    'user.multiple_cancel_confirm',
+    'cas.bulk_add_cas_users',
+
+    // Taxonomy editing.
+    'entity.taxonomy_term.edit_form',
+    'entity.taxonomy_term.add_form',
+    'entity.taxonomy_term.delete_form',
+    'entity.taxonomy_vocabulary.overview_form',
+    'entity.taxonomy_vocabulary.collection',
+    'entity.taxonomy_vocabulary.add_form',
+    'entity.taxonomy_vocabulary.edit_form',
+
+    // Block and media management.
+    'entity.block_content.collection',
+    'entity.block_content.add_form',
+    'entity.block_content.edit_form',
+    'entity.media.collection',
+    'entity.media.add_form',
+    'entity.media.edit_form',
+    'view.media.media_page_list',
+
+    // Configuration and development.
+    'config.sync',
+    'config.import_full',
+    'config.export_full',
+    'config.diff',
+    'devel.admin_settings',
+    'devel.switch',
+    'system.performance_settings',
+    'system.logging_settings',
+    'system.cron_settings',
+    'system.site_information_settings',
+
+    // Reports and maintenance.
+    'system.status',
+    'dblog.overview',
+    'update.status',
+    'system.run_cron',
+  ];
+
+  // Path patterns to exclude (for routes not caught above).
+  $excluded_path_patterns = [
+    '/admin',
+    '/node/add',
+    '/layout_builder',
+    '/devel',
+  ];
+
+  // Check if current route should be excluded.
+  if (in_array($route_name, $excluded_routes)) {
+    return FALSE;
+  }
+
+  // Check for editing paths in current path.
+  if (preg_match('/\/(edit|add|delete|layout)($|\/)/i', $current_path)) {
+    return FALSE;
+  }
+
+  // Check excluded path patterns.
+  foreach ($excluded_path_patterns as $pattern) {
+    if (strpos($current_path, $pattern) === 0) {
+      return FALSE;
+    }
+  }
+
+  // Allow SiteImprove on all other pages (front-facing content).
+  return TRUE;
 }
 
 /**


### PR DESCRIPTION
## [YSP-1129: Remove siteimprove code from authoring experience pages](https://yaleits.atlassian.net/browse/YSP-1129)

### Description of work
- Conditional SiteImprove Loading: Modified `ys_core_page_attachments()` in `ys_core.module` to conditionally load SiteImprove JavaScript based on page type
- New Helper Function: Added `_ys_core_should_load_siteimprove()` to determine which pages should load analytics scripts
- Comprehensive Route Exclusions: Excludes admin pages, content editing interfaces, layout builder, user management, taxonomy editing, media management, configuration pages, and development tools
- Path Pattern Matching: Uses regex and string matching to catch editing paths (`/edit, /add, /delete, /layout) and admin patterns (/admin/*, /devel/*`)
- Maintains Production Check: Preserves existing production-only loading via `config_split.config_split.production_config`

#### SiteImprove Loads On:
- Homepage and node pages (/node/123)
- Taxonomy term pages (/taxonomy/term/456)
- Public user profiles (/user/789)
- Search results (/search)
- Contact forms and webforms on public pages
- Error pages (404/403)

#### SiteImprove Excluded From:
- All /admin/* pages
- Content editing (/node/*/edit, /node/add/*)
- Layout Builder interfaces (/node/*/layout)
- User management pages
- Taxonomy/media/block editing interfaces
- Configuration and development pages

### Functional testing steps:
- [ ] Test SiteImprove loads on front-facing pages: Visit homepage, node pages, taxonomy term pages - verify SiteImprove script loads in browser dev tools
- [ ] Test SiteImprove excluded from admin pages: Visit /admin/content, /admin/structure - verify SiteImprove script does NOT load
- [ ] Test exclusion on editing pages: Edit any node (/node/*/edit), add new content (/node/add/*) - verify SiteImprove script does NOT load
- [ ] Test exclusion on Layout Builder: Access Layout Builder on any node (/node/*/layout) - verify SiteImprove script does NOT load
- [ ] Test user management exclusions: Visit /admin/people, edit user accounts - verify SiteImprove script does NOT load
- [ ] Test taxonomy editing exclusions: Edit taxonomy terms, vocabularies - verify SiteImprove script does NOT load
- [ ] Test media/block management: Visit media library, block admin - verify SiteImprove script does NOT load
- [ ] Verify production environment check: Confirm SiteImprove only loads when config_split.config_split.production_config status is true
- [ ] Test public user profiles: Visit public user profile pages (/user/123) - verify SiteImprove script DOES load (should be included)
- [ ] Test webforms on public pages: Visit contact forms, other webforms on front-facing pages - verify SiteImprove script DOES load

### Performance Impact

- Reduced HTTP requests on all administrative and editing interfaces
- Faster page loads for content editors and site administrators
- Cleaner analytics data focused only on public visitor interactions
- No impact on front-facing page performance (SiteImprove continues loading normally)

