### PR TITLE
1173: "Moderation control" placeholder text visible on published nodes

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/EventSubscriber/ExtraFieldPlaceholderSubscriber.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/EventSubscriber/ExtraFieldPlaceholderSubscriber.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\ys_core\EventSubscriber;
+
+use Drupal\layout_builder\Event\SectionComponentBuildRenderArrayEvent;
+use Drupal\layout_builder\LayoutBuilderEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Prevents ExtraFieldBlock placeholder text from rendering on published pages.
+ *
+ * Layout Builder's ExtraFieldBlock always sets placeholder markup in its
+ * build() method that should be replaced by hook_entity_view_alter(). In edge
+ * cases (stale cache, render pipeline issues), this replacement can fail,
+ * causing "Placeholder for the ..." text to be visible to site visitors.
+ *
+ * This subscriber acts as a safety net: outside of Layout Builder preview
+ * mode, it removes the placeholder markup for targeted extra fields so it
+ * can never leak to end users.
+ *
+ * @see \Drupal\layout_builder\Plugin\Block\ExtraFieldBlock::build()
+ * @see \Drupal\layout_builder\EventSubscriber\BlockComponentRenderArray::onBuildRender()
+ */
+class ExtraFieldPlaceholderSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Extra field names whose placeholder markup should be suppressed.
+   *
+   * - Empty array []: disabled, no placeholders are suppressed.
+   * - ['all']: ALL ExtraFieldBlock placeholders are suppressed outside preview.
+   * - ['content_moderation_control', ...]: only listed fields are suppressed.
+   *
+   * @var string[]
+   */
+  protected const TARGETED_FIELDS = [
+    'content_moderation_control',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    // Run at priority 50, after BlockComponentRenderArray at priority 100.
+    $events[LayoutBuilderEvents::SECTION_COMPONENT_BUILD_RENDER_ARRAY] = ['onBuildRender', 50];
+    return $events;
+  }
+
+  /**
+   * Removes placeholder markup from extra field blocks outside preview mode.
+   *
+   * @param \Drupal\layout_builder\Event\SectionComponentBuildRenderArrayEvent $event
+   *   The section component render event.
+   */
+  public function onBuildRender(SectionComponentBuildRenderArrayEvent $event) {
+    if ($event->inPreview()) {
+      return;
+    }
+
+    $build = $event->getBuild();
+
+    if (!isset($build['content']['#extra_field_placeholder_field_name'])) {
+      return;
+    }
+
+    $field_name = $build['content']['#extra_field_placeholder_field_name'];
+
+    if (in_array('all', static::TARGETED_FIELDS, TRUE) || in_array($field_name, static::TARGETED_FIELDS, TRUE)) {
+      unset($build['content']['#markup']);
+      $event->setBuild($build);
+    }
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/EventSubscriber/ExtraFieldPlaceholderSubscriberTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/EventSubscriber/ExtraFieldPlaceholderSubscriberTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Unit\EventSubscriber;
+
+use Drupal\layout_builder\Event\SectionComponentBuildRenderArrayEvent;
+use Drupal\layout_builder\LayoutBuilderEvents;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_core\EventSubscriber\ExtraFieldPlaceholderSubscriber;
+
+/**
+ * Unit tests for ExtraFieldPlaceholderSubscriber.
+ *
+ * @covers \Drupal\ys_core\EventSubscriber\ExtraFieldPlaceholderSubscriber
+ * @group ys_core
+ */
+class ExtraFieldPlaceholderSubscriberTest extends UnitTestCase {
+
+  /**
+   * Creates a mock event with the given build and preview state.
+   */
+  protected function createEvent(array $build, bool $in_preview): SectionComponentBuildRenderArrayEvent {
+    $event = $this->createMock(SectionComponentBuildRenderArrayEvent::class);
+    $event->method('inPreview')->willReturn($in_preview);
+    $event->method('getBuild')->willReturn($build);
+    return $event;
+  }
+
+  /**
+   * Tests that the subscriber registers on the correct event at priority 50.
+   */
+  public function testGetSubscribedEvents(): void {
+    $events = ExtraFieldPlaceholderSubscriber::getSubscribedEvents();
+    $this->assertArrayHasKey(LayoutBuilderEvents::SECTION_COMPONENT_BUILD_RENDER_ARRAY, $events);
+    $this->assertEquals(['onBuildRender', 50], $events[LayoutBuilderEvents::SECTION_COMPONENT_BUILD_RENDER_ARRAY]);
+  }
+
+  /**
+   * Tests placeholder markup is removed for a targeted field outside preview.
+   */
+  public function testNonPreviewRemovesMarkupForTargetedField(): void {
+    $build = [
+      'content' => [
+        '#extra_field_placeholder_field_name' => 'content_moderation_control',
+        '#markup' => 'Placeholder for the "Moderation control" field',
+      ],
+    ];
+    $event = $this->createEvent($build, FALSE);
+    $event->expects($this->once())
+      ->method('setBuild')
+      ->with($this->callback(function (array $actual_build): bool {
+        return !isset($actual_build['content']['#markup']);
+      }));
+
+    $subscriber = new ExtraFieldPlaceholderSubscriber();
+    $subscriber->onBuildRender($event);
+  }
+
+  /**
+   * Tests that placeholder markup is preserved in preview mode.
+   */
+  public function testPreviewModeKeepsMarkup(): void {
+    $build = [
+      'content' => [
+        '#extra_field_placeholder_field_name' => 'content_moderation_control',
+        '#markup' => 'Placeholder for the "Moderation control" field',
+      ],
+    ];
+    $event = $this->createEvent($build, TRUE);
+    $event->expects($this->never())->method('setBuild');
+
+    $subscriber = new ExtraFieldPlaceholderSubscriber();
+    $subscriber->onBuildRender($event);
+  }
+
+  /**
+   * Tests that a field not in TARGETED_FIELDS is left untouched.
+   */
+  public function testNonTargetedFieldIsUntouched(): void {
+    $build = [
+      'content' => [
+        '#extra_field_placeholder_field_name' => 'links',
+        '#markup' => 'Placeholder for the "Links" field',
+      ],
+    ];
+    $event = $this->createEvent($build, FALSE);
+    $event->expects($this->never())->method('setBuild');
+
+    $subscriber = new ExtraFieldPlaceholderSubscriber();
+    $subscriber->onBuildRender($event);
+  }
+
+  /**
+   * Tests that a build without #extra_field_placeholder_field_name is ignored.
+   */
+  public function testBuildWithoutPlaceholderKeyIsIgnored(): void {
+    $build = [
+      'content' => [
+        '#markup' => 'Some regular content',
+      ],
+    ];
+    $event = $this->createEvent($build, FALSE);
+    $event->expects($this->never())->method('setBuild');
+
+    $subscriber = new ExtraFieldPlaceholderSubscriber();
+    $subscriber->onBuildRender($event);
+  }
+
+  /**
+   * Tests that an empty build is ignored.
+   */
+  public function testEmptyBuildIsIgnored(): void {
+    $event = $this->createEvent([], FALSE);
+    $event->expects($this->never())->method('setBuild');
+
+    $subscriber = new ExtraFieldPlaceholderSubscriber();
+    $subscriber->onBuildRender($event);
+  }
+
+  /**
+   * Tests that 'all' wildcard suppresses any extra field placeholder.
+   */
+  public function testAllWildcardSuppressesAnyField(): void {
+    $build = [
+      'content' => [
+        '#extra_field_placeholder_field_name' => 'links',
+        '#markup' => 'Placeholder for the "Links" field',
+      ],
+    ];
+    $event = $this->createEvent($build, FALSE);
+    $event->expects($this->once())
+      ->method('setBuild')
+      ->with($this->callback(function (array $actual_build): bool {
+        return !isset($actual_build['content']['#markup']);
+      }));
+
+    $subscriber = new AllFieldsExtraFieldPlaceholderSubscriber();
+    $subscriber->onBuildRender($event);
+  }
+
+  /**
+   * Tests that an empty TARGETED_FIELDS disables all suppression.
+   */
+  public function testEmptyTargetedFieldsDisablesSuppression(): void {
+    $build = [
+      'content' => [
+        '#extra_field_placeholder_field_name' => 'content_moderation_control',
+        '#markup' => 'Placeholder for the "Moderation control" field',
+      ],
+    ];
+    $event = $this->createEvent($build, FALSE);
+    $event->expects($this->never())->method('setBuild');
+
+    $subscriber = new DisabledExtraFieldPlaceholderSubscriber();
+    $subscriber->onBuildRender($event);
+  }
+
+}
+
+/**
+ * Test variant with 'all' wildcard to cover the catch-all behavior.
+ */
+class AllFieldsExtraFieldPlaceholderSubscriber extends ExtraFieldPlaceholderSubscriber {
+
+  protected const TARGETED_FIELDS = ['all'];
+
+}
+
+/**
+ * Test variant with empty TARGETED_FIELDS to verify disabled behavior.
+ */
+class DisabledExtraFieldPlaceholderSubscriber extends ExtraFieldPlaceholderSubscriber {
+
+  protected const TARGETED_FIELDS = [];
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.services.yml
@@ -33,6 +33,11 @@ services:
   ys_core.facts_and_figures_icon_manager:
     class: Drupal\ys_core\FactsAndFiguresIconManager
     arguments: ['@cache.default', '@module_handler', '@logger.factory']
+  # Prevents ExtraFieldBlock placeholder text from leaking to published pages.
+  ys_core.extra_field_placeholder_subscriber:
+    class: Drupal\ys_core\EventSubscriber\ExtraFieldPlaceholderSubscriber
+    tags:
+      - { name: event_subscriber }
   # Provides user 1 bypass for CAS forced login.
   ys_core.cas_user1_bypass_subscriber:
     class: Drupal\ys_core\EventSubscriber\CasUser1BypassSubscriber


### PR DESCRIPTION
## [1173: bug: "Moderation control" placeholder text visible on published nodes](https://github.com/yalesites-org/YaleSites-Internal/issues/1173)

### Description of work
- Adds `ExtraFieldPlaceholderSubscriber` to `ys_core` — an event subscriber
  on `SECTION_COMPONENT_BUILD_RENDER_ARRAY` (priority 50) that removes
  `#markup` from Layout Builder ExtraFieldBlock builds outside of preview mode
- Targets `content_moderation_control` by default; supports an `['all']`
  wildcard or `[]` to disable entirely
- While investigation suggests the visible text on divinity.yale.edu stems
  from a stale Varnish/page cache entry, the placeholder should never be
  reachable by anonymous users under any circumstances — this ensures it
  cannot be cached in that state going forward
- Adds 8 unit tests covering all TARGETED_FIELDS modes and preview passthrough

### Functional testing steps:
- [ ] Visit a published event, page, post, profile, or resource as an
  anonymous user — confirm "Placeholder for the 'Moderation control' field"
  text does not appear
- [ ] Open a node in Layout Builder edit mode — confirm the "Placeholder for
  the 'Moderation control' field" label still appears in the editor preview
  for the Moderation control block
- [ ] After deploying to pkp, clear Pantheon page cache for affected URLs and
  confirm the placeholder text is gone

Closes yalesites-org/YaleSites-Internal#1173

Again, I could not recreate this, and feel a cache clear was the answer to this, but this does ensure that if it happens to attempt to be shown it will remove it.  The other option is to close this and wait for the next time this happens to implement.  I am hesitant to add this code if it's not widespread.