### PR TITLE
1225: RC: Publication Resource Cleanup V2

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/block_content.type.related_content.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block_content.type.related_content.yml
@@ -1,3 +1,4 @@
+uuid: 0d57a9c7-02f5-4f71-914d-264306130a2d
 langcode: en
 status: true
 dependencies: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.related_content.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.related_content.default.yml
@@ -1,3 +1,4 @@
+uuid: daaa651d-aa42-457a-a364-ca2a2b4968a1
 langcode: en
 status: true
 dependencies:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.resource.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.resource.default.yml
@@ -122,7 +122,6 @@ third_party_settings:
     group_basic_info:
       children:
         - title
-        - field_category
         - field_content_description
         - field_media
         - field_related_content
@@ -165,6 +164,7 @@ third_party_settings:
       children:
         - field_academic_years
         - field_audience
+        - field_category
         - field_custom_vocab
         - field_geographic_areas
         - field_discipline
@@ -203,7 +203,6 @@ third_party_settings:
       children:
         - field_publish_date
         - field_date_format
-        - field_revision_date
       label: 'Date Group'
       region: content
       parent_name: group_publication_info
@@ -412,12 +411,6 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_revision_date:
-    type: datetime_default
-    weight: 12
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_tags:
     type: chosen_select
     weight: 21
@@ -501,6 +494,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_revision_date: true
   layout_builder__layout: true
   promote: true
   revision_log: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.related_content.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.related_content.default.yml
@@ -1,3 +1,4 @@
+uuid: ab56811a-1a3d-42bf-920c-2d38aa178f53
 langcode: en
 status: true
 dependencies:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.resource.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.resource.default.yml
@@ -131,8 +131,8 @@ third_party_settings:
               label: 'Related Content'
               label_display: ''
               provider: ys_layouts
-              heading: 'Related Content'
               context_mapping: {  }
+              heading: 'Related Content'
             weight: 0
             additional: {  }
         third_party_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.resource.portrait_grid.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.resource.portrait_grid.yml
@@ -71,6 +71,14 @@ content:
     third_party_settings: {  }
     weight: 4
     region: content
+  field_discipline:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 7
+    region: content
   field_external_source:
     type: link_separate
     label: hidden
@@ -82,23 +90,6 @@ content:
       target: '0'
     third_party_settings: {  }
     weight: 5
-    region: content
-  field_teaser_media:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: card_grid_portrait_5_8
-      link: false
-    third_party_settings: {  }
-    weight: 2
-    region: content
-  field_discipline:
-    type: entity_reference_label
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 7
     region: content
   field_journal_publication_issue:
     type: string
@@ -123,6 +114,15 @@ content:
       link: false
     third_party_settings: {  }
     weight: 5
+    region: content
+  field_teaser_media:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: card_grid_portrait_5_8
+      link: false
+    third_party_settings: {  }
+    weight: 2
     region: content
   field_teaser_text:
     type: text_default

--- a/web/profiles/custom/yalesites_profile/config/sync/editor.editor.restricted_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/editor.editor.restricted_html.yml
@@ -13,6 +13,8 @@ settings:
     items:
       - bold
       - italic
+      - subscript
+      - superscript
       - '|'
       - link
       - anchor

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.related_content.field_heading.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.related_content.field_heading.yml
@@ -1,3 +1,4 @@
+uuid: bd941583-3707-4253-8e39-c0b3df4205ce
 langcode: en
 status: true
 dependencies:

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.resource.field_abstract.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.resource.field_abstract.yml
@@ -4,7 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_abstract
-    - filter.format.basic_html
+    - filter.format.restricted_html
     - node.type.resource
   module:
     - text
@@ -20,5 +20,5 @@ default_value: {  }
 default_value_callback: ''
 settings:
   allowed_formats:
-    - basic_html
+    - restricted_html
 field_type: text_long

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.resource.field_citation.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.resource.field_citation.yml
@@ -4,7 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_citation
-    - filter.format.basic_html
+    - filter.format.restricted_html
     - node.type.resource
   module:
     - text
