### PR TITLE
1105 :: Sustainability news migration

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/README.md
@@ -1,0 +1,166 @@
+# YaleSites Migrate: Sustainability News
+
+Migrates Drupal 7 **news** nodes from the Sustainability Yale D7 site into
+Drupal 10 **post** nodes on the current YaleSites platform, including taxonomy
+terms, images, media entities, and Layout Builder sections.
+
+---
+
+## Requirements
+
+### Drupal modules
+
+The following modules must be enabled before running the migration:
+
+- `ys_migrate` (parent module)
+- `ys_migrate_sustainability_news` (this module)
+- `migrate_plus`
+- `migrate_tools`
+
+Enable with:
+
+```bash
+lando drush en ys_migrate_sustainability_news
+```
+
+---
+
+## Step 1 — Set up the D7 database connection
+
+The D7 source database must be available as a second database connection named
+`d7_sustainability` in `web/sites/default/settings.local.php`:
+
+```php
+$databases['d7_sustainability']['default'] = [
+  'database' => 'd7_sustainability',
+  'username' => 'root',
+  'password' => '',
+  'host'     => 'database',
+  'port'     => '3306',
+  'driver'   => 'mysql',
+  'prefix'   => '',
+];
+```
+
+> The host `database` is Lando's internal name for the MySQL service. The
+> root user has no password by default in the Lando Pantheon recipe. If your
+> setup uses different credentials check `lando info` for the database service
+> details.
+
+### Import the D7 database
+
+```bash
+# 1. (Optional) Create a fresh backup on Pantheon
+lando terminus backup:create <site>.<env> --element=db
+
+# 2. Download the backup to your project root
+lando terminus backup:get <site>.<env> --element=db --to=/app/d7-db.sql.gz
+
+# 3. Create the d7_sustainability database and grant access
+lando mysql -uroot -e "
+  CREATE DATABASE IF NOT EXISTS d7_sustainability;
+  GRANT ALL PRIVILEGES ON d7_sustainability.* TO 'root'@'%';
+  FLUSH PRIVILEGES;
+"
+
+# 4. Import the dump
+lando ssh -c "gunzip -c /app/d7-db.sql.gz | mysql -uroot d7_sustainability"
+
+# 5. Verify the import
+lando mysql -uroot d7_sustainability -e "SHOW TABLES;" | head -20
+```
+
+Replace `<site>.<env>` with the Pantheon site and environment, e.g.
+`sustainability-d7.dev`.
+
+---
+
+## Step 2 — Copy D7 source files
+
+The D7 public files must be copied into a staging directory inside the D10
+public files directory **before** running the migration. The migration reads
+from this directory and copies each image into `public://news/`.
+
+**Required path:** `web/sites/default/files/d7_source/`
+
+The D7 directory structure must be preserved. For example, a D7 file at
+`public://2024/01/image.jpg` must exist at:
+
+```
+web/sites/default/files/d7_source/2024/01/image.jpg
+```
+
+After a successful migration, the staging directory can be
+deleted — D10 file entities reference `public://news/` and `d7_source/` is no
+longer needed.
+
+---
+
+## Step 3 — Run the migration
+
+### Full run (recommended)
+
+```bash
+lando drush migrate:import --group=ys_sn --execute-dependencies
+```
+
+### Step by step
+
+```bash
+lando drush migrate:import ys_sn_news_terms
+lando drush migrate:import ys_sn_files
+lando drush migrate:import ys_sn_media
+lando drush migrate:import ys_sn_news
+```
+
+### Check migration status
+
+```bash
+lando drush migrate:status --group=ys_sn
+```
+
+---
+
+## Rolling back
+
+```bash
+lando drush migrate:rollback --group=ys_sn
+```
+
+> Rolling back **deletes the D10 entities** (nodes, media, file records, terms)
+> and clears the migration map tables. Physical files in `news/` are also
+> deleted by Drupal's file management. Files in `d7_source/` are **not**
+> affected — you do not need to re-copy them before re-running.
+
+---
+
+## Migration overview
+
+The migrations run in dependency order. Use `--execute-dependencies` to have
+Drush handle this automatically.
+
+| ID | Label | Depends on | Description |
+|----|-------|------------|-------------|
+| `ys_sn_news_terms` | Sustainability News Terms | — | Migrates D7 `take_action_topics` taxonomy terms into the D10 `post_category` vocabulary. |
+| `ys_sn_files` | Sustainability News Files | — | Migrates D7 `file_managed` records for public images into D10 `entity:file`, physically copying files from `d7_source/` to `public://news/`. |
+| `ys_sn_media` | Sustainability News Media | `ys_sn_files` | Creates D10 `media:image` entities for each migrated file. Alt and title text are sourced from D7 field data (`field_image2` takes precedence over `field_news_image`). All media items are tagged *Imported from migration* in the `tags` vocabulary. |
+| `ys_sn_news` | Sustainability News | `ys_sn_files`, `ys_sn_media`, `ys_sn_news_terms` | Migrates D7 `news` nodes to D10 `post` nodes, including Layout Builder sections with inline image and text blocks. |
+
+### Field mapping
+
+| D7 field | D10 field | Notes |
+|----------|-----------|-------|
+| `title` | `title` | |
+| `field_date` | `field_publish_date` | Converted from datetime to date |
+| `field_link_to_external_story` | `field_external_source` | URL only; 123 nodes |
+| `field_image2` / `field_news_image` | `field_teaser_media` | `field_image2` preferred; 199 / 132 nodes respectively |
+| `body/summary` | `field_teaser_text` | 156 nodes; format: `heading_html` |
+| `field_take_action_topic` | `field_category` | 161 nodes; looked up from `ys_sn_news_terms` |
+| `body/value` | Layout Builder text block | 440 nodes; inline block created per node |
+| `field_image2` / `field_news_image` | Layout Builder image block | Inline block; `field_image2` preferred |
+| `status` | `moderation_state` | `0` → `draft`, `1` → `published` |
+| `field_feature_on_homepage` | — | Skipped (unused since 2022) |
+| `metatags` | — | Skipped |
+| `redirect` | — | Skipped |
+| Author | `uid` | Hardcoded to `uid = 1` (admin) |
+

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration.ys_sn_files.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration.ys_sn_files.yml
@@ -45,28 +45,17 @@ migration_tags:
 migration_group: ys_sn
 
 # Migrate only public image files from the D7 database.
