### PR TITLE
1222: Bug: Font Style Option 1 incorrectly shows old-style numerals; restructure all three options for #292

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/font-preview.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/font-preview.css
@@ -33,6 +33,8 @@
 .font-preview-yalenew .preview-heading {
   font-family: "YaleNew", serif;
   font-size: 1.75rem;
+  font-variant-numeric: oldstyle-nums;
+  font-feature-settings: "onum" 1;
   margin-bottom: 0.75rem;
 }
 
@@ -43,11 +45,12 @@
   margin: 0;
 }
 
-/* Yale Old-Style Numerals / Mallory font pairing preview */
+/* Yale New / Mallory font pairing preview */
 .font-preview-yalenew-oldstyle .preview-heading {
   font-family: "YaleNew", serif;
   font-size: 1.75rem;
-  font-variant-numeric: oldstyle-nums;
+  font-variant-numeric: normal;
+  font-feature-settings: "onum" 0;
   margin-bottom: 0.75rem;
 }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -244,9 +244,9 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
     $form['font_pairing'] = [
       '#type' => 'radios',
       '#options' => [
-        'yalenew' => $this->t('YaleNew / Mallory (YaleNew for headings, Mallory for paragraph text)'),
+        'yalenew' => $this->t('Yale New (Old-Style Numerals) / Mallory (YaleNew with old-style numerals for headings and site title, Mallory for paragraph text)'),
         'mallory' => $this->t('Mallory / Mallory (Mallory for headings, Mallory for paragraph text)'),
-        'yalenew-oldstyle' => $this->t('Yale Old-Style Numerals / Mallory (YaleNew with old-style numerals for headings and site title, Mallory for paragraph text)'),
+        'yalenew-oldstyle' => $this->t('Yale New / Mallory (YaleNew for headings and site title, Mallory for paragraph text)'),
       ],
       '#description' => $this->t('This font pairing will apply site-wide and affect all heading levels (h1-h6)'),
       '#title' => $this->t('Font Pairing'),
@@ -273,13 +273,13 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
         'heading' => [
           '#type' => 'html_tag',
           '#tag' => 'h2',
-          '#value' => $this->t('YaleNew Heading Sample'),
+          '#value' => $this->t('1234567890'),
           '#attributes' => ['class' => ['preview-heading']],
         ],
         'text' => [
           '#type' => 'html_tag',
           '#tag' => 'p',
-          '#value' => $this->t('This is a sample paragraph in Mallory.'),
+          '#value' => $this->t('Old-Style Numerals — some digits (3, 4, 5, 7, 9) descend below the text baseline, similar to lowercase letters.'),
           '#attributes' => ['class' => ['preview-text']],
         ],
       ],
