### PR TITLE
YSP-1165: Support new MS Forms source

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/MicrosoftForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/MicrosoftForm.php
@@ -20,12 +20,12 @@ class MicrosoftForm extends EmbedSourceBase implements EmbedSourceInterface {
   /**
    * {@inheritdoc}
    */
-  protected static $pattern = '/^<iframe.+src=\"https:\/\/forms\.office\.com\/Pages\/ResponsePage.aspx(?<form_params>[^"]+)".+/';
+  protected static $pattern = '/^<iframe.+src=\"https:\/\/(?:(?:forms\.office\.com\/Pages\/ResponsePage\.aspx(?<office_params>\?[^"]+))|(?:forms\.cloud\.microsoft\/r\/(?<form_id>[^"\?]+)(?:\?[^"]*)?))".+/';
 
   /**
    * {@inheritdoc}
    */
-  protected static $template = '<iframe width="640px" height="480px" src="https://forms.office.com/Pages/ResponsePage.aspx{{ form_params }}" height="100%" width="100%" loading="lazy"></iframe>\r\n';
+  protected static $template = '<iframe width="640px" height="480px" src="{{ url }}" height="100%" width="100%" loading="lazy"></iframe>\r\n';
 
   /**
    * {@inheritdoc}
@@ -52,9 +52,56 @@ class MicrosoftForm extends EmbedSourceBase implements EmbedSourceInterface {
   /**
    * {@inheritdoc}
    */
+  public function build(array $params): array {
+    // Add the constructed URL to params for template use.
+    $params['url'] = $this->getUrl($params);
+    return parent::build($params);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getUrl(array $params): string {
-    $form_params = $params['form_params'];
-    return 'https://forms.office.com/Pages/ResponsePage.aspx' . $form_params;
+    if (isset($params['office_params']) && !empty($params['office_params'])) {
+      $sanitized_params = $this->sanitizeOfficeParams($params['office_params']);
+      return 'https://forms.office.com/Pages/ResponsePage.aspx' . $sanitized_params;
+    }
+    if (isset($params['form_id']) && !empty($params['form_id'])) {
+      $sanitized_id = $this->sanitizeFormId($params['form_id']);
+      return 'https://forms.cloud.microsoft/r/' . $sanitized_id;
+    }
+    return '';
+  }
+
+  /**
+   * Sanitizes office.com form parameters.
+   *
+   * @param string $params
+   *   The query string parameters.
+   *
+   * @return string
+   *   The sanitized parameters.
+   */
+  protected function sanitizeOfficeParams(string $params): string {
+    // Minimal sanitization: prevent quote injection and XSS, preserve Microsoft params.
+    $sanitized = str_replace('"', '', $params);
+    $sanitized = htmlspecialchars($sanitized, ENT_QUOTES, 'UTF-8');
+    return substr($sanitized, 0, 2000);
+  }
+
+  /**
+   * Sanitizes cloud.microsoft form ID.
+   *
+   * @param string $form_id
+   *   The form ID.
+   *
+   * @return string
+   *   The sanitized form ID.
+   */
+  protected function sanitizeFormId(string $form_id): string {
+    // Minimal sanitization: prevent quote injection and basic XSS, preserve Microsoft IDs.
+    $sanitized = str_replace(['"', '<', '>', '&'], '', $form_id);
+    return substr($sanitized, 0, 100);
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/MicrosoftForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/MicrosoftForm.php
@@ -83,7 +83,8 @@ class MicrosoftForm extends EmbedSourceBase implements EmbedSourceInterface {
    *   The sanitized parameters.
    */
   protected function sanitizeOfficeParams(string $params): string {
-    // Minimal sanitization: prevent quote injection and XSS, preserve Microsoft params.
+    // Minimal sanitization: prevent quote injection and XSS,
+    // preserve Microsoft params.
     $sanitized = str_replace('"', '', $params);
     $sanitized = htmlspecialchars($sanitized, ENT_QUOTES, 'UTF-8');
     return substr($sanitized, 0, 2000);
@@ -99,7 +100,8 @@ class MicrosoftForm extends EmbedSourceBase implements EmbedSourceInterface {
    *   The sanitized form ID.
    */
   protected function sanitizeFormId(string $form_id): string {
-    // Minimal sanitization: prevent quote injection and basic XSS, preserve Microsoft IDs.
+    // Minimal sanitization: prevent quote injection and basic XSS,
+    // preserve Microsoft IDs.
     $sanitized = str_replace(['"', '<', '>', '&'], '', $form_id);
     return substr($sanitized, 0, 100);
   }


### PR DESCRIPTION
## [YSP-1165: Support new MS Forms source](https://yaleits.atlassian.net/browse/YSP-1165)

### Description of work

- Adds support for forms.cloud.microsoft URLs in addition to existing forms.office.com URLs
- Updates regex pattern to capture both URL structures (office.com with query params and cloud.microsoft with path-based form IDs)
- Implements secure URL reconstruction following patterns used by other embed sources (GoogleMaps, Qualtrics)
- Adds minimal sanitization that prevents injection attacks while preserving Microsoft's actual URL parameters
- Fixes getUrl() method logic to properly detect and handle both URL formats based on captured parameters
- Replaces overly restrictive parameter filtering with minimal sanitization approach to support unknown Microsoft URL variations

### Functional testing steps:

- [ ] Create a Microsoft Form on forms.office.com and copy the embed code
- [ ] Add the office.com embed code to a Drupal page using the Microsoft Forms embed source
- [ ] Verify the form displays correctly and is functional
- [ ] Create a Microsoft Form on forms.cloud.microsoft and copy the embed code
- [ ] Add the cloud.microsoft embed code to a Drupal page using the Microsoft Forms embed source
- [ ] Verify the cloud.microsoft form displays correctly and is functional
- [ ] Test that both URL formats generate correct iframe src URLs (office.com should keep forms.office.com domain, cloud.microsoft should keep forms.cloud.microsoft domain)
- [ ] Verify that special characters in form URLs (like +, /, spaces) are preserved and work correctly
- [ ] Test that malicious input (quotes, script tags) is properly sanitized without breaking legitimate Microsoft parameters
- [ ] Confirm that both old and new Microsoft Forms continue to work after the changes