### PR TITLE
#1157 :: Extend Banner Width Control to All Banner Blocks

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.cta_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.cta_banner.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.block_content.cta_banner.field_padding_options
     - field.field.block_content.cta_banner.field_style_color
     - field.field.block_content.cta_banner.field_style_position
+    - field.field.block_content.cta_banner.field_style_width
     - field.field.block_content.cta_banner.field_text
   module:
     - allowed_formats
@@ -107,6 +108,12 @@ content:
   field_style_position:
     type: options_select
     weight: 8
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_style_width:
+    type: options_select
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.grand_hero.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.grand_hero.default.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.block_content.grand_hero.field_style_color
     - field.field.block_content.grand_hero.field_style_position
     - field.field.block_content.grand_hero.field_style_variation
+    - field.field.block_content.grand_hero.field_style_width
     - field.field.block_content.grand_hero.field_text
   module:
     - allowed_formats
@@ -127,6 +128,12 @@ content:
   field_style_variation:
     type: options_select
     weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_style_width:
+    type: options_select
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.image_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.image_banner.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.block_content.image_banner.field_media
     - field.field.block_content.image_banner.field_padding_options
     - field.field.block_content.image_banner.field_style_variation
+    - field.field.block_content.image_banner.field_style_width
     - field.field.block_content.image_banner.field_text
   module:
     - allowed_formats
@@ -39,6 +40,12 @@ content:
   field_style_variation:
     type: options_select
     weight: 11
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_style_width:
+    type: options_select
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.cta_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.cta_banner.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.block_content.cta_banner.field_padding_options
     - field.field.block_content.cta_banner.field_style_color
     - field.field.block_content.cta_banner.field_style_position
+    - field.field.block_content.cta_banner.field_style_width
     - field.field.block_content.cta_banner.field_text
   module:
     - link
@@ -100,6 +101,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 6
+    region: content
+  field_style_width:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 9
     region: content
   field_text:
     type: text_default

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.grand_hero.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.grand_hero.default.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.block_content.grand_hero.field_style_color
     - field.field.block_content.grand_hero.field_style_position
     - field.field.block_content.grand_hero.field_style_variation
+    - field.field.block_content.grand_hero.field_style_width
     - field.field.block_content.grand_hero.field_text
   module:
     - link
@@ -119,6 +120,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 7
+    region: content
+  field_style_width:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_text:
     type: text_default

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.image_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.image_banner.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.block_content.image_banner.field_media
     - field.field.block_content.image_banner.field_padding_options
     - field.field.block_content.image_banner.field_style_variation
+    - field.field.block_content.image_banner.field_style_width
     - field.field.block_content.image_banner.field_text
   module:
     - options
@@ -38,6 +39,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 5
+    region: content
+  field_style_width:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 6
     region: content
   field_text:
     type: text_default

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.image_banner.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.image_banner.default.yml
@@ -21,7 +21,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: default
+      view_mode: banner_16_5
       link: false
     third_party_settings: {  }
     weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_style_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_style_width.yml
@@ -1,0 +1,21 @@
+uuid: cd1a9a40-26ff-44b5-ac82-a3ff6766f73f
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.cta_banner
+    - field.storage.block_content.field_style_width
+  module:
+    - options
+id: block_content.cta_banner.field_style_width
+field_name: field_style_width
+entity_type: block_content
+bundle: cta_banner
+label: 'Banner Width'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ys_themes_default_value_function
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_style_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_style_width.yml
@@ -1,0 +1,21 @@
+uuid: 51e2f951-3e73-409a-b034-e34a8323d0b5
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.grand_hero
+    - field.storage.block_content.field_style_width
+  module:
+    - options
+id: block_content.grand_hero.field_style_width
+field_name: field_style_width
+entity_type: block_content
+bundle: grand_hero
+label: 'Banner Width'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ys_themes_default_value_function
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.image_banner.field_style_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.image_banner.field_style_width.yml
@@ -1,0 +1,21 @@
+uuid: 37a0f6bb-8c18-4f76-a9eb-186476f7aa82
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.image_banner
+    - field.storage.block_content.field_style_width
+  module:
+    - options
+id: block_content.image_banner.field_style_width
+field_name: field_style_width
+entity_type: block_content
+bundle: image_banner
+label: 'Banner Width'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ys_themes_default_value_function
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -41,6 +41,11 @@ cta_banner:
       left: Left
       right: Right
     default: bottom
