### PR TITLE
1349: RC: Embed block: missing title attribute on Bluesky, Instagram, and event map embeds

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/Bluesky.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/Bluesky.php
@@ -31,6 +31,11 @@ class Bluesky extends EmbedSourceBase implements EmbedSourceInterface {
   /**
    * {@inheritdoc}
    */
+  protected static $defaultTitle = 'Bluesky post embed';
+
+  /**
+   * {@inheritdoc}
+   */
   protected static $instructions = 'To embed a Bluesky post, go to the post on bsky.app, click the share icon, and select "Embed post". Click on "Copy code" to copy the entire embed code including both the blockquote and script tags.';
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/Instagram.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/Instagram.php
@@ -31,6 +31,11 @@ class Instagram extends EmbedSourceBase implements EmbedSourceInterface {
   /**
    * {@inheritdoc}
    */
+  protected static $defaultTitle = 'Instagram post embed';
+
+  /**
+   * {@inheritdoc}
+   */
   protected static $instructions = 'Find the embed code for an Instagram post by clicking the (...) more options icon on a post and clicking "Embed".';
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSourceBase.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSourceBase.php
@@ -77,6 +77,13 @@ abstract class EmbedSourceBase extends PluginBase implements EmbedSourceInterfac
   ];
 
   /**
+   * The accessible title to use when the editor leaves Title blank.
+   *
+   * @var string
+   */
+  protected static $defaultTitle = '';
+
+  /**
    * Creates a plugin instance.
    *
    * @param array $configuration
@@ -172,7 +179,7 @@ abstract class EmbedSourceBase extends PluginBase implements EmbedSourceInterfac
     return [
       '#theme' => 'embed_wrapper',
       '#embedType' => $this->getPluginId(),
-      '#title' => $params['title'],
+      '#title' => trim($params['title']) !== '' ? $params['title'] : static::$defaultTitle,
       '#url' => $this->getUrl($params),
       '#displayAttributes' => $displayAttributes,
       '#embedSource' => [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/templates/embed-wrapper.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/templates/embed-wrapper.html.twig
@@ -1,5 +1,7 @@
 {% if displayAttributes['isIframe'] %}
   <iframe data-embed-type="{{ embedType }}" src="{{ url }}" title="{{ title }}" height="{{ displayAttributes['height'] }}" width="{{ displayAttributes['width'] }} scrolling="{{ displayAttributes['scrolling'] }}" frameborder="{{ displayAttributes['frameborder'] }}"></iframe>   
+{% elseif title|trim != '' %}
+  <div role="group" aria-label="{{ title }}">{{ embedSource }}</div>
 {% else %}
   {{ embedSource }}
 {% endif %}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Unit/BlueskyTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Unit/BlueskyTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\Tests\ys_embed\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_embed\Plugin\EmbedSource\Bluesky;
+
+/**
+ * @coversDefaultClass \Drupal\ys_embed\Plugin\EmbedSource\Bluesky
+ *
+ * @group yalesites
+ */
+class BlueskyTest extends UnitTestCase {
+
+  /**
+   * The Bluesky plugin instance.
+   *
+   * @var \Drupal\ys_embed\Plugin\EmbedSource\Bluesky
+   */
+  protected $plugin;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $configFactory = $this->getConfigFactoryStub([
+      'media.settings' => ['icon_base_uri' => 'public://media-icons'],
+    ]);
+    $this->plugin = new Bluesky([], 'bluesky', [], $configFactory);
+  }
+
+  /**
+   * @covers ::build
+   */
+  public function testBuildFallsBackToDefaultTitleWhenBlank(): void {
+    $params = ['title' => ''];
+    $build = $this->plugin->build($params);
+    $this->assertSame('Bluesky post embed', $build['#title']);
+  }
+
+  /**
+   * @covers ::build
+   */
+  public function testBuildUsesProvidedTitleOverDefault(): void {
+    $params = ['title' => 'Custom Bluesky title'];
+    $build = $this->plugin->build($params);
+    $this->assertSame('Custom Bluesky title', $build['#title']);
+  }
+
+  /**
+   * @covers ::build
+   */
+  public function testBuildPreservesLiteralZeroTitle(): void {
+    $params = ['title' => '0'];
+    $build = $this->plugin->build($params);
+    $this->assertSame('0', $build['#title']);
+  }
+
+  /**
+   * @covers ::build
+   */
+  public function testBuildFallsBackToDefaultTitleWhenWhitespaceOnly(): void {
+    $params = ['title' => '   '];
+    $build = $this->plugin->build($params);
+    $this->assertSame('Bluesky post embed', $build['#title']);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Unit/InstagramTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Unit/InstagramTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\Tests\ys_embed\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_embed\Plugin\EmbedSource\Instagram;
+
+/**
+ * @coversDefaultClass \Drupal\ys_embed\Plugin\EmbedSource\Instagram
+ *
+ * @group yalesites
+ */
+class InstagramTest extends UnitTestCase {
+
+  /**
+   * The Instagram plugin instance.
+   *
+   * @var \Drupal\ys_embed\Plugin\EmbedSource\Instagram
+   */
+  protected $plugin;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $configFactory = $this->getConfigFactoryStub([
+      'media.settings' => ['icon_base_uri' => 'public://media-icons'],
+    ]);
+    $this->plugin = new Instagram([], 'instagram', [], $configFactory);
+  }
+
+  /**
+   * @covers ::build
+   */
+  public function testBuildFallsBackToDefaultTitleWhenBlank(): void {
+    $params = ['title' => ''];
+    $build = $this->plugin->build($params);
+    $this->assertSame('Instagram post embed', $build['#title']);
+  }
+
+  /**
+   * @covers ::build
+   */
+  public function testBuildUsesProvidedTitleOverDefault(): void {
+    $params = ['title' => 'Custom Instagram title'];
+    $build = $this->plugin->build($params);
+    $this->assertSame('Custom Instagram title', $build['#title']);
+  }
+
+  /**
+   * @covers ::build
+   */
+  public function testBuildPreservesLiteralZeroTitle(): void {
+    $params = ['title' => '0'];
+    $build = $this->plugin->build($params);
+    $this->assertSame('0', $build['#title']);
+  }
+
+  /**
+   * @covers ::build
+   */
+  public function testBuildFallsBackToDefaultTitleWhenWhitespaceOnly(): void {
+    $params = ['title' => '   '];
+    $build = $this->plugin->build($params);
+    $this->assertSame('Instagram post embed', $build['#title']);
+  }
+
+}


### PR DESCRIPTION
## [1349: RC: Embed block: missing title attribute on Bluesky, Instagram, and event map embeds](https://github.com/yalesites-org/YaleSites-Internal/issues/1349)

### Description of work
- Adds a per-plugin default accessible title (`ys_embed`) for Bluesky and Instagram embeds, used when the editor leaves Title blank
- Guards against PHP/Twig loose-falsy edge cases ("0", whitespace-only) silently discarding a real title or producing an empty aria-label
- Adds PHPUnit unit tests covering the new default-title fallback behavior
- Other work completed in: yalesites-org/atomic#470
- Other work completed in: yalesites-org/component-library-twig#652

### Functional testing steps:
- [ ] Add a Bluesky or Instagram embed with blank Title; confirm accessible name defaults to "Bluesky post embed" / "Instagram post embed"
- [ ] Add one with an explicit Title; confirm it overrides the default
- [ ] Run `lando ssh -c "vendor/bin/phpunit web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Unit/"` — all pass

Note: acceptance criteria #5 (WCAG AA sign-off from accessibility engineer) and #6 (User Guide docs note) are process steps outside this codebase, not addressed by code changes.

References yalesites-org/YaleSites-Internal#1349