@@ -20,5 +20,5 @@ default_value: {  }
 default_value_callback: ''
 settings:
   allowed_formats:
-    - basic_html
+    - restricted_html
 field_type: text_long

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.resource.field_content_description.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.resource.field_content_description.yml
@@ -4,7 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_content_description
-    - filter.format.basic_html
+    - filter.format.restricted_html
     - node.type.resource
   module:
     - text
@@ -20,5 +20,5 @@ default_value: {  }
 default_value_callback: ''
 settings:
   allowed_formats:
-    - basic_html
+    - restricted_html
 field_type: text_long

--- a/web/profiles/custom/yalesites_profile/config/sync/filter.format.restricted_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/filter.format.restricted_html.yml
@@ -21,7 +21,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<a id target rel class="ck-anchor" href data-entity-type data-entity-uuid data-entity-substitution> <br> <p> <strong> <em>'
+      allowed_html: '<a id target rel class="ck-anchor" href data-entity-type data-entity-uuid data-entity-substitution> <br> <p> <strong> <em> <sub> <sup>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.content_resources.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.content_resources.yml
@@ -208,6 +208,69 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        field_journal_publication_name:
+          id: field_journal_publication_name
+          table: node__field_journal_publication_name
+          field: field_journal_publication_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       pager:
         type: views_basic_full_pager
         options:

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.content_resources.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.content_resources.yml
@@ -425,6 +425,7 @@ display:
             title: title
             field_teaser_text: field_teaser_text
             field_teaser_title: field_teaser_title
+            field_journal_publication_name: field_journal_publication_name
         field_category_target_id:
           id: field_category_target_id
           table: node__field_category
@@ -558,52 +559,6 @@ display:
               site_admin: '0'
               platform_admin: '0'
             reduce: 0
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-        field_journal_publication_name_value:
-          id: field_journal_publication_name_value
-          table: node__field_journal_publication_name
-          field: field_journal_publication_name_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: field_journal_publication_name
-          plugin_id: string
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: field_journal_publication_name_value_op
-            label: 'Journal Publication Name'
-            description: ''
-            use_operator: false
-            operator: field_journal_publication_name_value_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: field_journal_publication_name_value
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              contributor: '0'
-              editor: '0'
-              site_admin: '0'
-              platform_admin: '0'
-            placeholder: ''
           is_grouped: false
           group_info:
             label: ''

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.entity_reference_for_fields.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.entity_reference_for_fields.yml
@@ -318,6 +318,86 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
+  embed_related_content:
+    id: embed_related_content
+    display_title: 'Related Content Embed'
+    display_plugin: embed
+    position: 2
+    display_options:
+      pager:
+        type: none
+        options:
+          offset: 0
+          items_per_page: 0
+      arguments:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+          default_action: 'not found'
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: true
+          not: false
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: related_content_card
+      defaults:
+        pager: false
+        style: false
+        row: false
+        arguments: false
+      display_description: ''
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
   entity_reference_1:
     id: entity_reference_1
     display_title: 'Content Entity Reference'
@@ -350,87 +430,6 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - 'user.node_grants:view'
-        - user.permissions
-      tags: {  }
-  embed_related_content:
-    id: embed_related_content
-    display_title: 'Related Content Embed'
-    display_plugin: embed
-    position: 2
-    display_options:
-      pager:
-        type: none
-        options:
-          offset: 0
-          items_per_page: 0
-      defaults:
-        pager: false
-        arguments: false
-        style: false
-        row: false
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          uses_fields: false
-      row:
-        type: 'entity:node'
-        options:
-          relationship: none
-          view_mode: related_content_card
-      arguments:
-        nid:
-          id: nid
-          table: node_field_data
-          field: nid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: nid
-          plugin_id: node_nid
-          default_action: 'not found'
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: fixed
-          default_argument_options:
-            argument: ''
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: true
-          not: false
-      display_description: ''
-      display_extenders:
-        metatag_display_extender:
-          metatags: {  }
-          tokenize: false
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
@@ -1151,3 +1151,60 @@ function ys_core_update_10012() {
 
   return t('Populated DCN Types vocabulary with @count terms.', ['@count' => $created]);
 }