+  field_style_width:
+    values:
+      site: Contained
+      full: 'Full Width'
+    default: site
 pull_quote:
   field_style_variation:
     values:
@@ -160,6 +165,11 @@ grand_hero:
       four: Four
       five: Five
     default: one
+  field_style_width:
+    values:
+      site: Contained
+      full: 'Full Width'
+    default: site
 divider:
   field_style_position:
     values:
@@ -317,6 +327,11 @@ image_banner:
       tall: Tall
       short: Short
     default: tall
+  field_style_width:
+    values:
+      site: Contained
+      full: 'Full Width'
+    default: site
 video_banner:
   field_style_width:
     values:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
@@ -27,6 +27,11 @@ cta_banner:
       left: Left
       right: Right
     default: bottom
+  field_style_width:
+    values:
+      site: Contained
+      full: 'Full Width'
+    default: site
 pull_quote:
   field_style_variation:
     values:
@@ -139,6 +144,11 @@ grand_hero:
       four: Four
       five: Five
     default: one
+  field_style_width:
+    values:
+      site: Contained
+      full: 'Full Width'
+    default: site
 divider:
   field_style_position:
     values:
@@ -286,6 +296,11 @@ image_banner:
       tall: Tall
       short: Short
     default: tall
+  field_style_width:
+    values:
+      site: Contained
+      full: 'Full Width'
+    default: site
 accordion:
   field_style_color:
     values:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.deploy.php
