### PR TITLE
1265: Update Drupal core to 10.6.10 to resolve CVE-2026-46644 (symfony/polyfill-intl-idn)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
   "require": {
     "composer/installers": "^1.9",
     "cweagans/composer-patches": "^1.7",
-    "drupal/core-composer-scaffold": "10.6.9",
-    "drupal/core-project-message": "10.6.9",
-    "drupal/core-recommended": "10.6.9",
+    "drupal/core-composer-scaffold": "10.6.10",
+    "drupal/core-project-message": "10.6.10",
+    "drupal/core-recommended": "10.6.10",
     "drush/drush": "^13",
     "league/commonmark": "^2.0",
     "pantheon-systems/drupal-integrations": "^10",


### PR DESCRIPTION
## [1265: Update Drupal core to 10.6.10 to resolve CVE-2026-46644 (symfony/polyfill-intl-idn)](https://github.com/yalesites-org/YaleSites-Internal/issues/1265)

### Description of work
- Bump `drupal/core-recommended`, `drupal/core-composer-scaffold`, and `drupal/core-project-message` from `10.6.9` → `10.6.10` to resolve CVE-2026-46644 in `symfony/polyfill-intl-idn`

### Functional testing steps:
- [ ] Confirm site loads without errors after deployment
- [ ] Run `lando composer audit` and verify no new advisories (SA-CONTRIB-2025-060 expected to remain)
- [ ] Smoke test key site functionality (content editing, CAS login, navigation)

References yalesites-org/YaleSites-Internal#1265