### PR TITLE
1033: Allow aria-level attributes on heading tags within the CKEditor Source View.

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/editor.editor.basic_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/editor.editor.basic_html.yml
@@ -119,11 +119,11 @@ settings:
         - '<blockquote cite>'
         - '<ul type>'
         - '<ol type>'
-        - '<h2 id>'
-        - '<h3 id>'
-        - '<h4 id>'
-        - '<h5 id>'
-        - '<h6 id>'
+        - '<h2 id aria-level>'
+        - '<h3 id aria-level>'
+        - '<h4 id aria-level>'
+        - '<h5 id aria-level>'
+        - '<h6 id aria-level>'
         - '<a hreflang>'
     editor_advanced_link_link:
       enabled_attributes:

--- a/web/profiles/custom/yalesites_profile/config/sync/filter.format.basic_html.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/filter.format.basic_html.yml
@@ -41,7 +41,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<a id target rel class hreflang href title data-entity-type data-entity-uuid data-entity-substitution> <br> <p class="text-align-left text-align-right"> <h2 id class="text-align-left text-align-right"> <h3 id class="text-align-left text-align-right"> <h4 id class="text-align-left text-align-right"> <h5 id class="text-align-left text-align-right"> <h6 id class="text-align-left text-align-right"> <cite> <dl> <dt> <dd> <span> <blockquote cite> <ul type> <ol type start> <strong> <em> <code class="language-*"> <pre class="text-align-left text-align-right"> <sub> <sup> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption>'
+      allowed_html: '<a id target rel class hreflang href title data-entity-type data-entity-uuid data-entity-substitution> <br> <p class="text-align-left text-align-right"> <h2 id aria-level class="text-align-left text-align-right"> <h3 id aria-level class="text-align-left text-align-right"> <h4 id aria-level class="text-align-left text-align-right"> <h5 id aria-level class="text-align-left text-align-right"> <h6 id aria-level class="text-align-left text-align-right"> <cite> <dl> <dt> <dd> <span> <blockquote cite> <ul type> <ol type start> <strong> <em> <code class="language-*"> <pre class="text-align-left text-align-right"> <sub> <sup> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/BasicHtmlAriaLevelTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/BasicHtmlAriaLevelTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\Core\Serialization\Yaml;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests that the Basic HTML text format permits aria-level on headings.
+ *
+ * Content editors need to set aria-level on heading tags via the CKEditor
+ * Source Editing view so a heading can be given a logical outline level
+ * independent of its visual level. That requires two config values to agree:
+ * the filter_html filter must keep the aria-level attribute on each heading it
+ * allows, and the CKEditor Source Editing plugin must list aria-level on those
+ * same headings so it is not stripped when the editor leaves Source view.
+ *
+ * @group ys_core
+ * @group yalesites
+ */
+class BasicHtmlAriaLevelTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['filter'];
+
+  /**
+   * The heading tags the Basic HTML format permits (h2-h6; h1 is reserved).
+   */
+  protected const HEADING_TAGS = ['h2', 'h3', 'h4', 'h5', 'h6'];
+
+  /**
+   * Reads a Basic HTML config file from the profile's sync directory.
+   */
+  protected function readConfig(string $name): array {
+    $path = \Drupal::root() . '/profiles/custom/yalesites_profile/config/sync/' . $name . '.yml';
+    return Yaml::decode(file_get_contents($path));
+  }
+
+  /**
+   * The filter_html filter keeps aria-level on every heading it allows.
+   */
+  public function testAriaLevelSurvivesFilterOnHeadings(): void {
+    $settings = $this->readConfig('filter.format.basic_html')['filters']['filter_html']['settings'];
+    $filter = $this->container->get('plugin.manager.filter')
+      ->createInstance('filter_html', ['settings' => $settings]);
+
+    foreach (self::HEADING_TAGS as $tag) {
+      $result = $filter->process("<$tag aria-level=\"3\">Heading</$tag>", 'en')
+        ->getProcessedText();
+      $this->assertStringContainsString('aria-level="3"', $result, "aria-level should survive filtering on <$tag>");
+    }
+  }
+
+  /**
+   * CKEditor Source Editing lists aria-level on every heading it allows.
+   *
+   * Guards against the filter and editor configs drifting apart: without this
+   * the attribute would pass the filter but be stripped by CKEditor's GHS.
+   */
+  public function testSourceEditingAllowsAriaLevelOnHeadings(): void {
+    $allowed_tags = $this->readConfig('editor.editor.basic_html')['settings']['plugins']['ckeditor5_sourceEditing']['allowed_tags'];
+
+    foreach (self::HEADING_TAGS as $tag) {
+      $entries = array_filter($allowed_tags, fn(string $entry) => str_starts_with($entry, "<$tag "));
+      $this->assertNotEmpty($entries, "Source Editing should list <$tag>");
+      foreach ($entries as $entry) {
+        $this->assertStringContainsString('aria-level', $entry, "Source Editing <$tag> should permit aria-level");
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
## [1033: Allow aria-level attributes on heading tags within the CKEditor Source View.](https://github.com/yalesites-org/YaleSites-Internal/issues/1033)

### Description of work
- Permit the `aria-level` attribute on heading tags (h2-h6) in the Basic HTML text format, so content editors can give a heading a logical outline level independent of its visual level via the CKEditor Source Editing view.
- `filter.format.basic_html`: added `aria-level` to the `allowed_html` attributes on each heading so the filter keeps it.
- `editor.editor.basic_html`: added `aria-level` to the CKEditor Source Editing `allowed_tags` for h2-h6 so CKEditor's General HTML Support does not strip it when leaving Source view.
- Added a kernel test (`BasicHtmlAriaLevelTest`) asserting `aria-level` survives the filter on every heading and that the editor and filter configs stay in sync.
- Scope note: Basic HTML does not include `<h1>` (Drupal reserves h1 for the page title and the heading plugin only enables h2-h6), so this covers h2-h6.

### Functional testing steps:
- [x] Edit content using the Basic HTML editor (for example, an Event's Description field).
- [x] Open the CKEditor Source Editing view (the `</>` Source button, under the toolbar overflow menu) and add a heading with an aria-level, e.g. `<h2 aria-level="3">Example heading</h2>`.
- [x] Leave the Source Editing view, then re-open it and confirm the `aria-level="3"` attribute is still present (not stripped).
- [x] Save the content and confirm the `aria-level` attribute persists on the rendered heading.
- [x] Confirm a non-permitted attribute (e.g. `data-foo="x"`) is still stripped when leaving Source view.

References yalesites-org/YaleSites-Internal#1033

---
Created with AI
