### PR TITLE
835: Remove 'media' as a type in link fields

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/linkit.linkit_profile.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/linkit.linkit_profile.default.yml
@@ -53,13 +53,3 @@ matchers:
     uuid: fc376fae-0029-4b92-9905-c5a021f32fc5
     settings: {  }
     weight: -10
-  7a6406c1-fb96-416d-bfe4-31dca268bb26:
-    id: 'entity:media'
-    uuid: 7a6406c1-fb96-416d-bfe4-31dca268bb26
-    settings:
-      metadata: ''
-      bundles: {  }
-      group_by_bundle: false
-      substitution_type: media_download_inline
-      limit: 100
-    weight: -6

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_file_management/src/Service/MediaLinkConverter.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_file_management/src/Service/MediaLinkConverter.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace Drupal\ys_file_management\Service;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\ContentEntityStorageInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Entity\RevisionableInterface;
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\file\FileInterface;
+use Drupal\media\MediaInterface;
+
+/**
+ * Rewrites legacy "media" links in rich text into direct file links.
+ *
+ * @see \Drupal\ys_file_management\Service\MediaLinkConverterInterface
+ */
+class MediaLinkConverter implements MediaLinkConverterInterface {
+
+  /**
+   * The logger channel name for this module.
+   */
+  private const LOGGER_CHANNEL = 'ys_file_management';
+
+  /**
+   * Formatted-text field types that may hold Linkit markup.
+   */
+  private const TEXT_FIELD_TYPES = ['text_long', 'text_with_summary', 'text'];
+
+  /**
+   * Substring identifying an anchor authored as a media link.
+   */
+  private const MEDIA_LINK_MARKER = 'data-entity-type="media"';
+
+  /**
+   * Resolved media-UUID to file lookups, memoized for the run.
+   *
+   * The same document is often linked from many pages, so caching avoids
+   * re-querying for a UUID already resolved.
+   *
+   * @var array<string, \Drupal\file\FileInterface|null>
+   */
+  protected array $mediaFileCache = [];
+
+  /**
+   * Constructs a MediaLinkConverter service.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entityFieldManager
+   *   The entity field manager.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entityRepository
+   *   The entity repository, used to load media by UUID.
+   * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
+   *   The file URL generator.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
+   *   The logger factory.
+   */
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected EntityFieldManagerInterface $entityFieldManager,
+    protected EntityRepositoryInterface $entityRepository,
+    protected FileUrlGeneratorInterface $fileUrlGenerator,
+    protected LoggerChannelFactoryInterface $loggerFactory,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function convertAllContent(): array {
+    $stats = [
+      'entities_updated' => 0,
+      'entities_failed' => 0,
+      'links_converted' => 0,
+      'links_skipped' => 0,
+    ];
+
+    foreach ($this->entityFieldManager->getFieldMap() as $entity_type_id => $fields) {
+      $text_fields = [];
+      foreach ($fields as $field_name => $info) {
+        if (in_array($info['type'], self::TEXT_FIELD_TYPES, TRUE)) {
+          $text_fields[$field_name] = $info['type'];
+        }
+      }
+      if (!$text_fields) {
+        continue;
+      }
+
+      try {
+        $storage = $this->entityTypeManager->getStorage($entity_type_id);
+      }
+      catch (\Exception $e) {
+        continue;
+      }
+      if (!$storage instanceof ContentEntityStorageInterface) {
+        continue;
+      }
+
+      foreach ($this->loadCandidates($storage, $entity_type_id, $text_fields) as $entity) {
+        if (!$entity instanceof FieldableEntityInterface) {
+          continue;
+        }
+
+        // Only the default revision is scanned/saved; pending moderation drafts
+        // and other non-default revisions keep their original markup.
+        $result = $this->convertEntity($entity, $text_fields);
+        $stats['links_skipped'] += $result['skipped'];
+        if (!$result['changed']) {
+          continue;
+        }
+
+        // Update in place rather than spawning a revision per entity. Guard on
+        // the entity type actually being revisionable — ContentEntityBase
+        // implements RevisionableInterface even for non-revisionable types.
+        if ($entity instanceof RevisionableInterface && $entity->getEntityType()->isRevisionable()) {
+          $entity->setNewRevision(FALSE);
+        }
+
+        // Isolate each save so a single bad entity (e.g. a validation
+        // constraint added since it was authored) cannot abort the whole
+        // bulk run; only count links that actually persisted.
+        try {
+          $entity->save();
+          $stats['links_converted'] += $result['converted'];
+          $stats['entities_updated']++;
+        }
+        catch (\Exception $e) {
+          $stats['entities_failed']++;
+          $this->getLogger()->warning('Could not save @type @id while converting media links: @message', [
+            '@type' => $entity_type_id,
+            '@id' => $entity->id(),
+            '@message' => $e->getMessage(),
+          ]);
+        }
+      }
+    }
+
+    return $stats;
+  }
+
+  /**
+   * Rewrites the media links in one entity's text fields (in memory).
+   *
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+   *   The entity to process.
+   * @param array $text_fields
+   *   Map of field name to field type for the text fields to scan.
+   *
+   * @return array
+   *   Result with keys 'changed' (bool — whether any value was rewritten),
+   *   'converted' and 'skipped' (link counts for this entity).
+   */
+  protected function convertEntity(FieldableEntityInterface $entity, array $text_fields): array {
+    $changed = FALSE;
+    $converted = 0;
+    $skipped = 0;
+    foreach ($text_fields as $field_name => $type) {
+      if (!$entity->hasField($field_name)) {
+        continue;
+      }
+      foreach ($entity->get($field_name) as $item) {
+        foreach ($this->textProperties($type) as $property) {
+          $value = (string) ($item->{$property} ?? '');
+          if ($value === '') {
+            continue;
+          }
+          $result = $this->convertMarkup($value);
+          $converted += $result['converted'];
+          $skipped += $result['skipped'];
+          if ($result['converted'] > 0) {
+            $item->{$property} = $result['html'];
+            $changed = TRUE;
+          }
+        }
+      }
+    }
+
+    return ['changed' => $changed, 'converted' => $converted, 'skipped' => $skipped];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function convertMarkup(string $html): array {
+    $converted = 0;
+    $skipped = 0;
+
+    // Cheap guard mirroring the Linkit filter: skip strings with no entity
+    // links at all so untouched content is never round-tripped through the DOM.
+    if (strpos($html, 'data-entity-type') === FALSE) {
+      return ['html' => $html, 'converted' => 0, 'skipped' => 0];
+    }
+
+    $dom = Html::load($html);
+    $xpath = new \DOMXPath($dom);
+    foreach ($xpath->query('//a[@data-entity-type="media" and @data-entity-uuid]') as $anchor) {
+      /** @var \DOMElement $anchor */
+      $uuid = $anchor->getAttribute('data-entity-uuid');
+      if ($uuid === '') {
+        continue;
+      }
+
+      try {
+        $file = $this->resolveMediaFile($uuid);
+        if (!$file instanceof FileInterface) {
+          // No downloadable file (e.g. remote video/embed) or missing media —
+          // leave the link untouched.
+          $skipped++;
+          continue;
+        }
+
+        $anchor->setAttribute('data-entity-type', 'file');
+        $anchor->setAttribute('data-entity-uuid', $file->uuid());
+        $anchor->setAttribute('data-entity-substitution', 'file');
+        $anchor->setAttribute('href', $this->fileUrlGenerator->generateString($file->getFileUri()));
+        $converted++;
+      }
+      catch (\Exception $e) {
+        $skipped++;
+        $this->getLogger()->warning('Could not convert media link @uuid to a file link: @message', [
+          '@uuid' => $uuid,
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+
+    // Preserve the original markup byte-for-byte when nothing was rewritten.
+    if ($converted === 0) {
+      return ['html' => $html, 'converted' => 0, 'skipped' => $skipped];
+    }
+
+    return ['html' => Html::serialize($dom), 'converted' => $converted, 'skipped' => $skipped];
+  }
+
+  /**
+   * Loads the content entities whose text fields contain a media link.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityStorageInterface $storage
+   *   The storage handler for the entity type.
+   * @param string $entity_type_id
+   *   The entity type ID (for logging).
+   * @param array $text_fields
+   *   Map of field name to field type for the text fields to scan.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface[]
+   *   The candidate entities, keyed by ID.
+   */
+  protected function loadCandidates(ContentEntityStorageInterface $storage, string $entity_type_id, array $text_fields): array {
+    $ids = [];
+    foreach ($text_fields as $field_name => $type) {
+      try {
+        $query = $storage->getQuery()->accessCheck(FALSE);
+        $group = $query->orConditionGroup()
+          ->condition($field_name . '.value', '%' . self::MEDIA_LINK_MARKER . '%', 'LIKE');
+        if ($type === 'text_with_summary') {
+          $group->condition($field_name . '.summary', '%' . self::MEDIA_LINK_MARKER . '%', 'LIKE');
+        }
+        $query->condition($group);
+        foreach ($query->execute() as $id) {
+          $ids[$id] = $id;
+        }
+      }
+      catch (\Exception $e) {
+        $this->getLogger()->warning('Could not scan @type field @field for media links: @message', [
+          '@type' => $entity_type_id,
+          '@field' => $field_name,
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+
+    return $ids ? $storage->loadMultiple($ids) : [];
+  }
+
+  /**
+   * Resolves a media UUID to its source file entity, if any.
+   *
+   * @param string $uuid
+   *   The media entity UUID stored on the link.
+   *
+   * @return \Drupal\file\FileInterface|null
+   *   The referenced file, or NULL when the media or its file is unavailable.
+   */
+  protected function resolveMediaFile(string $uuid): ?FileInterface {
+    if (array_key_exists($uuid, $this->mediaFileCache)) {
+      return $this->mediaFileCache[$uuid];
+    }
+
+    $file = NULL;
+    $media = $this->entityRepository->loadEntityByUuid('media', $uuid);
+    if ($media instanceof MediaInterface) {
+      $source_field = $media->getSource()->getConfiguration()['source_field'] ?? NULL;
+      if ($source_field && $media->hasField($source_field)) {
+        $target = $media->get($source_field)->entity;
+        $file = $target instanceof FileInterface ? $target : NULL;
+      }
+    }
+
+    return $this->mediaFileCache[$uuid] = $file;
+  }
+
+  /**
+   * Returns the text item properties to scan for a given field type.
+   *
+   * @param string $type
+   *   The field type.
+   *
+   * @return string[]
+   *   The property names holding markup.
+   */
+  protected function textProperties(string $type): array {
+    return $type === 'text_with_summary' ? ['value', 'summary'] : ['value'];
+  }
+
+  /**
+   * Gets the logger channel for this service.
+   *
+   * @return \Drupal\Core\Logger\LoggerChannelInterface
+   *   The logger channel.
+   */
+  protected function getLogger(): LoggerChannelInterface {
+    return $this->loggerFactory->get(self::LOGGER_CHANNEL);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_file_management/src/Service/MediaLinkConverterInterface.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_file_management/src/Service/MediaLinkConverterInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\ys_file_management\Service;
+
+/**
+ * Converts legacy "media" links in rich text into direct file links.
+ *
+ * Issue #835 removed the media matcher from the Linkit profile because a media
+ * link to a document resolves to the media entity's canonical route, which is
+ * not accessible to site visitors. Content authored before that change still
+ * carries `<a data-entity-type="media" …>` markup, so this service rewrites
+ * those anchors to point at the referenced media's underlying file — the same
+ * accessible target the file matcher produces.
+ */
+interface MediaLinkConverterInterface {
+
+  /**
+   * Rewrites media links to file links across all content entities.
+   *
+   * @return array
+   *   Stats with keys: 'entities_updated', 'links_converted', 'links_skipped'.
+   */
+  public function convertAllContent(): array;
+
+  /**
+   * Rewrites the media links found in a single HTML string.
+   *
+   * @param string $html
+   *   The stored field markup.
+   *
+   * @return array
+   *   Result with keys: 'html' (the possibly-rewritten markup), 'converted'
+   *   (links pointed at a file) and 'skipped' (media links left as-is because
+   *   the media or its file could not be resolved).
+   */
+  public function convertMarkup(string $html): array;
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_file_management/tests/src/Kernel/MediaLinkConverterTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_file_management/tests/src/Kernel/MediaLinkConverterTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Drupal\Tests\ys_file_management\Kernel;
+
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\file\Entity\File;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\media\Entity\Media;
+use Drupal\media\MediaInterface;
+use Drupal\Tests\media\Traits\MediaTypeCreationTrait;
+
+/**
+ * Kernel tests for MediaLinkConverter.
+ *
+ * Issue #835 removes "media" as a link type. Existing content that already
+ * linked a document via a media entity keeps markup that resolves to an
+ * inaccessible media page, so the converter rewrites those links to point at
+ * the underlying file (the accessible target the file matcher would produce).
+ *
+ * @group ys_file_management
+ * @group yalesites
+ */
+class MediaLinkConverterTest extends KernelTestBase {
+
+  use MediaTypeCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'file',
+    'image',
+    'media',
+    'entity_test',
+    'ys_file_management',
+  ];
+
+  /**
+   * The media link converter service.
+   *
+   * @var \Drupal\ys_file_management\Service\MediaLinkConverterInterface
+   */
+  protected $converter;
+
+  /**
+   * The document media type (file source).
+   *
+   * @var \Drupal\media\MediaTypeInterface
+   */
+  protected $documentType;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('media');
+    $this->installEntitySchema('entity_test');
+    $this->installSchema('file', 'file_usage');
+    $this->installSchema('system', 'sequences');
+    $this->installConfig(['system', 'field', 'file', 'media', 'ys_file_management']);
+
+    // A formatted-text field on the generic test entity stands in for a node
+    // body / block text field carrying Linkit markup.
+    FieldStorageConfig::create([
+      'entity_type' => 'entity_test',
+      'field_name' => 'field_body',
+      'type' => 'text_long',
+    ])->save();
+    FieldConfig::create([
+      'entity_type' => 'entity_test',
+      'field_name' => 'field_body',
+      'bundle' => 'entity_test',
+    ])->save();
+
+    // A document media type uses the "file" source (field_media_file).
+    $this->documentType = $this->createMediaType('file', ['id' => 'document']);
+
+    $this->converter = $this->container->get('ys_file_management.media_link_converter');
+  }
+
+  /**
+   * Creates a document media entity wrapping a saved file.
+   *
+   * @return array
+   *   A [media, file] tuple.
+   */
+  protected function createDocumentMedia(string $filename): array {
+    $file = File::create([
+      'uri' => 'public://' . $filename,
+      'filename' => $filename,
+    ]);
+    $file->save();
+
+    $source_field = $this->documentType->getSource()->getConfiguration()['source_field'];
+    $media = Media::create([
+      'bundle' => 'document',
+      'name' => $filename,
+      $source_field => ['target_id' => $file->id()],
+    ]);
+    $media->save();
+
+    return [$media, $file];
+  }
+
+  /**
+   * Builds an anchor with the media data-attributes Linkit stores.
+   */
+  protected function mediaLink(MediaInterface $media): string {
+    return sprintf(
+      '<p><a data-entity-type="media" data-entity-uuid="%s" data-entity-substitution="media_download_inline" href="/media/%s/download?inline">My document</a></p>',
+      $media->uuid(),
+      $media->id()
+    );
+  }
+
+  /**
+   * The service is wired and honours its interface.
+   */
+  public function testServiceExists(): void {
+    $this->assertInstanceOf(
+      'Drupal\ys_file_management\Service\MediaLinkConverterInterface',
+      $this->converter
+    );
+  }
+
+  /**
+   * A document media link is rewritten to point at the underlying file.
+   */
+  public function testConvertMarkupRewritesMediaLinkToFile(): void {
+    [$media, $file] = $this->createDocumentMedia('reference.pdf');
+    $file_url = $this->container->get('file_url_generator')->generateString($file->getFileUri());
+
+    $result = $this->converter->convertMarkup($this->mediaLink($media));
+
+    $this->assertSame(1, $result['converted']);
+    $this->assertSame(0, $result['skipped']);
+    $this->assertStringContainsString('data-entity-type="file"', $result['html']);
+    $this->assertStringContainsString('data-entity-uuid="' . $file->uuid() . '"', $result['html']);
+    $this->assertStringContainsString('data-entity-substitution="file"', $result['html']);
+    $this->assertStringContainsString('href="' . $file_url . '"', $result['html']);
+    $this->assertStringNotContainsString('data-entity-type="media"', $result['html']);
+  }
+
+  /**
+   * Non-media links (node, plain URL) are left untouched.
+   */
+  public function testConvertMarkupLeavesNonMediaLinksUnchanged(): void {
+    $html = '<p><a data-entity-type="node" data-entity-uuid="abc" href="/node/1">A page</a> and <a href="https://example.com">external</a></p>';
+
+    $result = $this->converter->convertMarkup($html);
+
+    $this->assertSame(0, $result['converted']);
+    $this->assertSame(0, $result['skipped']);
+    $this->assertSame($html, $result['html']);
+  }
+
+  /**
+   * A media link whose entity cannot be resolved is skipped, not mangled.
+   */
+  public function testConvertMarkupSkipsUnresolvableMedia(): void {
+    $html = '<p><a data-entity-type="media" data-entity-uuid="00000000-0000-0000-0000-000000000000" href="/media/999/download?inline">Ghost</a></p>';
+
+    $result = $this->converter->convertMarkup($html);
+
+    $this->assertSame(0, $result['converted']);
+    $this->assertSame(1, $result['skipped']);
+    $this->assertSame($html, $result['html']);
+  }
+
+  /**
+   * The bulk pass rewrites and saves every entity carrying a media link.
+   */
+  public function testConvertAllContentUpdatesEntities(): void {
+    [$media, $file] = $this->createDocumentMedia('report.pdf');
+    $file_url = $this->container->get('file_url_generator')->generateString($file->getFileUri());
+
+    $entity = EntityTest::create([
+      'name' => 'Has media link',
+      'field_body' => [
+        'value' => $this->mediaLink($media),
+        'format' => 'basic_html',
+      ],
+    ]);
+    $entity->save();
+
+    $stats = $this->converter->convertAllContent();
+
+    $this->assertSame(1, $stats['links_converted']);
+    $this->assertSame(1, $stats['entities_updated']);
+    $this->assertSame(0, $stats['entities_failed']);
+
+    $reloaded = EntityTest::load($entity->id());
+    $value = $reloaded->get('field_body')->value;
+    $this->assertStringContainsString('data-entity-type="file"', $value);
+    $this->assertStringContainsString('href="' . $file_url . '"', $value);
+    $this->assertStringNotContainsString('data-entity-type="media"', $value);
+    // The stored text format must be preserved.
+    $this->assertSame('basic_html', $reloaded->get('field_body')->format);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_file_management/tests/src/Unit/LinkitMediaMatcherRemovedTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_file_management/tests/src/Unit/LinkitMediaMatcherRemovedTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\Tests\ys_file_management\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Guards the Linkit "default" profile against re-introducing a media matcher.
+ *
+ * A "media" link resolves to the media entity's canonical route, which for a
+ * document is /media/{id}/edit and is forbidden to anonymous visitors, so
+ * linking a document via "media" produced an inaccessible page. Because every
+ * CKEditor instance and Linkit link-field widget shares this single "default"
+ * profile, issue #835 removed the entity:media matcher so documents can only be
+ * linked via the working file matcher. This test fails if the exported profile
+ * regains a media matcher.
+ *
+ * @group yalesites
+ */
+class LinkitMediaMatcherRemovedTest extends UnitTestCase {
+
+  /**
+   * Absolute path to the profile's exported config/sync directory.
+   */
+  protected function configSyncDir(): string {
+    return dirname(__DIR__, 6) . '/config/sync';
+  }
+
+  /**
+   * The default Linkit profile must not offer a media matcher.
+   */
+  public function testDefaultProfileHasNoMediaMatcher(): void {
+    $file = $this->configSyncDir() . '/linkit.linkit_profile.default.yml';
+    $this->assertFileExists($file);
+    $profile = Yaml::parseFile($file);
+
+    $this->assertArrayHasKey('matchers', $profile, 'The Linkit "default" profile must define matchers.');
+
+    foreach ($profile['matchers'] as $uuid => $matcher) {
+      $this->assertNotSame('entity:media', $matcher['id'] ?? NULL, sprintf('The Linkit "default" profile must not offer a media link matcher (found matcher %s). Media links resolve to an inaccessible page; link documents via the file matcher instead (issue #835).', $uuid));
+    }
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_file_management/ys_file_management.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_file_management/ys_file_management.deploy.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Drush deploy hooks for the ys_file_management module.
+ */
+
+/**
+ * Converts legacy media links in rich text into direct file links (#835).
+ */
+function ys_file_management_deploy_9001() {
+  $stats = \Drupal::service('ys_file_management.media_link_converter')->convertAllContent();
+
+  return t('Converted @converted media link(s) to file links across @entities entit(y|ies). @skipped media link(s) were left unchanged (no downloadable file); @failed entit(y|ies) could not be saved.', [
+    '@converted' => $stats['links_converted'],
+    '@entities' => $stats['entities_updated'],
+    '@skipped' => $stats['links_skipped'],
+    '@failed' => $stats['entities_failed'],
+  ]);
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_file_management/ys_file_management.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_file_management/ys_file_management.services.yml
@@ -12,3 +12,16 @@ services:
   # Alias to allow type-hinting against the interface.
   Drupal\ys_file_management\Service\MediaFileDeleterInterface:
     alias: ys_file_management.media_file_deleter
+
+  ys_file_management.media_link_converter:
+    class: Drupal\ys_file_management\Service\MediaLinkConverter
+    arguments:
+      - '@entity_type.manager'
+      - '@entity_field.manager'
+      - '@entity.repository'
+      - '@file_url_generator'
+      - '@logger.factory'
+
+  # Alias to allow type-hinting against the interface.
+  Drupal\ys_file_management\Service\MediaLinkConverterInterface:
+    alias: ys_file_management.media_link_converter


### PR DESCRIPTION
## [835: Remove 'media' as a type in link fields](https://github.com/yalesites-org/YaleSites-Internal/issues/835)

### Description of work
- Removed the `entity:media` matcher from the shared `default` Linkit profile, so editors can no longer insert a "media" link. A media link resolved to the media entity's canonical route (`/media/{id}/edit`), which is forbidden to anonymous visitors, so linking a document via "media" opened an inaccessible page — whereas the file link points straight at the accessible file URL. Because the single `default` profile feeds CKEditor and every linkit link-field widget (and the header/footer/alert settings forms), the confusing/broken option is removed everywhere at once. Documents remain linkable via the file matcher.
- Added a `MediaLinkConverter` service (module `ys_file_management`) and the `ys_file_management_deploy_9001` deploy hook that convert existing `<a data-entity-type="media">` links in content to file links, so links authored before this change resolve to the accessible file URL (the same target the file matcher produces). An entity query pre-filters candidates on the media-link marker so only affected entities load; media with no downloadable file (remote video, embed) is left unchanged; each entity is saved in isolation so one failing save cannot abort the run. The conversion runs once, after config import.
- Added a Unit guard test (fails if a media matcher is ever reintroduced to the profile) and Kernel tests covering the conversion, the leave-untouched and skip paths, and the bulk save.

### Known limitations (reviewer notes)
- Only the **default revision** is converted; pending moderation drafts / non-default revisions keep their original markup until re-saved.
- Links stored via the Header/Footer/Alert **settings forms** are a URI string in config (not `<a>` markup), so they are outside this content-markup converter.

### Functional testing steps:
- [ ] In a page or text block, open the CKEditor link dialog, search, and confirm the autocomplete no longer offers "media" results (content, files, etc. still appear).
- [ ] Confirm a document can still be linked via the file option and the resulting link opens/downloads the file.
- [ ] On an environment that has pre-existing media links in content, run `drush deploy` (or `drush deploy:hook`), confirm the deploy message reports the number of converted links, and confirm those links now point at `/sites/default/files/…` and open the file instead of an "Access denied" page.

References yalesites-org/YaleSites-Internal#835

---
Created with AI