@@ -6,6 +6,40 @@
  */
 
 /**
+ * Sets field_style_width to 'site' on existing banner blocks that have no value.
+ */
+function ys_themes_deploy_10302() {
+  $block_storage = \Drupal::entityTypeManager()->getStorage('block_content');
+  $bundles = ['cta_banner', 'grand_hero', 'image_banner'];
+
+  foreach ($bundles as $bundle) {
+    $ids = $block_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', $bundle)
+      ->execute();
+
+    foreach ($ids as $id) {
+      $block = $block_storage->load($id);
+      /** @var \Drupal\Core\Entity\Sql\SqlContentEntityStorage $block_storage */
+      $latest_revision_id = $block_storage->getLatestRevisionId($id);
+
+      if (!$latest_revision_id) {
+        $latest_revision = $block_storage->createRevision($block);
+      }
+      else {
+        $latest_revision = $block_storage->loadRevision($latest_revision_id);
+      }
+
+      /** @var \Drupal\block_content\Entity\BlockContent $latest_revision */
+      if ($latest_revision->get('field_style_width')->isEmpty()) {
+        $latest_revision->set('field_style_width', 'site');
+        $latest_revision->save();
+      }
+    }
+  }
+}
+
+/**
  * Updates existing accordions with default value for component theme.
  */
 function ys_themes_deploy_10301() {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.deploy.php
@@ -6,7 +6,38 @@
  */
 
 /**
- * Sets field_style_width to 'site' on existing banner blocks that have no value.
+ * Updates existing accordions with default value for component theme.
+ */
+function ys_themes_deploy_10301() {
+  $block_storage = \Drupal::entityTypeManager()->getStorage('block_content');
+  $query = $block_storage->getQuery();
+  $query->accessCheck(FALSE)
+    ->condition('type', 'accordion');
+
+  $block_ids = $query->execute();
+
+  foreach ($block_ids as $id) {
+    $block = $block_storage->load($id);
+    /** @var Drupal\Core\Entity\Sql\SqlContentEntityStorage $block_storage */
+    $latestRevisionId = $block_storage->getLatestRevisionId($id);
+
+    if (!$latestRevisionId) {
+      $latestRevision = $block_storage->createRevision($block);
+    }
+    else {
+      $latestRevision = $block_storage->loadRevision($latestRevisionId);
+    }
+
+    /** @var Drupal\block_content\Entity\BlockContent $latestRevision */
+    if ($latestRevision->get('field_style_color')->isEmpty()) {
+      $latestRevision->set('field_style_color', 'default');
+      $latestRevision->save();
+    }
+  }
+}
+
+/**
+ * Sets field_style_width to 'site' on existing banner blocks.
  */
 function ys_themes_deploy_10302() {
   $block_storage = \Drupal::entityTypeManager()->getStorage('block_content');
@@ -35,37 +66,6 @@ function ys_themes_deploy_10302() {
         $latest_revision->set('field_style_width', 'site');
         $latest_revision->save();
       }
-    }
-  }
-}
-
-/**
- * Updates existing accordions with default value for component theme.
- */
-function ys_themes_deploy_10301() {
-  $block_storage = \Drupal::entityTypeManager()->getStorage('block_content');
-  $query = $block_storage->getQuery();
-  $query->accessCheck(FALSE)
-    ->condition('type', 'accordion');
-
-  $block_ids = $query->execute();
-
-  foreach ($block_ids as $id) {
-    $block = $block_storage->load($id);
-    /** @var Drupal\Core\Entity\Sql\SqlContentEntityStorage $block_storage */
-    $latestRevisionId = $block_storage->getLatestRevisionId($id);
-
-    if (!$latestRevisionId) {
-      $latestRevision = $block_storage->createRevision($block);
-    }
-    else {
-      $latestRevision = $block_storage->loadRevision($latestRevisionId);
-    }
-
-    /** @var Drupal\block_content\Entity\BlockContent $latestRevision */
-    if ($latestRevision->get('field_style_color')->isEmpty()) {
-      $latestRevision->set('field_style_color', 'default');
-      $latestRevision->save();
     }
   }
 }


### PR DESCRIPTION
## [#1157 :: Extend Banner Width Control to All Banner Blocks](https://github.com/yalesites-org/YaleSites-Internal/issues/1157)

### Description of work

- Adds a field_style_width "dial" (site / full) to CTA Banner, Grand Hero, and Image Banner block types, surfaced under the Design tab in Layout Builder.
- Defaults all new banner blocks to site width via ys_themes.component_overrides.yml (mirrors the existing video_banner width pattern).
- Adds deploy hook ys_themes_deploy_10302 to backfill existing banner blocks (cta_banner, grand_hero, image_banner) that have no field_style_width value, setting them to site so the colored background overlay continues to render.

**Note:** I notice that the image banner doesn't respect focal point. It has image display set to Default (original image). Grand Hero is also set to original image, but it seems to center the image a little better. You'll notice that if you set the image banner to short, you only see the very top. Let me know if you would like me to update css or image style for the image banner.

Demo:
https://pr-1279-yalesites-platform.pantheonsite.io/node/128/layout

### Functional testing steps:
- [ ] Confirm existing banners gain a site value (no regression — colored background should still render on existing CTA banners).
- [ ] In Layout Builder, add a new CTA Banner / Grand Hero / Image Banner. Under the Design tab, confirm the Width field appears with options Site and Full.
- [ ] Set each banner type to Full and verify the background image/color spans edge-to-edge of the viewport (not just the page content width).
- [ ] Set each back to Site and verify it returns to the standard contained width.
- [ ] Verify no horizontal scrollbar appears at desktop or mobile breakpoints when Full is selected.

Atomic PR: https://github.com/yalesites-org/atomic/pull/462
CL PR: https://github.com/yalesites-org/component-library-twig/pull/645