### PR TITLE
#1153 :: Sitewide Branding reverts to "Yale University" when admin edits Header Settings for a content collection In Site Header

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/HeaderSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/HeaderSettingsForm.php
@@ -425,16 +425,21 @@ class HeaderSettingsForm extends ConfigFormBase {
     // Header settings config.
     $headerConfig = $this->config('ys_core.header_settings');
 
-    // Handle the filesystem if needed.
-    $this->ysMediaManager->handleMediaFilesystem(
-      $form_state->getValue('site_name_image'),
-      $headerConfig->get('site_name_image')
-    );
-
     $headerConfig->set('header_variation', $form_state->getValue('header_variation'));
-    $headerConfig->set('site_name_image', $form_state->getValue('site_name_image'));
-    $headerConfig->set('site_wide_branding_name', $form_state->getValue('site_wide_branding_name'));
-    $headerConfig->set('site_wide_branding_link', $form_state->getValue('site_wide_branding_link'));
+
+    // Only platform admins see (and may change) these fields; skip saving them
+    // for other roles to prevent overwriting existing values with NULL.
+    if (ys_core_allow_secret_items($this->currentUserSession)) {
+      // Handle the filesystem if needed.
+      $this->ysMediaManager->handleMediaFilesystem(
+        $form_state->getValue('site_name_image'),
+        $headerConfig->get('site_name_image')
+      );
+
+      $headerConfig->set('site_name_image', $form_state->getValue('site_name_image'));
+      $headerConfig->set('site_wide_branding_name', $form_state->getValue('site_wide_branding_name'));
+      $headerConfig->set('site_wide_branding_link', $form_state->getValue('site_wide_branding_link'));
+    }
     $headerConfig->set('nav_position', $form_state->getValue('nav_position'));
     $headerConfig->set('dropdown_button_title', $form_state->getValue('dropdown_button_title'));
     $headerConfig->set('cta_content', $form_state->getValue('cta_content'));


### PR DESCRIPTION
## [#1153: Sitewide Branding reverts to "Yale University" when admin edits Header Settings for a content collection In Site Header](https://github.com/yalesites-org/YaleSites-Internal/issues/1159)

### Description of work
- Ensure no overwrite of sitewide header happens for non-admins

### Functional testing steps:
- [ ] As an admin set site_wide_branding_name to something custom (e.g. "Yale School of Nursing"). Save and confirm the name appears correctly in the header.
- [ ] Log out, then log back in as a user with the **site admin role**. Confirm you do not see the "Sitewide Branding" or "Site Name Image" fieldsets (those should be invisible to this role).
- [ ] Make any change that is available to a site admin — e.g. toggle the header variation or adjust a nav position setting. Save the form. 
- [ ] Check the front-end header. The branding name should still read "Yale School of Nursing" — not "Yale University".
- [ ] Confirm platform admin is unaffected Log back in as an admin. Confirm the "Sitewide Branding" fieldset is still visible and pre-populated with "Yale School of Nursing".
- [ ] Make a change and save — confirm the name still saves and displays correctly.