### PR TITLE
Release Update: 1136: "Apply" Button Incorrectly Displays on Calendar Block When No Filters Are Configured

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Form/EventCalendarFilterForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Form/EventCalendarFilterForm.php
@@ -281,12 +281,7 @@ class EventCalendarFilterForm extends FormBase {
     }
 
     // Add Apply button only when at least one filter is configured.
-    $hasExposedFilters = !empty($exposedFilterOptions['show_search_filter']) ||
-      !empty($exposedFilterOptions['show_category_filter']) ||
-      !empty($exposedFilterOptions['show_audience_filter']) ||
-      !empty($exposedFilterOptions['show_custom_vocab_filter']);
-
-    if ($hasExposedFilters) {
+    if ($weight > 0) {
       $form['filters_container']['actions'] = [
         '#type' => 'actions',
         '#weight' => $weight++,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Form/EventCalendarFilterForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Form/EventCalendarFilterForm.php
@@ -280,23 +280,30 @@ class EventCalendarFilterForm extends FormBase {
       $form['filters_container']['custom_vocab_included_terms'] = $custom_vocab_element;
     }
 
-    // Add Apply button (matching views exposed form structure).
-    $form['filters_container']['actions'] = [
-      '#type' => 'actions',
-      '#weight' => $weight++,
-    ];
-    $form['filters_container']['actions']['submit'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Apply'),
-      '#ajax' => [
-        'callback' => '::ajaxFilterCallback',
-        'wrapper' => self::CALENDAR_WRAPPER_ID,
-        'progress' => ['type' => 'none'],
-      ],
-      '#attributes' => [
-        'class' => ['button', 'button--primary'],
-      ],
-    ];
+    // Add Apply button only when at least one filter is configured.
+    $hasExposedFilters = !empty($exposedFilterOptions['show_search_filter']) ||
+      !empty($exposedFilterOptions['show_category_filter']) ||
+      !empty($exposedFilterOptions['show_audience_filter']) ||
+      !empty($exposedFilterOptions['show_custom_vocab_filter']);
+
+    if ($hasExposedFilters) {
+      $form['filters_container']['actions'] = [
+        '#type' => 'actions',
+        '#weight' => $weight++,
+      ];
+      $form['filters_container']['actions']['submit'] = [
+        '#type' => 'submit',
+        '#value' => $this->t('Apply'),
+        '#ajax' => [
+          'callback' => '::ajaxFilterCallback',
+          'wrapper' => self::CALENDAR_WRAPPER_ID,
+          'progress' => ['type' => 'none'],
+        ],
+        '#attributes' => [
+          'class' => ['button', 'button--primary'],
+        ],
+      ];
+    }
   }
 
   /**


### PR DESCRIPTION
## [Release Update: 1136: "Apply" Button Incorrectly Displays on Calendar Block When No Filters Are Configured](https://github.com/yalesites-org/YaleSites-Internal/issues/1136)

### Description of work
- Fixes Apply button always rendering on calendar blocks regardless of filter configuration
- Guards Apply button behind a check for at least one enabled exposed filter option

Closes https://github.com/yalesites-org/YaleSites-Internal/issues/1136

### Functional testing steps:
- [ ] Visit https://pr-1228-yalesites-platform.pantheonsite.io/empty-testing-page to see a filtered and unfiltered example
- [ ] Visit https://pr-1228-yalesites-platform.pantheonsite.io to make the below changes
- [ ] Visit a calendar block with no filters configured and confirm the Apply button does not appear
- [ ] Visit a calendar block with one or more filters enabled (search, category, audience, or custom vocab) and confirm the Apply button appears and works
- [ ] Confirm filtering still functions correctly when filters are configured
- [ ] Verify Post Feed and Calendar List blocks are unaffected