+
+/**
+ * Migrate Resource text fields from basic_html to restricted_html.
+ */
+function ys_core_update_10013(&$sandbox) {
+  $fields = ['field_abstract', 'field_citation', 'field_content_description'];
+  $allowed_tags = '<a><br><p><strong><em>';
+
+  $node_type = \Drupal::entityTypeManager()->getStorage('node_type')->load('resource');
+  if (!$node_type) {
+    return t('Resource content type does not exist; skipping text format migration.');
+  }
+
+  if (!isset($sandbox['nids'])) {
+    $sandbox['nids'] = array_values(\Drupal::entityQuery('node')
+      ->condition('type', 'resource')
+      ->accessCheck(FALSE)
+      ->execute());
+    $sandbox['total'] = count($sandbox['nids']);
+    $sandbox['current'] = 0;
+
+    if ($sandbox['total'] === 0) {
+      return t('No resource nodes found; nothing to migrate.');
+    }
+  }
+
+  $batch_size = 50;
+  $nids = array_slice($sandbox['nids'], $sandbox['current'], $batch_size);
+
+  $nodes = \Drupal::entityTypeManager()->getStorage('node')->loadMultiple($nids);
+  foreach ($nodes as $node) {
+    $changed = FALSE;
+    foreach ($fields as $field_name) {
+      if ($node->hasField($field_name) && !$node->get($field_name)->isEmpty()) {
+        $value = $node->get($field_name)->first();
+        if ($value->format === 'basic_html') {
+          $value->format = 'restricted_html';
+          $value->value = strip_tags($value->value, $allowed_tags);
+          $changed = TRUE;
+        }
+      }
+    }
+    if ($changed) {
+      $node->save();
+    }
+  }
+
+  $sandbox['current'] += $batch_size;
+  $sandbox['#finished'] = $sandbox['total'] > 0
+    ? min(1, $sandbox['current'] / $sandbox['total'])
+    : 1;
+
+  return t('Migrated text format for @current of @total resource nodes.', [
+    '@current' => min($sandbox['current'], $sandbox['total']),
+    '@total' => $sandbox['total'],
+  ]);
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/src/Plugin/Field/FieldWidget/ViewsContentResourcesDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/src/Plugin/Field/FieldWidget/ViewsContentResourcesDefaultWidget.php
@@ -232,12 +232,15 @@ class ViewsContentResourcesDefaultWidget extends WidgetBase implements Container
         'show_tags' => $this->t('Show Tags'),
         'show_teaser_text' => $this->t('Show Teaser Text'),
         'show_discipline' => $this->t('Show Discipline'),
-        'show_publication' => $this->t('Show Publication Information'),
+        'show_journal_name' => $this->t('Show Journal/Publication Name'),
+        'show_journal_issue' => $this->t('Show Journal/Publication Issue'),
+        'show_authors' => $this->t('Show Authors'),
+        'show_publish_date' => $this->t('Show Publish Date'),
       ],
       '#title' => $this->t('Field Display Options'),
       '#tree' => TRUE,
       '#default_value' => ($isNewForm && empty($fieldOptionValue))
-        ? ['show_thumbnail', 'show_category', 'show_teaser_text']
+        ? ['show_thumbnail', 'show_teaser_text']
         : $fieldOptionDefaultValue,
       'show_thumbnail' => [
         '#states' => [
@@ -250,7 +253,40 @@ class ViewsContentResourcesDefaultWidget extends WidgetBase implements Container
           ],
         ],
       ],
