### PR TITLE
538: Fix Views Category Tags Display — For multidev only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # YaleSites Project
 
+
 YaleSites Project is a **Pantheon custom upstream for Drupal 10** that serves as the foundation for Yale's web platform. The YaleSites platform empowers the Yale community to create digital experiences for the web in applications that are secure, cost-effective, accessible, and sustainable.
 
 This is a sophisticated multi-repository system that includes:


### PR DESCRIPTION
## [#538: Fix Views Category Tags Display](https://github.com/yalesites-org/YaleSites-Internal/issues/538)

### Description of work
- Multidev trigger only — actual changes are in component-library-twig#635
- Other work completed in: yalesites-org/component-library-twig#635

### Functional Review Steps
- [ ] Verify the tags list on views shows all items inline with no "+N more" link
- [ ] Verify reference cards with many tags render correctly
- [ ] Verify calendar cell events show all type tags
- [ ] Verify tags wrap responsively on mobile