### PR TITLE
#1140 :: Support Portrait Images in Resource Category View Block

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.card_grid_portrait_5_8.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.card_grid_portrait_5_8.yml
@@ -1,0 +1,36 @@
+uuid: 0ffef952-b1ac-4696-b07c-c4eb45b2afda
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.card_grid_portrait_5_8
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_tags
+    - media.type.image
+    - responsive_image.styles.card_grid_portrait_5_8
+  module:
+    - responsive_image
+id: media.image.card_grid_portrait_5_8
+targetEntityType: media
+bundle: image
+mode: card_grid_portrait_5_8
+content:
+  field_media_image:
+    type: responsive_image
+    label: hidden
+    settings:
+      responsive_image_style: card_grid_portrait_5_8
+      image_link: ''
+      image_loading:
+        attribute: eager
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  addtoany: true
+  created: true
+  field_tags: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.resource.portrait_grid.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.resource.portrait_grid.yml
@@ -1,0 +1,104 @@
+uuid: 3dbf4f81-fdb3-4570-9d00-b6f497f0b4ad
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.portrait_grid
+    - field.field.node.resource.field_affiliation
+    - field.field.node.resource.field_audience
+    - field.field.node.resource.field_category
+    - field.field.node.resource.field_content_description
+    - field.field.node.resource.field_custom_vocab
+    - field.field.node.resource.field_date_format
+    - field.field.node.resource.field_external_source
+    - field.field.node.resource.field_login_required
+    - field.field.node.resource.field_media
+    - field.field.node.resource.field_metatags
+    - field.field.node.resource.field_publish_date
+    - field.field.node.resource.field_tags
+    - field.field.node.resource.field_teaser_media
+    - field.field.node.resource.field_teaser_text
+    - field.field.node.resource.field_teaser_title
+    - field.field.node.resource.layout_builder__layout
+    - node.type.resource
+  module:
+    - link
+    - options
+    - text
+    - user
+id: node.resource.portrait_grid
+targetEntityType: node
+bundle: resource
+mode: portrait_grid
+content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
+  field_category:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_date_format:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_external_source:
+    type: link_separate
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: true
+      url_plain: true
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_teaser_media:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: card_grid_portrait_5_8
+      link: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_teaser_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_teaser_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  addtoany: true
+  field_affiliation: true
+  field_audience: true
+  field_content_description: true
+  field_custom_vocab: true
+  field_login_required: true
+  field_media: true
+  field_metatags: true
+  field_publish_date: true
+  field_tags: true
+  layout_builder__layout: true
+  links: true
+  search_api_excerpt: true
+  workflow_buttons: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_mode.media.card_grid_portrait_5_8.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_mode.media.card_grid_portrait_5_8.yml
@@ -1,0 +1,11 @@
+uuid: 8d27dfe8-4e17-4c0e-9d7a-c45dcf987f97
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.card_grid_portrait_5_8
+label: 'Card Grid - Portrait (1:1.6)'
+description: ''
+targetEntityType: media
+cache: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_mode.node.portrait_grid.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_mode.node.portrait_grid.yml
@@ -1,0 +1,11 @@
+uuid: 93076ea7-1fb7-4b28-92d6-2177a8686bb4
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.portrait_grid
+label: 'Portrait Grid'
+description: ''
+targetEntityType: node
+cache: true

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_1120.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_1120.yml
@@ -1,0 +1,17 @@
+uuid: 5f54d77f-944c-4cdd-8cd0-11228333b9cc
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: '5_8_1120'
+label: '5:8 (1120)'
+effects:
+  3107138a-f6cd-4f06-822f-3c1a648976f3:
+    uuid: 3107138a-f6cd-4f06-822f-3c1a648976f3
+    id: focal_point_scale_and_crop
+    weight: 2
+    data:
+      width: 1120
+      height: 1792
+      crop_type: focal_point

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_175.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_175.yml
@@ -1,0 +1,17 @@
+uuid: d340f6b6-f576-45cf-a2bd-ef507b57677f
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: '5_8_175'
+label: '5:8 (175)'
+effects:
+  7392d09f-f827-4479-b5d8-a5f4c336ac8e:
+    uuid: 7392d09f-f827-4479-b5d8-a5f4c336ac8e
+    id: focal_point_scale_and_crop
+    weight: 2
+    data:
+      width: 175
+      height: 280
+      crop_type: focal_point

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_320.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_320.yml
@@ -1,0 +1,17 @@
+uuid: f8f49aa2-9483-48bd-b6b5-2d6e9309341d
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: '5_8_320'
+label: '5:8 (320)'
+effects:
+  5ca1d83c-f8ff-4b0d-a8b2-b87773475f57:
+    uuid: 5ca1d83c-f8ff-4b0d-a8b2-b87773475f57
+    id: focal_point_scale_and_crop
+    weight: 2
+    data:
+      width: 320
+      height: 512
+      crop_type: focal_point

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_480.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_480.yml
@@ -1,0 +1,17 @@
+uuid: 6c22caec-fef5-4647-81af-e6d48be875b7
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: '5_8_480'
+label: '5:8 (480)'
+effects:
+  4294de0b-d3fb-4947-b177-1873b0ef84d9:
+    uuid: 4294de0b-d3fb-4947-b177-1873b0ef84d9
+    id: focal_point_scale_and_crop
+    weight: 2
+    data:
+      width: 480
+      height: 768
+      crop_type: focal_point

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_540.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_540.yml
@@ -1,0 +1,17 @@
+uuid: 56b3466d-942b-4d1a-ab5e-a967cf0c3266
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: '5_8_540'
+label: '5:8 (540)'
+effects:
+  0ea7b8b3-4396-4f51-ba4f-66a6f11ce020:
+    uuid: 0ea7b8b3-4396-4f51-ba4f-66a6f11ce020
+    id: focal_point_scale_and_crop
+    weight: 2
+    data:
+      width: 540
+      height: 864
+      crop_type: focal_point

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_640.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_640.yml
@@ -1,0 +1,17 @@
+uuid: d630fae1-16ad-44b1-8441-1230aeb795c9
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: '5_8_640'
+label: '5:8 (640)'
+effects:
+  4e037760-9a64-4d39-aaae-9c4b32dd76f3:
+    uuid: 4e037760-9a64-4d39-aaae-9c4b32dd76f3
+    id: focal_point_scale_and_crop
+    weight: 2
+    data:
+      width: 640
+      height: 1024
+      crop_type: focal_point

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_800.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_800.yml
@@ -1,0 +1,17 @@
+uuid: 656b536e-54fd-4983-8fdd-aa850b3cf9a2
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: '5_8_800'
+label: '5:8 (800)'
+effects:
+  c50b4d0e-5812-4a62-bc0b-caac1289ed4a:
+    uuid: c50b4d0e-5812-4a62-bc0b-caac1289ed4a
+    id: focal_point_scale_and_crop
+    weight: 2
+    data:
+      width: 800
+      height: 1280
+      crop_type: focal_point

