### PR TITLE
1346: Update Drupal core to 10.6.12 and Paragraphs to 1.21.0 (security + dependency updates)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
   "require": {
     "composer/installers": "^1.9",
     "cweagans/composer-patches": "^1.7",
-    "drupal/core-composer-scaffold": "10.6.11",
-    "drupal/core-project-message": "10.6.11",
-    "drupal/core-recommended": "10.6.11",
+    "drupal/core-composer-scaffold": "10.6.12",
+    "drupal/core-project-message": "10.6.12",
+    "drupal/core-recommended": "10.6.12",
     "drush/drush": "^13",
     "league/commonmark": "^2.0",
     "pantheon-systems/drupal-integrations": "^10",

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -84,7 +84,7 @@
     "drupal/override_node_options": "2.9.0",
     "drupal/pantheon_advanced_page_cache": "2.3.4",
     "drupal/pantheon_secrets": "1.0.6",
-    "drupal/paragraphs": "1.20.0",
+    "drupal/paragraphs": "1.21.0",
     "drupal/paragraphs_features": "2.2.0",
     "drupal/pathauto": "1.15.0",
     "drupal/quick_node_clone": "1.22.0",


### PR DESCRIPTION
## [1346: Update Drupal core to 10.6.12 and Paragraphs to 1.21.0 (security + dependency updates)](https://github.com/yalesites-org/YaleSites-Internal/issues/1346)

### Description of work
- Bump `drupal/core-recommended`, `drupal/core-composer-scaffold`, `drupal/core-project-message` from `10.6.11` → `10.6.12` (root `composer.json`)
- Bump `drupal/paragraphs` from `1.20.0` → `1.21.0` (profile `composer.json`)
- Core 10.6.12 is a bugfix release: bundled guzzle bump (`psr7` 2.12.1 / `guzzle` 7.12.1, upstream advisories) and a Claro tabledrag/Firefox fix ([#3578398](https://www.drupal.org/project/drupal/issues/3578398)). The media-preview label-leak fix ([#3593390](https://www.drupal.org/project/drupal/issues/3593390)) was **reverted from 10.6.x and is not in 10.6.12**.
- Paragraphs 1.21.0 is a security release (SA-CONTRIB-2026-060 / -061, access bypass), but **both require the `paragraphs_library` submodule, which is not enabled on YaleSites** — no exposure change here. The change that affects us is functional: the sticky content/behavior tab UI in the paragraph editor ([#3562282](https://www.drupal.org/project/paragraphs/issues/3562282)).

### Functional testing steps:
- [ ] **Build:** the multidev builds successfully. A green build means core `10.6.12` and paragraphs `1.21.0` resolved and installed cleanly (build runs composer install + config import) — no manual drush steps needed.
- [ ] **Paragraphs editing (regression):** edit a node/component using a paragraph field — add, edit, reorder (drag), collapse/expand, and remove items work; saved values persist after reload.
- [ ] **Paragraphs sticky tabs ([#3562282](https://www.drupal.org/project/paragraphs/issues/3562282)):** on a paragraph with Content + Behavior tabs, switch between them and scroll a long form — the sticky tab header stays usable and does not overlap/hide behind the Gin admin toolbar. Verify at both desktop and narrow/mobile widths.
- [ ] **Claro/Gin tabledrag in Firefox ([#3578398](https://www.drupal.org/project/drupal/issues/3578398)) — conditional, low priority:** in Firefox, open a tabledrag screen with expandable/nested rows (Structure → Menus → edit a menu, or a Field UI "Manage form display" page); reorder rows and expand/collapse nested rows. Handles/toggles render correctly (no broken/overlapping elements). Compare to Chrome if anything looks off. May not surface since Gin overrides much of Claro.

**Not applicable to this platform (no test needed):** SA-CONTRIB-2026-060/-061 require `paragraphs_library` (not enabled); core media-leak fix #3593390 was reverted out of 10.6.12.

References yalesites-org/YaleSites-Internal#1346
