### PR TITLE
#1094 :: Require a Name for Custom Vocabularies

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -239,6 +239,7 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       '#description' => $this->t('This field will update the name of the custom vocabulary for the site. By default, the name is "Custom Vocab".'),
       '#title' => $this->t('Custom Vocabulary Name'),
       '#default_value' => $yaleConfig->get('taxonomy')['custom_vocab_name'] ?? 'Custom Vocab',
+      '#required' => TRUE,
     ];
 
     $form['font_pairing'] = [
@@ -410,7 +411,7 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       ->set('page.posts', $form_state->getValue('site_page_posts'))
       ->set('page.events', $form_state->getValue('site_page_events'))
       ->set('seo.google_site_verification', $form_state->getValue('google_site_verification'))
-      ->set('taxonomy.custom_vocab_name', $form_state->getValue('custom_vocab_name'))
+      ->set('taxonomy.custom_vocab_name', $form_state->getValue('custom_vocab_name') ?: 'Custom Vocab')
       ->set('image_fallback.teaser', $form_state->getValue('teaser_image_fallback'))
       ->set('custom_favicon', $form_state->getValue('favicon'))
       ->set('font_pairing', $form_state->getValue('font_pairing'))
@@ -424,18 +425,19 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
 
     $yaleSiteConfig->save();
 
+    $submitted_vocab_name = $form_state->getValue('custom_vocab_name') ?: 'Custom Vocab';
     $custom_vocab_name = $this->configFactory->getEditable('taxonomy.vocabulary.custom_vocab')->get('name');
-    if ($custom_vocab_name !== $form_state->getValue('custom_vocab_name')) {
+    if ($custom_vocab_name !== $submitted_vocab_name) {
       // Update the custom vocab vocabulary name.
       $this->configFactory->getEditable('taxonomy.vocabulary.custom_vocab')
-        ->set('name', $form_state->getValue('custom_vocab_name'))
+        ->set('name', $submitted_vocab_name)
         ->save();
 
       $content_types = ['event', 'page', 'post', 'profile', 'resource'];
       // Update the custom vocab field label for each content type.
       foreach ($content_types as $type) {
         $this->configFactory->getEditable("field.field.node.{$type}.field_custom_vocab")
-          ->set('label', $form_state->getValue('custom_vocab_name'))
+          ->set('label', $submitted_vocab_name)
           ->save();
       }
       // Clear cache so the new label is reflected in the node form.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -239,7 +239,6 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       '#description' => $this->t('This field will update the name of the custom vocabulary for the site. By default, the name is "Custom Vocab".'),
       '#title' => $this->t('Custom Vocabulary Name'),
       '#default_value' => $yaleConfig->get('taxonomy')['custom_vocab_name'] ?? 'Custom Vocab',
-      '#required' => TRUE,
     ];
 
     $form['font_pairing'] = [


### PR DESCRIPTION
## [#1094: Require a Name for Custom Vocabularies](https://github.com/yalesites-org/YaleSites-Internal/issues/1094)

### Description of work
- Makes custom vocabulary field value 'Custom Vocab' if none is provided

### Functional testing steps:
- [ ] Go to Site Settings: https://pr-1231-yalesites-platform.pantheonsite.io/admin/yalesites/settings
- [ ] Verify if you blank out the Custom Vocabularies field, the value gets set to Custom Vocab