### PR TITLE
164: Do not show future posts (Post Feed/View)

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.post_list.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.post_list.yml
@@ -264,6 +264,53 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_publish_date_value:
+          id: field_publish_date_value
+          table: node__field_publish_date
+          field: field_publish_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_publish_date
+          plugin_id: datetime
+          operator: '<='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         field_category_target_id:
           id: field_category_target_id
           table: node__field_category

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
@@ -498,6 +498,45 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        post_publish_date:
+          id: post_publish_date
+          table: node_field_data
+          field: post_publish_date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: post_publish_date
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         combine:
           id: combine
           table: views

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/PostPublishDate.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/PostPublishDate.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\ys_views_basic\Plugin\views\filter;
+
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+
+/**
+ * Excludes posts whose publish date has not yet been reached.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("post_publish_date")
+ */
+class PostPublishDate extends FilterPluginBase {
+
+  /**
+   * Add this filter to the query.
+   */
+  public function query() {
+    // Only gate post listings. Pages and profiles share this scaffold view but
+    // have no publish date, and events use a separate scaffold, so leave any
+    // non-post listing untouched.
+    if (($this->view->args[0] ?? NULL) !== 'post') {
+      return;
+    }
+
+    // Ensure the base table for this handler is in the query.
+    $this->ensureMyTable();
+    /** @var \Drupal\views\Plugin\views\query\Sql $query */
+    $query = $this->query;
+
+    $lookupTable = $query->addTable('node__field_publish_date');
+    $field = "$lookupTable.field_publish_date_value";
+
+    // field_publish_date is a date-only field stored as an ISO 'Y-m-d' string,
+    // so compare lexicographically against today. Posts dated today are kept
+    // (on or past the publish date); only strictly future posts are excluded.
+    $query->addWhere($this->options['group'], $field, date('Y-m-d'), '<=');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/tests/modules/ys_views_basic_test/test_views/views.view.ys_views_basic_test_publish_date.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/tests/modules/ys_views_basic_test/test_views/views.view.ys_views_basic_test_publish_date.yml
@@ -1,0 +1,57 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - ys_views_basic
+id: ys_views_basic_test_publish_date
+label: 'YS Views Basic Test Publish Date'
+module: views
+description: 'Fixture view exercising the post_publish_date filter.'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: none
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: true
+      pager:
+        type: none
+        options: {  }
+      exposed_form:
+        type: basic
+        options: {  }
+      style:
+        type: default
+      row:
+        type: fields
+      fields:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+      filters:
+        post_publish_date:
+          id: post_publish_date
+          table: node_field_data
+          field: post_publish_date
+          plugin_id: post_publish_date
+          group: 1
+      sorts: {  }
+      arguments: {  }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/tests/modules/ys_views_basic_test/ys_views_basic_test.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/tests/modules/ys_views_basic_test/ys_views_basic_test.info.yml
@@ -1,0 +1,8 @@
+name: 'YS Views Basic Test'
+type: module
+description: 'Provides test fixtures (views) for ys_views_basic kernel tests.'
+package: Testing
+core_version_requirement: ^10 || ^11
+dependencies:
+  - drupal:node
+  - drupal:views

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/tests/src/Kernel/PostPublishDateFilterTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/tests/src/Kernel/PostPublishDateFilterTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ys_views_basic\Kernel;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\Tests\views\Kernel\ViewsKernelTestBase;
+use Drupal\views\Tests\ViewTestData;
+use Drupal\views\Views;
+
+/**
+ * Tests that the post_publish_date filter hides future-dated posts.
+ *
+ * @group yalesites
+ * @group ys_views_basic
+ */
+class PostPublishDateFilterTest extends ViewsKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'field',
+    'text',
+    'filter',
+    'datetime',
+    'node',
+    'path_alias',
+    'ys_views_basic',
+    'ys_views_basic_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $testViews = ['ys_views_basic_test_publish_date'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp($import_test_views = TRUE): void {
+    parent::setUp(FALSE);
+
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['node', 'field', 'filter']);
+
+    NodeType::create(['type' => 'post', 'name' => 'Post'])->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'field_publish_date',
+      'entity_type' => 'node',
+      'type' => 'datetime',
+      'settings' => ['datetime_type' => 'date'],
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_publish_date',
+      'entity_type' => 'node',
+      'bundle' => 'post',
+      'label' => 'Publish Date',
+    ])->save();
+
+    ViewTestData::createTestViews(static::class, ['ys_views_basic_test']);
+
+    $this->createPost('Past post', date('Y-m-d', strtotime('-5 days')));
+    $this->createPost('Today post', date('Y-m-d'));
+    $this->createPost('Future post', date('Y-m-d', strtotime('+5 days')));
+  }
+
+  /**
+   * Creates a published post with a given publish date.
+   */
+  private function createPost(string $title, string $publish_date): void {
+    Node::create([
+      'type' => 'post',
+      'title' => $title,
+      'status' => 1,
+      'field_publish_date' => $publish_date,
+    ])->save();
+  }
+
+  /**
+   * Executes the fixture view and returns the resulting node titles.
+   *
+   * @param array $args
+   *   View arguments; index 0 is the content-type machine name.
+   *
+   * @return string[]
+   *   The titles of the nodes in the result set.
+   */
+  private function executedTitles(array $args): array {
+    $view = Views::getView('ys_views_basic_test_publish_date');
+    $this->executeView($view, $args);
+    $titles = [];
+    foreach ($view->result as $row) {
+      $titles[] = $row->_entity->label();
+    }
+    return $titles;
+  }
+
+  /**
+   * A post listing hides posts whose publish date is in the future.
+   */
+  public function testFutureDatedPostsExcludedForPostListing(): void {
+    $titles = $this->executedTitles(['post']);
+    $this->assertContains('Past post', $titles);
+    $this->assertContains('Today post', $titles);
+    $this->assertNotContains('Future post', $titles, 'A future-dated post must not appear in a post listing.');
+  }
+
+  /**
+   * The filter is inert when the listing is not a post listing.
+   */
+  public function testFilterInertForNonPostListing(): void {
+    $titles = $this->executedTitles(['page']);
+    // A non-post listing must be untouched: the cutoff adds no condition, so
+    // every post — including the future-dated one — remains.
+    $this->assertContains('Past post', $titles);
+    $this->assertContains('Today post', $titles);
+    $this->assertContains('Future post', $titles, 'The publish-date cutoff must not affect non-post listings.');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -75,6 +75,13 @@ function ys_views_basic_views_data_alter(array &$data) {
       'id' => 'post_year_filter',
     ],
   ];