+# Uses the same d7_news_images source plugin as ys_sn_media so both
+# migrations iterate over an identical set of files.
 source:
-  plugin: d7_file
+  plugin: d7_news_images
   key: d7_sustainability
-  scheme: public
-  # Filter to image MIME types to avoid migrating unrelated files.
-  # Remove this filter if you need to migrate other file types (e.g. PDFs).
-  mime_type:
-    - image/jpeg
-    - image/png
-    - image/gif
-    - image/webp
-    - image/svg+xml
   constants:
     # Staging directory: where D7 files have been placed before migration.
     d7_source_dir: d7_source
     # Destination directory: where migrated news images will live in D10.
     # D10 file entities will reference public://news/... URIs.
     d7_dest_dir: news
-    # Required by the d7_file source plugin's prepareRow() to compute the
-    # 'filepath' property. We don't use filepath in our process, but without
-    # this key PHP emits an "Undefined array key" warning on every row.
-    source_base_path: ''
 
 process:
   uid:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration.ys_sn_files.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration.ys_sn_files.yml
@@ -1,0 +1,112 @@
+# Migration: YaleSite Sustainability News Files
+# Description: Migrates Drupal 7 file_managed records for public image files
+# into Drupal 10 managed file entities (entity:file). This is a prerequisite
+# for the media migrations, which reference these D10 file entity IDs.
+#
+# IMPORTANT: Before running this migration, the physical D7 files must be
+# copied into the staging directory (d7_source) inside the D10 public files
+# directory, preserving the D7 directory structure.
+#
+# Example: a D7 file at public://2024/01/foo.jpg must exist at
+#   web/sites/default/files/d7_source/2024/01/foo.jpg
+#
+# During migration, each file is COPIED from d7_source/ into the destination
+# directory (news/), so the D10 file entities reference public://news/...
+# Once the migration is complete and verified, d7_source/ can be deleted
+# safely — it is only a staging area and is not referenced by any D10 entity.
+#
+# To copy D7 files into the staging directory (choose one):
+#
+#   From a live Pantheon D7 environment:
+#     ddev exec terminus rsync sustainability-d7.dev:files/ \
+#       /var/www/html/web/sites/default/files/d7_source/ -- --size-only
+#
+#   From a local archive:
+#     ddev exec tar -xzf /var/www/html/d7-files.tar.gz \
+#       -C /var/www/html/web/sites/default/files/d7_source/
+#
+#   From a local directory (outside the container):
+#     cp -r /path/to/d7/sites/default/files/* web/sites/default/files/d7_source/
+#
+# After migration, remove the staging directory:
+#   ddev exec rm -rf /var/www/html/web/sites/default/files/d7_source
+
+id: ys_sn_files
+label: 'YaleSites Sustainability News Files'
+status: true
+dependencies:
+  enforced:
+    module:
+      - ys_migrate_sustainability_news
+class: Drupal\migrate\Plugin\Migration
+migration_tags:
+  - 'Drupal 7'
+  - File
+migration_group: ys_sn
+
+# Migrate only public image files from the D7 database.
+source:
+  plugin: d7_file
+  key: d7_sustainability
+  scheme: public
+  # Filter to image MIME types to avoid migrating unrelated files.
+  # Remove this filter if you need to migrate other file types (e.g. PDFs).
+  mime_type:
+    - image/jpeg
+    - image/png
+    - image/gif
+    - image/webp
+    - image/svg+xml
+  constants:
+    # Staging directory: where D7 files have been placed before migration.
+    d7_source_dir: d7_source
+    # Destination directory: where migrated news images will live in D10.
+    # D10 file entities will reference public://news/... URIs.
+    d7_dest_dir: news
+    # Required by the d7_file source plugin's prepareRow() to compute the
+    # 'filepath' property. We don't use filepath in our process, but without
+    # this key PHP emits an "Undefined array key" warning on every row.
+    source_base_path: ''
+
+process:
+  uid:
+    plugin: default_value
+    default_value: constants/admin_uid
+  filename: filename
+
+  # Build the source URI: where the file currently lives in the staging dir.
+  # e.g. public://2024/01/image.jpg → public://d7_source/2024/01/image.jpg
+  _source_uri:
+    plugin: str_replace
+    source: uri
+    search: 'public://'
+    replace: 'public://d7_source/'
+
+  # Build the destination URI: where the file will live after migration.
+  # e.g. public://2024/01/image.jpg → public://news/2024/01/image.jpg
+  _dest_uri:
+    plugin: str_replace
+    source: uri
+    search: 'public://'
+    replace: 'public://news/'
+
+  # Physically copy the file from d7_source/ to news/ and record the
+  # destination URI as the file entity's uri field.
+  uri:
+    plugin: file_copy
+    source:
+      - '@_source_uri'
+      - '@_dest_uri'
+    move: false
+
+  filemime: filemime
+  filesize: filesize
+  status: status
+  created: timestamp
+
+# D7 file records are migrated into Drupal 10 managed file entities.
+destination:
+  plugin: entity:file
+
+migration_dependencies:
+  required: {}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration.ys_sn_media.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration.ys_sn_media.yml
@@ -29,19 +29,16 @@ migration_group: ys_sn
 # reference files stored here. A single migration covers both fields since
 # fid is the shared key used by the migration_lookup in ys_sn_news.
 source:
-  plugin: d7_file
+  # Custom source plugin that JOINs file_managed with field_data_field_image2
+  # and field_data_field_news_image to expose alt and title text.
+  # Filters to public images only — no additional mime_type or scheme config
+  # needed as those conditions are built into the plugin query.
+  plugin: d7_news_images
   key: d7_sustainability
-  scheme: public
-  mime_type:
-    - image/jpeg
-    - image/png
-    - image/gif
-    - image/webp
-    - image/svg+xml
   constants:
-    # Required by the d7_file source plugin's prepareRow() to suppress an
-    # "Undefined array key" warning. We don't use the computed filepath property.
-    source_base_path: ''
+    # Tag applied to every migrated media item so they can be identified and
+    # bulk-managed in the media library after migration.
+    migration_tag_name: 'Imported from migration'
 
 process:
   name: filename
@@ -59,14 +56,22 @@ process:
     source: fid
     no_stub: true
 
-  # alt and title are not available from file_managed; default to empty.
-  # Update in the media library after migration if needed.
-  'field_media_image/alt':
-    plugin: default_value
-    default_value: ''
-  'field_media_image/title':
-    plugin: default_value
-    default_value: ''
+  # Alt and title text sourced from field_image2 or field_news_image,
+  # whichever has a value (field_image2 takes precedence). Falls back to
+  # an empty string if neither field has alt/title for this file.
+  'field_media_image/alt': alt
+  'field_media_image/title': title
+
+  # Tag every migrated media item so they can be identified in the media
+  # library. entity_generate looks up the term by name and creates it if it
+  # does not yet exist.
+  'field_tags/target_id':
+    plugin: entity_generate
+    source: constants/migration_tag_name
+    entity_type: taxonomy_term
+    bundle_key: vid
+    bundle: tags
+    value_key: name
 
 destination:
   plugin: entity:media

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration.ys_sn_media.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration.ys_sn_media.yml
@@ -1,0 +1,77 @@
+# Migration: YaleSite Sustainability News Media
+# Description: Creates Drupal 10 media:image entities for all public image
+# files in the D7 file_managed table. Keyed by D7 fid so that ys_sn_news
+# can look up the D10 media entity for both field_news_image and field_image2
+# via migration_lookup.
+#
+# Note: alt and title text is stored per-field-instance in D7 (in the
+# field_data_field_* tables), not on the file entity itself. Since we are
+# sourcing from file_managed only, alt/title are left empty here. Editors
+# can update alt text in the D10 media library after migration.
+#
+# Depends on ys_sn_files to have already created the D10 file entities.
+
+id: ys_sn_media
+label: 'YaleSites Sustainability News Media (Image)'
+status: true
+dependencies:
+  enforced:
+    module:
+      - ys_migrate_sustainability_news
+class: Drupal\migrate\Plugin\Migration
+migration_tags:
+  - 'Drupal 7'
+  - Media
+migration_group: ys_sn
+
+# Source: all public image files from the D7 file_managed table.
+# Both field_news_image (132 older nodes) and field_image2 (199 recent nodes)
+# reference files stored here. A single migration covers both fields since
+# fid is the shared key used by the migration_lookup in ys_sn_news.
+source:
+  plugin: d7_file
+  key: d7_sustainability
+  scheme: public
+  mime_type:
+    - image/jpeg
+    - image/png
+    - image/gif
+    - image/webp
+    - image/svg+xml
+  constants:
+    # Required by the d7_file source plugin's prepareRow() to suppress an
+    # "Undefined array key" warning. We don't use the computed filepath property.
+    source_base_path: ''
+
+process:
+  name: filename
+  status: status
+  created: timestamp
+  uid:
+    plugin: default_value
+    default_value: constants/admin_uid
+
+  # Look up the D10 file entity ID migrated by ys_sn_files.
+  # The D7 fid is the shared key between file_managed and ys_sn_files.
+  'field_media_image/target_id':
+    plugin: migration_lookup
+    migration: ys_sn_files
+    source: fid
+    no_stub: true
+
+  # alt and title are not available from file_managed; default to empty.
+  # Update in the media library after migration if needed.
+  'field_media_image/alt':
+    plugin: default_value
+    default_value: ''
+  'field_media_image/title':
+    plugin: default_value
+    default_value: ''
+
+destination:
+  plugin: entity:media
+  default_bundle: image
+
+migration_dependencies:
+  required:
+    - ys_sn_files

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration.ys_sn_news.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration.ys_sn_news.yml
@@ -98,7 +98,7 @@ process:
     source: 'body/0/summary'
   field_teaser_text/format:
     plugin: default_value
