### PR TITLE
YSP-1135:  Environment Indicators: User found the messaging to be misleading

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -70,6 +70,17 @@ if (!empty($_ENV['PANTHEON_ENVIRONMENT']) && !empty($_ENV['CACHE_HOST'])) {
  * Environment Indicator.
  */
 $env = $_ENV['PANTHEON_ENVIRONMENT'] ?? 'lando';
+
+// Get version from profile info file.
+$profile_info_file = DRUPAL_ROOT . '/profiles/custom/yalesites_profile/yalesites_profile.info.yml';
+$version = '';
+if (file_exists($profile_info_file)) {
+  $profile_info = file_get_contents($profile_info_file);
+  if (preg_match('/^version:\s*(.+)$/m', $profile_info, $matches)) {
+    $version = trim($matches[1]);
+  }
+}
+
 $env_options = [
   'lando' => [
     'bg_color' => '#94bdff',
@@ -79,17 +90,17 @@ $env_options = [
   'development' => [
     'bg_color' => '#3b82f6',
     'fg_color' => '#ffffff',
-    'name' => 'Development',
+    'name' => 'Development' . ($version ? ' - ' . $version : ''),
   ],
   'test' => [
     'bg_color' => '#8b5cf6',
     'fg_color' => '#ffffff',
-    'name' => 'YaleSites Team Testing Only.',
+    'name' => 'YaleSites Team Testing Only.' . ($version ? ' - ' . $version : ''),
   ],
   'live' => [
     'bg_color' => '#22c55e',
     'fg_color' => '#000000',
-    'name' => 'Live Site',
+    'name' => 'Live Site' . ($version ? ' - ' . $version : ''),
   ],
   'multidev' => [
     'bg_color' => '#e1821f',

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ * @file
  * Load services definition file.
  */
 
@@ -9,7 +10,7 @@ $settings['container_yamls'][] = __DIR__ . '/services.yml';
 /**
  * Include the Pantheon-specific settings file.
  *
- * n.b. The settings.pantheon.php file makes some changes
+ * N.b. The settings.pantheon.php file makes some changes
  *      that affect all environments that this site
  *      exists in.  Always include this file, even in
  *      a local development environment, to ensure that
@@ -22,16 +23,15 @@ include __DIR__ . "/settings.pantheon.php";
  * work better, but will also raise a warning when you
  * install Drupal.
  *
- * https://www.drupal.org/project/drupal/issues/3091285
+ * Https://www.drupal.org/project/drupal/issues/3091285
  */
 // $settings['skip_permissions_hardening'] = TRUE;
-
 // Config split for production environments.
 $config['config_split.config_split.local_config']['status'] = FALSE;
 $config['config_split.config_split.production_config']['status'] = TRUE;
 
 /**
- * If there is a local settings file, then include it
+ * If there is a local settings file, then include it.
  */
 $local_settings = __DIR__ . "/settings.local.php";
 if (file_exists($local_settings)) {
@@ -39,7 +39,7 @@ if (file_exists($local_settings)) {
 }
 
 /**
- * If there is a site-specific settings file, then include it
+ * If there is a site-specific settings file, then include it.
  */
 if (isset($_ENV['PANTHEON_SITE_NAME'])) {
   $site_settings = __DIR__ . "/settings." . $_ENV['PANTHEON_SITE_NAME'] . ".php";
@@ -79,7 +79,7 @@ $env_options = [
   'development' => [
     'bg_color' => '#3b82f6',
     'fg_color' => '#ffffff',
-    'name' => 'Development - Build & Test. Make big changes here, then request go-live.',
+    'name' => 'Development',
   ],
   'test' => [
     'bg_color' => '#8b5cf6',
@@ -89,7 +89,7 @@ $env_options = [
   'live' => [
     'bg_color' => '#22c55e',
     'fg_color' => '#000000',
-    'name' => 'Live Site - Published. Make small edits and add content here.',
+    'name' => 'Live Site',
   ],
   'multidev' => [
     'bg_color' => '#e1821f',


### PR DESCRIPTION
## [YSP-1135: Environment Indicators: User found the messaging to be misleading](https://yaleits.atlassian.net/browse/YSP-1135)

### Description of work
- Adds version number display to environment indicators for development, test, and live environments
- Updates environment indicator names to include profile version (e.g., "Development - 2.9.0")
- Implements dynamic version parsing from yalesites_profile.info.yml file

### Functional testing steps:
- [ ] Keep in mind you may not be able to truly test this on your own without some help.  It might be better to see it in action on a local instance with me.  Just let me know.