### PR TITLE
YSP-926: Views: Card grid stroke outline

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/imagemagick.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/imagemagick.settings.yml
@@ -2,8 +2,9 @@ _core:
   default_config_hash: do7QLcSY6lDV82NBI3jy5FNsUwWFjjJzXmHPTGsSvIQ
 quality: 100
 binaries: imagemagick
+imagemagick_version: v6
 path_to_binaries: ''
-prepend: '-limit area 20MP -limit memory 96MB -limit map 192MB'
+prepend: '-limit area 20MP -limit memory 96MB -limit map 192MB -alpha on -channel RGBA'
 log_warnings: true
 debug: false
 image_formats:
@@ -58,4 +59,3 @@ advanced:
   colorspace: '0'
   profile: ''
   coalesce: false
-imagemagick_version: v6

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -1080,3 +1080,36 @@ function ys_core_page_top(array &$page_top) {
     unset($page_top['indicator']);
   }
 }
+
+/**
+ * Implements hook_imagemagick_arguments_alter().
+ *
+ * Preserves PNG transparency across all image style operations.
+ */
+function ys_core_imagemagick_arguments_alter(\Drupal\imagemagick\ImagemagickExecArguments $arguments, $command) {
+  // Only process 'convert' operations (image transformations).
+  if ($command !== 'convert') {
+    return;
+  }
+
+  // Get the source image path to check if it's a PNG.
+  $source = $arguments->getSource();
+  if (!$source) {
+    return;
+  }
+
+  // Check if source is a PNG file.
+  $source_extension = strtolower(pathinfo($source, PATHINFO_EXTENSION));
+  $source_mime = mime_content_type($source);
+
+  if ($source_extension === 'png' || $source_mime === 'image/png') {
+    // Add transparency preservation arguments for PNG files.
+    // Use ImageMagick v6 compatible syntax.
+    $arguments->add('-alpha on');
+    $arguments->add('-channel RGBA');
+
+    // Ensure PNG compression is optimized while preserving transparency.
+    $arguments->add('-define png:preserve-colormap=true');
+    $arguments->add('-define png:exclude-chunks=date');
+  }
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -5,6 +5,7 @@
  * Contains ys_core.module functions.
  */
 
+use Drupal\imagemagick\ImagemagickExecArguments;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Cache\Cache;
@@ -1086,7 +1087,7 @@ function ys_core_page_top(array &$page_top) {
  *
  * Preserves PNG transparency across all image style operations.
  */
-function ys_core_imagemagick_arguments_alter(\Drupal\imagemagick\ImagemagickExecArguments $arguments, $command) {
+function ys_core_imagemagick_arguments_alter(ImagemagickExecArguments $arguments, $command) {
   // Only process 'convert' operations (image transformations).
   if ($command !== 'convert') {
     return;


### PR DESCRIPTION
## [YSP-926: Views: Card grid stroke outline](https://yaleits.atlassian.net/browse/YSP-926)

### Description of work
- Ensure PNG transparency is retained during all image style operations by adding ImageMagick arguments for alpha channel and RGBA support.
- Also optimize PNG compression and exclude unnecessary chunks.
- Update config to apply these arguments globally for ImageMagick v6.
- Other work completed in https://github.com/yalesites-org/component-library-twig/pull/576

### Functional testing steps:
- [ ] Upload a new PNG image with transparency
- [ ] Add it to a custom card
- [ ] Ensure you can see the border around the whole card
- [ ] Go into the browser inspector, and change the `background-color` of the `a.custom-card__image-link` to a crazy color to observe that it is transparent
