### PR TITLE
Temporary CVE Allowlist: Drupal Core and Symfony Security Advisory Ignores

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,30 @@
   },
   "config": {
     "audit": {
-      "ignore": ["SA-CONTRIB-2025-060", "SA-CORE-2025-007", "SA-CORE-2025-008", "SA-CORE-2025-005", "SA-CORE-2025-006", "SA-CORE-2026-001", "SA-CORE-2026-002", "PKSA-d8tb-wwz2-ctxk", "PKSA-dh1f-zjm5-qg8y", "PKSA-bn52-vyzy-rmnm", "PKSA-xj83-g6g8-41vf"]
+      "ignore":[
+        "SA-CONTRIB-2025-060",
+        "SA-CORE-2025-007",
+        "SA-CORE-2025-008",
+        "SA-CORE-2025-005",
+        "SA-CORE-2025-006",
+        "SA-CORE-2026-001",
+        "SA-CORE-2026-002",
+        "SA-CORE-2026-004",
+        "PKSA-d8tb-wwz2-ctxk",
+        "PKSA-dh1f-zjm5-qg8y",
+        "PKSA-bn52-vyzy-rmnm",
+        "PKSA-xj83-g6g8-41vf",
+        "PKSA-5k7f-wvjj-jrgw",
+        "PKSA-sjvz-tbbr-vwth",
+        "PKSA-h8hf-ytnd-5t9q",
+        "PKSA-wwb1-81rc-pd65",
+        "PKSA-kvv6-36cr-fkzb",
+        "PKSA-n14z-jjjg-g8vd",
+        "PKSA-3mcc-k66d-pydb",
+        "PKSA-gw7n-z4yx-7xjt",
+        "PKSA-dpx1-78wg-1kqs",
+        "PKSA-21g2-dzjv-sky5"
+      ]
     },
     "preferred-install": "dist",
     "sort-packages": true,


### PR DESCRIPTION
## CVE Allowlist: Drupal Core and Symfony Security Advisory Ignores

### Description of work
- Adds new entries to composer audit ignore list for recent drupal/core and symfony releases.
- Extends existing allowlist to unblock Pantheon multidev builds affected by new Drupal core security advisories

### Functional testing steps:
- [ ] Confirm Pantheon multidev build completes without security advisory errors
- [ ] Verify `composer audit` passes locally (`lando composer audit`)
- [ ] Confirm no regression in site functionality on the multidev
- [ ] ...
