### PR TITLE
#292 :: Add Third Font Style Option to Site Settings: Yale Old-Style Numerals / Mallory

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/font-preview.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/font-preview.css
@@ -43,6 +43,21 @@
   margin: 0;
 }
 
+/* Yale Old-Style Numerals / Mallory font pairing preview */
+.font-preview-yalenew-oldstyle .preview-heading {
+  font-family: "YaleNew", serif;
+  font-size: 1.75rem;
+  font-variant-numeric: oldstyle-nums;
+  margin-bottom: 0.75rem;
+}
+
+.font-preview-yalenew-oldstyle .preview-text {
+  font-family: "Mallory", sans-serif;
+  font-size: 1rem;
+  line-height: 1.4;
+  margin: 0;
+}
+
 /* Mallory font pairing preview */
 .font-preview-mallory .preview-heading {
   font-family: "Mallory", sans-serif;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -244,8 +244,9 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
     $form['font_pairing'] = [
       '#type' => 'radios',
       '#options' => [
-        'yalenew' => $this->t('YaleNew (YaleNew for headings, Mallory for paragraph text)'),
-        'mallory' => $this->t('Mallory (Mallory for headings, Mallory for paragraph text)'),
+        'yalenew' => $this->t('YaleNew / Mallory (YaleNew for headings, Mallory for paragraph text)'),
+        'mallory' => $this->t('Mallory / Mallory (Mallory for headings, Mallory for paragraph text)'),
+        'yalenew-oldstyle' => $this->t('Yale Old-Style Numerals / Mallory (YaleNew with old-style numerals for headings and site title, Mallory for paragraph text)'),
       ],
       '#description' => $this->t('This font pairing will apply site-wide and affect all heading levels (h1-h6)'),
       '#title' => $this->t('Font Pairing'),
@@ -292,6 +293,25 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
           '#type' => 'html_tag',
           '#tag' => 'h2',
           '#value' => $this->t('Mallory Heading Sample'),
+          '#attributes' => ['class' => ['preview-heading']],
+        ],
+        'text' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('This is a sample paragraph in Mallory.'),
+          '#attributes' => ['class' => ['preview-text']],
+        ],
+      ],
+      'yalenew-oldstyle' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['font-preview', 'font-preview-yalenew-oldstyle'],
+          'data-font-pairing' => 'yalenew-oldstyle',
+        ],
+        'heading' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h2',
+          '#value' => $this->t('Yale Old-Style Numerals Heading Sample — 1234567890'),
           '#attributes' => ['class' => ['preview-heading']],
         ],
         'text' => [


### PR DESCRIPTION
## [#292: Add Third Font Style Option to Site Settings: Yale Old-Style Numerals / Mallory](https://github.com/yalesites-org/YaleSites-Internal/issues/292)

### Description of work
- Adds option to site settings form for Yale Old-Style Numerals
- Adds supporting preview and css

### Functional testing steps:
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...

CL PR: https://github.com/yalesites-org/component-library-twig/pull/634