### PR TITLE
Temporary CVE Allowlist: Drupal Core Security Advisory Ignores

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
   },
   "config": {
     "audit": {
-      "ignore": ["SA-CONTRIB-2025-060", "SA-CORE-2025-007", "SA-CORE-2025-008", "SA-CORE-2025-005", "SA-CORE-2025-006", "PKSA-d8tb-wwz2-ctxk", "PKSA-dh1f-zjm5-qg8y", "PKSA-bn52-vyzy-rmnm", "PKSA-xj83-g6g8-41vf"]
+      "ignore": ["SA-CONTRIB-2025-060", "SA-CORE-2025-007", "SA-CORE-2025-008", "SA-CORE-2025-005", "SA-CORE-2025-006", "SA-CORE-2026-001", "SA-CORE-2026-002", "PKSA-d8tb-wwz2-ctxk", "PKSA-dh1f-zjm5-qg8y", "PKSA-bn52-vyzy-rmnm", "PKSA-xj83-g6g8-41vf"]
     },
     "preferred-install": "dist",
     "sort-packages": true,


### PR DESCRIPTION
## CVE Allowlist: Drupal Core Security Advisory Ignores

### Description of work
- Adds SA-CORE-2026-001 and SA-CORE-2026-002 to composer audit ignore list
- Extends existing allowlist to unblock Pantheon multidev builds affected by new Drupal core security advisories
- SA-CORE-2026-001 (Critical XSS in jQuery AJAX modal dialogs) and SA-CORE-2026-002 (gadget chain) are temporary ignores pending an active Drupal core upgrade

### Functional testing steps:
- [ ] Confirm Pantheon multidev build completes without security advisory errors
- [ ] Verify `composer audit` passes locally (`lando composer audit`)
- [ ] Confirm no regression in site functionality on the multidev
- [ ] ...
