### PR TITLE
1299: Image Banner: Add "mini" media height option

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -316,6 +316,7 @@ image_banner:
     values:
       tall: Tall
       short: Short
+      mini: Mini
     default: tall
 video_banner:
   field_style_width:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
@@ -285,6 +285,7 @@ image_banner:
     values:
       tall: Tall
       short: Short
+      mini: Mini
     default: tall
 accordion:
   field_style_color:


### PR DESCRIPTION
## [1299: Image Banner: Add "mini" media height option](https://github.com/yalesites-org/YaleSites-Internal/issues/1299)

### Description of work
- Add a `mini: Mini` value to the Image Banner `field_style_variation` dial so editors can choose a compact banner height, matching the Grand Hero Banner mini option.
- Update both the active/sync config and the `ys_themes` module install config so new installs and existing sites stay in sync.
- Other work completed in: yalesites-org/component-library-twig#648

### Functional testing steps:
- [ ] On the multidev, edit a page and add (or edit) an Image Banner block.
- [ ] In the block's Media Size dial, confirm `Mini` appears as an option alongside `Tall` and `Short`.
- [ ] Select `Mini`, save, and confirm the banner renders at the compact (14rem) height on the published page across breakpoints.
- [ ] Confirm existing Image Banners (default `Tall`) are visually unchanged.

References yalesites-org/YaleSites-Internal#1299



Created with AI


---

## Caption contrast fix (follow-up to review)

A review comment on this PR found the image banner caption rendering **white-on-white** in some global theme settings. Fixed in component-library-twig (`components/02-molecules/banner/image/yds-image-banner.scss`), CLT commit `ad27f808`.

**Root cause:** The caption sits on a hardcoded white bar (`background-color: var(--color-basic-white)`). In themed banners the shared `.caption` rule set the text to `var(--color-text)`, which component themes one/three/five remap to white (`slot-eight`) — i.e. white text on a white bar.

**Fix:** On the `figcaption`, reset `--color-text` to `var(--color-slot-seven)` — the palette's existing "text on light background" slot. It resolves to a dark color in every global and component theme, so the shared caption rule stays readable. No invented colors; an existing token only. Documented in-code; can be swapped to `var(--color-basic-black)` if a flat black caption is preferred later.

**Caption text color by theme (on the white bar):**

| Context | Resolved color | Contrast |
|---|---|---|
| default / component theme `two` | brown-gray `rgb(120,112,104)` | 4.87:1 (unchanged) |
| component themes `one`/`three`/`four`/`five` | slot-seven → gray-800 `rgb(33,33,33)` | 16.1:1 |
| any component theme under global theme `five` | slot-seven → gray-900 `rgb(28,28,28)` | 17.04:1 |
| any component theme under global theme `four` | slot-seven → blue-yale `rgb(0,54,107)` | 12.07:1 |

**Verified:** all 7 global × 6 component-theme permutations (42 total) pass WCAG 2.1 A/AA (minimum 4.87:1) in **both** Storybook and the Drupal/Lando instance.

**Out of scope:** a link placed *inside* a caption (none in the test content) still inherits the banner link color — a pre-existing behavior, not changed here.
