### PR TITLE
717: Add warning alert to pre-built form block for users with default site email

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -318,7 +318,6 @@ function ys_core_preprocess_block(&$variables) {
     }
   }
 
-  _ys_core_webform_valid_email_check($variables);
 }
 
 /**
@@ -997,32 +996,6 @@ function _ys_core_disable_event_fields(&$form, $form_id) {
     foreach ($fieldsToDisable as $field) {
       $form[$field]['#disabled'] = TRUE;
     }
-  }
-}
-
-/**
- * Validates the email address in the webform plugin.
- *
- * @param array $variables
- *   The render variables array.
- */
-function _ys_core_webform_valid_email_check(&$variables) {
-  $plugin_id = $variables['plugin_id'];
-  $in_layout_builder = $variables['in_preview'] ?? FALSE;
-  $validEmail = TRUE;
-
-  if ($in_layout_builder && $plugin_id == 'inline_block:webform') {
-    $config = \Drupal::config('system.site');
-    $siteMail = $config->get('mail');
-
-    $validEmail = ($siteMail != 'noreply@noreply.yale.edu');
-  }
-
-  if (!$validEmail) {
-    $settingsUrl = Url::fromRoute('ys_core.admin_site_settings')->toString();
-    $variables['content']['#configuration_issue'] = t('Form submissions will be sent to the default no-reply address and will not be received. Update the site email in Site Settings to receive submissions.');
-    $variables['content']['#configuration_issue_link_content'] = t('Update site email');
-    $variables['content']['#configuration_issue_link_url'] = $settingsUrl;
   }
 }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -85,6 +85,21 @@ function ys_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if ($form_id === 'layout_builder_update_block' || $form_id === 'layout_builder_add_block') {
     $block_type = ys_core_get_block_type($form, $form_state);
 
+    if ($block_type === 'webform') {
+      $siteMail = \Drupal::config('system.site')->get('mail');
+      if ($siteMail === 'noreply@noreply.yale.edu') {
+        $settingsUrl = Url::fromRoute('ys_core.admin_site_settings')->toString();
+        $form['settings']['block_form']['email_warning'] = [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['messages', 'messages--warning']],
+          '#weight' => -100,
+          'message' => [
+            '#markup' => t('Form submissions will be sent to the default no-reply address and will not be received. <a href="@url">Update the site email in Site Settings</a> to receive submissions.', ['@url' => $settingsUrl]),
+          ],
+        ];
+      }
+    }
+
     if ($block_type === 'grand_hero') {
 
       // Get the block entity.
@@ -1004,7 +1019,10 @@ function _ys_core_webform_valid_email_check(&$variables) {
   }
 
   if (!$validEmail) {
-    $variables['content']['#configuration_issue'] = t('Please go into Settings->Site Settings and update the site email to an email address that can receive this submission.');
+    $settingsUrl = Url::fromRoute('ys_core.admin_site_settings')->toString();
+    $variables['content']['#configuration_issue'] = t('Form submissions will be sent to the default no-reply address and will not be received. Update the site email in Site Settings to receive submissions.');
+    $variables['content']['#configuration_issue_link_content'] = t('Update site email');
+    $variables['content']['#configuration_issue_link_url'] = $settingsUrl;
   }
 }
 


### PR DESCRIPTION
## [717: Add warning alert to pre-built form block for users with default site email](https://github.com/yalesites-org/YaleSites-Internal/issues/717)

### Description of work
- Removes the `_ys_core_webform_valid_email_check()` function and its call in `ys_core_preprocess_block()`, since the preview inline-message only rendered for inline blocks and not reusable blocks
- The warning in the block configuration form sidebar already works universally for both block types and is sufficient
- Other work completed in: yalesites-org/atomic#450

Closes yalesites-org/YaleSites-Internal#717

### Functional testing steps:
- [ ] Set site email to `noreply@noreply.yale.edu`
- [ ] Add an inline webform block in Layout Builder — confirm the warning appears in the config form sidebar but NOT in the block preview
- [ ] Add/use a reusable webform block — confirm the same: warning in config form, no inline-message in preview
- [ ] Set site email to a real address — confirm no warning appears in either location