### PR TITLE
#1160 :: SoundCloud embed code with double-encoded track ID fails validation

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/SoundCloud.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/SoundCloud.php
@@ -21,7 +21,7 @@ class SoundCloud extends EmbedSourceBase implements EmbedSourceInterface {
   /**
    * {@inheritdoc}
    */
-  protected static $pattern = '/^<iframe.+src=\"https:\/\/w\.soundcloud\.com\S+(?<track_or_playlist>tracks|playlists)\/(?<track_id>\d+).+><\/iframe>/';
+  protected static $pattern = '/^<iframe.+src=\"https:\/\/w\.soundcloud\.com\S+(?<track_or_playlist>tracks|playlists)\/(?:soundcloud%253A(?:tracks|playlists)%253A)?(?<track_id>\d+).+><\/iframe>/';
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
## [#1160: SoundCloud embed code with double-encoded track ID fails validation](https://github.com/yalesites-org/YaleSites-Internal/issues/1160)

### Description of work
- Update soundcloud regex to make double-encoded prefix optional

### Functional testing steps:
- [ ] Add Soundcloud embed with the new double-encoded format (see ticket), verify it passes validation and works properly. Verify the original style of embed also passes validation and works properly

Demo: https://pr-1246-yalesites-platform.pantheonsite.io/soundcloud-test

(the top one is the example from the ticket, and the bottom one is the original embed code version)
