### PR TITLE
#561 :: Blocks containing max paragraph children error

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.gallery.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.gallery.default.yml
@@ -34,7 +34,7 @@ content:
       closed_mode_threshold: 0
       add_mode: button
       form_display_mode: default
-      default_paragraph_type: _none
+      default_paragraph_type: gallery_item
       features:
         add_above: add_above
         collapse_edit_all: collapse_edit_all

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.gallery.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.gallery.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.block_content.gallery.field_padding_options
   module:
     - allowed_formats
+    - hide_revision_field
     - markup
     - maxlength
     - paragraphs
@@ -33,10 +34,11 @@ content:
       closed_mode_threshold: 0
       add_mode: button
       form_display_mode: default
-      default_paragraph_type: gallery_item
+      default_paragraph_type: _none
       features:
         add_above: add_above
         collapse_edit_all: collapse_edit_all
+        convert: '0'
         duplicate: duplicate
     third_party_settings:
       paragraphs_features:
@@ -44,6 +46,7 @@ content:
         add_in_between_link_count: 3
         delete_confirmation: true
         show_drag_and_drop: true
+        show_collapse_all: true
   field_heading:
     type: text_textfield
     weight: 1

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.link_grid.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.link_grid.default.yml
@@ -63,10 +63,11 @@ content:
       closed_mode_threshold: 0
       add_mode: button
       form_display_mode: default
-      default_paragraph_type: link_list
+      default_paragraph_type: _none
       features:
         add_above: add_above
         collapse_edit_all: collapse_edit_all
+        convert: '0'
         duplicate: duplicate
     third_party_settings:
       paragraphs_features:
@@ -74,6 +75,7 @@ content:
         add_in_between_link_count: 3
         delete_confirmation: true
         show_drag_and_drop: true
+        show_collapse_all: true
   field_padding_options:
     type: options_select
     weight: 5

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.link_grid.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.link_grid.default.yml
@@ -63,7 +63,7 @@ content:
       closed_mode_threshold: 0
       add_mode: button
       form_display_mode: default
-      default_paragraph_type: _none
+      default_paragraph_type: link_list
       features:
         add_above: add_above
         collapse_edit_all: collapse_edit_all

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.tabs.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.tabs.default.yml
@@ -42,7 +42,7 @@ content:
       closed_mode_threshold: 0
       add_mode: button
       form_display_mode: default
-      default_paragraph_type: _none
+      default_paragraph_type: tab
       features:
         add_above: add_above
         collapse_edit_all: collapse_edit_all

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.tabs.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.tabs.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.block_content.tabs.field_padding_options
     - field.field.block_content.tabs.field_tabs
   module:
+    - hide_revision_field
     - markup
     - paragraphs
     - paragraphs_features
@@ -41,10 +42,11 @@ content:
       closed_mode_threshold: 0
       add_mode: button
       form_display_mode: default
-      default_paragraph_type: tab
+      default_paragraph_type: _none
       features:
         add_above: add_above
         collapse_edit_all: collapse_edit_all
+        convert: '0'
         duplicate: duplicate
     third_party_settings:
       paragraphs_features:
@@ -52,6 +54,7 @@ content:
         add_in_between_link_count: 3
         delete_confirmation: true
         show_drag_and_drop: true
+        show_collapse_all: true
   info:
     type: string_textfield
     weight: 2

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.tabs.field_tabs.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.tabs.field_tabs.yml
@@ -25,94 +25,37 @@ settings:
       tab: tab
     negate: 0
     target_bundles_drag_drop:
-      accordion:
-        weight: 31
-        enabled: false
       accordion_item:
         weight: 32
-        enabled: false
-      basic_view:
-        weight: 33
-        enabled: false
-      callout:
-        weight: 34
         enabled: false
       callout_item:
         weight: 35
         enabled: false
-      cta_banner:
-        weight: 36
+      cta_link:
+        weight: 14
         enabled: false
       custom_card:
         weight: 37
         enabled: false
-      custom_cards:
-        weight: 38
-        enabled: false
-      divider:
-        weight: 39
-        enabled: false
-      embed:
-        weight: 40
-        enabled: false
-      event_cards:
-        weight: 41
-        enabled: false
-      event_list:
-        weight: 42
-        enabled: false
-      gallery:
-        weight: 43
+      facts_item:
+        weight: 16
         enabled: false
       gallery_item:
         weight: 44
         enabled: false
-      grand_hero:
-        weight: 45
-        enabled: false
-      image:
-        weight: 46
-        enabled: false
-      media_grid:
-        weight: 47
+      link_list:
+        weight: 18
         enabled: false
       media_grid_item:
         weight: 48
         enabled: false