--- a/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_960.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/image.style.5_8_960.yml
@@ -1,0 +1,17 @@
+uuid: 47db3b2b-fa0e-4d6e-bf08-bc4938ad637f
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: '5_8_960'
+label: '5:8 (960)'
+effects:
+  b38d6565-fb39-479b-ac1e-b74318aed85a:
+    uuid: b38d6565-fb39-479b-ac1e-b74318aed85a
+    id: focal_point_scale_and_crop
+    weight: 2
+    data:
+      width: 960
+      height: 1536
+      crop_type: focal_point

--- a/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.card_grid_portrait_5_8.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/responsive_image.styles.card_grid_portrait_5_8.yml
@@ -1,0 +1,33 @@
+uuid: e99c9ac6-f3b2-473e-9f0b-813b5cd6c593
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.5_8_1120
+    - image.style.5_8_175
+    - image.style.5_8_320
+    - image.style.5_8_480
+    - image.style.5_8_540
+    - image.style.5_8_640
+    - image.style.5_8_800
+    - image.style.5_8_960
+id: card_grid_portrait_5_8
+label: 'Card Grid - Portrait (1:1.6)'
+image_style_mappings:
+  -
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: '(min-width: 1344px) 540px, (min-width: 992px) 32vw, 50vw'
+      sizes_image_styles:
+        - '5_8_175'
+        - '5_8_320'
+        - '5_8_480'
+        - '5_8_540'
+        - '5_8_640'
+        - '5_8_800'
+        - '5_8_960'
+        - '5_8_1120'
+    breakpoint_id: responsive_image.viewport_sizing
+    multiplier: 1x
+breakpoint_group: responsive_image
+fallback_image_style: '5_8_320'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/icons/display-type-portrait-grid.svg
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/icons/display-type-portrait-grid.svg
@@ -1,0 +1,9 @@
+<svg width="122" height="89" viewBox="0 0 122 89" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="1" y="1" width="120" height="87" rx="4" fill="#F8F8F8" stroke="#B8B8B8" stroke-width="2"/>
+  <rect x="14" y="14" width="24" height="52" rx="2" fill="#D9D9D9"/>
+  <rect x="49" y="14" width="24" height="52" rx="2" fill="#D9D9D9"/>
+  <rect x="84" y="14" width="24" height="52" rx="2" fill="#D9D9D9"/>
+  <rect x="14" y="70" width="24" height="5" rx="1.5" fill="#B8B8B8"/>
+  <rect x="49" y="70" width="24" height="5" rx="1.5" fill="#B8B8B8"/>
+  <rect x="84" y="70" width="24" height="5" rx="1.5" fill="#B8B8B8"/>
+</svg>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/style/ViewsBasicDynamicStyle.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/style/ViewsBasicDynamicStyle.php
@@ -125,12 +125,19 @@ class ViewsBasicDynamicStyle extends StylePluginBase implements ContainerFactory
     // Map the view mode in Drupal to the type attribute for the component.
     $viewModesMap = [
       'card' => 'grid',
+      'portrait_grid' => 'grid',
       'list_item' => 'list',
       'condensed' => 'condensed',
       'directory' => 'profile-directory',
     ];
 
     $type = $viewModesMap[$this->view->rowPlugin->options['view_mode']];
