### PR TITLE
#1129: IYY: Main Navigation issue - hierarchy indentation and drag and drop features not working

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -27,7 +27,7 @@
     "drupal/anchor_link": "3.0.0-beta1",
     "drupal/auto_entitylabel": "3.3.0",
     "drupal/better_exposed_filters": "6.0.5",
-    "drupal/bigmenu": "^2.1",
+    "drupal/bigmenu": "2.1.0",
     "drupal/book": "2.0.4",
     "drupal/calendar_link": "3.0.3",
     "drupal/captcha": "2.0.10",

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -27,6 +27,7 @@
     "drupal/anchor_link": "3.0.0-beta1",
     "drupal/auto_entitylabel": "3.3.0",
     "drupal/better_exposed_filters": "6.0.5",
+    "drupal/bigmenu": "^2.1",
     "drupal/book": "2.0.4",
     "drupal/calendar_link": "3.0.3",
     "drupal/captcha": "2.0.10",

--- a/web/profiles/custom/yalesites_profile/config/sync/bigmenu.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/bigmenu.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: 0PQ26SEP3kb1ONdQ9EBVa5eKzqMUl38a3gUOt0tOZrM
+max_depth: 1

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -16,6 +16,7 @@ module:
   allowed_formats: 0
   anchor_link: 0
   better_exposed_filters: 0
+  bigmenu: 0
   block: 0
   block_content: 0
   book: 0


### PR DESCRIPTION
## [#1129: IYY: Main Navigation issue - hierarchy indentation and drag and drop features not working](https://github.com/yalesites-org/YaleSites-Internal/issues/1129)

### Description of work
- Install bigmenu module to allow editing of the menu items on iyy

### Functional testing steps:
- [ ] Go to menu admin, verify you can move and edit the menu items. I imported the iyy database into the multidev so we can see it working: https://pr-1235-yalesites-platform.pantheonsite.io/admin/structure/menu/manage/main

