### PR TITLE
#1145 :: Content collection weights cannot be set by admins

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/src/Access/BookOutlineAccessCheck.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/src/Access/BookOutlineAccessCheck.php
@@ -1,8 +1,5 @@
 <?php
 
-/**
- * Access checker for content collection outline admin page.
- */
 namespace Drupal\ys_book\Access;
 
 use Drupal\Core\Access\AccessResult;
@@ -10,13 +7,25 @@ use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\Core\Session\AccountInterface;
 
+/**
+ * Determines access to the book outline admin edit form.
+ *
+ * Allows access for accounts that have either the broad
+ * 'administer book outlines' permission or the narrower 'reorder book pages'
+ * permission. This avoids requiring the full administer permission just to
+ * reorder content collection pages.
+ */
 class BookOutlineAccessCheck implements AccessInterface {
 
   /**
-   * Access checker for content collection outline admin page.
+   * Checks access to the book outline admin edit form.
    *
-   * @return AccessResultInterface
-   *   Allowed if either of two permissions is granted to account.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The current user account.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   Allowed if the account has 'administer book outlines' or
+   *   'reorder book pages' permission; neutral otherwise.
    */
   public function access(AccountInterface $account): AccessResultInterface {
     $allowed = $account->hasPermission('administer book outlines')

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/src/Access/BookOutlineAccessCheck.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/src/Access/BookOutlineAccessCheck.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * Access checker for content collection outline admin page.
+ */
 namespace Drupal\ys_book\Access;
 
 use Drupal\Core\Access\AccessResult;
@@ -9,6 +12,12 @@ use Drupal\Core\Session\AccountInterface;
 
 class BookOutlineAccessCheck implements AccessInterface {
 
+  /**
+   * Access checker for content collection outline admin page.
+   *
+   * @return AccessResultInterface
+   *   Allowed if either of two permissions is granted to account.
+   */
   public function access(AccountInterface $account): AccessResultInterface {
     $allowed = $account->hasPermission('administer book outlines')
       || $account->hasPermission('reorder book pages');

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/src/Access/BookOutlineAccessCheck.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/src/Access/BookOutlineAccessCheck.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\ys_book\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Session\AccountInterface;
+
+class BookOutlineAccessCheck implements AccessInterface {
+
+  public function access(AccountInterface $account): AccessResultInterface {
+    $allowed = $account->hasPermission('administer book outlines')
+      || $account->hasPermission('reorder book pages');
+
+    return AccessResult::allowedIf($allowed);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.module
@@ -420,7 +420,8 @@ function ys_book_node_predelete($node) {
  *
  * This clears:
  * 1. The persistent cache entry for the navigation position function.
- * 2. The rendered page cache for all nodes in the book so headers re-render.
+ * 2. The rendered navigation block cache (tagged by bookTreeOutput).
+ * 3. The rendered page cache for all nodes in the book so headers re-render.
  *
  * @param int $bid
  *   The book ID (nid of the root book node).
@@ -434,7 +435,12 @@ function _ys_book_invalidate_collection_nav_cache(int $bid) {
   // the navigation position for this book.
   Cache::invalidateTags(['ys_collection_nav:' . $bid]);
 
-  // 3. Invalidate node cache tags for all nodes in the book.
+  // 3. Invalidate the cache tag that bookTreeOutput() sets on the navigation
+  // block render array. Without this, the block render cache keeps serving
+  // the old page order even after weights are saved.
+  Cache::invalidateTags(['config:system.book.' . $bid]);
+
+  // 4. Invalidate node cache tags for all nodes in the book.
   // This ensures the rendered pages are rebuilt with the new header.
   $nids = _ys_book_get_all_book_nids($bid);
   if (!empty($nids)) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.module
@@ -220,7 +220,7 @@ function ys_book_form_book_admin_edit_alter(&$form, FormStateInterface $form_sta
   }
 
   // Add cache invalidation submit handler.
-  $form['save']['#submit'][] = '_ys_book_admin_edit_submit';
+  $form['#submit'][] = '_ys_book_admin_edit_submit';
 }
 
 /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.routing.yml
@@ -15,18 +15,3 @@ book.admin_edit:
     _ys_book_outline_access: 'TRUE'
     _entity_access: 'node.view'
     node: \d+
-
-book.node_child_ordering:
-  path: '/node/{node}/child-ordering'
-  defaults:
-    _form: '\Drupal\book\Form\BookAdminEditForm'
-    _title: 'Re-order book pages and change titles'
-    parameters:
-      node:
-        type: entity:node
-  options:
-    _admin_route: TRUE
-  requirements:
-    _ys_book_outline_access: 'TRUE'
-    _entity_access: 'node.view'
-    node: \d+

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.routing.yml
@@ -5,3 +5,28 @@ book.admin:
     _title: 'Content Collections'
   requirements:
     _permission: 'administer book outlines'
+
+book.admin_edit:
+  path: '/admin/structure/book/{node}'
+  defaults:
+    _form: '\Drupal\book\Form\BookAdminEditForm'
+    _title: 'Re-order book pages and change titles'
+  requirements:
+    _ys_book_outline_access: 'TRUE'
+    _entity_access: 'node.view'
+    node: \d+
+
+book.node_child_ordering:
+  path: '/node/{node}/child-ordering'
+  defaults:
+    _form: '\Drupal\book\Form\BookAdminEditForm'
+    _title: 'Re-order book pages and change titles'
+    parameters:
+      node:
+        type: entity:node
+  options:
+    _admin_route: TRUE
+  requirements:
+    _ys_book_outline_access: 'TRUE'
+    _entity_access: 'node.view'
+    node: \d+

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.services.yml
@@ -1,0 +1,5 @@
+services:
+  access_check.ys_book.outline:
+    class: Drupal\ys_book\Access\BookOutlineAccessCheck
+    tags:
+      - { name: access_check, applies_to: _ys_book_outline_access }


### PR DESCRIPTION
## [#1145: Content collection weights cannot be set by admins](https://github.com/yalesites-org/YaleSites-Internal/issues/1145)

### Description of work
- Update access check on book reorder route to support "reorder book pages" permission in addition to "administer book outlines"
- Fix submit issue - the problem was that the submit handler was added to the save button rather than the full form submit and this made the code skip the default submit handler

### Functional testing steps:
- [ ] As a user with the Site admin or Platform admin role, go to /admin/structure/book/NID. Reorder the subpages. Verify you can reorder and save.
- [ ] Do the same as a user with the editor role. Verify you can reorder and save.
- [ ] Verify on save the cache is cleared on the book pages and the titles appear in the correct order in the menu.

Demo: https://pr-1271-yalesites-platform.pantheonsite.io/admin/structure/book/126