+
+    $contentType = $this->view->args[0];
+    $cardCollectionModifiers = [];
+    if ($contentType === 'resource' && $this->view->rowPlugin->options['view_mode'] === 'portrait_grid') {
+      $cardCollectionModifiers[] = 'resource-portrait';
+    }
 
     // Get node type to pass to template to determine width.
     $entity = $this->routeMatch->getParameter('node');
@@ -140,8 +147,9 @@ class ViewsBasicDynamicStyle extends StylePluginBase implements ContainerFactory
       '#theme' => 'views_basic_rows',
       '#rows' => $rows,
       '#card_collection_type' => $type,
+      '#card_collection_modifiers' => $cardCollectionModifiers,
       '#parentNode' => $parentNode,
-      '#contentType' => $this->view->args[0],
+      '#contentType' => $contentType,
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/templates/views-basic-rows.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/templates/views-basic-rows.html.twig
@@ -4,8 +4,13 @@
   {% set card_collection__width = "site" %}
 {% endif %}
 
+{% set card_collection__featured = 'true' %}
+{% if card_collection_modifiers is not empty and 'resource-portrait' in card_collection_modifiers %}
+  {% set card_collection__featured = 'false' %}
+{% endif %}
+
 {% embed "@organisms/card-collection/yds-card-collection.twig" with {
-    card_collection__featured: 'true',
+    card_collection__featured: card_collection__featured,
     card_collection__width: card_collection__width,
     card_collection__type: card_collection_type,
     card_collection__modifiers: card_collection_modifiers,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/templates/views-basic-rows.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/templates/views-basic-rows.html.twig
@@ -8,6 +8,7 @@
     card_collection__featured: 'true',
     card_collection__width: card_collection__width,
     card_collection__type: card_collection_type,
+    card_collection__modifiers: card_collection_modifiers,
     card_collection__source_type: contentType,
   } %}
   {% block card_collection__cards %}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -29,6 +29,7 @@ function ys_views_basic_theme($existing, $type, $theme, $path): array {
     'views_basic_rows' => [
       'variables' => [
         'card_collection_type' => NULL,
+        'card_collection_modifiers' => [],
         'rows' => [],
         'parentNode' => NULL,
         'contentType' => NULL,
@@ -145,6 +146,7 @@ function ys_views_basic_views_pre_view(ViewExecutable $view, $display_id, array 
 function ys_views_basic_node_view(array &$build, NodeInterface $node, EntityViewDisplayInterface $display, $view_mode) {
   $view_modes = [
     "card",
+    "portrait_grid",
     "condensed",
     "list_item",
   ];

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/src/Plugin/Field/FieldWidget/ViewsContentResourcesDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/src/Plugin/Field/FieldWidget/ViewsContentResourcesDefaultWidget.php
@@ -238,6 +238,7 @@ class ViewsContentResourcesDefaultWidget extends WidgetBase implements Container
           'visible' => [
             $formSelectors['view_mode_input_selector'] => [
               ['value' => 'card'],
+              ['value' => 'portrait_grid'],
               ['value' => 'list_item'],
             ],
           ],

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/src/ViewsContentResourcesManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/src/ViewsContentResourcesManager.php
@@ -35,6 +35,11 @@ class ViewsContentResourcesManager extends ControllerBase implements ContainerIn
       'img' => '/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/icons/display-type-card-grid.svg',
       'img_alt' => 'Icon showing 3 generic cards next to each other. Image placement is on the top of each card.',
     ],
+    'portrait_grid' => [
+      'label' => 'Portrait Grid',
+      'img' => '/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/icons/display-type-portrait-grid.svg',
+      'img_alt' => 'Placeholder icon for portrait grid display mode.',
+    ],
     'list_item' => [
       'label' => 'List',
       'img' => '/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/icons/display-type-list-view.svg',


### PR DESCRIPTION

## [#1140: Support Portrait Images in Resource Category View Block](https://github.com/yalesites-org/YaleSites-Internal/issues/1140)

### Description of work
- Adds image styles and responsive image style for resource portrait grid view mode
- Modifies the Content Resource widget to add new Portrait Grid view mode
- Adds placeholder image for Portrait Grid
- Updates ViewsBasicDynamicStyle plugin to add grid modifiers

### Functional testing steps:
- [ ] Add a Resource View to a page, select Portrait Grid. Verify it appears as expected, verify filters work normally.
- [ ] Verify the Portrait Grid and Portrait Grid Card appear in Storybook (see CL PR)

Demo: https://pr-1238-yalesites-platform.pantheonsite.io/resource-test

CL PR: https://github.com/yalesites-org/component-library-twig/pull/628
Atomic PR: https://github.com/yalesites-org/atomic/pull/449