### PR TITLE
YSP-844: Event Meta Block Date Visibility Improvements #2

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/EventMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/EventMetaBlock.php
@@ -115,6 +115,7 @@ class EventMetaBlock extends BlockBase implements ContainerFactoryPluginInterfac
       '#stream_embed_code' => $eventFieldData['stream_embed_code'],
       '#event_source' => $eventFieldData['event_source'],
       '#event_featured_date' => $eventFieldData['event_featured_date'],
+      '#event_featured_index' => $eventFieldData['event_featured_index'],
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
@@ -45,6 +45,7 @@ function ys_layouts_theme($existing, $type, $theme, $path): array {
         'event_source' => NULL,
         'event_id' => NULL,
         'event_featured_date' => NULL,
+        'event_featured_index' => NULL,
       ],
     ],
     'ys_page_meta_block' => [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -195,7 +195,8 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
     // Dates.
     $dates = $node->field_event_date->getValue();
     $this->orderEventDates($dates);
-    $featuredDate = $this->getFeaturedDate($dates);
+    $featuredIndex = $this->getFeaturedDateIndex($dates);
+    $featuredDate = $this->getFeaturedDateFromIndex($dates, $featuredIndex);
 
     // Teaser responsive image.
     $teaserMediaRender = [];
@@ -292,6 +293,7 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
       'stream_embed_code' => $streamEmbedCode,
       'event_source' => $eventSource,
       'event_featured_date' => $featuredDate,
+      'event_featured_index' => $featuredIndex,
     ];
   }
 
@@ -319,6 +321,36 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
       // Sort dates - first date is next upcoming date.
       asort($dates);
     }
+  }
+
+  /**
+   * Get the index of the featured date from the list of dates.
+   *
+   * @param array $dates
+   *   An array of dates.
+   *
+   * @return int|null
+   *   The index of the featured date or NULL.
+   */
+  protected function getFeaturedDateIndex($dates) {
+    $featuredIndex = NULL;
+
+    if (!is_array($dates)) {
+      return $dates;
+    }
+
+    foreach ($dates as $index => $date) {
+      if ($date['end_value'] >= time()) {
+        $featuredIndex = $index;
+        break;
+      }
+    }
+
+    if (!isset($featuredIndex)) {
+      $featuredIndex = array_key_last($dates);
+    }
+
+    return $featuredIndex;
   }
 
   /**
@@ -351,6 +383,29 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
     }
 
     return $featuredDate;
+  }
+
+  /**
+   * Get the featured date from the list of dates by index.
+   *
+   * @param array $dates
+   *   An array of dates.
+   * @param int $index
+   *   The index of the date to return.
+   *
+   * @return array|NodeInterface
+   *   The date at the given index or what was passed.
+   */
+  protected function getFeaturedDateFromIndex($dates, $index) {
+    if (!is_array($dates)) {
+      return $dates;
+    }
+
+    if (isset($dates[$index])) {
+      return $dates[$index];
+    }
+
+    return end($dates);
   }
 
 }


### PR DESCRIPTION
## [YSP-844: Event Meta Block Date Visibility Improvements #2](https://yaleits.atlassian.net/browse/YSP-844)

### Description of work
- Adds event_featured_index field to track which date is currently featured in event meta displays
- Refactors featured date logic to separate index calculation from date retrieval for better maintainability
- Exposes featured date index to theme layer via EventMetaBlock and theme template variables
- Improves event date management by providing explicit indexing of which date is being featured
- Other work completed in https://github.com/yalesites-org/component-library-twig/pull/578

### Functional testing steps:
- [ ] Create or edit an event with multiple dates (past, current, and future)
- [ ] Verify the event meta block displays the correct featured date (first upcoming or last past date)
- [ ] Confirm the featured date index is properly calculated and passed to the theme layer
- [ ] Test edge cases: events with only past dates, only future dates, and single date events
- [ ] Verify no regressions in existing event meta block functionality