### PR TITLE
chore: Backport twig/twig advisory hotfix to develop

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,6 +125,11 @@
         "PKSA-dh1f-zjm5-qg8y",
         "PKSA-bn52-vyzy-rmnm",
         "PKSA-xj83-g6g8-41vf",
+        "PKSA-fbvq-z33h-r2np",
+        "PKSA-g9zw-qxh8-pq8w",
+        "PKSA-yd6k-t2gh-1m43",
+        "PKSA-1tmc-rt7x-12w6",
+        "PKSA-xx6c-6d96-db2w",
         "PKSA-5k7f-wvjj-jrgw",
         "PKSA-sjvz-tbbr-vwth",
         "PKSA-h8hf-ytnd-5t9q",
@@ -134,7 +139,8 @@
         "PKSA-3mcc-k66d-pydb",
         "PKSA-gw7n-z4yx-7xjt",
         "PKSA-dpx1-78wg-1kqs",
-        "PKSA-21g2-dzjv-sky5"
+        "PKSA-21g2-dzjv-sky5",
+        "PKSA-dwsq-ppd2-mb1x"
       ]
     },
     "preferred-install": "dist",
@@ -153,6 +159,13 @@
       "php-http/discovery": true,
       "phpstan/extension-installer": true,
       "tbachert/spi": true
+    }
+  },
+  "policy": {
+    "advisories": {
+      "ignore": [
+        "twig/twig"
+      ]
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -125,11 +125,6 @@
         "PKSA-dh1f-zjm5-qg8y",
         "PKSA-bn52-vyzy-rmnm",
         "PKSA-xj83-g6g8-41vf",
-        "PKSA-fbvq-z33h-r2np",
-        "PKSA-g9zw-qxh8-pq8w",
-        "PKSA-yd6k-t2gh-1m43",
-        "PKSA-1tmc-rt7x-12w6",
-        "PKSA-xx6c-6d96-db2w",
         "PKSA-5k7f-wvjj-jrgw",
         "PKSA-sjvz-tbbr-vwth",
         "PKSA-h8hf-ytnd-5t9q",
@@ -139,8 +134,7 @@
         "PKSA-3mcc-k66d-pydb",
         "PKSA-gw7n-z4yx-7xjt",
         "PKSA-dpx1-78wg-1kqs",
-        "PKSA-21g2-dzjv-sky5",
-        "PKSA-dwsq-ppd2-mb1x"
+        "PKSA-21g2-dzjv-sky5"
       ]
     },
     "preferred-install": "dist",
@@ -159,13 +153,6 @@
       "php-http/discovery": true,
       "phpstan/extension-installer": true,
       "tbachert/spi": true
-    }
-  },
-  "policy": {
-    "advisories": {
-      "ignore": [
-        "twig/twig"
-      ]
     }
   },
   "scripts": {

--- a/web/profiles/custom/yalesites_profile/yalesites_profile.info.yml
+++ b/web/profiles/custom/yalesites_profile/yalesites_profile.info.yml
@@ -1,6 +1,6 @@
 name: YaleSites Profile
 type: profile
-version: 2.22.1
+version: 2.22.2
 description: 'Install profile for managing YaleSites platform sites.'
 core_version_requirement: '^9 || ^10'
 


### PR DESCRIPTION
## Backport twig/twig advisory hotfix to develop

### Description of work
- Gets master and develop back in sync (hotfix was only for 10.3, and 10.6 doesn't need it)

### Functional testing steps:
- [ ] Builds fine