-    default_value: 'basic_html'
+    default_value: 'heading_html'
 
   # Category/taxonomy: look up migrated post_category terms. 161 nodes in use.
   # D7 field: field_take_action_topic (term reference to Take Action Topic vocab).

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration.ys_sn_news.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration.ys_sn_news.yml
@@ -1,0 +1,176 @@
+# Migration: YaleSite Sustainability News Node Migration
+# Description: Migrates Drupal 7 'news' content to Drupal 10 'post' nodes.
+# This is the final migration in the chain. It depends on:
+#   - ys_sn_news_terms  (taxonomy terms → post_category)
+#   - ys_sn_files       (D7 file_managed records → D10 entity:file)
+#   - ys_sn_media       (all D7 image files → media:image entities, keyed by fid)
+#
+# NOTE: ys_sn_news_body and ys_sn_news_image_block are no longer required.
+# The sn_news_to_layout_builder plugin now creates image and text blocks
+# inline during this migration, so those separate migrations have been removed.
+#
+# Field mapping (confirmed D7 machine names):
+#   title                        → title
+#   field_date                   → field_publish_date
+#   field_link_to_external_story → field_external_source    (123 in use)
+#   field_news_image/0/fid       → field_teaser_media       (132 older nodes)
+#   field_image2/0/fid           → field_teaser_media       (199 recent nodes, fallback)
+#   body/0/summary               → field_teaser_text        (156 populated)
+#   field_take_action_topic      → field_category           (161 in use)
+#   body/0/value                 → layout_builder__layout   (440 with body)
+#   field_news_image / field_image2 → layout_builder__layout image block
+#   field_feature_on_homepage    → skip (none since 2022)
+#   metatags                     → skip
+#   redirect                     → skip
+
+id: ys_sn_news
+label: 'YaleSites Sustainability News'
+status: true
+dependencies:
+  enforced:
+    module:
+      - ys_migrate_sustainability_news
+class: Drupal\migrate\Plugin\Migration
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: ys_sn
+
+# Specifies the source is Drupal 7 nodes of the 'news' content type.
+source:
+  plugin: d7_node
+  key: d7_sustainability
+  node_type: news
+
+# Define how each field or property is mapped to the Drupal 10 post node.
+process:
+  langcode:
+    plugin: default_value
+    source: language
+    default_value: 'und'
+  title: title
+  status: status
+  created: created
+  changed: changed
+  promote: promote
+  sticky: sticky
+
+  # Publication date: D7 field_date stores as datetime; D10 stores as date only.
+  field_publish_date:
+    plugin: sub_process
+    source: field_date
+    process:
+      value:
+        plugin: format_date
+        from_format: 'Y-m-d H:i:s'
+        to_format: 'Y-m-d'
+        source: value
+
+  # External source: 123 news items use an external link (URL only, no title).
+  field_external_source:
+    plugin: field_link
+    source: field_link_to_external_story
+    uri_scheme: 'https://'
+
+  # Teaser media: 199 more recent nodes use field_image2; 132 older nodes use
+  # field_news_image. Both fields reference files in file_managed, all covered
+  # by ys_sn_media. We attempt field_image2 first, then fall back to
+  # field_news_image via a null_coalesce so every node gets a teaser image
+  # when available.
+  _teaser_mid_image2:
+    plugin: migration_lookup
+    migration: ys_sn_media
+    source: 'field_image2/0/fid'
+  _teaser_mid_image:
+    plugin: migration_lookup
+    migration: ys_sn_media
+    source: 'field_news_image/0/fid'
+  'field_teaser_media/target_id':
+    plugin: null_coalesce
+    source:
+      - '@_teaser_mid_image2'
+      - '@_teaser_mid_image'
+
+  # Teaser text: the D7 body summary field maps to the D10 teaser text.
+  # 156 nodes have a populated body summary.
+  field_teaser_text/value:
+    plugin: get
+    source: 'body/0/summary'
+  field_teaser_text/format:
+    plugin: default_value
+    default_value: 'basic_html'
+
+  # Category/taxonomy: look up migrated post_category terms. 161 nodes in use.
+  # D7 field: field_take_action_topic (term reference to Take Action Topic vocab).
+  field_category:
+    plugin: migration_lookup
+    migration: ys_sn_news_terms
+    source: field_take_action_topic
+
+  # Hardcode post_category to 'News' for all migrated nodes.
+  # This sets the post_type field (if it exists) or is informational.
+  # Remove this mapping if the post content type does not have this field.
+  # field_post_type:
+  #   plugin: default_value
+  #   default_value: 'news'
+
+  uid:
+    plugin: default_value
+    default_value: constants/admin_uid
+
+  # Author by: skip migration per the field mapping document. Hardcode uid=1.
+  # field_author is intentionally left unmapped.
+
+  # Moderation state: map D7 publish status to D10 content moderation states.
+  moderation_state:
+    plugin: static_map
+    source: status
+    default_value: draft
+    map:
+      '0': draft
+      '1': published
+
+  # Layout Builder: the plugin creates a default "Title and Metadata" section
+  # (required by Post nodes) plus a one-column content section containing an
+  # image block and a text block, both built inline from the current row.
+  #
+  # The image component tries field_image2's media entity first (@_teaser_mid_image2),
+  # then falls back to field_news_image's (@_teaser_mid_image). Both are
+  # already resolved above via migration_lookup, so '@' reads those
+  # destination properties directly.
+  #
+  # 'post_meta_block' confirmed via ys_layouts/src/Plugin/Block/PostMetaBlock.php
+  # and core.entity_view_display.node.post.default.yml.
+  #
+  # See src/Plugin/migrate/process/sustainability_news/NewsToLayoutBuilder.php
+  layout_builder__layout:
+    plugin: sn_news_to_layout_builder
+    create_default_section: true
+    default_section_type: post
+    sections:
+      - id: layout_onecol
+        components:
+          - type: image
+            # Tries field_image2 first (199 recent nodes), falls back to
+            # field_news_image (132 older nodes). Both look up ys_sn_media
+            # by fid since it covers all image files. Skipped if both NULL.
+            sources:
+              - '@_teaser_mid_image2'
+              - '@_teaser_mid_image'
+          - type: text
+            # 440 nodes have body content; empty bodies produce no block.
+            source: 'body/0/value'
+
+# Drupal 7 news content will be migrated into the post content type.
+destination:
+  plugin: entity:node
+  default_bundle: post
+
+# All prerequisite migrations must complete before running this migration.
+# ys_sn_news_body and ys_sn_news_image_block are no longer in this list
+# because blocks are now created inline by the sn_news_to_layout_builder plugin.
+migration_dependencies:
+  required:
+    - ys_sn_files
+    - ys_sn_news_terms
+    - ys_sn_media

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration.ys_sn_news_terms.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration.ys_sn_news_terms.yml
@@ -1,0 +1,45 @@
+# Migration: YaleSite Sustainability News Terms Migration
+# Description: Migrates taxonomy terms from the Drupal 7 'Take Action Topic'
+# vocabulary (field_take_action_topics) to the Drupal 10 'post_category' vocabulary.
+#
+# The D7 vocabulary machine name was confirmed by running:
+#   SELECT name, machine_name FROM taxonomy_vocabulary;
+# on the D7 database. Confirmed value: 'take_action_topics'.
+
+id: ys_sn_news_terms
+label: 'YaleSites Sustainability News Terms'
+status: true
+dependencies:
+  enforced:
+    module:
+      - ys_migrate_sustainability_news
+class: Drupal\migrate\Plugin\Migration
+migration_tags:
+  - 'Drupal 7'
+  - taxonomy_vocabulary
+migration_group: ys_sn
+
+# Specifies the source is Drupal 7 terms from the 'Take Action Topics' vocabulary.
+# Confirmed machine name: 'take_action_topics'.
+source:
+  plugin: d7_taxonomy_term
+  bundle: take_action_topics
+  key: d7_sustainability
+
+# Define how each field or property is mapped to the Drupal 10 platform.
+process:
+  vid:
+    plugin: default_value
+    default_value: post_category
+  name: name
+  description: description/value
+  weight: weight
+  parent: parent
+
+# Drupal 7 news terms will be migrated into the post_category vocabulary.
+destination:
+  plugin: entity:taxonomy_term
+  default_bundle: post_category
+
+migration_dependencies:
+  required: {}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration_group.ys_sn.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/config/optional/migrate_plus.migration_group.ys_sn.yml
@@ -1,0 +1,35 @@
+# Migration Group: YaleSite Sustainability News Migrations
+# Description: Defines the migration group for transferring news content and data
+# from a Drupal 7 Sustainability site to Drupal 10 (YaleSites Post content type).
+# This migration assumes that the Drupal 7 data is accessible via a database
+# connection named 'd7_sustainability', defined in the site's settings.php file.
+#
+# Add the following to settings.php:
+#
+# $databases['d7_sustainability']['default'] = [
+#   'database' => 'your_db_name',
+#   'username' => 'your_db_user',
+#   'password' => 'your_db_password',
+#   'prefix'   => '',
+#   'host'     => 'your_db_host',
+#   'port'     => '3306',
+#   'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+#   'driver'   => 'mysql',
+# ];
+
+id: ys_sn
+label: 'YaleSite Sustainability News Migrations'
+description: 'Migration group for Sustainability News D7 to D10.'
+langcode: en
+status: true
+dependencies: {  }
+
+source_type: ''
+
+shared_configuration:
+  source:
+    # Specifies the database key used to connect to the Drupal 7 database.
+    # This key must be defined in settings.php under the 'databases' array.
+    key: d7_sustainability
+    constants:
+      admin_uid: 1

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/src/Plugin/migrate/process/sustainability_news/NewsToLayoutBuilder.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/src/Plugin/migrate/process/sustainability_news/NewsToLayoutBuilder.php
@@ -142,9 +142,8 @@ class NewsToLayoutBuilder extends ProcessPluginBase implements ContainerFactoryP
       throw new MigrateException('sn_news_to_layout_builder: default_section_type is required when create_default_section is TRUE.');
     }
 