@@ -311,13 +311,13 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
         'heading' => [
           '#type' => 'html_tag',
           '#tag' => 'h2',
-          '#value' => $this->t('Yale Old-Style Numerals Heading Sample — 1234567890'),
+          '#value' => $this->t('1234567890'),
           '#attributes' => ['class' => ['preview-heading']],
         ],
         'text' => [
           '#type' => 'html_tag',
           '#tag' => 'p',
-          '#value' => $this->t('This is a sample paragraph in Mallory.'),
+          '#value' => $this->t('Lining Numerals — all digits align uniformly to the text baseline, similar to capital letters.'),
           '#attributes' => ['class' => ['preview-text']],
         ],
       ],

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -244,11 +244,11 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
     $form['font_pairing'] = [
       '#type' => 'radios',
       '#options' => [
-        'yalenew' => $this->t('Yale New (Old-Style Numerals) / Mallory (YaleNew with old-style numerals for headings, dates, and meta text; Mallory for paragraph text)'),
+        'yalenew' => $this->t('Yale New (Old-Style Numerals) / Mallory (YaleNew with old-style numerals for headings and other numeric text; Mallory for paragraph text)'),
         'mallory' => $this->t('Mallory / Mallory (Mallory for headings, Mallory for paragraph text)'),
-        'yalenew-oldstyle' => $this->t('Yale New / Mallory (YaleNew with lining numerals for headings, dates, and meta text; Mallory for paragraph text)'),
+        'yalenew-oldstyle' => $this->t('Yale New / Mallory (YaleNew with lining numerals for headings and other numeric text; Mallory for paragraph text)'),
       ],
-      '#description' => $this->t('This font pairing will apply site-wide and affect headings, dates, facts &amp; figures statistics, and meta text throughout the site.'),
+      '#description' => $this->t('This font pairing controls how numbers appear in headings and other numeric text across the site.'),
       '#title' => $this->t('Font Pairing'),
       '#default_value' => $yaleConfig->get('font_pairing') ?? 'yalenew',
       '#prefix' => '<div class="font-pairing-selector">',

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -244,11 +244,11 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
     $form['font_pairing'] = [
       '#type' => 'radios',
       '#options' => [
-        'yalenew' => $this->t('Yale New (Old-Style Numerals) / Mallory (YaleNew with old-style numerals for headings and site title, Mallory for paragraph text)'),
+        'yalenew' => $this->t('Yale New (Old-Style Numerals) / Mallory (YaleNew with old-style numerals for headings, dates, and meta text; Mallory for paragraph text)'),
         'mallory' => $this->t('Mallory / Mallory (Mallory for headings, Mallory for paragraph text)'),
-        'yalenew-oldstyle' => $this->t('Yale New / Mallory (YaleNew for headings and site title, Mallory for paragraph text)'),
+        'yalenew-oldstyle' => $this->t('Yale New / Mallory (YaleNew with lining numerals for headings, dates, and meta text; Mallory for paragraph text)'),
       ],
-      '#description' => $this->t('This font pairing will apply site-wide and affect all heading levels (h1-h6)'),
+      '#description' => $this->t('This font pairing will apply site-wide and affect headings, dates, facts &amp; figures statistics, and meta text throughout the site.'),
       '#title' => $this->t('Font Pairing'),
       '#default_value' => $yaleConfig->get('font_pairing') ?? 'yalenew',
       '#prefix' => '<div class="font-pairing-selector">',

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.libraries.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.libraries.yml
@@ -37,6 +37,7 @@ grand_hero_form:
 font_preview:
   css:
     theme:
+      https://yale-webfonts.yalespace.org/fonts.min.css: { type: external }
       css/font-preview.css: {}
   js:
     js/font-preview.js: {}


### PR DESCRIPTION
## [1222: Bug: Font Style Option 1 incorrectly shows old-style numerals; restructure all three options for #292](https://github.com/yalesites-org/YaleSites-Internal/issues/1222)

### Description of work
- Update Site Settings font pairing radio labels: Option 1 → "Yale New (Old-Style Numerals) / Mallory", Option 3 → "Yale New / Mallory"
- Fix admin font preview not rendering YaleNew: load the Yale webfonts CDN directly in the `font_preview` library since the atomic theme is not active under Gin
- Update font preview to show digit-only content with descriptive text explaining old-style vs lining numerals
- Add `font-feature-settings: "onum"` alongside `font-variant-numeric` to guard against Gin CSS normalization overriding the old-style setting
- Update font pairing field description to reflect that the setting controls how numbers appear in headings and other numeric text across the site
- Other work completed in: yalesites-org/component-library-twig#639

### Functional testing steps:

**Admin settings** (can be tested on the multidev for this PR)
- [ ] Go to `/admin/config/system/site-settings` — verify the three font pairing radio labels read correctly: "Yale New (Old-Style Numerals) / Mallory", "Mallory / Mallory", and "Yale New / Mallory"
- [ ] Verify the field description reads "This font pairing controls how numbers appear in headings and other numeric text across the site."
- [ ] Select "Yale New (Old-Style Numerals) / Mallory" — the preview shows "1234567890" in YaleNew with old-style numerals (digits like 3, 4, 5, 7, 9 descend below the baseline) and descriptive text explaining the style
- [ ] Select "Yale New / Mallory" — the preview shows "1234567890" with lining numerals (uniform cap height) and descriptive text explaining the style
- [ ] Select "Mallory / Mallory" — the preview updates accordingly

**Site-wide numeral rendering** (requires both this PR and yalesites-org/component-library-twig#639 to be merged and atomic updated)

For each component below, create a test page using Layout Builder and add the relevant block. Then toggle between "Yale New (Old-Style Numerals) / Mallory" and "Yale New / Mallory" in Site Settings and verify the numeral style changes on the front end.

- [ ] **Facts & Figures** — Add a Facts & Figures block with a numeric stat (e.g. "42,000"). Stat values should reflect the active numeral setting. There is no longer a per-block font style override.
- [ ] **Headings with numbers** — Add a Text block with a heading containing digits. Numerals should switch styles with the setting.
- [ ] **Events** — Create an Event node with a date. Visit the node and verify the date/time display reflects the active numeral setting.
- [ ] **Content cards** — Add a Card Collection block containing Post, Event, or Resource cards that have overline or eyebrow text with numbers. Overline and eyebrow numerals should switch with the setting.
- [ ] **Directory listing** — Add a Directory Listing block or view. Overline numerals on profile cards should switch with the setting.
- [ ] **Taxonomy category tags** — Add a block or view that displays taxonomy category tags containing numbers. Tag numerals should switch with the setting.

Closes yalesites-org/YaleSites-Internal#1222