### PR TITLE
1221: RC: Resource View Portrait Grid missing field display options

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.resource.portrait_grid.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.resource.portrait_grid.yml
@@ -49,6 +49,14 @@ content:
     third_party_settings: {  }
     weight: -20
     region: content
+  field_authors:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 6
+    region: content
   field_category:
     type: entity_reference_label
     label: hidden
@@ -85,6 +93,38 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  field_discipline:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_journal_publication_issue:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 9
+    region: content
+  field_journal_publication_name:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 8
+    region: content
+  field_tags:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 5
+    region: content
   field_teaser_text:
     type: text_default
     label: hidden
@@ -107,15 +147,11 @@ hidden:
   field_affiliation: true
   field_areas_of_study: true
   field_audience: true
-  field_authors: true
   field_cf_dcn: true
   field_citation: true
   field_content_description: true
   field_custom_vocab: true
-  field_discipline: true
   field_geographic_areas: true
-  field_journal_publication_issue: true
-  field_journal_publication_name: true
   field_login_required: true
   field_media: true
   field_metatags: true
@@ -123,7 +159,6 @@ hidden:
   field_publish_date: true
   field_related_content: true
   field_revision_date: true
-  field_tags: true
   layout_builder__layout: true
   links: true
   search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/src/Plugin/Field/FieldWidget/ViewsContentResourcesDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/src/Plugin/Field/FieldWidget/ViewsContentResourcesDefaultWidget.php
@@ -256,6 +256,7 @@ class ViewsContentResourcesDefaultWidget extends WidgetBase implements Container
             $formSelectors['view_mode_input_selector'] => [
               ['value' => 'card'],
               ['value' => 'list_item'],
+              ['value' => 'portrait_grid'],
             ],
           ],
         ],
@@ -266,6 +267,7 @@ class ViewsContentResourcesDefaultWidget extends WidgetBase implements Container
             $formSelectors['view_mode_input_selector'] => [
               ['value' => 'card'],
               ['value' => 'list_item'],
+              ['value' => 'portrait_grid'],
             ],
           ],
         ],
@@ -276,6 +278,7 @@ class ViewsContentResourcesDefaultWidget extends WidgetBase implements Container
             $formSelectors['view_mode_input_selector'] => [
               ['value' => 'card'],
               ['value' => 'list_item'],
+              ['value' => 'portrait_grid'],
             ],
           ],
         ],
@@ -286,6 +289,7 @@ class ViewsContentResourcesDefaultWidget extends WidgetBase implements Container
             $formSelectors['view_mode_input_selector'] => [
               ['value' => 'card'],
               ['value' => 'list_item'],
+              ['value' => 'portrait_grid'],
             ],
           ],
         ],

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/ys_views_content_resources.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/ys_views_content_resources.module
@@ -127,6 +127,7 @@ function ys_views_content_resources_node_view(array &$build, NodeInterface $node
     "card",
     "condensed",
     "list_item",
+    "portrait_grid",
   ];
 
   if (in_array($view_mode, $view_modes)) {


### PR DESCRIPTION
## [1221: RC: Resource View Portrait Grid missing field display options](https://github.com/yalesites-org/YaleSites-Internal/issues/1221)

### Description of work
- Added `portrait_grid` to the `#states` visibility conditions for show_publication, show_discipline, show_teaser_text, and show_tags in `ViewsContentResourcesDefaultWidget`, making those options visible to editors when portrait grid is selected
- Added `portrait_grid` to the cache invalidation view modes in `ys_views_content_resources_node_view()`
- Moved field_tags, field_discipline, field_authors, field_journal_publication_name, and field_journal_publication_issue from `hidden` to `content` in the portrait_grid entity view display config so the Twig template has rendered content to work with
- Other work completed in: yalesites-org/atomic#456

### Functional testing steps:
- [ ] In Layout Builder, add or edit a Resource Views block and select Portrait Grid
- [ ] Confirm all four checkboxes appear: Show Tags, Show Teaser Text, Show Discipline, Show Publication Information
- [ ] Toggle each option on/off and verify the field renders/hides on portrait grid cards
- [ ] Switch to Card Grid and List Item — confirm no regression

Closes yalesites-org/YaleSites-Internal#1221