### PR TITLE
929: Pre-built Form (Contact Us): Edit Icon Visible outside of Edit Layout and Content

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/WebformContextualLinksSuppressor.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/WebformContextualLinksSuppressor.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\ys_core;
+
+use Drupal\Core\Security\TrustedCallbackInterface;
+
+/**
+ * Decides when to strip the Webform module's contextual "edit" links.
+ *
+ * The Webform module unconditionally attaches a "webform" contextual-links
+ * group (Test / Results / Build / Settings) to every rendered submission form.
+ * On YaleSites that surfaces an edit icon — and a direct link to submission
+ * data — to anyone with "access contextual links" who merely views a page
+ * containing a Pre-Built Form block, outside of Layout Builder's "Edit Layout
+ * and Content" mode. The rule for when to remove that group is centralised here
+ * so it is unit-testable in isolation from the render pipeline.
+ *
+ * @see \_webform_form_webform_submission_form_after_build()
+ * @see ys_core_form_alter()
+ */
+class WebformContextualLinksSuppressor implements TrustedCallbackInterface {
+
+  /**
+   * Determines whether the webform contextual links should be removed.
+   *
+   * They are kept only while editing in Layout Builder (its routes are prefixed
+   * with "layout_builder."); on every view route — and defensively when no
+   * route matched — they are removed so the edit icon cannot leak submission
+   * data on the live page.
+   *
+   * @param string|null $route_name
+   *   The current route name, or NULL when no route matched.
+   *
+   * @return bool
+   *   TRUE if the webform contextual links should be removed.
+   */
+  public static function shouldSuppress(?string $route_name): bool {
+    return $route_name === NULL || !str_starts_with($route_name, 'layout_builder.');
+  }
+
+  /**
+   * Pre-render callback that strips the webform contextual-links group.
+   *
+   * Registered as a #pre_render so it runs after the Webform module's
+   * #after_build has attached the group, but before the contextual placeholder
+   * is built during preprocessing — so the edit icon is never rendered.
+   *
+   * @param array $element
+   *   The webform submission form render array.
+   *
+   * @return array
+   *   The render array without the webform contextual-links group.
+   */
+  public static function preRender(array $element): array {
+    // 'webform' is the contextual-links group the Webform module attaches.
+    unset($element['#contextual_links']['webform']);
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function trustedCallbacks() {
+    return ['preRender'];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/WebformContextualLinksSuppressorTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/WebformContextualLinksSuppressorTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_core\WebformContextualLinksSuppressor;
+
+/**
+ * Tests suppression of the Webform module's contextual "edit" links.
+ *
+ * Regression coverage for the bug where the Webform module's contextual links
+ * group (Test / Results / Build / Settings) — including access to submission
+ * data — appeared as an edit icon on Pre-Built Form blocks while a page was
+ * merely being viewed, outside of Layout Builder's "Edit Layout and Content".
+ * The links must stay only on Layout Builder editing routes and be removed on
+ * every view route.
+ *
+ * @coversDefaultClass \Drupal\ys_core\WebformContextualLinksSuppressor
+ *
+ * @group ys_core
+ */
+class WebformContextualLinksSuppressorTest extends UnitTestCase {
+
+  /**
+   * @covers ::shouldSuppress
+   *
+   * @dataProvider routeProvider
+   */
+  public function testShouldSuppress(?string $route_name, bool $expected): void {
+    $this->assertSame(
+      $expected,
+      WebformContextualLinksSuppressor::shouldSuppress($route_name)
+    );
+  }
+
+  /**
+   * Provides route names with the expected suppression decision.
+   *
+   * @return array
+   *   Each case: [route name, expected shouldSuppress()].
+   */
+  public static function routeProvider(): array {
+    return [
+      // View routes suppress the leaking edit icon.
+      'node canonical suppressed' => ['entity.node.canonical', TRUE],
+      'standalone webform page suppressed' => ['entity.webform.canonical', TRUE],
+      'front page suppressed' => ['view.frontpage.page_1', TRUE],
+      'node preview suppressed' => ['entity.node.preview', TRUE],
+
+      // Webform's own admin/test routes are suppressed too, by design: the same
+      // links exist there as local-task tabs, so removing the contextual pencil
+      // loses nothing (the target pages stay permission-gated regardless).
+      'webform test form suppressed' => ['entity.webform.test_form', TRUE],
+      'webform submission edit suppressed' => ['entity.webform_submission.edit_form', TRUE],
+
+      // Layout Builder editing routes keep the links (Edit Layout and Content).
+      'lb overrides view kept' => ['layout_builder.overrides.node.view', FALSE],
+      'lb defaults view kept' => ['layout_builder.defaults.node.view', FALSE],
+      'lb add block kept' => ['layout_builder.add_block', FALSE],
+      'lb configure block kept' => ['layout_builder.configure_block', FALSE],
+
+      // Defensive: no matched route removes the icon (fail closed on the leak).
+      'null route suppressed' => [NULL, TRUE],
+      'empty route suppressed' => ['', TRUE],
+    ];
+  }
+
+  /**
+   * @covers ::preRender
+   */
+  public function testPreRenderRemovesWebformGroup(): void {
+    $element = [
+      '#contextual_links' => [
+        'webform' => ['route_parameters' => ['webform' => 'contact']],
+        'layout_builder_block' => ['route_parameters' => ['foo' => 'bar']],
+      ],
+      '#markup' => 'form',
+    ];
+
+    $result = WebformContextualLinksSuppressor::preRender($element);
+
+    $this->assertArrayNotHasKey('webform', $result['#contextual_links']);
+    // Unrelated contextual-links groups are left untouched.
+    $this->assertArrayHasKey('layout_builder_block', $result['#contextual_links']);
+    $this->assertSame('form', $result['#markup']);
+  }
+
+  /**
+   * @covers ::preRender
+   */
+  public function testPreRenderIsNoOpWhenGroupAbsent(): void {
+    $element = ['#markup' => 'form'];
+
+    $result = WebformContextualLinksSuppressor::preRender($element);
+
+    $this->assertSame($element, $result);
+  }
+
+  /**
+   * The pre-render callback must be trusted or the renderer throws.
+   *
+   * @covers ::trustedCallbacks
+   */
+  public function testPreRenderIsTrusted(): void {
+    $this->assertContains(
+      'preRender',
+      WebformContextualLinksSuppressor::trustedCallbacks()
+    );
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -18,6 +18,7 @@ use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\ys_core\Editoria11yRouteSuppressor;
+use Drupal\ys_core\WebformContextualLinksSuppressor;
 
 // Include coffee commands.
 require_once __DIR__ . '/ys_core.coffee.inc';
@@ -83,6 +84,18 @@ function ys_core_theme($existing, $type, $theme, $path): array {
  * Implements hook_form_alter().
  */
 function ys_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Strip the Webform module's contextual "edit" links (Test, Results, Build,
+  // Settings) from Pre-Built Form submission forms when the page is being
+  // viewed rather than edited in Layout Builder. Without this, users with
+  // "access contextual links" get an edit icon exposing submission data on the
+  // live page. The links are attached in the Webform module's #after_build, so
+  // a #pre_render (a later phase) reliably removes them before the contextual
+  // placeholder is built.
+  if (str_starts_with($form_id, 'webform_submission')
+    && WebformContextualLinksSuppressor::shouldSuppress(\Drupal::routeMatch()->getRouteName())) {
+    $form['#pre_render'][] = [WebformContextualLinksSuppressor::class, 'preRender'];
+  }
+
   if ($form_id === 'layout_builder_update_block' || $form_id === 'layout_builder_add_block') {
     $block_type = ys_core_get_block_type($form, $form_state);
 


### PR DESCRIPTION
## [929: Pre-built Form (Contact Us): Edit Icon Visible outside of Edit Layout and Content](https://github.com/yalesites-org/YaleSites-Internal/issues/929)

### Description of work
- Logged-in administrators/editors saw a contextual edit icon on Pre-Built Form (Contact Us) blocks when simply **viewing** a page — outside of "Edit Layout and Content" — and it linked straight to submission data via the Webform "Results" link.
- Root cause: the Webform module unconditionally attaches its `webform` contextual-links group (Test / Results / Build / Settings) to every rendered submission form, ungated by route or edit mode. This is separate from the block-level Layout Builder edit link, which YaleSites already preview-gates.
- Fix (in `ys_core`): a new `WebformContextualLinksSuppressor` plus a `#pre_render` appended in `ys_core_form_alter()` on webform submission forms, which removes that contextual-links group on every route except Layout Builder editing routes. The `#pre_render` runs after the Webform module's `#after_build` (which attaches the group) and before the contextual placeholder is built, so the icon is never rendered. The links are kept in "Edit Layout and Content"; everywhere they are removed they are either the leak itself or redundant with the webform admin's own local-task tabs. Server-side route permissions are unchanged — this removes the front-end affordance, not the access control.
- Added unit tests (mirroring the existing `Editoria11yRouteSuppressorTest`) covering the route decision and the pre-render removal.

### Functional testing steps:
- [ ] Log in as an administrator or editor.
- [ ] Visit a page containing a Pre-Built Form (Contact Us) block (e.g. `/contact-us`) in normal view (NOT "Edit Layout and Content").
- [ ] Confirm there is no contextual edit icon/pencil on the form and no Test/Results/Build/Settings menu — and the form still renders and can be submitted.
- [ ] Open the same page via "Edit Layout and Content" and confirm the block is still editable (block-level edit still works).
- [ ] Confirm the webform can still be managed from the Webform admin UI (its Results/Build/Settings tabs).

References yalesites-org/YaleSites-Internal#929

---
Created with AI
