### PR TITLE
Bump atomic to v1.77.0

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -110,7 +110,7 @@
     "drupal/workflow_buttons": "1.0-beta7",
     "jjj/chosen": "2.2.1",
     "yalesites-org/ai_engine": "1.2.18",
-    "yalesites-org/atomic": "1.76.0",
+    "yalesites-org/atomic": "1.77.0",
     "yalesites-org/yale_cas": "v1.3.0"
   },
   "minimum-stability": "dev",


### PR DESCRIPTION
Bumps the `yalesites-org/atomic` dependency in the installation profile's `composer.json` from v1.76.0 to v1.77.0 to pick up the latest RC release.

Atomic release: https://github.com/yalesites-org/atomic/releases/tag/v1.77.0

This atomic release includes component-library-twig v1.79.1.