### PR TITLE
760: Accordion move icon contrast hover/select

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/multifield-form.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/multifield-form.css
@@ -11,9 +11,33 @@
   padding-left: 15px;
 }
 
+/*
+ * Accessibility (Issue #760): keep the paragraph reorder ("move") handle icon
+ * above the WCAG 2.1 AA non-text contrast minimum (3:1) in every state.
+ *
+ * Core paints this handle with a fixed-color background-image
+ * (core/misc/icons/787878/move.svg, a mid-gray). Because we hide Gin's
+ * recolorable ::after glyph (below) and show this .handle instead, none of
+ * Gin's or the Issue #1086 hover/focus recoloring reaches it, so it cannot
+ * adapt when the row background lightens on :hover / :focus-within. In dark
+ * mode that drops the icon to ~2.5:1 and it visually disappears.
+ *
+ * Repaint the glyph as a mask tinted with Gin's --gin-color-text, which
+ * auto-flips between light and dark admin modes (near-black on light,
+ * near-white on dark), so the handle stays high-contrast at rest, on hover,
+ * and on keyboard focus in both modes.
+ */
 .js .field--widget-paragraphs .tabledrag-handle .handle {
   width: 22px;
   margin-left: 8px;
+  background-color: var(--gin-color-text);
+  background-image: none;
+  mask-image: url("/core/misc/icons/787878/move.svg");
+  mask-repeat: no-repeat;
+  mask-position: 6px 7px;
+  -webkit-mask-image: url("/core/misc/icons/787878/move.svg");
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: 6px 7px;
 }
 
 .js .field--widget-paragraphs .draggable .tabledrag-handle::after {


### PR DESCRIPTION
## [760: Accordion move icon contrast hover/select](https://github.com/yalesites-org/YaleSites-Internal/issues/760)

### Description of work
- Fixed the paragraph reorder ("move") drag-handle icon losing contrast on hover and keyboard focus in the Layout Builder editor. In dark mode the icon dropped to ~2.5:1 — below the WCAG 2.1 AA non-text minimum of 3:1 — and effectively disappeared when a row was hovered or focused (matching the original report of "you can no longer see the icon").
- Root cause: `ys_core/css/multifield-form.css` hides Gin's recolorable `.tabledrag-handle::after` glyph and shows core's `.handle` element instead, whose fixed-color `background-image` (`core/misc/icons/787878/move.svg`, a mid-gray) can't adapt when the row background lightens on `:hover`/`:focus-within`. Neither Gin's nor the Issue #1086 hover recoloring reaches it because both target `::after`.
- Repainted the `.handle` glyph as a mask tinted with Gin's `--gin-color-text`, which auto-flips between light and dark admin modes (near-black on light, near-white on dark). The handle now stays high-contrast at rest, on hover, and on keyboard focus in both modes (measured dark hover ~7.5:1, light hover ~12.9:1). Applies to every paragraph-widget reorder handle (accordion, tabs, cards, etc.).

### Functional testing steps:
- [x] With the Gin admin theme in **dark mode**, edit a page in Layout Builder and open the configure panel of an Accordion block that has 2+ items (e.g. the "Text-Heavy Content" demo page).
- [x] Hover the "move" (four-arrows) drag handle on an accordion item — the icon stays clearly visible instead of washing out against the highlighted row.
- [x] Tab to the drag handle with the keyboard — the icon remains clearly visible while focused.
- [x] Switch the admin theme to **light mode** and repeat — the icon stays a dark, high-contrast glyph on hover and focus.

References yalesites-org/YaleSites-Internal#760

---
Created with AI
