### PR TITLE
1025: Ensure Event Date/Time Changes in Campus Groups Sync to Website

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/migrations/campus_groups_events.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/migrations/campus_groups_events.yml
@@ -199,6 +199,7 @@ destination:
     - field_localist_event_image_alt
     - field_localist_ics_url
     - field_event_source
+    - field_event_date
 migration_dependencies:
   required:
     - campus_groups_taxonomy


### PR DESCRIPTION
## [1025: Ensure Event Date/Time Changes in Campus Groups Sync to Website](https://github.com/yalesites-org/YaleSites-Internal/issues/1025)

### Description of work
- Added `field_event_date` to the `overwrite_properties` list in the Campus Groups events migration so that date/time changes in Campus Groups are propagated to Drupal on subsequent hourly syncs

### Functional testing steps:
- [ ] Import events via the Campus Groups migration
- [ ] Update an event's date/time in Campus Groups
- [ ] Navigate to Settings → Integrations → Campus Groups and click "Sync"
- [ ] Confirm the updated date/time is reflected on the Drupal event node

Closes yalesites-org/YaleSites-Internal#1025