### PR TITLE
1227: RC: Cleanup add child item in manage main menu

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -1354,3 +1354,39 @@ function ys_core_set_block_field_defaults(string $block_type, string $field_name
 
   return $updated_count;
 }
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter() for menu_link_content_form.
+ *
+ * Hides fields that aren't relevant for YaleSites editors.
+ */
+function ys_core_form_menu_link_content_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+  foreach (['description', 'view_mode', 'revision_log_message', 'expanded'] as $key) {
+    if (isset($form[$key])) {
+      $form[$key]['#access'] = FALSE;
+    }
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() for menu_edit_form.
+ *
+ * BigMenu adds a #theme => 'breadcrumb' element when editing children, but the
+ * Gin admin theme renders breadcrumbs in its own toolbar region, so the inline
+ * element is invisible. Replace it with a simple back link.
+ */
+function ys_core_form_menu_edit_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+  $menu_link = \Drupal::request()->query->get('menu_link');
+  if (!$menu_link) {
+    return;
+  }
+
+  $menu = $form_state->getFormObject()->getEntity();
+  $form['breadcrumb'] = [
+    '#type' => 'link',
+    '#title' => t('Back to @label top level', ['@label' => $menu->label()]),
+    '#url' => $menu->toUrl('edit-form'),
+    '#attributes' => ['class' => ['button', 'button--small']],
+    '#weight' => -100,
+  ];
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -1361,7 +1361,7 @@ function ys_core_set_block_field_defaults(string $block_type, string $field_name
  * Hides fields that aren't relevant for YaleSites editors.
  */
 function ys_core_form_menu_link_content_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
-  foreach (['description', 'view_mode', 'revision_log_message', 'expanded'] as $key) {
+  foreach (['description', 'menu_link_description', 'view_mode', 'revision_log_message', 'expanded'] as $key) {
     if (isset($form[$key])) {
       $form[$key]['#access'] = FALSE;
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -1361,11 +1361,27 @@ function ys_core_set_block_field_defaults(string $block_type, string $field_name
  * Hides fields that aren't relevant for YaleSites editors.
  */
 function ys_core_form_menu_link_content_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
-  foreach (['description', 'menu_link_description', 'view_mode', 'revision_log_message', 'expanded'] as $key) {
+  foreach (['description', 'view_mode', 'revision_log_message', 'expanded'] as $key) {
     if (isset($form[$key])) {
       $form[$key]['#access'] = FALSE;
     }
   }
+  // Claro (gin's base theme) creates 'menu_link_description' as a details
+  // wrapper around 'description' in its own hook_form_alter, which runs after
+  // all modules. Use #after_build so we can hide it after theme alters finish.
+  $form['#after_build'][] = 'ys_core_menu_link_content_form_after_build';
+}
+
+/**
+ * After-build callback for menu_link_content_form.
+ *
+ * Hides the 'menu_link_description' details wrapper created by the Claro theme.
+ */
+function ys_core_menu_link_content_form_after_build(array $form, FormStateInterface $form_state) {
+  if (isset($form['menu_link_description'])) {
+    $form['menu_link_description']['#access'] = FALSE;
+  }
+  return $form;
 }
 
 /**


### PR DESCRIPTION
## [1227: RC: Cleanup add child item in manage main menu](https://github.com/yalesites-org/YaleSites-Internal/issues/1227)

### Description of work
- Hide irrelevant fields from the menu link Add/Edit form (Description, View mode, Revision log message, Show as expanded) using `#access = FALSE` in a new `hook_form_BASE_FORM_ID_alter` in `ys_core.module`
- The Claro theme (gin's base theme) creates a separate `menu_link_description` details wrapper after all module form alters run; used an `#after_build` callback to hide it after theme alters complete
- Add a "Back to [menu] top level" button on the BigMenu child-edit view, replacing BigMenu's `#theme => 'breadcrumb'` element that is invisible under the Gin admin theme

### Functional testing steps:
- [x] Go to `/admin/structure/menu/manage/main/add` — confirm Description, View mode, Revision log message, and Show as expanded are all hidden
- [x] Confirm Menu link title, Link, Enabled, Mega Menu Top Level Link Text, Parent link, and Weight (inside Display settings) are still visible
- [x] Repeat on `/admin/structure/menu/manage/utility-navigation/add` to confirm both bundles are covered
- [x] Edit an existing menu link and save — confirm no validation errors and the link saves correctly
- [x] Go to `/admin/structure/menu/manage/main` — confirm no back link appears on the top-level view
- [x] Click "Edit child items" on a menu link that has children — confirm a "Back to Main navigation top level" button appears above the table
- [x] Click the back link and confirm it returns to the top-level menu edit page

References yalesites-org/YaleSites-Internal#1227