-    // Order matches core.entity_view_display.node.post.default.yml:
-    //   weight 0 → content_moderation_control
-    //   weight 1 → post_meta_block
+    // Order matches core.entity_view_display.node.post.default.yml.
+    // Weight 0: content_moderation_control, weight 1: post_meta_block.
     return new Section(
       'layout_onecol',
       ['label' => 'Title and Metadata'],

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/src/Plugin/migrate/process/sustainability_news/NewsToLayoutBuilder.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/src/Plugin/migrate/process/sustainability_news/NewsToLayoutBuilder.php
@@ -1,0 +1,393 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_migrate_sustainability_news\Plugin\migrate\process\sustainability_news;
+
+use Drupal\block_content\BlockContentInterface;
+use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\layout_builder\Section;
+use Drupal\layout_builder\SectionComponent;
+use Drupal\migrate\Attribute\MigrateProcess;
+use Drupal\migrate\MigrateException;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Transforms D7 news fields into Layout Builder sections for D10 Post nodes.
+ *
+ * Creates a default "Title and Metadata" section plus a one-column content
+ * section containing an image block and/or text block, built inline from
+ * the current row's source data. No prior block_content migrations are needed.
+ *
+ * Usage in migration YAML:
+ *
+ * @code
+ * process:
+ *   layout_builder__layout:
+ *     plugin: sn_news_to_layout_builder
+ *     create_default_section: true
+ *     default_section_type: post
+ *     sections:
+ *       - id: layout_onecol
+ *         components:
+ *           - type: image
+ *             # 'sources' tries each in order and uses the first non-null value.
+ *             sources:
+ *               - '@_teaser_mid_image2'
+ *               - '@_teaser_mid_image'
+ *           - type: text
+ *             source: 'body/0/value'
+ * @endcode
+ *
+ * Source values prefixed with '@' are resolved from destination (processed)
+ * properties set earlier in the pipeline; all others are source properties.
+ */
+#[MigrateProcess(id: 'sn_news_to_layout_builder')]
+class NewsToLayoutBuilder extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The current row being processed.
+   *
+   * Held only for the duration of transform() and reset to NULL afterwards.
+   *
+   * @var \Drupal\migrate\Row|null
+   */
+  private ?Row $row = NULL;
+
+  /**
+   * Constructs the plugin instance.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly UuidInterface $uuid,
+    private readonly LoggerChannelInterface $logger,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new self(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('uuid'),
+      $container->get('logger.factory')->get('migrate'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @return \Drupal\layout_builder\Section[]
+   *   An array of Layout Builder sections for the node.
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property): array {
+    if (empty($this->configuration['sections'])) {
+      throw new MigrateException('sn_news_to_layout_builder: you must specify at least one section.');
+    }
+
+    $this->row = $row;
+    $layout_sections = [];
+
+    // The default "Title and Metadata" section is normally added by Drupal
+    // when a node layout is first saved via the UI. During migration it must
+    // be created explicitly, otherwise the post header is never rendered.
+    if ($this->configuration['create_default_section'] ?? TRUE) {
+      $layout_sections[] = $this->createDefaultSection();
+    }
+
+    foreach ($this->configuration['sections'] as $section) {
+      if (empty($section['components'])) {
+        continue;
+      }
+      if ($layout_section = $this->mapSection($section)) {
+        $layout_sections[] = $layout_section;
+      }
+    }
+
+    $this->row = NULL;
+    return $layout_sections;
+  }
+
+  /**
+   * Creates the default "Title and Metadata" Layout Builder section.
+   *
+   * Mirrors the section Drupal auto-generates on first layout save for the
+   * given node type. Without it the post meta block (date, author, tags)
+   * will not appear on migrated nodes.
+   *
+   * @return \Drupal\layout_builder\Section
+   *   The default section.
+   *
+   * @throws \Drupal\migrate\MigrateException
+   *   If default_section_type is not configured.
+   */
+  public function createDefaultSection(): Section {
+    $node_type = $this->configuration['default_section_type'] ?? NULL;
+
+    if (!$node_type) {
+      throw new MigrateException('sn_news_to_layout_builder: default_section_type is required when create_default_section is TRUE.');
+    }
+
+    // Order matches core.entity_view_display.node.post.default.yml:
+    //   weight 0 → content_moderation_control
+    //   weight 1 → post_meta_block
+    return new Section(
+      'layout_onecol',
+      ['label' => 'Title and Metadata'],
+      [
+        new SectionComponent($this->uuid->generate(), 'content', [
+          'id' => 'extra_field_block:node:' . $node_type . ':content_moderation_control',
+          'label_display' => FALSE,
+          'context_mapping' => [
+            'entity' => 'layout_builder.entity',
+          ],
+        ]),
+        new SectionComponent($this->uuid->generate(), 'content', [
+          'id' => $node_type . '_meta_block',
+          'label' => ucfirst($node_type) . ' Meta Block',
+          'label_display' => '',
+          'provider' => 'ys_layouts',
+        ]),
+      ],
+    );
+  }
+
+  /**
+   * Dispatches a section definition to the appropriate builder method.
+   *
+   * @param array $section
+   *   Section configuration from the migration YAML.
+   *
+   * @return \Drupal\layout_builder\Section|null
+   *   The built section, or NULL if the layout type is unsupported.
+   */
+  public function mapSection(array $section): ?Section {
+    return match ($section['id']) {
+      'layout_onecol' => $this->createOneColumnSection($section),
+      default => NULL,
+    };
+  }
+
+  /**
+   * Creates a one-column Layout Builder section from a list of components.
+   *
+   * @param array $section
+   *   Section configuration including a 'components' key.
+   *
+   * @return \Drupal\layout_builder\Section
+   *   The one-column section (may have zero components if all blocks failed).
+   */
+  public function createOneColumnSection(array $section): Section {
+    $section_components = [];
+
+    foreach ($section['components'] as $component) {
+      if ($block = $this->mapComponents($component)) {
+        $section_components[] = new SectionComponent($this->uuid->generate(), 'content', [
+          'id' => 'inline_block:' . $block->bundle(),
+          'label' => $block->label(),
+          'provider' => 'layout_builder',
+          'label_display' => FALSE,
+          'view_mode' => 'full',
+          'block_revision_id' => $block->getRevisionId(),
+          'context_mapping' => [],
+        ]);
+      }
+    }
+
+    return new Section('layout_onecol', components: $section_components);
+  }
+
+  /**
+   * Resolves a component definition to a saved block_content entity.
+   *
+   * @param array $component
+   *   Component definition with 'type' and either 'source' or 'sources'.
+   *
+   * @return \Drupal\block_content\BlockContentInterface|null
+   *   The created block, or NULL if the source value was empty or invalid.
+   */
+  public function mapComponents(array $component): ?BlockContentInterface {
+    $type = $component['type'];
+    $source = $this->resolveSource($component);
+
+    if ($source === NULL || $source === '') {
+      return NULL;
+    }
+
+    return match ($type) {
+      'image' => $this->createImageBlock($source),
+      'text'  => $this->createTextBlock($source, $component),
+      default => NULL,
+    };
+  }
+
+  /**
+   * Creates and saves an image block_content entity from a media entity ID.
+   *
+   * Loads the D10 media entity (created by ys_sn_media / ys_sn_media2) and
+   * wraps it in a new inline image block. The media image alt text is used
+   * as the optional caption.
+   *
+   * @param mixed $media_id
+   *   The D10 media entity ID resolved from the migration lookup.
+   *
+   * @return \Drupal\block_content\BlockContentInterface|null
+   *   The saved image block, or NULL if the media entity cannot be loaded.
+   */
+  private function createImageBlock(mixed $media_id): ?BlockContentInterface {
+    $media = $this->entityTypeManager->getStorage('media')->load($media_id);
+
+    if (!$media) {
+      $this->logger->warning(
+        'sn_news_to_layout_builder: could not load media entity @id — image block skipped.',
+        ['@id' => $media_id],
+      );
+      return NULL;
+    }
+
+    // Use the image alt text as an optional caption wrapped in a paragraph.
+    $caption = '';
+    if ($alt = $media->get('field_media_image')->alt) {
+      $caption = '<p>' . $alt . '</p>';
+    }
+
+    $block = $this->entityTypeManager->getStorage('block_content')->create([
+      'type'      => 'image',
+      'info'      => 'Image Block',
+      'reusable'  => FALSE,
+      'field_media' => ['target_id' => $media->id()],
+      'field_text'  => ['value' => $caption, 'format' => 'basic_html'],
+    ]);
+    $block->save();
+    return $block;
+  }
+
+  /**
+   * Creates and saves a text block_content entity from a body value string.
+   *
+   * @param string $value
+   *   The HTML body text (D7 body/0/value).
+   * @param array $component
+   *   Component definition; supports an optional 'wrap_value' boolean key to
+   *   wrap plain text in a <p> tag before saving.
+   *
+   * @return \Drupal\block_content\BlockContentInterface
+   *   The saved text block.
+   */
+  private function createTextBlock(string $value, array $component): BlockContentInterface {
+    $value = $this->sanitizeBodyHtml($value);
+
+    if ($component['wrap_value'] ?? FALSE) {
+      $value = '<p>' . $value . '</p>';
+    }
+
+    $block = $this->entityTypeManager->getStorage('block_content')->create([
+      'type'     => 'text',
+      'info'     => 'Text Block',
+      'reusable' => FALSE,
+      'field_text' => [
+        'value'  => $value,
+        'format' => 'basic_html',
+      ],
+    ]);
+    $block->save();
+    return $block;
+  }
+
+  /**
+   * Removes D7-specific inline tokens that have no D10 equivalent.
+   *
+   * Strips two patterns commonly found in D7 WYSIWYG body fields:
+   *
+   * 1. Node Embed tokens: [[nid:1096]]
+   *    Inserted by the Node Embed / Insert Node module to render another node's
+   *    content inline. There is no equivalent in D10; the token would otherwise
+   *    appear as literal text in the migrated body.
+   *
+   * 2. D7 Media WYSIWYG embeds: [[{"type":"media","fid":"123",...}]]
+   *    Inserted by the D7 Media module's WYSIWYG integration. These JSON blobs
+   *    are D7-specific and would also render as literal text in D10.
+   *
+   * @param string $value
+   *   Raw body HTML from the D7 source.
+   *
+   * @return string
+   *   The sanitized HTML with D7 tokens removed.
+   */
+  private function sanitizeBodyHtml(string $value): string {
+    // Strip [[nid:NNN]] Node Embed tokens.
+    $value = preg_replace('/\[\[nid:\d+\]\]/', '', $value);
+
+    // Strip [[{...JSON...}]] D7 Media WYSIWYG embed tokens.
+    // These always start with [[ and contain a JSON object.
+    $value = preg_replace('/\[\[\{[^\]]*\}\]\]/', '', $value);
+
+    return $value;
+  }
+
+  /**
+   * Returns the first non-null resolved value for a component.
+   *
+   * Supports two YAML keys:
+   *   - 'sources' (array): tried in order; the first non-null/empty value wins.
+   *   - 'source'  (string): a single source key.
+   *
+   * @param array $component
+   *   The component definition.
+   *
+   * @return mixed
+   *   The resolved value, or NULL if nothing resolved.
+   */
+  private function resolveSource(array $component): mixed {
+    if (!empty($component['sources'])) {
+      foreach ($component['sources'] as $source) {
+        $value = $this->getSourceValue($source);
+        if ($value !== NULL && $value !== '') {
+          return $value;
+        }
+      }
+      return NULL;
+    }
+
+    if (isset($component['source'])) {
+      return $this->getSourceValue($component['source']);
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Reads a value from the current row.
+   *
+   * Keys prefixed with '@' are resolved from destination (processed)
+   * properties set earlier in the migration pipeline; all others are treated
+   * as source properties (supports nested path notation, e.g. body/0/value).
+   *
+   * @param string $source
+   *   The property key, optionally prefixed with '@'.
+   *
+   * @return mixed
+   *   The resolved value, or NULL if not found.
+   */
+  private function getSourceValue(string $source): mixed {
+    if (str_starts_with($source, '@')) {
+      return $this->row->getDestinationProperty(substr($source, 1));
+    }
+    return $this->row->getSourceProperty($source);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/src/Plugin/migrate/process/sustainability_news/NewsToLayoutBuilder.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/src/Plugin/migrate/process/sustainability_news/NewsToLayoutBuilder.php
@@ -269,7 +269,7 @@ class NewsToLayoutBuilder extends ProcessPluginBase implements ContainerFactoryP
       'info'      => 'Image Block',
       'reusable'  => FALSE,
       'field_media' => ['target_id' => $media->id()],
-      'field_text'  => ['value' => $caption, 'format' => 'basic_html'],
+      'field_text'  => ['value' => $caption, 'format' => 'restricted_html'],
     ]);
     $block->save();
     return $block;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/src/Plugin/migrate/source/D7NewsImages.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/src/Plugin/migrate/source/D7NewsImages.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_migrate_sustainability_news\Plugin\migrate\source;
+
+use Drupal\migrate\Row;
+use Drupal\migrate_drupal\Plugin\migrate\source\DrupalSqlBase;
+
+/**
+ * D7 source plugin for public image files with per-field alt and title text.
+ *
+ * Extends the standard file_managed query with LEFT JOINs on both D7 image
+ * field tables (field_news_image and field_image2) so that alt and title text
+ * are available as source properties. When a file is referenced by both
+ * fields, field_image2 takes precedence (it covers the more recent nodes).
+ *
+ * Produces the same base fields as the core d7_file plugin, plus:
+ *   - alt:   Coalesced alt text from field_image2 or field_news_image.
+ *   - title: Coalesced title text from field_image2 or field_news_image.
+ *
+ * Usage in migration YAML:
+ *
+ * @code
+ * source:
+ *   plugin: d7_news_images
+ *   key: d7_sustainability
+ * @endcode
+ *
+ * @MigrateSource(
+ *   id = "d7_news_images",
+ *   source_module = "file"
+ * )
+ */
+class D7NewsImages extends DrupalSqlBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $query = $this->select('file_managed', 'fm')
+      ->fields('fm')
+      ->condition('fm.uri', 'temporary://%', 'NOT LIKE')
+      ->condition('fm.uri', 'public://%', 'LIKE')
+      ->condition('fm.filemime', [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+        'image/svg+xml',
+      ], 'IN')
+      ->orderBy('fm.timestamp');
+
+    // LEFT JOIN field_image2 to get alt/title for newer nodes (199 nodes).
+    $query->leftJoin(
+      'field_data_field_image2',
+      'fi2',
+      'fi2.field_image2_fid = fm.fid'
+    );
+
+    // LEFT JOIN field_news_image to get alt/title for older nodes (132 nodes).
+    $query->leftJoin(
+      'field_data_field_news_image',
+      'fni',
+      'fni.field_news_image_fid = fm.fid'
+    );
+
+    // Prefer field_image2 alt/title; fall back to field_news_image.
+    $query->addExpression(
+      'COALESCE(fi2.field_image2_alt, fni.field_news_image_alt)',
+      'alt'
+    );
+    $query->addExpression(
+      'COALESCE(fi2.field_image2_title, fni.field_news_image_title)',
+      'title'
+    );
+
+    // Deduplicate: a file may be referenced by multiple nodes, which would
+    // produce multiple rows. GROUP BY fid keeps one row per file.
+    $query->groupBy('fm.fid');
+
+    return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepareRow(Row $row) {
+    // Normalise NULL alt/title to empty strings so downstream process
+    // plugins can safely use default_value fallbacks.
+    if ($row->getSourceProperty('alt') === NULL) {
+      $row->setSourceProperty('alt', '');
+    }
+    if ($row->getSourceProperty('title') === NULL) {
+      $row->setSourceProperty('title', '');
+    }
+    return parent::prepareRow($row);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    return [
+      'fid'       => $this->t('File ID'),
+      'uid'       => $this->t('The user who added the file.'),
+      'filename'  => $this->t('File name'),
+      'uri'       => $this->t('File URI'),
+      'filemime'  => $this->t('File MIME type'),
+      'filesize'  => $this->t('File size in bytes'),
+      'status'    => $this->t('Published status'),
+      'timestamp' => $this->t('Time the file was added'),
+      'alt'       => $this->t('Alt text (coalesced from field_image2 or field_news_image)'),
+      'title'     => $this->t('Title text (coalesced from field_image2 or field_news_image)'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() {
+    return [
+      'fid' => [
+        'type'  => 'integer',
+        'alias' => 'fm',
+      ],
+    ];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/ys_migrate_sustainability_news.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/modules/ys_migrate_sustainability_news/ys_migrate_sustainability_news.info.yml
@@ -1,0 +1,9 @@
+name: YaleSites migrate Sustainability News
+type: module
+description: Sustainability-specific migration support for YaleSites
+core_version_requirement: '^9 || ^10'
+package: YaleSites
+dependencies:
+  - ys_migrate:ys_migrate
+  - migrate_plus
+  - migrate_tools


### PR DESCRIPTION
## [#1105: Sustainability news migration](https://github.com/yalesites-org/YaleSites-Internal/issues/1105)

### Description of work
- Adds migration module with migration yml files and NewsToLayoutBuilder plugin for migration of sustainability news

Note: We won't be able to run the migration on a multidev because it's not feasible to connect to a source database and files from a multidev, but I imported my database and the news files from my local to the multidev after I ran the migration as a demo. For the live migration I'll need to checkout the sustainability repo and add the remote (d7) database connection to run the migration once the migration files have been merged.

### Functional testing steps:
- [ ] You can see the migrated news here: https://pr-1215-yalesites-platform.pantheonsite.io/posts
- [ ] Edit a post. 
-- Verify the teaser text and teaser image have been migrated as expected
- - Verify any category tags from D7 have been migrated to the category field.
- [ ] Edit layout for a post. 
-- Verify the title and publish date have been migrated to the title and metadata block. 
-- Verify the body has been migrated to a text block. Verify the text looks clean and that any [[ nid: xxx ]] tags have been removed
-- Verify the image has been migrated to an image block at the top of the post.
- [ ] In the layout, edit an image.
-- Verify the image has been migrated to a media item
-- Verify the alt text has been migrated
-- Verify the caption has been migrated
-- Verify that the media has been tagged with "Imported from migration" 