### PR TITLE
1341: Editoria11y overlay appears on content creation pages in the admin UI

### DIFF
--- a/.ci/deploy/pantheon/dev-multidev
+++ b/.ci/deploy/pantheon/dev-multidev
@@ -21,7 +21,10 @@ else
 fi
 
 # Wake the environment to make sure the database is reachable.
-terminus -n env:wake "$TERMINUS_SITE.$TERMINUS_ENV" --retry=5 --delay=30
+# The preceding build:env:create switches the environment to SFTP mode, which
+# restarts its app containers in the background; 5x30s wasn't enough margin for
+# that restart under current Pantheon platform conditions, so give it more room.
+terminus -n env:wake "$TERMINUS_SITE.$TERMINUS_ENV" --retry=10 --delay=30
 
 # Run drush deploy - updb, cr, cim, cr, deploy:hook
 terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- deploy -v -y

--- a/.ci/deploy/pantheon/dev-multidev
+++ b/.ci/deploy/pantheon/dev-multidev
@@ -21,10 +21,7 @@ else
 fi
 
 # Wake the environment to make sure the database is reachable.
-# The preceding build:env:create switches the environment to SFTP mode, which
-# restarts its app containers in the background; 5x30s wasn't enough margin for
-# that restart under current Pantheon platform conditions, so give it more room.
-terminus -n env:wake "$TERMINUS_SITE.$TERMINUS_ENV" --retry=10 --delay=30
+terminus -n env:wake "$TERMINUS_SITE.$TERMINUS_ENV" --retry=5 --delay=30
 
 # Run drush deploy - updb, cr, cim, cr, deploy:hook
 terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- deploy -v -y

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Editoria11yRouteSuppressor.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Editoria11yRouteSuppressor.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\ys_core;
+
+/**
+ * Decides whether the Editoria11y checker should run on a given route.
+ *
+ * Editoria11y attaches its library on every page, including authoring forms
+ * where its overlay adds no value. This helper centralises the rule for which
+ * routes it should be removed from, so the decision is unit-testable in
+ * isolation from the render pipeline.
+ */
+class Editoria11yRouteSuppressor {
+
+  /**
+   * Routes where Editoria11y must keep running despite living under /admin.
+   *
+   * These are Editoria11y's own pages (the results dashboard and the demo),
+   * which need the library to function.
+   */
+  protected const ALLOWED_ROUTES = [
+    'editoria11y.reports_dashboard',
+    'editoria11y.demo',
+  ];
+
+  /**
+   * Determines whether Editoria11y should be suppressed on a route.
+   *
+   * @param string|null $route_name
+   *   The current route name, or NULL when no route matched.
+   * @param bool $is_admin_route
+   *   Whether the current route is an administrative route.
+   *
+   * @return bool
+   *   TRUE if Editoria11y should be removed (admin/authoring routes), FALSE if
+   *   it should be left in place (front-facing pages and Editoria11y's own
+   *   pages).
+   */
+  public static function shouldSuppress(?string $route_name, bool $is_admin_route): bool {
+    if ($route_name === NULL) {
+      return FALSE;
+    }
+
+    // Keep Editoria11y on its own pages, even though they live under /admin.
+    if (in_array($route_name, self::ALLOWED_ROUTES, TRUE)) {
+      return FALSE;
+    }
+
+    // Suppress on admin routes (e.g. node add/edit when the admin theme is used
+    // for editing, plus /admin/* forms such as block, media, and term add).
+    if ($is_admin_route) {
+      return TRUE;
+    }
+
+    // Also suppress on entity authoring forms that are not flagged as admin
+    // routes (e.g. taxonomy term edit at /taxonomy/term/{id}/edit).
+    return (bool) preg_match('/\.(add|add_form|edit_form|delete_form)$/', $route_name)
+      || str_ends_with($route_name, '_create');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/Editoria11yRouteSuppressorTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/Editoria11yRouteSuppressorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_core\Editoria11yRouteSuppressor;
+
+/**
+ * Tests the route rules for suppressing the Editoria11y checker.
+ *
+ * Regression coverage for the bug where the Editoria11y overlay appeared on
+ * content authoring forms in the admin UI. The checker should run on
+ * front-facing content and on Editoria11y's own pages, but not on
+ * admin/authoring routes.
+ *
+ * @coversDefaultClass \Drupal\ys_core\Editoria11yRouteSuppressor
+ *
+ * @group ys_core
+ */
+class Editoria11yRouteSuppressorTest extends UnitTestCase {
+
+  /**
+   * @covers ::shouldSuppress
+   *
+   * @dataProvider routeProvider
+   */
+  public function testShouldSuppress(?string $route_name, bool $is_admin_route, bool $expected): void {
+    $this->assertSame(
+      $expected,
+      Editoria11yRouteSuppressor::shouldSuppress($route_name, $is_admin_route)
+    );
+  }
+
+  /**
+   * Provides route names with the admin flag and the expected suppression.
+   *
+   * @return array
+   *   Each case: [route name, is admin route, expected shouldSuppress()].
+   */
+  public static function routeProvider(): array {
+    return [
+      // Editoria11y's own pages are kept even though they are admin routes.
+      'reports dashboard kept' => ['editoria11y.reports_dashboard', TRUE, FALSE],
+      'demo kept' => ['editoria11y.demo', TRUE, FALSE],
+
+      // Front-facing routes keep the checker.
+      'node canonical kept' => ['entity.node.canonical', FALSE, FALSE],
+      'public profile kept' => ['entity.user.canonical', FALSE, FALSE],
+      'view listing kept' => ['view.frontend_listing.page_1', FALSE, FALSE],
+      'node preview kept' => ['entity.node.preview', FALSE, FALSE],
+
+      // Admin routes are suppressed regardless of name.
+      'admin content listing suppressed' => ['system.admin_content', TRUE, TRUE],
+      'admin config suppressed' => ['system.admin_config', TRUE, TRUE],
+
+      // Authoring forms are suppressed by name pattern even when the route is
+      // not flagged as an admin route (e.g. taxonomy term edit).
+      'node add suppressed' => ['node.add', FALSE, TRUE],
+      'node edit suppressed' => ['entity.node.edit_form', FALSE, TRUE],
+      'node delete suppressed' => ['entity.node.delete_form', FALSE, TRUE],
+      'term add suppressed' => ['entity.taxonomy_term.add_form', FALSE, TRUE],
+      'term edit suppressed' => ['entity.taxonomy_term.edit_form', FALSE, TRUE],
+      'block add suppressed' => ['entity.block_content.add_form', FALSE, TRUE],
+      'media edit suppressed' => ['entity.media.edit_form', FALSE, TRUE],
+      'user create suppressed' => ['user.admin_create', FALSE, TRUE],
+
+      // No matched route keeps the checker (defensive: never crash on NULL).
+      'null route kept' => [NULL, FALSE, FALSE],
+    ];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -17,6 +17,7 @@ use Drupal\Core\Session\AccountProxy;
 use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\Component\Utility\NestedArray;
+use Drupal\ys_core\Editoria11yRouteSuppressor;
 
 // Include coffee commands.
 require_once __DIR__ . '/ys_core.coffee.inc';
@@ -529,6 +530,30 @@ function ys_core_page_attachments(array &$page) {
   $favicons = \Drupal::service('ys_core.media_manager')->getFavicons();
   foreach ($favicons as $name => $favicon) {
     $page['#attached']['html_head'][] = [$favicon, $name];
+  }
+}
+
+/**
+ * Implements hook_page_attachments_alter().
+ */
+function ys_core_page_attachments_alter(array &$attachments) {
+  // The Editoria11y accessibility checker attaches its library on every page
+  // (including authoring forms), where its overlay adds no value. Remove it on
+  // admin/authoring routes so it only runs on front-facing content and on
+  // Editoria11y's own pages. Done in the alter so it runs after Editoria11y's
+  // own hook_page_attachments().
+  $libraries = $attachments['#attached']['library'] ?? [];
+  if (!in_array('editoria11y/editoria11y', $libraries, TRUE)) {
+    return;
+  }
+
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  $is_admin_route = \Drupal::service('router.admin_context')->isAdminRoute();
+  if (Editoria11yRouteSuppressor::shouldSuppress($route_name, $is_admin_route)) {
+    $attachments['#attached']['library'] = array_values(array_diff($libraries, [
+      'editoria11y/editoria11y',
+      'editoria11y/editoria11y-dashboard',
+    ]));
   }
 }
 


### PR DESCRIPTION
## [1341: Editoria11y overlay appears on content creation pages in the admin UI](https://github.com/yalesites-org/YaleSites-Internal/issues/1341)

### Description of work
- Add a `hook_page_attachments_alter()` in `ys_core` that removes the Editoria11y libraries on admin/authoring routes, so the checker no longer loads on content creation/edit forms. No contrib module edits.
- Decision logic lives in a pure, unit-tested helper `Editoria11yRouteSuppressor::shouldSuppress()` — keeps Editoria11y on front-facing pages and on its own pages (results dashboard, demo); suppresses it on admin routes and entity authoring forms (node/term/block/media add/edit/delete, incl. taxonomy term edit, which is not flagged as an admin route).
- Add `Editoria11yRouteSuppressorTest` (17 unit cases).

### Also included: security updates (CVEs)
`develop` currently fails `static_tests` because a newly published advisory blocks the pinned version of `drupal/paragraphs`, so this PR bundles the dependency bump that resolves it. These updates are unrelated to the Editoria11y fix and become a no-op once the same bump is merged to `develop` on its own:
- `drupal/paragraphs` 1.20.0 → 1.21.0 — fixes SA-CONTRIB-2026-060 / SA-CONTRIB-2026-061 (Composer's advisory pool filter excludes 1.20.0).
- `drupal/core` (core-recommended / core-composer-scaffold / core-project-message) 10.6.11 → 10.6.12.

### Functional testing steps:
- [ ] Run `drush cr` after deploy (a new hook implementation must register before it runs).
- [ ] Visit `/node/add/page` (and Post/Event) — Editoria11y overlay/toggle should NOT appear.
- [ ] Edit an existing node (`/node/{id}/edit`) — no overlay.
- [ ] Edit a taxonomy term, a reusable block, and a media item — no overlay.
- [ ] View a published front-facing Page/Post/Event — overlay still appears and works.
- [ ] Visit `/admin/reports/editoria11y` — results dashboard still loads.
- [ ] Confirm `composer install` / `static_tests` pass (paragraphs resolves to 1.21.0, no advisory block).

References yalesites-org/YaleSites-Internal#1341