### PR TITLE
1177: Add Breadcrumb Visibility Toggle to Page Meta Settings

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
@@ -68,6 +68,7 @@ third_party_settings:
               provider: ys_layouts
               context_mapping: {  }
               page_title_display: visible
+              breadcrumb_display: visible
             weight: 0
             additional: {  }
         third_party_settings:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/page-meta/layout--page-meta.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/page-meta/layout--page-meta.html.twig
@@ -8,6 +8,7 @@
  * - content: The content for this layout.
  * - attributes: HTML attributes for the layout <div>.
  * - show_secondary_nav: Whether or not to show the secondary nav.
+ * - show_breadcrumbs: Whether or not to show the breadcrumb trail.
  */
 #}
 {%
@@ -36,7 +37,9 @@
 {% if content.page_meta %}
   <div{{ attributes.addClass(classes) }}>
     <div {{ region_attribute_classes }}>
-      {{ drupal_entity('block', 'yalesitesbreadcrumbs', check_access=false) }}
+      {% if show_breadcrumbs is not defined or show_breadcrumbs %}
+        {{ drupal_entity('block', 'yalesitesbreadcrumbs', check_access=false) }}
+      {% endif %}
 
       {% if show_secondary_nav %}
         {{ drupal_entity('block', 'atomic_custombooknavigation', check_access=false) }}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PageMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/PageMetaBlock.php
@@ -120,6 +120,18 @@ class PageMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
       '#description' => $this->t('For more information about conditional banner titles, <a href="https://yalesites.yale.edu/posts/2023-10-17-community-spotlight-yale-united-way-campaign#tips" target="_blank">view our tips and tricks on this topic</a>.'),
     ];
 
+    // Controls whether the breadcrumb trail displays above this page.
+    $form['breadcrumb_display'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Breadcrumb Display'),
+      '#default_value' => $config['breadcrumb_display'] ?? 'visible',
+      '#options' => [
+        'visible' => $this->t('Display breadcrumbs: Show the breadcrumb trail above this page'),
+        'hidden' => $this->t('Hide breadcrumbs: Useful for top-level pages where the trail adds little value'),
+      ],
+      '#description' => $this->t('Breadcrumbs help visitors understand where a page sits within the site. They are shown by default.'),
+    ];
+
     return $form;
   }
 
@@ -129,6 +141,7 @@ class PageMetaBlock extends BlockBase implements ContainerFactoryPluginInterface
   public function blockSubmit($form, FormStateInterface $form_state) : void {
     parent::blockSubmit($form, $form_state);
     $this->configuration['page_title_display'] = $form_state->getValue('page_title_display');
+    $this->configuration['breadcrumb_display'] = $form_state->getValue('breadcrumb_display');
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\Context\Context;
 use Drupal\Core\Plugin\Context\EntityContextDefinition;
@@ -352,6 +353,30 @@ function ys_layouts_preprocess_layout(&$variables) {
       // Replace underscores with hyphens.
       $padding_options = str_replace('_', '-', $config['padding_options']);
       $variables['settings']['padding'] = $padding_options;
+    }
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for the page_meta layout.
+ *
+ * Reads the breadcrumb visibility setting from the Page Meta block and exposes
+ * it to the layout template, which renders the breadcrumb block at the layout
+ * level rather than inside the block itself. Breadcrumbs default to visible so
+ * existing pages are unaffected.
+ */
+function ys_layouts_preprocess_layout__page_meta(&$variables) {
+  $variables['show_breadcrumbs'] = TRUE;
+
+  $entity = $variables['content']['#entity'] ?? NULL;
+  if ($entity instanceof FieldableEntityInterface && $entity->hasField('layout_builder__layout')) {
+    foreach ($entity->get('layout_builder__layout')->getSections() as $section) {
+      foreach ($section->getComponents() as $component) {
+        $configuration = $component->get('configuration');
+        if (($configuration['id'] ?? '') === 'page_meta_block' && ($configuration['breadcrumb_display'] ?? 'visible') === 'hidden') {
+          $variables['show_breadcrumbs'] = FALSE;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## [1177: Add Breadcrumb Visibility Toggle to Page Meta Settings](https://github.com/yalesites-org/YaleSites-Internal/issues/1177)

### Description of work
- Adds a "Breadcrumb Display" dropdown (Display / Hide, default Display) to the Page Meta block settings in the Layout Builder, mirroring the existing Title Display control.
- Bridges the setting to the page-meta layout via a new `ys_layouts_preprocess_layout__page_meta()` hook that reads the Page Meta block configuration and exposes a `show_breadcrumbs` flag; the layout template gates the breadcrumb block on it.
- Sets `breadcrumb_display: visible` as the default in the Page content type's default layout, so existing pages are unaffected.
- Scope: the Page Meta block exists only on the Page content type, so this control applies to Page only. Post, Event, Profile, and Resource render breadcrumbs from their node templates and are unchanged.

### Functional testing steps:
- [ ] On a Page that currently shows breadcrumbs (one nested under another in the navigation), go to "Edit Layout and Content" → edit the Page Meta Block → confirm a "Breadcrumb Display" dropdown appears beside "Title Display", defaulting to "Display breadcrumbs".
- [ ] Set it to "Hide breadcrumbs", save the block and the layout; view the page and confirm the breadcrumb trail no longer appears (the rest of the page renders normally).
- [ ] Set it back to "Display breadcrumbs"; confirm the breadcrumb trail returns.
- [ ] Visit another nested Page you did not edit; confirm its breadcrumbs still display (default behavior unchanged).
- [ ] Visit a Post, Event, Profile, and Resource; confirm breadcrumbs are unchanged (out of scope for this issue).
- [ ] Confirm the "Breadcrumb Display" dropdown is keyboard accessible (focus and change it using only the keyboard).

References yalesites-org/YaleSites-Internal#1177
