### PR TITLE
fix(YISP-124): allow Basic HTML format on Resource Description field

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.node.resource.field_content_description.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.node.resource.field_content_description.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_content_description
+    - filter.format.basic_html
     - filter.format.restricted_html
     - node.type.resource
   module:
@@ -21,4 +22,5 @@ default_value_callback: ''
 settings:
   allowed_formats:
     - restricted_html
+    - basic_html
 field_type: text_long


### PR DESCRIPTION
## Problem
Editing a Resource shows the **Description** field disabled with *"This field has been disabled because you do not have sufficient permissions to edit it."*

## Root cause
Resource Description (`field_content_description`) bodies are stored with the `basic_html` text format, but the field's `allowed_formats` permitted only `restricted_html`. Drupal core's filter element disables the widget when a value's stored format isn't in the field's allowed set — even though editors *do* have permission to use `basic_html`.

## Fix
Add `basic_html` to `allowed_formats` on `node.resource.field_content_description`. `restricted_html` stays listed first, so it remains the default format for new content; `basic_html` simply becomes selectable, which makes the existing migrated Descriptions editable.

## Notes
- Typed `fix:` (patch). If you'd rather treat "new allowed format" as `feat:` (minor bump), relabel on merge — flagging since the bump propagates platform-wide.
- Some migrated bodies contain inline `<img>`, which `basic_html` filters on render (images route through media embeds). That's a separate content follow-up, not addressed here.

🤖 Generated in collaboration with Claude Code