### PR TITLE
953: Option to remove Register CTA in Event View

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.node.event.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_format
+    - field.field.node.event.field_event_hide_register
     - field.field.node.event.field_event_id
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_recurring
@@ -323,6 +324,13 @@ content:
     settings:
       rows: 5
       placeholder: ''
+    third_party_settings: {  }
+  field_event_hide_register:
+    type: boolean_checkbox
+    weight: 50
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_event_id:
     type: string_textfield

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_event_hide_register.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.event.field_event_hide_register.yml
@@ -1,0 +1,21 @@
+uuid: ff0ccd2a-ebd5-4dfe-98a7-225ebe0d278b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_hide_register
+    - node.type.event
+id: node.event.field_event_hide_register
+field_name: field_event_hide_register
+entity_type: node
+bundle: event
+label: 'Hide registration button'
+description: 'Hide the Register / Buy Tickets button on this event, even when a registration link is present.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_event_hide_register.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.node.field_event_hide_register.yml
@@ -1,0 +1,18 @@
+uuid: 6b7ee7f5-d721-4864-b0cd-5184f1118e67
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_event_hide_register
+field_name: field_event_hide_register
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -140,6 +140,30 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
   }
 
   /**
+   * Suppresses the registration CTA when an editor has opted to hide it.
+   *
+   * When hidden, both the register flag and the ticket/registration link are
+   * cleared so the event template — which renders the button from those values
+   * — shows no registration CTA (#953).
+   *
+   * @param bool $hide
+   *   Whether the editor opted to hide the registration button.
+   * @param bool $hasRegister
+   *   The computed register flag.
+   * @param string|null $ticketLink
+   *   The computed ticket/registration URL.
+   *
+   * @return array
+   *   A [hasRegister, ticketLink] pair with the suppression applied.
+   */
+  public static function applyRegisterSuppression(bool $hide, bool $hasRegister, ?string $ticketLink): array {
+    if ($hide) {
+      return [FALSE, NULL];
+    }
+    return [$hasRegister, $ticketLink];
+  }
+
+  /**
    * Gets event all fields.
    */
   public function getEventData($node) {
@@ -191,6 +215,15 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
     else {
       $hasRegister = FALSE;
     }
+
+    // Editors can hide the registration / buy-tickets CTA on an event even
+    // when a registration link is present — the Localist feed (e.g. Campus
+    // Groups) always fills field_ticket_registration_url, so this gives the
+    // same opt-out the "Add to Calendar" link has (#953).
+    $hideRegister = $node->hasField('field_event_hide_register')
+      && !$node->get('field_event_hide_register')->isEmpty()
+      && (bool) $node->get('field_event_hide_register')->first()->getValue()['value'];
+    [$hasRegister, $ticketLink] = self::applyRegisterSuppression($hideRegister, $hasRegister, $ticketLink);
 
     // Dates.
     $dates = $node->field_event_date->getValue();

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/tests/src/Unit/RegisterSuppressionTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/tests/src/Unit/RegisterSuppressionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\Tests\ys_localist\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_localist\MetaFieldsManager;
+
+/**
+ * Tests the event registration-CTA suppression helper (#953).
+ *
+ * @coversDefaultClass \Drupal\ys_localist\MetaFieldsManager
+ *
+ * @group yalesites
+ */
+class RegisterSuppressionTest extends UnitTestCase {
+
+  /**
+   * When not hidden, the register flag and ticket link pass through unchanged.
+   *
+   * @covers ::applyRegisterSuppression
+   */
+  public function testPassthroughWhenNotHidden() {
+    $this->assertSame(
+      [TRUE, 'https://example.com/rsvp'],
+      MetaFieldsManager::applyRegisterSuppression(FALSE, TRUE, 'https://example.com/rsvp')
+    );
+    $this->assertSame(
+      [FALSE, NULL],
+      MetaFieldsManager::applyRegisterSuppression(FALSE, FALSE, NULL)
+    );
+  }
+
+  /**
+   * When hidden, both the register flag and the ticket link are cleared.
+   *
+   * @covers ::applyRegisterSuppression
+   */
+  public function testSuppressedWhenHidden() {
+    // Even with a register flag and an always-present rsvp link, hiding wins.
+    $this->assertSame(
+      [FALSE, NULL],
+      MetaFieldsManager::applyRegisterSuppression(TRUE, TRUE, 'https://example.com/rsvp')
+    );
+  }
+
+}


### PR DESCRIPTION
## [953: Option to remove Register CTA in Event View](https://github.com/yalesites-org/YaleSites-Internal/issues/953)

### Description of work
- Add a per-event "Hide registration button" field (`field_event_hide_register`) on the event content type, surfaced on the event edit form.
- `MetaFieldsManager::getEventData()` reads it and, when set, clears `has_register` and the ticket/registration URL via the unit-tested `applyRegisterSuppression()` helper, so the event templates render no registration CTA. Mirrors the existing "Add to Calendar" hide; addresses the always-present Campus Groups/Localist RSVP link.
- chore: temporarily ignore `SA-CORE-2026-005..009` in composer to unblock dependency resolution (stopgap — core stays on 10.6.10; proper fix is a core upgrade).

Note for review: the alternative of relabeling "Register" to "Details" was not taken (confirm hide-vs-relabel with product). Visual hiding depends on the atomic event template gating on `has_register`/`ticket_url`; verify on a running site.

### Functional testing steps:
- [ ] On an event with a registration/ticket link, confirm the Register / Buy Tickets button still appears in the event feed.
- [ ] Check "Hide registration button" and save; confirm the button no longer renders in the feed/teaser.
- [ ] Uncheck it; confirm the button returns.

References yalesites-org/YaleSites-Internal#953

Created with AI