-      post_cards:
-        weight: 49
-        enabled: false
-      post_list:
-        weight: 50
-        enabled: false
-      pull_quote:
-        weight: 51
-        enabled: false
-      quick_links:
-        weight: 52
-        enabled: false
-      section:
-        weight: 53
-        enabled: false
       tab:
         weight: 54
         enabled: true
-      tabs:
-        weight: 55
-        enabled: false
       text:
         weight: 56
         enabled: false
-      text_with_image:
-        weight: 57
-        enabled: false
-      video:
-        weight: 58
-        enabled: false
-      webform:
-        weight: 59
-        enabled: false
-      wrapped_image:
-        weight: 60
+      tile:
+        weight: 22
         enabled: false
 field_type: entity_reference_revisions

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_tabs.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_tabs.yml
@@ -14,7 +14,7 @@ settings:
   target_type: paragraph
 module: entity_reference_revisions
 locked: false
-cardinality: -1
+cardinality: 5
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/js/block-form.js
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/js/block-form.js
@@ -13,6 +13,23 @@
         }
       }
 
+      /**
+       * True when a link field table row has a URI (core leaves an extra empty
+       * row for "add another" that must not count toward min/max).
+       */
+      function linkTableRowHasUri(row) {
+        const uriInputs = row.querySelectorAll(
+          'input[name*="[uri]"], input[name*="[link]"], input.js-linkit-autocomplete, input.linkit-widget-uri'
+        );
+        for (let i = 0; i < uriInputs.length; i += 1) {
+          const v = uriInputs[i].value;
+          if (v && String(v).trim() !== "") {
+            return true;
+          }
+        }
+        return false;
+      }
+
       /*
        * Function to validate that all media items contain media.
        *
@@ -23,11 +40,18 @@
        *   The error message or empty string.
        * */
       function getErrors(blockType) {
-        // Get all items of the specified type.
         const items = document.querySelectorAll(blockType.itemSelector);
-
-        // Count the number of items present.
-        const numberOfItems = items.length;
+        let numberOfItems;
+        if (blockType.onlyCountFilledLinkRows) {
+          numberOfItems = 0;
+          for (let i = 0; i < items.length; i += 1) {
+            if (linkTableRowHasUri(items[i])) {
+              numberOfItems += 1;
+            }
+          }
+        } else {
+          numberOfItems = items.length;
+        }
         if (
           numberOfItems < blockType.min ||
           (blockType.max > 0 && numberOfItems > blockType.max)
@@ -38,9 +62,7 @@
           } else {
             messageText = `Number of ${blockType.type} must be ${blockType.min} or more. `;
           }
-          return (
-            messageText + `Number of ${blockType.type} added: ${numberOfItems}.`
-          );
+          return `${messageText}Number of ${blockType.type} added: ${numberOfItems}.`;
         }
 
         // An empty string signifies no errors and resets validation for the input.
@@ -122,7 +144,9 @@
           type: "tabs",
         },
         {
-          // Quick links
+          // Quick Links: `field_links` is a multi-value link field (Linkit), not
+          // paragraphs — each draggable table row is one link delta.
+          onlyCountFilledLinkRows: true,
           itemSelector: "table[id^='field-links-values'] tr.draggable",
           inputSelector: [
             'input[data-drupal-selector^="edit-field-heading"]',


### PR DESCRIPTION
## [#561: Blocks containing max paragraph children error](https://github.com/yalesites-org/YaleSites-Internal/issues/561)

### Description of work
These are all kind of special cases:
- Quick links actually doesn't have child paragraphs, it's a Link field with unlimited cardinality. So I had to add a helper function in the code so that our validation ignores empty items (there is no option not to add new Link items).
- Gallery has a minimum of 2 but no maximum, so I made no change there.
- Link Grid had a maximum cardinality set in the paragraph settings, so that once you reach 4 Link Lists, there is no option to add another one
- I updated Tabs to have maximum cardinality of 5 tabs set in paragraph settings also, so now once you reach 5, there is no option to add another.

### Functional testing steps:
- [ ] Add a block of type Quick Links Add the max number of items. Edit the item in Layout Builder. Verify that if an empty item is added you can still save. Verify that if you fill that item, the validation is triggered.
- [ ] Add a block of type Tabs. Verify that once you have added 5, you do not have an option to add more. Verify you must add at least 2.
- [ ] Add a block of type Link Grid. Verify that once you have added 4 Link Lists, you do not have the option to add more.

Demo: https://pr-1270-yalesites-platform.pantheonsite.io/node/128/layout
