### PR TITLE
1241: Publication/Resource image shows filename as alt text on resource detail page

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_resources.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.manage_resources.yml
@@ -21,7 +21,7 @@ dependencies:
 id: manage_resources
 label: 'Manage Resources'
 module: views
-description: 'Interface used by authors to manage post content.'
+description: 'Interface used by authors to manage resource content.'
 tag: ''
 base_table: node_field_data
 base_field: nid
@@ -770,7 +770,7 @@ display:
           plugin_id: text
           empty: true
           content:
-            value: 'Your site does not have any post content'
+            value: 'Your site does not have any resource content.'
             format: basic_html
           tokenize: false
       sorts:
@@ -1118,7 +1118,7 @@ display:
           plugin_id: text
           empty: false
           content:
-            value: 'The post content type is useful for posted articles, posts, and stories, about your organization as featured content or in a reverse-chronological content feed. '
+            value: 'Resource content is useful for sharing PDFs, videos, and publications, with structured metadata for authors, citations, and abstracts.'
             format: basic_html
           tokenize: false
       footer: {  }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/ResourceMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/ResourceMetaBlock.php
@@ -12,6 +12,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
+use Drupal\ys_layouts\Service\MediaAltResolver;
 use Drupal\ys_layouts\Service\ResourceAuthorBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -70,6 +71,13 @@ class ResourceMetaBlock extends BlockBase implements ContainerFactoryPluginInter
   protected $resourceAuthorBuilder;
 
   /**
+   * The media cover-image alt text resolver.
+   *
+   * @var \Drupal\ys_layouts\Service\MediaAltResolver
+   */
+  protected $mediaAltResolver;
+
+  /**
    * Constructs a new ResourceMetaBlock object.
    *
    * @param array $configuration
@@ -90,6 +98,8 @@ class ResourceMetaBlock extends BlockBase implements ContainerFactoryPluginInter
    *   The entity type manager service.
    * @param \Drupal\ys_layouts\Service\ResourceAuthorBuilder $resource_author_builder
    *   The resource author list builder.
+   * @param \Drupal\ys_layouts\Service\MediaAltResolver $media_alt_resolver
+   *   The media cover-image alt text resolver.
    */
   public function __construct(
     array $configuration,
@@ -101,6 +111,7 @@ class ResourceMetaBlock extends BlockBase implements ContainerFactoryPluginInter
     DateFormatter $date_formatter,
     EntityTypeManager $entity_type_manager,
     ResourceAuthorBuilder $resource_author_builder,
+    MediaAltResolver $media_alt_resolver,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
@@ -110,6 +121,7 @@ class ResourceMetaBlock extends BlockBase implements ContainerFactoryPluginInter
     $this->dateFormatter = $date_formatter;
     $this->entityTypeManager = $entity_type_manager;
     $this->resourceAuthorBuilder = $resource_author_builder;
+    $this->mediaAltResolver = $media_alt_resolver;
   }
 
   /**
@@ -126,6 +138,7 @@ class ResourceMetaBlock extends BlockBase implements ContainerFactoryPluginInter
       $container->get('date.formatter'),
       $container->get('entity_type.manager'),
       $container->get('ys_layouts.resource_author_builder'),
+      $container->get('ys_layouts.media_alt_resolver'),
     );
   }
 
@@ -349,7 +362,7 @@ class ResourceMetaBlock extends BlockBase implements ContainerFactoryPluginInter
                 '#width' => $thumbnail?->width,
                 '#attributes' => [
                   'loading' => 'lazy',
-                  'alt' => $media->label(),
+                  'alt' => $this->mediaAltResolver->resolve($media),
                 ],
               ];
             }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Service/MediaAltResolver.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Service/MediaAltResolver.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\ys_layouts\Service;
+
+use Drupal\media\MediaInterface;
+
+/**
+ * Resolves the alt text for a Resource media entity's cover/thumbnail image.
+ *
+ * The resource detail page (ResourceMetaBlock) and the resource card/list
+ * templates (atomic_preprocess_node) both hand-build a responsive_image render
+ * array from the media's thumbnail derivative. This service centralizes how
+ * their alt text is derived so both surfaces stay identical.
+ *
+ * For image media the alt configured on the image field is used, preserving an
+ * empty value so an image marked decorative renders with alt="". Media bundles
+ * without an image field (documents, etc.) fall back to the media label so the
+ * auto-generated thumbnail still has a meaningful description.
+ */
+class MediaAltResolver {
+
+  /**
+   * Resolves the alt text for a media entity's cover image.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *   The media entity whose thumbnail is being rendered.
+   *
+   * @return string
+   *   The alt text to apply to the rendered image.
+   */
+  public function resolve(MediaInterface $media): string {
+    if ($media->hasField('field_media_image') && !$media->get('field_media_image')->isEmpty()) {
+      // Image media: use the alt configured on the image field. An empty value
+      // is preserved so an image marked decorative renders with alt="".
+      return (string) $media->get('field_media_image')->alt;
+    }
+
+    // Bundles without an image field (documents, etc.) have no configured alt;
+    // fall back to the media label so the thumbnail is still described.
+    return (string) $media->label();
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/MediaAltResolverTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/MediaAltResolverTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Drupal\Tests\ys_layouts\Kernel;
+
+use Drupal\file\Entity\File;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\media\Traits\MediaTypeCreationTrait;
+use Drupal\ys_layouts\Service\MediaAltResolver;
+
+/**
+ * Tests alt-text resolution for resource cover images.
+ *
+ * Regression test for the bug where a resource's book-cover image rendered
+ * the media name (the uploaded filename) as its alt text instead of the alt
+ * configured on the media's image field.
+ *
+ * @coversDefaultClass \Drupal\ys_layouts\Service\MediaAltResolver
+ *
+ * @group ys_layouts
+ * @group yalesites
+ */
+class MediaAltResolverTest extends KernelTestBase {
+
+  use MediaTypeCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'file',
+    'field',
+    'image',
+    'media',
+  ];
+
+  /**
+   * The resolver under test.
+   *
+   * @var \Drupal\ys_layouts\Service\MediaAltResolver
+   */
+  protected MediaAltResolver $resolver;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('media');
+    $this->installSchema('file', 'file_usage');
+    $this->installConfig(['system', 'field', 'file', 'media']);
+
+    $this->resolver = new MediaAltResolver();
+  }
+
+  /**
+   * Creates a saved file entity for referencing from media.
+   */
+  protected function createFile(): File {
+    $file = File::create([
+      'uri' => 'public://fun-home-cover.jpg',
+      'filename' => 'fun-home-cover.jpg',
+    ]);
+    $file->save();
+    return $file;
+  }
+
+  /**
+   * An image media returns the alt configured on its image field.
+   *
+   * @covers ::resolve
+   */
+  public function testConfiguredAltUsedForImageMedia(): void {
+    $this->createMediaType('image', ['id' => 'image']);
+    $file = $this->createFile();
+
+    $media = $this->container->get('entity_type.manager')
+      ->getStorage('media')
+      ->create([
+        'bundle' => 'image',
+        'name' => 'fun-home-cover.jpg',
+        'field_media_image' => [
+          'target_id' => $file->id(),
+          'alt' => 'Cover of Fun Home: A Family Tragicomic',
+        ],
+      ]);
+    $media->save();
+
+    $this->assertSame(
+      'Cover of Fun Home: A Family Tragicomic',
+      $this->resolver->resolve($media),
+    );
+  }
+
+  /**
+   * An image with empty alt stays empty (decorative), not the media name.
+   *
+   * @covers ::resolve
+   */
+  public function testDecorativeImageReturnsEmptyAlt(): void {
+    $this->createMediaType('image', ['id' => 'image']);
+    $file = $this->createFile();
+
+    $media = $this->container->get('entity_type.manager')
+      ->getStorage('media')
+      ->create([
+        'bundle' => 'image',
+        'name' => 'decorative-flourish.png',
+        'field_media_image' => [
+          'target_id' => $file->id(),
+          'alt' => '',
+        ],
+      ]);
+    $media->save();
+
+    $this->assertSame('', $this->resolver->resolve($media));
+  }
+
+  /**
+   * A non-image media (no alt field) falls back to the media label.
+   *
+   * @covers ::resolve
+   */
+  public function testNonImageMediaFallsBackToLabel(): void {
+    $this->createMediaType('file', ['id' => 'document']);
+    $file = File::create([
+      'uri' => 'public://syllabus.pdf',
+      'filename' => 'syllabus.pdf',
+    ]);
+    $file->save();
+
+    $media = $this->container->get('entity_type.manager')
+      ->getStorage('media')
+      ->create([
+        'bundle' => 'document',
+        'name' => 'Fall 2026 Syllabus',
+        'field_media_file' => [
+          'target_id' => $file->id(),
+        ],
+      ]);
+    $media->save();
+
+    $this->assertSame(
+      'Fall 2026 Syllabus',
+      $this->resolver->resolve($media),
+    );
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.services.yml
@@ -19,3 +19,8 @@ services:
   ys_layouts.resource_author_builder:
     class: Drupal\ys_layouts\Service\ResourceAuthorBuilder
     arguments: ['@ys_layouts.author_collator']
+  # Resolves cover-image alt text for Resource media.
+  # Used by ResourceMetaBlock and atomic_preprocess_node() so the block
+  # render and the card/list templates apply identical alt text.
+  ys_layouts.media_alt_resolver:
+    class: Drupal\ys_layouts\Service\MediaAltResolver


### PR DESCRIPTION
## [1241: Publication/Resource image shows filename as alt text on resource detail page](https://github.com/yalesites-org/YaleSites-Internal/issues/1241)

### Description of work
- Fix resource cover images on the detail page rendering the media name (the uploaded filename) as alt text instead of the alt configured on the media's image field. Views/cards were already correct because they go through the normal image formatter.
- Add a `ys_layouts.media_alt_resolver` service returning the configured `field_media_image` alt for image media (preserving an empty value so decorative images render `alt=""`), falling back to the media label for bundles without an image field (documents, etc.); inject it into `ResourceMetaBlock`.
- Mirrors the existing `ys_layouts.resource_author_builder` pattern so the block and `atomic_preprocess_node()` share one implementation instead of duplicating logic.
- Add kernel test `MediaAltResolverTest` (image -> configured alt, decorative -> empty, non-image -> label).
- Other work completed in: yalesites-org/atomic#481

### Functional testing steps:
- [x] Create/edit a Resource whose Resource Media is an image with a configured alt different from the file name.
- [x] View the resource detail page (e.g. `/resource/<slug>`) and inspect the cover image in dev tools.
- [x] Confirm the cover image `alt` shows the configured alt, not the filename.
- [x] Confirm a blank-alt image renders `alt=""` and a PDF/document resource still shows a sensible description.

References yalesites-org/YaleSites-Internal#1241
