### PR TITLE
1345: RC: reCAPTCHA badge overlay appearing in bottom right on pages with pre-built forms

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/recaptcha_v3.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/recaptcha_v3.settings.yml
@@ -7,3 +7,4 @@ verify_hostname: true
 default_challenge: recaptcha/reCAPTCHA
 error_message: 'Antibot verification failed.'
 cacheable: false
+hide_badge: true

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/css/recaptcha-disclosure.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/css/recaptcha-disclosure.css
@@ -1,0 +1,18 @@
+/**
+ * @file
+ * Layout for the reCAPTCHA disclosure rendered below a form.
+ *
+ * The disclosure uses the inline-message component, contained to the form's
+ * width rather than the full page. This adds the gap that separates it from
+ * the form above, plus consistent internal padding so the content is not flush
+ * against the box edge in layouts (such as multi-column) where the component's
+ * usual site-gutter is suppressed. Both values reuse shared spacing tokens.
+ */
+
+.ys-captcha-disclosure {
+  margin-block-start: var(--size-spacing-7);
+}
+
+.ys-captcha-disclosure .inline-message {
+  padding-inline: var(--size-spacing-site-gutter);
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/tests/src/Kernel/ReCaptchaDisclosureTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/tests/src/Kernel/ReCaptchaDisclosureTest.php
@@ -6,11 +6,12 @@ use Drupal\Core\Form\FormState;
 use Drupal\KernelTests\KernelTestBase;
 
 /**
- * Tests the reCAPTCHA disclosure added when the badge is hidden.
+ * Tests ys_captcha's form alterations for forms carrying a captcha element.
  *
- * Google's reCAPTCHA terms require the "protected by reCAPTCHA" disclosure to
- * be shown in the user flow when the badge is hidden. ys_captcha adds it to
- * forms that carry a captcha element.
+ * The module adds the shared "form-item" class to the captcha fieldset so it
+ * lines up with the form's fields, and -- because Google's reCAPTCHA terms
+ * require the "protected by reCAPTCHA" disclosure to be shown in the user flow
+ * when the badge is hidden -- adds that disclosure inline.
  *
  * @group ys_captcha
  * @group yalesites
@@ -73,21 +74,34 @@ class ReCaptchaDisclosureTest extends KernelTestBase {
   }
 
   /**
-   * Disclosure is added when the badge is hidden and a captcha is present.
+   * Disclosure is added, via the inline-message component, when badge hidden.
    */
   public function testDisclosureAddedWhenBadgeHiddenAndCaptchaPresent(): void {
     $this->setHideBadge(TRUE);
     $form = $this->alter($this->formWithCaptcha());
 
     $this->assertArrayHasKey(self::DISCLOSURE_KEY, $form);
-    $markup = (string) $form[self::DISCLOSURE_KEY]['text']['#markup'];
-    $this->assertStringContainsString('reCAPTCHA', $markup);
-    $this->assertStringContainsString('https://policies.google.com/privacy', $markup);
-    $this->assertStringContainsString('https://policies.google.com/terms', $markup);
+    $this->assertSame('inline_template', $form[self::DISCLOSURE_KEY]['#type']);
+    $this->assertStringContainsString('@molecules/inline-message/yds-inline-message.twig', $form[self::DISCLOSURE_KEY]['#template']);
+
+    $content = (string) $form[self::DISCLOSURE_KEY]['#context']['content'];
+    $this->assertStringContainsString('reCAPTCHA', $content);
+    $this->assertStringContainsString('https://policies.google.com/privacy', $content);
+    $this->assertStringContainsString('https://policies.google.com/terms', $content);
   }
 
   /**
-   * Disclosure is added when the captcha element is nested (webform case).
+   * The captcha fieldset gets the form-item class regardless of badge state.
+   */
+  public function testCaptchaFieldsetGetsFormItemClass(): void {
+    $this->setHideBadge(FALSE);
+    $form = $this->alter($this->formWithCaptcha());
+
+    $this->assertContains('form-item', $form['captcha']['#attributes']['class']);
+  }
+
+  /**
+   * Nested captcha elements (webform case) get both alterations applied.
    */
   public function testDisclosureAddedForNestedCaptcha(): void {
     $this->setHideBadge(TRUE);
@@ -105,6 +119,7 @@ class ReCaptchaDisclosureTest extends KernelTestBase {
     $form = $this->alter($form);
 
     $this->assertArrayHasKey(self::DISCLOSURE_KEY, $form);
+    $this->assertContains('form-item', $form['elements']['wrapper']['captcha']['#attributes']['class']);
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/tests/src/Kernel/ReCaptchaDisclosureTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/tests/src/Kernel/ReCaptchaDisclosureTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Drupal\Tests\ys_captcha\Kernel;
+
+use Drupal\Core\Form\FormState;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the reCAPTCHA disclosure added when the badge is hidden.
+ *
+ * Google's reCAPTCHA terms require the "protected by reCAPTCHA" disclosure to
+ * be shown in the user flow when the badge is hidden. ys_captcha adds it to
+ * forms that carry a captcha element.
+ *
+ * @group ys_captcha
+ * @group yalesites
+ */
+class ReCaptchaDisclosureTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'captcha',
+    'recaptcha_v3',
+    'ys_captcha',
+  ];
+
+  /**
+   * The render array key the disclosure is added under.
+   */
+  const DISCLOSURE_KEY = 'ys_captcha_recaptcha_disclosure';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['recaptcha_v3']);
+  }
+
+  /**
+   * Sets the recaptcha_v3 hide_badge setting.
+   */
+  protected function setHideBadge(bool $hide): void {
+    $this->config('recaptcha_v3.settings')->set('hide_badge', $hide)->save();
+  }
+
+  /**
+   * Builds a minimal form array carrying a top-level captcha element.
+   */
+  protected function formWithCaptcha(): array {
+    return [
+      '#type' => 'form',
+      'name' => ['#type' => 'textfield'],
+      'captcha' => [
+        '#type' => 'captcha',
+        '#captcha_type' => 'recaptcha_v3/form_submission',
+      ],
+      'actions' => ['#type' => 'actions'],
+    ];
+  }
+
+  /**
+   * Invokes the form alter hook against a form, returning the altered form.
+   */
+  protected function alter(array $form): array {
+    $form_state = new FormState();
+    ys_captcha_form_alter($form, $form_state, 'some_form');
+    return $form;
+  }
+
+  /**
+   * Disclosure is added when the badge is hidden and a captcha is present.
+   */
+  public function testDisclosureAddedWhenBadgeHiddenAndCaptchaPresent(): void {
+    $this->setHideBadge(TRUE);
+    $form = $this->alter($this->formWithCaptcha());
+
+    $this->assertArrayHasKey(self::DISCLOSURE_KEY, $form);
+    $markup = (string) $form[self::DISCLOSURE_KEY]['text']['#markup'];
+    $this->assertStringContainsString('reCAPTCHA', $markup);
+    $this->assertStringContainsString('https://policies.google.com/privacy', $markup);
+    $this->assertStringContainsString('https://policies.google.com/terms', $markup);
+  }
+
+  /**
+   * Disclosure is added when the captcha element is nested (webform case).
+   */
+  public function testDisclosureAddedForNestedCaptcha(): void {
+    $this->setHideBadge(TRUE);
+    $form = [
+      '#type' => 'form',
+      'elements' => [
+        'wrapper' => [
+          'captcha' => [
+            '#type' => 'captcha',
+            '#captcha_type' => 'recaptcha_v3/form_submission',
+          ],
+        ],
+      ],
+    ];
+    $form = $this->alter($form);
+
+    $this->assertArrayHasKey(self::DISCLOSURE_KEY, $form);
+  }
+
+  /**
+   * No disclosure when the form has no captcha element.
+   */
+  public function testNoDisclosureWhenNoCaptcha(): void {
+    $this->setHideBadge(TRUE);
+    $form = $this->alter([
+      '#type' => 'form',
+      'name' => ['#type' => 'textfield'],
+      'actions' => ['#type' => 'actions'],
+    ]);
+
+    $this->assertArrayNotHasKey(self::DISCLOSURE_KEY, $form);
+  }
+
+  /**
+   * No disclosure when the badge is visible (hide_badge FALSE).
+   */
+  public function testNoDisclosureWhenBadgeVisible(): void {
+    $this->setHideBadge(FALSE);
+    $form = $this->alter($this->formWithCaptcha());
+
+    $this->assertArrayNotHasKey(self::DISCLOSURE_KEY, $form);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/ys_captcha.libraries.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/ys_captcha.libraries.yml
@@ -1,0 +1,4 @@
+disclosure:
+  css:
+    theme:
+      css/recaptcha-disclosure.css: {}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/ys_captcha.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/ys_captcha.module
@@ -35,33 +35,53 @@ function ys_captcha_form_recaptcha_v3_settings_alter(&$form, &$form_state, $form
 /**
  * Implements hook_form_alter().
  *
+ * Styles the captcha fieldset to line up with the form's fields, and -- when
+ * the reCAPTCHA v3 badge is hidden -- adds Google's required disclosure inline.
+ *
  * The reCAPTCHA v3 module hides its floating badge (via the "hide_badge"
  * setting) with CSS only. Google's reCAPTCHA terms permit hiding the badge
- * only if the disclosure is shown in the user flow instead, so add it to any
- * form that carries a captcha element.
+ * only if the disclosure is shown in the user flow instead.
  */
 function ys_captcha_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
-  // Only needed when the badge is hidden; the badge carries the disclosure
-  // itself when visible.
+  $captcha = &_ys_captcha_find_captcha($form);
+  if ($captcha === NULL) {
+    return;
+  }
+
+  // Constrain the contrib captcha fieldset to the shared form-field width and
+  // give it bottom spacing, reusing the form-item styling the same way the
+  // radio fieldset does. Applies whenever a captcha is present, independent of
+  // the badge setting.
+  $captcha['#attributes']['class'][] = 'form-item';
+
+  // The badge carries Google's disclosure itself when visible, so only add the
+  // inline disclosure when the badge is hidden.
   if (!\Drupal::config('recaptcha_v3.settings')->get('hide_badge')) {
     return;
   }
 
-  if (!_ys_captcha_form_has_captcha($form)) {
-    return;
-  }
-
+  // Render the disclosure inside the inline-message component so it gets a
+  // styled box with theme-guaranteed color contrast. The "data-embedded-
+  // components" marker stops the layout from applying its context-dependent
+  // site-gutter (which varies between one-column and multi-column regions);
+  // ys_captcha/disclosure then applies consistent internal padding and the
+  // spacing that separates the box from the form above.
   $form['ys_captcha_recaptcha_disclosure'] = [
-    '#type' => 'container',
+    '#type' => 'inline_template',
     // Sort below the form's fields and actions.
     '#weight' => 1000,
-    '#attributes' => ['class' => ['recaptcha-v3-disclosure']],
-    'text' => [
-      '#markup' => t('This site is protected by reCAPTCHA and the Google <a href=":privacy">Privacy Policy</a> and <a href=":terms">Terms of Service</a> apply.', [
+    '#template' => '<div class="ys-captcha-disclosure" data-embedded-components>{% include "@molecules/inline-message/yds-inline-message.twig" with { inline_message__content: content } %}</div>',
+    '#context' => [
+      'content' => t('This site is protected by reCAPTCHA and the Google <a href=":privacy">Privacy Policy</a> and <a href=":terms">Terms of Service</a> apply.', [
         ':privacy' => 'https://policies.google.com/privacy',
         ':terms' => 'https://policies.google.com/terms',
       ]),
+      // The inline-message icon resolves its sprite path from "directory",
+      // which Drupal normally injects into theme templates. inline_template
+      // does not, so pass the active theme's path explicitly.
+      'directory' => \Drupal::theme()->getActiveTheme()->getPath(),
     ],
+    '#attached' => ['library' => ['ys_captcha/disclosure']],
   ];
 }
 
@@ -80,24 +100,32 @@ function ys_captcha_module_implements_alter(&$implementations, $hook) {
 }
 
 /**
- * Checks whether a render array contains a captcha element.
+ * Finds the first captcha element in a render array, by reference.
+ *
+ * Recurses so nested captcha elements (for example those inside a webform's
+ * element tree) are found. Returning by reference lets callers alter the
+ * element in place.
  *
  * @param array $elements
- *   A render array (or subtree) to scan. Recurses so nested captcha elements
- *   (for example those inside a webform's element tree) are found.
+ *   A render array (or subtree) to scan.
  *
- * @return bool
- *   TRUE if any descendant element is of type 'captcha'.
+ * @return array|null
+ *   The first captcha element found, by reference, or NULL if none is present.
  */
-function _ys_captcha_form_has_captcha(array $elements) {
+function &_ys_captcha_find_captcha(array &$elements) {
+  $null = NULL;
   foreach (Element::children($elements) as $key) {
-    $child = $elements[$key];
-    if (isset($child['#type']) && $child['#type'] === 'captcha') {
-      return TRUE;
+    if (!is_array($elements[$key])) {
+      continue;
     }
-    if (_ys_captcha_form_has_captcha($child)) {
-      return TRUE;
+    if (isset($elements[$key]['#type']) && $elements[$key]['#type'] === 'captcha') {
+      return $elements[$key];
     }
+    $found = &_ys_captcha_find_captcha($elements[$key]);
+    if ($found !== NULL) {
+      return $found;
+    }
+    unset($found);
   }
-  return FALSE;
+  return $null;
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/ys_captcha.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_captcha/ys_captcha.module
@@ -5,6 +5,9 @@
  * The ys_captcha module.
  */
 
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+
 /**
  * Implements hook_form_FORM_ID_alter().
  */
@@ -27,4 +30,74 @@ function ys_captcha_form_recaptcha_v3_settings_alter(&$form, &$form_state, $form
   $form['site_key']['#default_value'] = "HIDDEN";
   $form['secret_key']['#disabled'] = TRUE;
   $form['secret_key']['#default_value'] = "HIDDEN";
+}
+
+/**
+ * Implements hook_form_alter().
+ *
+ * The reCAPTCHA v3 module hides its floating badge (via the "hide_badge"
+ * setting) with CSS only. Google's reCAPTCHA terms permit hiding the badge
+ * only if the disclosure is shown in the user flow instead, so add it to any
+ * form that carries a captcha element.
+ */
+function ys_captcha_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+  // Only needed when the badge is hidden; the badge carries the disclosure
+  // itself when visible.
+  if (!\Drupal::config('recaptcha_v3.settings')->get('hide_badge')) {
+    return;
+  }
+
+  if (!_ys_captcha_form_has_captcha($form)) {
+    return;
+  }
+
+  $form['ys_captcha_recaptcha_disclosure'] = [
+    '#type' => 'container',
+    // Sort below the form's fields and actions.
+    '#weight' => 1000,
+    '#attributes' => ['class' => ['recaptcha-v3-disclosure']],
+    'text' => [
+      '#markup' => t('This site is protected by reCAPTCHA and the Google <a href=":privacy">Privacy Policy</a> and <a href=":terms">Terms of Service</a> apply.', [
+        ':privacy' => 'https://policies.google.com/privacy',
+        ':terms' => 'https://policies.google.com/terms',
+      ]),
+    ],
+  ];
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ *
+ * Run this module's form_alter after the captcha module's, so the captcha
+ * element it injects is present when we scan the form for it.
+ */
+function ys_captcha_module_implements_alter(&$implementations, $hook) {
+  if ($hook === 'form_alter' && isset($implementations['ys_captcha'])) {
+    $group = $implementations['ys_captcha'];
+    unset($implementations['ys_captcha']);
+    $implementations['ys_captcha'] = $group;
+  }
+}
+
+/**
+ * Checks whether a render array contains a captcha element.
+ *
+ * @param array $elements
+ *   A render array (or subtree) to scan. Recurses so nested captcha elements
+ *   (for example those inside a webform's element tree) are found.
+ *
+ * @return bool
+ *   TRUE if any descendant element is of type 'captcha'.
+ */
+function _ys_captcha_form_has_captcha(array $elements) {
+  foreach (Element::children($elements) as $key) {
+    $child = $elements[$key];
+    if (isset($child['#type']) && $child['#type'] === 'captcha') {
+      return TRUE;
+    }
+    if (_ys_captcha_form_has_captcha($child)) {
+      return TRUE;
+    }
+  }
+  return FALSE;
 }


### PR DESCRIPTION
## [1345: RC: reCAPTCHA badge overlay appearing in bottom right on pages with pre-built forms](https://github.com/yalesites-org/YaleSites-Internal/issues/1345)

### Description of work
- Set `hide_badge: true` in the `recaptcha_v3.settings` config so the reCAPTCHA v3 module attaches the CSS that hides the floating `.grecaptcha-badge`. The badge was never suppressed before — the key was simply absent and defaults to `false` (reCAPTCHA was enabled in YALB-880), so the overlay is net-new behavior from enabling reCAPTCHA, not a module-update reset.
- Add the Google-required reCAPTCHA disclosure ("This site is protected by reCAPTCHA and the Google Privacy Policy and Terms of Service apply.") inline on any form that carries a captcha element, via `ys_captcha`'s `hook_form_alter`. Hiding the badge removes Google's only on-page disclosure, so showing it inline keeps us compliant with Google's reCAPTCHA terms.
- Use `hook_module_implements_alter` so the alter runs after the captcha module injects the captcha element.
- Add a kernel test covering the disclosure gate conditions (badge hidden/visible, captcha present/absent, nested captcha).

### Functional testing steps:
- [ ] On an environment with valid reCAPTCHA keys, visit a page with a pre-built form (e.g. a Contact form block).
- [ ] Confirm the floating "protected by reCAPTCHA" badge no longer appears in the bottom-right corner.
- [ ] Confirm the inline disclosure text appears on the form, with working links to Google's Privacy Policy and Terms of Service.
- [ ] Submit the form and confirm reCAPTCHA still validates (spam protection still works).

References yalesites-org/YaleSites-Internal#1345