+  $data['node_field_data']['post_publish_date'] = [
+    'title' => t('Post Publish Date'),
+    'filter' => [
+      'help' => t('Excludes posts whose publish date is in the future.'),
+      'id' => 'post_publish_date',
+    ],
+  ];
 
 }
 


### PR DESCRIPTION
## [164: Do not show future posts (Post Feed/View)](https://github.com/yalesites-org/YaleSites-Internal/issues/164)

### Description of work
- Published posts with a **future** publish date were appearing in post listings before that date was reached. Now a post only appears once the current date is on or past its `field_publish_date` (posts dated **today** still appear).
- Both post-listing paths are fixed:
  - **"View" block** (dynamic `views_basic_scaffold` view): a new `PostPublishDate` Views filter plugin in `ys_views_basic` excludes future-dated posts. It self-guards on the post bundle, so Page/Profile listings that share the same scaffold view are left untouched. Mirrors the existing `EventTimePeriod` filter pattern.
  - **"Post feed" block** (`post_list` view, rendered on pages such as `/posts`): a core `datetime` filter (`field_publish_date <= now`). Mirrors the existing `event_list` view.
- **Events are intentionally unaffected** — they are a separate content type rendered by separate views (`views_basic_scaffold_events` / `event_list`), so future events still display.
- Adds a `ViewsKernelTestBase` test (`PostPublishDateFilterTest`) covering the cutoff (past/today shown, future excluded) and the non-post guard.

### Functional testing steps:
- [x] Create a Post with a publish date in the future (e.g. next week) and publish it; create one dated today and one in the past, and publish both.
- [x] View a page with a "Post feed" block (e.g. `/posts`): the future-dated post should NOT appear; today's and past posts should appear.
- [x] Add/insert a "View" block set to Posts on a page: confirm the future-dated post is hidden there too, and today's/past posts show.
- [x] Confirm Page and Profile "View" listings still show all of their items (they must not be emptied).
- [x] Confirm an Events listing still shows future-dated events (events unaffected).

References yalesites-org/YaleSites-Internal#164

---
Created with AI