-      'show_publication' => [
+      'show_journal_name' => [
+        '#states' => [
+          'visible' => [
+            $formSelectors['view_mode_input_selector'] => [
+              ['value' => 'card'],
+              ['value' => 'list_item'],
+              ['value' => 'portrait_grid'],
+            ],
+          ],
+        ],
+      ],
+      'show_journal_issue' => [
+        '#states' => [
+          'visible' => [
+            $formSelectors['view_mode_input_selector'] => [
+              ['value' => 'card'],
+              ['value' => 'list_item'],
+              ['value' => 'portrait_grid'],
+            ],
+          ],
+        ],
+      ],
+      'show_authors' => [
+        '#states' => [
+          'visible' => [
+            $formSelectors['view_mode_input_selector'] => [
+              ['value' => 'card'],
+              ['value' => 'list_item'],
+              ['value' => 'portrait_grid'],
+            ],
+          ],
+        ],
+      ],
+      'show_publish_date' => [
         '#states' => [
           'visible' => [
             $formSelectors['view_mode_input_selector'] => [
@@ -302,7 +338,6 @@ class ViewsContentResourcesDefaultWidget extends WidgetBase implements Container
       '#options' => [
         'show_search_filter' => $this->t('Show Search'),
         'show_year_filter' => $this->t('Show Year'),
-        'show_journal_publication_name_filter' => $this->t('Show Journal Publication Name'),
         'show_category_filter' => $this->t('Show Category'),
         'show_custom_vocab_filter' => $this->t('Show @vocab', ['@vocab' => $custom_vocab_label]),
         'show_audience_filter' => $this->t('Show Audience'),
@@ -314,6 +349,28 @@ class ViewsContentResourcesDefaultWidget extends WidgetBase implements Container
       '#title' => $this->t('Exposed Filter Options'),
       '#tree' => TRUE,
       '#default_value' => ($items[$delta]->params) ? $this->viewsContentResourcesManager->getDefaultParamValue('exposed_filter_options', $items[$delta]->params) : [],
+    ];
+
+    $form['group_user_selection']['entity_and_view_mode']['search_fields'] = [
+      '#type' => 'checkboxes',
+      '#options' => [
+        'title' => $this->t('Title'),
+        'field_teaser_text' => $this->t('Teaser Text'),
+        'field_teaser_title' => $this->t('Teaser Title'),
+        'field_journal_publication_name' => $this->t('Journal/Publication Name'),
+      ],
+      '#title' => $this->t('Search Fields'),
+      '#description' => $this->t('Select which fields the search filter will search across.'),
+      '#tree' => TRUE,
+      '#default_value' => ($items[$delta]->params)
+        ? $this->viewsContentResourcesManager->getDefaultParamValue('search_fields', $items[$delta]->params)
+        : ['title', 'field_teaser_text', 'field_teaser_title'],
+      '#element_validate' => [[static::class, 'validateSearchFields']],
+      '#states' => [
+        'visible' => [
+          $formSelectors['show_search_filter_selector'] => ['checked' => TRUE],
+        ],
+      ],
     ];
 
     $form['group_user_selection']['entity_and_view_mode']['category_filter_label'] = [
@@ -496,6 +553,22 @@ class ViewsContentResourcesDefaultWidget extends WidgetBase implements Container
   }
 
   /**
+   * Validates that at least one search field is selected.
+   */
+  public static function validateSearchFields(array &$element, FormStateInterface $form_state): void {
+    $parents = array_slice($element['#parents'], 0, -1);
+    $filterParents = array_merge($parents, ['exposed_filter_options', 'show_search_filter']);
+    $searchEnabled = $form_state->getValue($filterParents);
+
+    if ($searchEnabled) {
+      $selected = array_filter($element['#value']);
+      if (empty($selected)) {
+        $form_state->setError($element, t('At least one search field must be selected when search is enabled.'));
+      }
+    }
+  }
+
+  /**
    * Get data from user selection and save into params field.
    */
   public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
@@ -514,6 +587,7 @@ class ViewsContentResourcesDefaultWidget extends WidgetBase implements Container
         ],
         "field_options" => $form['group_user_selection']['entity_and_view_mode']['field_options']['#value'],
         "exposed_filter_options" => $form['group_user_selection']['entity_and_view_mode']['exposed_filter_options']['#value'],
+        "search_fields" => $form['group_user_selection']['entity_and_view_mode']['search_fields']['#value'],
         "category_filter_label" => $form['group_user_selection']['entity_and_view_mode']['category_filter_label']['#value'],
         "category_included_terms" => $form['group_user_selection']['entity_and_view_mode']['category_included_terms']['#value'],
         "custom_vocab_included_terms" => $form['group_user_selection']['entity_and_view_mode']['custom_vocab_included_terms']['#value'],

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/src/ViewsContentResourcesManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/src/ViewsContentResourcesManager.php
@@ -241,21 +241,42 @@ class ViewsContentResourcesManager extends ControllerBase implements ContainerIn
     }
 
     if (!isset($paramsDecoded['exposed_filter_options']['show_search_filter'])) {
-      // If the 'show_search_filter' option is not set,
-      // remove the 'combine' filter.
-      // The 'combine' filter is used for full-text search
-      // across multiple fields.
       unset($filters['combine']);
     }
+    else {
+      // Legacy: map old journal publication name filter to search fields.
+      if (!empty($paramsDecoded['exposed_filter_options']['show_journal_publication_name_filter'])
+          && empty($paramsDecoded['search_fields'])) {
+        $paramsDecoded['search_fields'] = [
+          'title' => 'title',
+          'field_teaser_text' => 'field_teaser_text',
+          'field_teaser_title' => 'field_teaser_title',
+          'field_journal_publication_name' => 'field_journal_publication_name',
+        ];
+      }
 
-    if (!isset($paramsDecoded['exposed_filter_options']['show_year_filter'])) {
-      // Remove the 'Year' filter if the 'show_year_filter' is not set.
-      unset($filters['resource_year_filter']);
+      if (!empty($paramsDecoded['search_fields']) && is_array($paramsDecoded['search_fields'])) {
+        $selectedFields = array_filter($paramsDecoded['search_fields']);
+        if (empty($selectedFields)) {
+          $selectedFields = [
+            'title' => 'title',
+            'field_teaser_text' => 'field_teaser_text',
+            'field_teaser_title' => 'field_teaser_title',
+          ];
+        }
+        $fieldsArray = [];
+        foreach ($selectedFields as $field) {
+          $fieldsArray[$field] = $field;
+        }
+        $filters['combine']['fields'] = $fieldsArray;
+      }
     }
 
-    if (!isset($paramsDecoded['exposed_filter_options']['show_journal_publication_name_filter'])) {
-      // Remove the 'Journal Publication Name' filter if not enabled.
-      unset($filters['field_journal_publication_name_value']);
+    // Remove legacy journal publication name filter.
+    unset($filters['field_journal_publication_name_value']);
+
+    if (!isset($paramsDecoded['exposed_filter_options']['show_year_filter'])) {
+      unset($filters['resource_year_filter']);
     }
 
     // Set the modified filters back to the view display options.
@@ -323,10 +344,22 @@ class ViewsContentResourcesManager extends ControllerBase implements ContainerIn
     // (pre-existing view)
     $no_field_display_options_saved = !array_key_exists('field_options', $paramsDecoded) || !is_array($paramsDecoded['field_options']);
 
+    // Legacy mapping: show_publication → individual fields.
+    if (!$no_field_display_options_saved && isset($paramsDecoded['field_options']['show_publication'])) {
+      $legacyValue = !empty($paramsDecoded['field_options']['show_publication']);
+      $paramsDecoded['field_options']['show_journal_name'] ??= $legacyValue;
+      $paramsDecoded['field_options']['show_journal_issue'] ??= $legacyValue;
+      $paramsDecoded['field_options']['show_authors'] ??= $legacyValue;
+      $paramsDecoded['field_options']['show_publish_date'] ??= $legacyValue;
+    }
+
     $field_display_options = [
       'show_category' => (int) !empty($paramsDecoded['field_options']['show_category']),
       'show_thumbnail' => (int) $no_field_display_options_saved || !empty($paramsDecoded['field_options']['show_thumbnail']),
-      'show_publication' => (int) !empty($paramsDecoded['field_options']['show_publication']),
+      'show_journal_name' => (int) !empty($paramsDecoded['field_options']['show_journal_name']),
+      'show_journal_issue' => (int) !empty($paramsDecoded['field_options']['show_journal_issue']),
+      'show_authors' => (int) !empty($paramsDecoded['field_options']['show_authors']),
+      'show_publish_date' => (int) !empty($paramsDecoded['field_options']['show_publish_date']),
       'show_discipline' => (int) !empty($paramsDecoded['field_options']['show_discipline']),
       'show_teaser_text' => (int) !empty($paramsDecoded['field_options']['show_teaser_text']),
       'show_tags' => (int) !empty($paramsDecoded['field_options']['show_tags']),
@@ -586,6 +619,20 @@ class ViewsContentResourcesManager extends ControllerBase implements ContainerIn
         $defaultParam = (empty($paramsDecoded['field_options']) || !is_array($paramsDecoded['field_options'])) ? [] : $paramsDecoded['field_options'];
         break;
 
+      case 'search_fields':
+        if (!empty($paramsDecoded['search_fields'])
+            && is_array($paramsDecoded['search_fields'])) {
+          $defaultParam = $paramsDecoded['search_fields'];
+        }
+        else {
+          $defaultParam = [
+            'title' => 'title',
+            'field_teaser_text' => 'field_teaser_text',
+            'field_teaser_title' => 'field_teaser_title',
+          ];
+        }
+        break;
+
       default:
         $defaultParam = $paramsDecoded[$type] ?? NULL;
         break;
@@ -764,6 +811,7 @@ class ViewsContentResourcesManager extends ControllerBase implements ContainerIn
           'view_mode_input_selector' => ':input[name="block_form[group_user_selection][entity_and_view_mode][view_mode]"]',
           'view_mode_ajax' => ($form) ? $form['block_form']['group_user_selection']['entity_and_view_mode']['view_mode'] : NULL,
           'category_included_terms_ajax' => ($form) ? $form['block_form']['group_user_selection']['entity_and_view_mode']['category_included_terms'] : NULL,
+          'show_search_filter_selector' => ':input[name="block_form[group_user_selection][entity_and_view_mode][exposed_filter_options][show_search_filter]"]',
           'show_category_filter_selector' => ':input[name="block_form[group_user_selection][entity_and_view_mode][exposed_filter_options][show_category_filter]"]',
           'show_custom_vocab_filter_selector' => ':input[name="block_form[group_user_selection][entity_and_view_mode][exposed_filter_options][show_custom_vocab_filter]"]',
           'custom_vocab_included_terms_ajax' => ($form) ? $form['block_form']['group_user_selection']['entity_and_view_mode']['custom_vocab_included_terms'] : NULL,
@@ -833,6 +881,7 @@ class ViewsContentResourcesManager extends ControllerBase implements ContainerIn
           'view_mode_input_selector' => ':input[name="settings[block_form][group_user_selection][entity_and_view_mode][view_mode]"]',
           'view_mode_ajax' => ($form) ? $form['settings']['block_form']['group_user_selection']['entity_and_view_mode']['view_mode'] : NULL,
           'category_included_terms_ajax' => ($form) ? $form['settings']['block_form']['group_user_selection']['entity_and_view_mode']['category_included_terms'] : NULL,
+          'show_search_filter_selector' => ':input[name="settings[block_form][group_user_selection][entity_and_view_mode][exposed_filter_options][show_search_filter]"]',
           'show_category_filter_selector' => ':input[name="settings[block_form][group_user_selection][entity_and_view_mode][exposed_filter_options][show_category_filter]"]',
           'show_custom_vocab_filter_selector' => ':input[name="settings[block_form][group_user_selection][entity_and_view_mode][exposed_filter_options][show_custom_vocab_filter]"]',
           'custom_vocab_included_terms_ajax' => ($form) ? $form['settings']['block_form']['group_user_selection']['entity_and_view_mode']['custom_vocab_included_terms'] : NULL,
@@ -916,6 +965,7 @@ class ViewsContentResourcesManager extends ControllerBase implements ContainerIn
         'view_mode_input_selector' => ':input[name="view_mode"]',
         'view_mode_ajax' => ($form) ? $form['group_user_selection']['entity_and_view_mode']['view_mode'] : NULL,
         'category_included_terms_ajax' => ($form) ? $form['group_user_selection']['entity_and_view_mode']['category_included_terms'] : NULL,
+        'show_search_filter_selector' => ':input[name="show_search_filter"]',
         'show_category_filter_selector' => ':input[name="show_category_filter"]',
         'show_custom_vocab_filter_selector' => ':input[name="show_custom_vocab_filter"]',
         'custom_vocab_included_terms_ajax' => ($form) ? $form['group_user_selection']['entity_and_view_mode']['custom_vocab_included_terms'] : NULL,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/ys_views_content_resources.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/ys_views_content_resources.module
@@ -82,13 +82,13 @@ function ys_views_content_resources_views_pre_render(ViewExecutable $view): void
       $pin_label = $pin_options->pin_label;
     }
     $field_display_options = json_decode($view->args[7]);
-    // Loop through each row in the view's results and update the node's
-    // properties based on show_category, show_thumbnail, and show_publication
-    // configuration.
     foreach ($view->result as $row) {
       $row->_entity->show_category = $field_display_options->show_category;
       $row->_entity->show_thumbnail = $field_display_options->show_thumbnail;
-      $row->_entity->show_publication = $field_display_options->show_publication ?? 0;
+      $row->_entity->show_journal_name = $field_display_options->show_journal_name ?? 0;
+      $row->_entity->show_journal_issue = $field_display_options->show_journal_issue ?? 0;
+      $row->_entity->show_authors = $field_display_options->show_authors ?? 0;
+      $row->_entity->show_publish_date = $field_display_options->show_publish_date ?? 0;
       $row->_entity->show_discipline = $field_display_options->show_discipline ?? 0;
       $row->_entity->show_teaser_text = $field_display_options->show_teaser_text ?? 0;
       $row->_entity->show_tags = $field_display_options->show_tags ?? 0;


### PR DESCRIPTION
## [1225: RC: Publication Resource Cleanup V2](https://github.com/yalesites-org/YaleSites-Internal/issues/1225)

### Description of work
- Hide unused revision date field from Resource edit form
- Move category field from Basic Info tab to Taxonomies tab
- Change default Resource View state to only show teaser image and text
- Break show_publication into individual per-field checkboxes (journal name, journal issue, authors, publish date) with backward compatibility
- Restrict abstract, citation, and description fields to restricted_html with batch update hook for existing content
- Add `<sub>` and `<sup>` tags to restricted_html format for academic formatting
- Replace separate journal publication name filter with configurable search field checkboxes on the combine filter
- Add form validation requiring at least one search field when search is enabled
- Re-export config to resolve persistent import diffs (missing UUIDs, key ordering)
- Add journal publication name as Views field handler for combine filter
- Other work completed in: yalesites-org/component-library-twig#640, yalesites-org/atomic#457

### Functional testing steps:
- [x] Edit a Resource node — verify revision date is hidden, category is under Taxonomies tab
- [x] Add a new Resource View block — verify only Teaser Image and Teaser Text are checked by default
- [x] Toggle Journal Name, Journal Issue, Authors, Publish Date individually — verify each works
- [x] Enable search and verify Search Fields checkboxes appear; search by title, teaser text, and journal name
- [x] Verify existing blocks with legacy show_publication data still render correctly
- [x] Verify abstract/citation/description fields use restricted_html format (with sub/sup support)
- [x] Run config import twice — verify no persistent diffs
- [x] Visit a Resource page — verify download icon appears on the CTA

References yalesites-org/YaleSites-Internal#1225