### PR TITLE
#1267 :: Surface Manage Settings actions out of triple dot menu

### DIFF
--- a/web/themes/custom/ys_admin_theme/ys_admin_theme.theme
+++ b/web/themes/custom/ys_admin_theme/ys_admin_theme.theme
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
 use Drupal\node\Entity\Node;
 
 /**
@@ -45,6 +46,17 @@ function ys_admin_theme_set_title_on_node_edit_page(array &$variables) {
  * Implements hook_form_BASE_FORM_ID_alter() for node_form.
  */
 function ys_admin_theme_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Surface workflow action buttons instead of hiding them in Gin's "More
+  // actions" overflow: flag each submit so Gin shows it inline. Delete is a
+  // link, which Gin keeps in the overflow.
+  if (isset($form['actions'])) {
+    foreach (Element::children($form['actions']) as $action_key) {
+      if (($form['actions'][$action_key]['#type'] ?? '') === 'submit') {
+        $form['actions'][$action_key]['#gin_action_item'] = TRUE;
+      }
+    }
+  }
+
   /** @var Drupal\node\NodeForm $node_form */
   $node_form = $form_state->getFormObject();
 

--- a/web/themes/custom/ys_admin_theme/ys_admin_theme.theme
+++ b/web/themes/custom/ys_admin_theme/ys_admin_theme.theme
@@ -63,6 +63,15 @@ function ys_admin_theme_form_node_form_alter(&$form, FormStateInterface $form_st
   /** @var Drupal\node\Entity\Node $node */
   $node = $node_form->getEntity();
 
+  // Demote the event "Archive" button. Prepended to run before Gin's
+  // after_build.
+  if ($node->bundle() === 'event') {
+    $form['#after_build'] = array_merge(
+      ['ys_admin_theme_demote_archive_button'],
+      $form['#after_build'] ?? []
+    );
+  }
+
   // Only run for page nodes.
   if ($node->bundle() !== 'page') {
     return;
@@ -144,4 +153,33 @@ function ys_admin_theme_book_fields_validate(&$form, FormStateInterface $form_st
       }
     }
   }
+}
+
+/**
+ * After-build: hide the "Archive" button on new nodes, else move it to kebab.
+ *
+ * @param array $form
+ *   The built form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The current state of the form.
+ *
+ * @return array
+ *   The altered form.
+ */
+function ys_admin_theme_demote_archive_button(array $form, FormStateInterface $form_state) {
+  $is_new = $form_state->getFormObject()->getEntity()->isNew();
+
+  foreach (['actions', 'actions_top'] as $region) {
+    if (!isset($form[$region]['moderation_state_archived'])) {
+      continue;
+    }
+    if ($is_new) {
+      $form[$region]['moderation_state_archived']['#access'] = FALSE;
+    }
+    else {
+      $form[$region]['moderation_state_archived']['#gin_action_item'] = FALSE;
+    }
+  }
+
+  return $form;
 }

--- a/web/themes/custom/ys_admin_theme/ys_admin_theme.theme
+++ b/web/themes/custom/ys_admin_theme/ys_admin_theme.theme
@@ -63,11 +63,11 @@ function ys_admin_theme_form_node_form_alter(&$form, FormStateInterface $form_st
   /** @var Drupal\node\Entity\Node $node */
   $node = $node_form->getEntity();
 
-  // Demote the event "Archive" button. Prepended to run before Gin's
+  // Hide the "Archive" button on new nodes. Prepended to run before Gin's
   // after_build.
-  if ($node->bundle() === 'event') {
+  if ($node->isNew()) {
     $form['#after_build'] = array_merge(
-      ['ys_admin_theme_demote_archive_button'],
+      ['ys_admin_theme_hide_archive_button'],
       $form['#after_build'] ?? []
     );
   }
@@ -156,7 +156,7 @@ function ys_admin_theme_book_fields_validate(&$form, FormStateInterface $form_st
 }
 
 /**
- * After-build: hide the "Archive" button on new nodes, else move it to kebab.
+ * After-build: hide the "Archive" workflow button (used on new nodes).
  *
  * @param array $form
  *   The built form.
@@ -166,18 +166,11 @@ function ys_admin_theme_book_fields_validate(&$form, FormStateInterface $form_st
  * @return array
  *   The altered form.
  */
-function ys_admin_theme_demote_archive_button(array $form, FormStateInterface $form_state) {
-  $is_new = $form_state->getFormObject()->getEntity()->isNew();
-
+function ys_admin_theme_hide_archive_button(array $form, FormStateInterface $form_state) {
+  // workflow_buttons copies the actions into actions_top under Gin.
   foreach (['actions', 'actions_top'] as $region) {
-    if (!isset($form[$region]['moderation_state_archived'])) {
-      continue;
-    }
-    if ($is_new) {
+    if (isset($form[$region]['moderation_state_archived'])) {
       $form[$region]['moderation_state_archived']['#access'] = FALSE;
-    }
-    else {
-      $form[$region]['moderation_state_archived']['#gin_action_item'] = FALSE;
     }
   }
 


### PR DESCRIPTION
## [#1267: Surface Manage Settings actions out of triple dot menu](https://github.com/yalesites-org/YaleSites-Internal/issues/1267)

### Description of work
- Surface node manage settings outside of kebab menu

### Functional testing steps:
- [ ] Visit any node edit form
- [ ] Verify the manage action buttons are outside of the kebab menu (other than delete). This is the same behavior as previous.
