### PR TITLE
1339: Gate the Beacon Integration Behind a Platform Admin Settings Toggle

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -144,6 +144,7 @@ permissions:
   - 'administer coffee'
   - 'administer google_tag_container'
   - 'administer main menu items'
+  - 'administer platform admin settings'
   - 'administer redirects'
   - 'administer users'
   - 'administer utility-drop-button-navigation menu items'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/install/ys_beacon.settings.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/install/ys_beacon.settings.yml
@@ -1,4 +1,5 @@
 enable_chat: false
+platform_authorized: false
 enable_metadata_fields: true
 floating_button: false
 floating_button_text: 'Beacon Chat'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/schema/ys_beacon.schema.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/schema/ys_beacon.schema.yml
@@ -5,6 +5,9 @@ ys_beacon.settings:
     enable_chat:
       type: boolean
       label: 'Enable the chat widget'
+    platform_authorized:
+      type: boolean
+      label: 'Platform admin has authorized Beacon for this site'
     enable_metadata_fields:
       type: boolean
       label: 'Show AI metadata fields on content forms'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/ys_ai_tester.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/ys_ai_tester.routing.yml
@@ -5,6 +5,7 @@ ys_ai_tester.tester:
     _title: 'AI Tester'
   requirements:
     _permission: 'use ys ai tester'
+    _ys_beacon_authorized: 'TRUE'
 
 ys_ai_tester.run:
   path: '/admin/config/yalesites/ys-beacon/tester/{run_id}'
@@ -13,6 +14,7 @@ ys_ai_tester.run:
     _title: 'AI Tester Run'
   requirements:
     _permission: 'use ys ai tester'
+    _ys_beacon_authorized: 'TRUE'
     run_id: '\d+'
 
 ys_ai_tester.compare:
@@ -22,6 +24,7 @@ ys_ai_tester.compare:
     _title: 'Compare AI Tester Runs'
   requirements:
     _permission: 'use ys ai tester'
+    _ys_beacon_authorized: 'TRUE'
     run_a: '\d+'
     run_b: '\d+'
 
@@ -32,6 +35,7 @@ ys_ai_tester.compare_json:
     _title: 'Download Comparison JSON'
   requirements:
     _permission: 'use ys ai tester'
+    _ys_beacon_authorized: 'TRUE'
     run_a: '\d+'
     run_b: '\d+'
 
@@ -42,6 +46,7 @@ ys_ai_tester.compare_csv:
     _title: 'Download Comparison CSV'
   requirements:
     _permission: 'use ys ai tester'
+    _ys_beacon_authorized: 'TRUE'
     run_a: '\d+'
     run_b: '\d+'
 
@@ -52,6 +57,7 @@ ys_ai_tester.download_json:
     _title: 'Download JSON'
   requirements:
     _permission: 'use ys ai tester'
+    _ys_beacon_authorized: 'TRUE'
     run_id: '\d+'
 
 ys_ai_tester.download_yaml:
@@ -61,4 +67,5 @@ ys_ai_tester.download_yaml:
     _title: 'Download YAML'
   requirements:
     _permission: 'use ys ai tester'
+    _ys_beacon_authorized: 'TRUE'
     run_id: '\d+'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Access/BeaconAuthorizedAccessCheck.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Access/BeaconAuthorizedAccessCheck.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\ys_beacon\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\ys_beacon\BeaconAuthorization;
+
+/**
+ * Checks that Beacon is platform-authorized for the site.
+ *
+ * Applied additively to the Beacon settings and system instructions routes, so
+ * their menu links and pages are denied until a platform admin authorizes
+ * Beacon. It gates on the per-site authorization flag only; the existing
+ * permission and integration checks on those routes continue to apply.
+ */
+class BeaconAuthorizedAccessCheck implements AccessInterface {
+
+  /**
+   * Constructs a BeaconAuthorizedAccessCheck object.
+   *
+   * @param \Drupal\ys_beacon\BeaconAuthorization $beaconAuthorization
+   *   The Beacon authorization service.
+   */
+  public function __construct(
+    protected BeaconAuthorization $beaconAuthorization,
+  ) {
+  }
+
+  /**
+   * Checks access based on the per-site Beacon authorization flag.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The currently logged in account.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(AccountInterface $account) {
+    $cache_tags = ['config:' . BeaconAuthorization::CONFIG_NAME];
+    if (!$this->beaconAuthorization->isAuthorized()) {
+      return AccessResult::forbidden('Beacon is not authorized for this site.')
+        ->addCacheTags($cache_tags);
+    }
+    return AccessResult::allowed()->addCacheTags($cache_tags);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/BeaconAuthorization.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/BeaconAuthorization.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\ys_beacon;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+
+/**
+ * Single source of truth for whether Beacon is authorized on this site.
+ *
+ * A platform admin authorizes Beacon per site from the Platform Admin Settings
+ * page; until then every Beacon surface stays hidden and inert. All Beacon
+ * gates (the integration card, the settings and instructions access checks, the
+ * content feed, and the indexing hooks) consult this service so the
+ * authorization rule lives in exactly one place.
+ *
+ * The flag is stored in ys_beacon.settings (config_ignored, so it is per-site
+ * and survives config import). The config override that forces the chat off for
+ * unauthorized sites reads the flag from raw storage rather than through this
+ * service, to avoid re-entering the config factory while overrides resolve.
+ */
+class BeaconAuthorization {
+
+  /**
+   * The config object holding the authorization flag.
+   */
+  public const CONFIG_NAME = 'ys_beacon.settings';
+
+  /**
+   * The boolean flag key authorizing Beacon for the site.
+   */
+  public const FLAG = 'platform_authorized';
+
+  /**
+   * Constructs a BeaconAuthorization object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   */
+  public function __construct(
+    protected ConfigFactoryInterface $configFactory,
+  ) {
+  }
+
+  /**
+   * Whether a platform admin has authorized Beacon for this site.
+   *
+   * @return bool
+   *   TRUE when Beacon is authorized for the site.
+   */
+  public function isAuthorized(): bool {
+    return (bool) $this->configFactory->get(self::CONFIG_NAME)->get(self::FLAG);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Config/YsBeaconConfigOverrides.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Config/YsBeaconConfigOverrides.php
@@ -21,6 +21,12 @@ use Drupal\Core\Config\StorageInterface;
  * The index is also disabled at runtime whenever the chat widget is turned
  * off or a site has not configured its index name yet, so unconfigured or
  * disabled sites never attempt to reach Azure.
+ *
+ * Finally, when a platform admin has not authorized Beacon for a site, this
+ * override forces the chat off (ys_beacon.settings:enable_chat) so the site
+ * behaves exactly as if the site admin had disabled it: the widget, APIs, and
+ * index all stand down. The authorization flag is read from raw storage, so
+ * this never re-enters the config factory while overrides resolve.
  */
 class YsBeaconConfigOverrides implements ConfigFactoryOverrideInterface {
 
@@ -33,6 +39,11 @@ class YsBeaconConfigOverrides implements ConfigFactoryOverrideInterface {
    * runtime to support a second index without code changes.
    */
   protected const VDB_CONFIG = 'ai_vdb_provider_azure_ai_search.settings';
+
+  /**
+   * The Beacon settings config whose chat toggle this class overrides.
+   */
+  protected const SETTINGS_CONFIG = 'ys_beacon.settings';
 
   /**
    * Default key entity id holding the Azure AI Search endpoint URL.
@@ -77,6 +88,21 @@ class YsBeaconConfigOverrides implements ConfigFactoryOverrideInterface {
     $index_config = $this->indexConfigName($settings);
     $index_name = $settings['azure_index_name'] ?? '';
 
+    // A site is only "chat enabled" when its own toggle is on AND a platform
+    // admin has authorized Beacon for it. Folding authorization in here means
+    // an unauthorized site behaves exactly as if chat were turned off, without
+    // touching the site admin's saved enable_chat value.
+    $authorized = !empty($settings['platform_authorized']);
+    $enable_chat = ($settings['enable_chat'] ?? FALSE) && $authorized;
+
+    // When Beacon is not authorized, force the chat off for every consumer that
+    // reads enable_chat through the config factory (the widget attach, the
+    // conversation API, the floating button). The saved value is untouched, so
+    // re-authorizing restores it.
+    if (!$authorized && in_array(self::SETTINGS_CONFIG, $names, TRUE)) {
+      $overrides[self::SETTINGS_CONFIG] = ['enable_chat' => FALSE];
+    }
+
     if (in_array($server_config, $names, TRUE) && $index_name !== '') {
       $overrides[$server_config] = [
         'backend_config' => [
@@ -91,8 +117,8 @@ class YsBeaconConfigOverrides implements ConfigFactoryOverrideInterface {
       // The chat toggle is the primary driver of index status: the settings
       // form enables or disables the index explicitly in sync with it. This
       // override only acts as a safety net, forcing the index off whenever
-      // chat is disabled or no index name has been configured yet.
-      $enable_chat = $settings['enable_chat'] ?? FALSE;
+      // chat is disabled (including an unauthorized site) or no index name has
+      // been configured yet.
       if (!$enable_chat || $index_name === '') {
         $overrides[$index_config] = ['status' => FALSE];
       }
@@ -122,6 +148,7 @@ class YsBeaconConfigOverrides implements ConfigFactoryOverrideInterface {
    */
   protected function mayBeRelevant(string $name): bool {
     return $name === self::VDB_CONFIG
+      || $name === self::SETTINGS_CONFIG
       || str_starts_with($name, 'search_api.server.')
       || str_starts_with($name, 'search_api.index.');
   }
@@ -233,6 +260,7 @@ class YsBeaconConfigOverrides implements ConfigFactoryOverrideInterface {
     $settings = $this->getSettings();
     $ours = [
       self::VDB_CONFIG,
+      self::SETTINGS_CONFIG,
       $this->serverConfigName($settings),
       $this->indexConfigName($settings),
     ];

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Controller/ContentFeedController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Controller/ContentFeedController.php
@@ -3,6 +3,7 @@
 namespace Drupal\ys_beacon\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\ys_beacon\BeaconAuthorization;
 use Drupal\ys_beacon\Service\ContentFeedBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -16,11 +17,15 @@ use Symfony\Component\HttpFoundation\Request;
  * ContentFeedBuilder builds every item as the anonymous user, so the feed only
  * ever exposes content a logged-out visitor could read: published, anonymously
  * viewable, and not opted out via the ai_disable_indexing metatag.
+ *
+ * The feed is closed with a 403 on sites where a platform admin has not
+ * authorized Beacon, so no AI-related activity runs there.
  */
 class ContentFeedController extends ControllerBase {
 
   public function __construct(
     protected ContentFeedBuilder $feedBuilder,
+    protected BeaconAuthorization $beaconAuthorization,
   ) {
   }
 
@@ -28,7 +33,10 @@ class ContentFeedController extends ControllerBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static($container->get('ys_beacon.content_feed_builder'));
+    return new static(
+      $container->get('ys_beacon.content_feed_builder'),
+      $container->get('ys_beacon.authorization'),
+    );
   }
 
   /**
@@ -44,6 +52,10 @@ class ContentFeedController extends ControllerBase {
    *   The feed payload, or a 400 for an unsupported type.
    */
   public function feed(Request $request): JsonResponse {
+    if (!$this->beaconAuthorization->isAuthorized()) {
+      return new JsonResponse(['error' => 'The content feed is not enabled.'], 403);
+    }
+
     $type = (string) $request->query->get('type', 'node');
     $page = (int) $request->query->get('page', 1);
     $page_size = (int) $request->query->get('page_size', ContentFeedBuilder::DEFAULT_PAGE_SIZE);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/PlatformAdminSetting/BeaconPlatformAdminSetting.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/PlatformAdminSetting/BeaconPlatformAdminSetting.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\ys_beacon\Plugin\PlatformAdminSetting;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\ys_beacon\BeaconAuthorization;
+use Drupal\ys_core\Attribute\PlatformAdminSetting;
+use Drupal\ys_core\PlatformAdminSettingBase;
+
+/**
+ * Platform admin toggle authorizing Beacon for the site.
+ *
+ * Contributes the per-site Beacon authorization flag to the Platform Admin
+ * Settings page. Only platform admins reach that page, so this is where Beacon
+ * is switched on for a site; site admins then configure it as usual.
+ */
+#[PlatformAdminSetting(
+  id: 'ys_beacon',
+  label: new TranslatableMarkup('Beacon (AI Chat)'),
+  weight: 0,
+)]
+class BeaconPlatformAdminSetting extends PlatformAdminSettingBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildSettings(array $form, FormStateInterface $form_state): array {
+    $authorized = (bool) $this->configFactory
+      ->get(BeaconAuthorization::CONFIG_NAME)
+      ->get(BeaconAuthorization::FLAG);
+
+    $form['platform_authorized'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Allow site admins to configure and use Beacon'),
+      '#description' => $this->t('When enabled, site administrators can turn on and configure the Beacon AI chat for this site. When disabled, all Beacon features are hidden and inactive for this site.'),
+      '#default_value' => $authorized,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitSettings(array &$form, FormStateInterface $form_state): void {
+    $value = (bool) $form_state->getValue([$this->getPluginId(), 'platform_authorized']);
+    $this->configFactory
+      ->getEditable(BeaconAuthorization::CONFIG_NAME)
+      ->set(BeaconAuthorization::FLAG, $value)
+      ->save();
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/ys_integrations/BeaconIntegrationPlugin.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/ys_integrations/BeaconIntegrationPlugin.php
@@ -7,6 +7,7 @@ use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
+use Drupal\ys_beacon\BeaconAuthorization;
 use Drupal\ys_beacon\Service\SystemInstructionsStorage;
 use Drupal\ys_integrations\Attribute\Integration;
 use Drupal\ys_integrations\IntegrationPluginBase;
@@ -37,6 +38,13 @@ class BeaconIntegrationPlugin extends IntegrationPluginBase {
   protected DateFormatterInterface $dateFormatter;
 
   /**
+   * The Beacon authorization service.
+   *
+   * @var \Drupal\ys_beacon\BeaconAuthorization
+   */
+  protected BeaconAuthorization $beaconAuthorization;
+
+  /**
    * Constructs a new BeaconIntegrationPlugin object.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
@@ -49,11 +57,14 @@ class BeaconIntegrationPlugin extends IntegrationPluginBase {
    *   The system instructions storage.
    * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
    *   The date formatter.
+   * @param \Drupal\ys_beacon\BeaconAuthorization $beacon_authorization
+   *   The Beacon authorization service.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, array $plugin_definition, AccountInterface $current_user, SystemInstructionsStorage $instructions_storage, DateFormatterInterface $date_formatter) {
+  public function __construct(ConfigFactoryInterface $config_factory, array $plugin_definition, AccountInterface $current_user, SystemInstructionsStorage $instructions_storage, DateFormatterInterface $date_formatter, BeaconAuthorization $beacon_authorization) {
     parent::__construct($config_factory, $plugin_definition, $current_user);
     $this->instructionsStorage = $instructions_storage;
     $this->dateFormatter = $date_formatter;
+    $this->beaconAuthorization = $beacon_authorization;
   }
 
   /**
@@ -66,6 +77,7 @@ class BeaconIntegrationPlugin extends IntegrationPluginBase {
       $container->get('current_user'),
       $container->get('ys_beacon.system_instructions_storage'),
       $container->get('date.formatter'),
+      $container->get('ys_beacon.authorization'),
     );
   }
 
@@ -73,10 +85,10 @@ class BeaconIntegrationPlugin extends IntegrationPluginBase {
    * {@inheritdoc}
    */
   public function isTurnedOn(): bool {
-    // The Beacon card must always be actionable: admins reach the Configure and
-    // Manage Instructions screens from here to enable chat and set the index
-    // name, so the card can never gate itself off.
-    return TRUE;
+    // The card is actionable only once a platform admin has authorized Beacon
+    // for this site; otherwise it shows "not configured". Site admins reach the
+    // Configure and Manage Instructions screens from the actionable card.
+    return $this->beaconAuthorization->isAuthorized();
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconAuthorizationTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconAuthorizationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\BeaconAuthorization;
+
+/**
+ * Tests the Beacon authorization service.
+ *
+ * The single source of truth for whether a platform admin has authorized
+ * Beacon for the site, read from ys_beacon.settings:platform_authorized.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\BeaconAuthorization
+ */
+class BeaconAuthorizationTest extends UnitTestCase {
+
+  /**
+   * Builds the service with a config factory stub for the given settings.
+   */
+  private function authorization(array $settings): BeaconAuthorization {
+    return new BeaconAuthorization(
+      $this->getConfigFactoryStub(['ys_beacon.settings' => $settings]),
+    );
+  }
+
+  /**
+   * A missing or falsy flag is not authorized; a truthy flag is.
+   *
+   * @covers ::isAuthorized
+   */
+  public function testReflectsFlag(): void {
+    $this->assertFalse($this->authorization([])->isAuthorized());
+    $this->assertFalse($this->authorization(['platform_authorized' => FALSE])->isAuthorized());
+    $this->assertTrue($this->authorization(['platform_authorized' => TRUE])->isAuthorized());
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconAuthorizedAccessCheckTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconAuthorizedAccessCheckTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\Access\BeaconAuthorizedAccessCheck;
+use Drupal\ys_beacon\BeaconAuthorization;
+
+/**
+ * Tests the Beacon authorization access check.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Access\BeaconAuthorizedAccessCheck
+ */
+class BeaconAuthorizedAccessCheckTest extends UnitTestCase {
+
+  /**
+   * Builds the access check with an authorization service stubbed to $value.
+   */
+  private function check(bool $value): BeaconAuthorizedAccessCheck {
+    $authorization = $this->createMock(BeaconAuthorization::class);
+    $authorization->method('isAuthorized')->willReturn($value);
+    return new BeaconAuthorizedAccessCheck($authorization);
+  }
+
+  /**
+   * Access is allowed when Beacon is authorized, and tags the settings config.
+   *
+   * @covers ::access
+   */
+  public function testAllowedWhenAuthorized(): void {
+    $result = $this->check(TRUE)->access($this->createMock(AccountInterface::class));
+    $this->assertTrue($result->isAllowed());
+    $this->assertContains('config:ys_beacon.settings', $result->getCacheTags());
+  }
+
+  /**
+   * Access is forbidden when Beacon is not authorized.
+   *
+   * @covers ::access
+   */
+  public function testForbiddenWhenNotAuthorized(): void {
+    $result = $this->check(FALSE)->access($this->createMock(AccountInterface::class));
+    $this->assertTrue($result->isForbidden());
+    $this->assertContains('config:ys_beacon.settings', $result->getCacheTags());
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconConfigDefaultsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconConfigDefaultsTest.php
@@ -33,6 +33,13 @@ class BeaconConfigDefaultsTest extends UnitTestCase {
   }
 
   /**
+   * Beacon ships unauthorized: a platform admin must turn it on per site.
+   */
+  public function testPlatformAuthorizedDefaultsToOff(): void {
+    $this->assertFalse($this->installSettings()['platform_authorized']);
+  }
+
+  /**
    * The floating button icon ships fixed to the "sparkles" mark.
    */
   public function testFloatingButtonIconDefaultsToSparkles(): void {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconIntegrationPluginTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconIntegrationPluginTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\ys_beacon\Unit;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\BeaconAuthorization;
 use Drupal\ys_beacon\Plugin\ys_integrations\BeaconIntegrationPlugin;
 use Drupal\ys_beacon\Service\SystemInstructionsStorage;
 
@@ -42,21 +43,25 @@ class BeaconIntegrationPluginTest extends UnitTestCase {
       $this->createMock(AccountInterface::class),
       $this->createMock(SystemInstructionsStorage::class),
       $this->createMock(DateFormatterInterface::class),
+      new BeaconAuthorization($config_factory),
     );
   }
 
   /**
-   * The Beacon card is always actionable, regardless of chat/index config.
+   * The card is actionable only once the platform authorizes Beacon.
    *
-   * Admins reach Configure / Manage Instructions from the card to enable chat
-   * and set the index name, so the card must never gate itself off.
+   * The card drives the Configure / Manage Instructions actions; until a
+   * platform admin authorizes Beacon for the site it must show "not
+   * configured", independent of the site admin's chat/index settings.
    *
    * @covers ::isTurnedOn
    */
-  public function testIsAlwaysTurnedOn(): void {
-    $this->assertTrue($this->buildPlugin([])->isTurnedOn());
-    $this->assertTrue($this->buildPlugin(['enable_chat' => FALSE, 'azure_index_name' => ''])->isTurnedOn());
-    $this->assertTrue($this->buildPlugin(['enable_chat' => TRUE, 'azure_index_name' => 'site-live'])->isTurnedOn());
+  public function testIsTurnedOnReflectsAuthorization(): void {
+    $this->assertFalse($this->buildPlugin([])->isTurnedOn());
+    $this->assertFalse($this->buildPlugin(['platform_authorized' => FALSE])->isTurnedOn());
+    // The chat/index settings do not make the card actionable on their own.
+    $this->assertFalse($this->buildPlugin(['enable_chat' => TRUE, 'azure_index_name' => 'site-live'])->isTurnedOn());
+    $this->assertTrue($this->buildPlugin(['platform_authorized' => TRUE])->isTurnedOn());
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconPlatformAdminSettingTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconPlatformAdminSettingTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\Plugin\PlatformAdminSetting\BeaconPlatformAdminSetting;
+
+/**
+ * Tests the Beacon platform admin setting plugin.
+ *
+ * The toggle that authorizes Beacon for the site, contributed to the Platform
+ * Admin Settings page: its checkbox reflects the stored flag and its submit
+ * saves the flag back to ys_beacon.settings.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Plugin\PlatformAdminSetting\BeaconPlatformAdminSetting
+ */
+class BeaconPlatformAdminSettingTest extends UnitTestCase {
+
+  /**
+   * Builds the plugin against a read-only config factory stub.
+   */
+  private function pluginForRead(array $settings): BeaconPlatformAdminSetting {
+    $plugin = new BeaconPlatformAdminSetting(
+      [],
+      'ys_beacon',
+      [],
+      $this->getConfigFactoryStub(['ys_beacon.settings' => $settings]),
+      $this->createMock(AccountInterface::class),
+    );
+    $plugin->setStringTranslation($this->getStringTranslationStub());
+    return $plugin;
+  }
+
+  /**
+   * The checkbox default value reflects the stored authorization flag.
+   *
+   * @covers ::buildSettings
+   */
+  public function testCheckboxDefaultReflectsFlag(): void {
+    $form_state = new FormState();
+
+    $on = $this->pluginForRead(['platform_authorized' => TRUE])
+      ->buildSettings([], $form_state);
+    $this->assertTrue((bool) $on['platform_authorized']['#default_value']);
+    $this->assertSame('checkbox', $on['platform_authorized']['#type']);
+
+    $off = $this->pluginForRead([])->buildSettings([], $form_state);
+    $this->assertFalse((bool) $off['platform_authorized']['#default_value']);
+  }
+
+  /**
+   * Submitting saves the checkbox value to ys_beacon.settings.
+   *
+   * @covers ::submitSettings
+   */
+  public function testSubmitSavesFlag(): void {
+    $config = $this->createMock(Config::class);
+    $config->expects($this->once())
+      ->method('set')
+      ->with('platform_authorized', TRUE)
+      ->willReturnSelf();
+    $config->expects($this->once())->method('save')->willReturnSelf();
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('getEditable')->with('ys_beacon.settings')->willReturn($config);
+
+    $plugin = new BeaconPlatformAdminSetting(
+      [],
+      'ys_beacon',
+      [],
+      $factory,
+      $this->createMock(AccountInterface::class),
+    );
+    $plugin->setStringTranslation($this->getStringTranslationStub());
+
+    $form_state = new FormState();
+    // The section is rendered with #tree under the plugin id, so the value is
+    // nested under 'ys_beacon'.
+    $form_state->setValue(['ys_beacon', 'platform_authorized'], 1);
+    $form = [];
+    $plugin->submitSettings($form, $form_state);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconPlatformAuthorizationUpdateTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconPlatformAuthorizationUpdateTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Tests the grandfather update hook for platform authorization.
+ *
+ * The ys_beacon_update_10004() hook authorizes Beacon on any site already using
+ * it (chat enabled, or the ys_beacon integration turned on), so no live site
+ * loses Beacon when the platform gate ships, and leaves other sites off.
+ *
+ * @group ys_beacon
+ */
+class BeaconPlatformAuthorizationUpdateTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 3) . '/ys_beacon.install';
+  }
+
+  /**
+   * Puts a config factory into the container for the update hook.
+   *
+   * @param \Drupal\Core\Config\Config $beacon
+   *   The editable ys_beacon.settings config.
+   * @param bool $integrationOn
+   *   Whether the ys_integrations.integration_settings:ys_beacon flag is on.
+   */
+  private function setConfigFactory(Config $beacon, bool $integrationOn): void {
+    $integration = $this->createMock(Config::class);
+    $integration->method('get')->with('ys_beacon')->willReturn($integrationOn ? 1 : 0);
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('getEditable')->with('ys_beacon.settings')->willReturn($beacon);
+    $factory->method('get')->with('ys_integrations.integration_settings')->willReturn($integration);
+
+    $container = new ContainerBuilder();
+    $container->set('config.factory', $factory);
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * A site with chat enabled is authorized.
+   */
+  public function testAuthorizesWhenChatEnabled(): void {
+    $beacon = $this->createMock(Config::class);
+    $beacon->method('isNew')->willReturn(FALSE);
+    $beacon->method('get')->with('enable_chat')->willReturn(TRUE);
+    $beacon->expects($this->once())
+      ->method('set')
+      ->with('platform_authorized', TRUE)
+      ->willReturnSelf();
+    $beacon->expects($this->once())->method('save')->willReturnSelf();
+    $this->setConfigFactory($beacon, FALSE);
+
+    ys_beacon_update_10004();
+  }
+
+  /**
+   * A site with the integration on but chat off is still authorized.
+   */
+  public function testAuthorizesWhenIntegrationOnButChatOff(): void {
+    $beacon = $this->createMock(Config::class);
+    $beacon->method('isNew')->willReturn(FALSE);
+    $beacon->method('get')->with('enable_chat')->willReturn(FALSE);
+    $beacon->expects($this->once())
+      ->method('set')
+      ->with('platform_authorized', TRUE)
+      ->willReturnSelf();
+    $beacon->expects($this->once())->method('save')->willReturnSelf();
+    $this->setConfigFactory($beacon, TRUE);
+
+    ys_beacon_update_10004();
+  }
+
+  /**
+   * A site using neither chat nor the integration is left unauthorized.
+   */
+  public function testDeauthorizesWhenNeitherInUse(): void {
+    $beacon = $this->createMock(Config::class);
+    $beacon->method('isNew')->willReturn(FALSE);
+    $beacon->method('get')->with('enable_chat')->willReturn(FALSE);
+    $beacon->expects($this->once())
+      ->method('set')
+      ->with('platform_authorized', FALSE)
+      ->willReturnSelf();
+    $beacon->expects($this->once())->method('save')->willReturnSelf();
+    $this->setConfigFactory($beacon, FALSE);
+
+    ys_beacon_update_10004();
+  }
+
+  /**
+   * Sites with no Beacon settings are left untouched; no config is created.
+   */
+  public function testLeavesAbsentSettingsUntouched(): void {
+    $beacon = $this->createMock(Config::class);
+    $beacon->method('isNew')->willReturn(TRUE);
+    $beacon->expects($this->never())->method('set');
+    $beacon->expects($this->never())->method('save');
+    $this->setConfigFactory($beacon, FALSE);
+
+    ys_beacon_update_10004();
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/YsBeaconConfigOverridesTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/YsBeaconConfigOverridesTest.php
@@ -31,6 +31,11 @@ class YsBeaconConfigOverridesTest extends UnitTestCase {
   protected const INDEX_CONFIG = 'search_api.index.ys_beacon';
 
   /**
+   * The Beacon settings config name whose chat toggle is overridden.
+   */
+  protected const SETTINGS_CONFIG = 'ys_beacon.settings';
+
+  /**
    * Builds the override with stubbed settings and a stubbed key repository.
    *
    * @param array $settings
@@ -154,18 +159,63 @@ class YsBeaconConfigOverridesTest extends UnitTestCase {
   }
 
   /**
-   * The index is left enabled when chat is on and an index name is configured.
+   * The index is left enabled when chat is on, authorized, and index named.
    *
    * @covers ::loadOverrides
    */
   public function testIndexNotForcedOffWhenChatEnabledAndIndexNamed(): void {
     $override = $this->buildOverride(
-      ['enable_chat' => TRUE, 'azure_index_name' => 'somesite-live'],
+      ['enable_chat' => TRUE, 'platform_authorized' => TRUE, 'azure_index_name' => 'somesite-live'],
       [],
     );
 
     $overrides = $override->loadOverrides([self::INDEX_CONFIG]);
     $this->assertArrayNotHasKey(self::INDEX_CONFIG, $overrides);
+  }
+
+  /**
+   * An unauthorized site has its chat toggle forced off for all consumers.
+   *
+   * @covers ::loadOverrides
+   */
+  public function testEnableChatForcedOffWhenNotAuthorized(): void {
+    $override = $this->buildOverride(
+      ['enable_chat' => TRUE, 'platform_authorized' => FALSE],
+      [],
+    );
+
+    $overrides = $override->loadOverrides([self::SETTINGS_CONFIG]);
+    $this->assertFalse($overrides[self::SETTINGS_CONFIG]['enable_chat']);
+  }
+
+  /**
+   * An authorized site's saved chat toggle is left untouched.
+   *
+   * @covers ::loadOverrides
+   */
+  public function testEnableChatNotOverriddenWhenAuthorized(): void {
+    $override = $this->buildOverride(
+      ['enable_chat' => TRUE, 'platform_authorized' => TRUE],
+      [],
+    );
+
+    $overrides = $override->loadOverrides([self::SETTINGS_CONFIG]);
+    $this->assertArrayNotHasKey(self::SETTINGS_CONFIG, $overrides);
+  }
+
+  /**
+   * An unauthorized site forces the index off even with chat on and named.
+   *
+   * @covers ::loadOverrides
+   */
+  public function testIndexForcedOffWhenNotAuthorized(): void {
+    $override = $this->buildOverride(
+      ['enable_chat' => TRUE, 'platform_authorized' => FALSE, 'azure_index_name' => 'somesite-live'],
+      [],
+    );
+
+    $overrides = $override->loadOverrides([self::INDEX_CONFIG]);
+    $this->assertFalse($overrides[self::INDEX_CONFIG]['status']);
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.install
@@ -290,3 +290,25 @@ function ys_beacon_update_10002() {
 function ys_beacon_update_10003() {
   \Drupal::service('ys_beacon.migration')->migrate();
 }
+
+/**
+ * Authorize Beacon on sites already using it so no live site loses it.
+ *
+ * The new platform_authorized flag gates every Beacon surface and ships off by
+ * default, so a platform admin must authorize each site. Sites already running
+ * Beacon (chat enabled, or the ys_beacon integration turned on) must keep it,
+ * so authorize them here. This runs in the updatedb phase before config:import;
+ * ys_beacon.settings is config_ignored, so the per-site value survives the
+ * import.
+ */
+function ys_beacon_update_10004() {
+  $settings = \Drupal::configFactory()->getEditable('ys_beacon.settings');
+  // Only act on sites that actually have Beacon settings; never create the
+  // config object here.
+  if ($settings->isNew()) {
+    return;
+  }
+  $in_use = (bool) $settings->get('enable_chat')
+    || (bool) \Drupal::config('ys_integrations.integration_settings')->get('ys_beacon');
+  $settings->set('platform_authorized', $in_use)->save();
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.module
@@ -120,8 +120,10 @@ function ys_beacon_entity_update(EntityInterface $entity) {
   if (!in_array($entity->getEntityTypeId(), ['node', 'media'], TRUE)) {
     return;
   }
-  // Cheap gate: skip everything on sites where Beacon indexing is off.
-  if (!\Drupal::config('ys_beacon.settings')->get('azure_index_name')) {
+  // Cheap gate: skip everything on sites where a platform admin has not
+  // authorized Beacon, or where Beacon indexing is not configured.
+  if (!\Drupal::service('ys_beacon.authorization')->isAuthorized()
+    || !\Drupal::config('ys_beacon.settings')->get('azure_index_name')) {
     return;
   }
   if (!$original) {
@@ -247,6 +249,10 @@ function ys_beacon_entity_insert(EntityInterface $entity) {
  *   The media entity that may hold a PDF.
  */
 function _ys_beacon_queue_pdf_extraction(MediaInterface $media) {
+  // Nothing runs on sites where a platform admin has not authorized Beacon.
+  if (!\Drupal::service('ys_beacon.authorization')->isAuthorized()) {
+    return;
+  }
   // Only extract on sites where Beacon indexing is configured; without an
   // index there is nothing to feed the extracted text into.
   if (!\Drupal::config('ys_beacon.settings')->get('azure_index_name')) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.routing.yml
@@ -21,6 +21,7 @@ ys_beacon.settings:
     _title: 'YaleSites Beacon settings'
   requirements:
     _permission: 'manage ys beacon settings'
+    _ys_beacon_authorized: 'TRUE'
 
 ys_beacon.admin_settings:
   path: '/admin/config/yalesites/ys-beacon/admin'
@@ -37,6 +38,7 @@ ys_beacon.instructions:
     _title: 'Beacon system instructions'
   requirements:
     _ys_beacon_instructions_access: 'TRUE'
+    _ys_beacon_authorized: 'TRUE'
 
 ys_beacon.instructions_versions:
   path: '/admin/config/yalesites/ys-beacon/instructions/versions'
@@ -45,6 +47,7 @@ ys_beacon.instructions_versions:
     _title: 'Beacon system instructions version history'
   requirements:
     _ys_beacon_instructions_access: 'TRUE'
+    _ys_beacon_authorized: 'TRUE'
 
 ys_beacon.instructions_view:
   path: '/admin/config/yalesites/ys-beacon/instructions/versions/{version}'
@@ -53,6 +56,7 @@ ys_beacon.instructions_view:
     _title: 'View Beacon system instructions version'
   requirements:
     _ys_beacon_instructions_access: 'TRUE'
+    _ys_beacon_authorized: 'TRUE'
     version: \d+
 
 ys_beacon.instructions_revert:
@@ -62,4 +66,5 @@ ys_beacon.instructions_revert:
     _title: 'Revert Beacon system instructions'
   requirements:
     _ys_beacon_instructions_access: 'TRUE'
+    _ys_beacon_authorized: 'TRUE'
     version: \d+

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.services.yml
@@ -84,12 +84,24 @@ services:
       - '@renderer'
       - '@account_switcher'
 
+  ys_beacon.authorization:
+    class: Drupal\ys_beacon\BeaconAuthorization
+    arguments:
+      - '@config.factory'
+
   ys_beacon.system_instructions_access_check:
     class: Drupal\ys_beacon\Access\SystemInstructionsAccessCheck
     arguments:
       - '@config.factory'
     tags:
       - { name: access_check, applies_to: _ys_beacon_instructions_access }
+
+  ys_beacon.authorized_access_check:
+    class: Drupal\ys_beacon\Access\BeaconAuthorizedAccessCheck
+    arguments:
+      - '@ys_beacon.authorization'
+    tags:
+      - { name: access_check, applies_to: _ys_beacon_authorized }
 
   ys_beacon.config_overrides:
     class: Drupal\ys_beacon\Config\YsBeaconConfigOverrides

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Attribute/PlatformAdminSetting.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Attribute/PlatformAdminSetting.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_core\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Defines a PlatformAdminSetting attribute for plugin discovery.
+ *
+ * A platform admin setting plugin contributes a self-contained section to the
+ * platform-admin-only Platform Admin Settings page. Additional attribute keys
+ * can be defined in hook_ys_core_platform_admin_setting_info_alter().
+ *
+ * @ingroup ys_core
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class PlatformAdminSetting extends Plugin {
+
+  /**
+   * Constructs a PlatformAdminSetting attribute.
+   *
+   * @param string $id
+   *   The plugin ID.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup|null $label
+   *   (optional) The human-readable name of the settings section.
+   * @param int $weight
+   *   (optional) The order weight; lower weights render first. Defaults to 0.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly ?TranslatableMarkup $label = NULL,
+    public readonly int $weight = 0,
+  ) {}
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/PlatformAdminSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/PlatformAdminSettingsForm.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Drupal\ys_core\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\ys_core\PlatformAdminSettingManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Platform-admin-only settings form.
+ *
+ * Discovers PlatformAdminSetting plugins and renders one section each, ordered
+ * by the plugin attribute weight (label as tiebreaker). Each plugin owns its
+ * own build, validate, and save logic; this form only orchestrates discovery,
+ * ordering, and delegation, so new platform-admin-only settings are added by
+ * contributing a plugin rather than editing this form.
+ */
+class PlatformAdminSettingsForm extends FormBase {
+
+  /**
+   * Constructs a PlatformAdminSettingsForm object.
+   *
+   * @param \Drupal\ys_core\PlatformAdminSettingManager $pluginManager
+   *   The platform admin setting plugin manager.
+   */
+  public function __construct(
+    protected PlatformAdminSettingManager $pluginManager,
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('ys_core.platform_admin_setting_manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'ys_core_platform_admin_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    foreach ($this->sortedDefinitions() as $id => $definition) {
+      $instance = $this->pluginManager->createInstance($id);
+      // Each section is namespaced (#tree) under the plugin id so plugins never
+      // collide on element keys and can read their own values back by id.
+      $form[$id] = [
+        '#type' => 'details',
+        '#title' => $definition['label'] ?? $id,
+        '#open' => TRUE,
+        '#tree' => TRUE,
+      ] + $instance->buildSettings([], $form_state);
+    }
+
+    $form['actions'] = [
+      '#type' => 'actions',
+      'submit' => [
+        '#type' => 'submit',
+        '#value' => $this->t('Save configuration'),
+        '#button_type' => 'primary',
+      ],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    foreach (array_keys($this->sortedDefinitions()) as $id) {
+      $this->pluginManager->createInstance($id)->validateSettings($form, $form_state);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    foreach (array_keys($this->sortedDefinitions()) as $id) {
+      $this->pluginManager->createInstance($id)->submitSettings($form, $form_state);
+    }
+    $this->messenger()->addStatus($this->t('The configuration options have been saved.'));
+  }
+
+  /**
+   * Returns plugin definitions sorted by attribute weight, then label.
+   *
+   * @return array[]
+   *   Plugin definitions keyed by plugin id.
+   */
+  protected function sortedDefinitions(): array {
+    $definitions = $this->pluginManager->getDefinitions();
+    uasort($definitions, function (array $a, array $b): int {
+      return [$a['weight'] ?? 0, (string) ($a['label'] ?? '')]
+        <=> [$b['weight'] ?? 0, (string) ($b['label'] ?? '')];
+    });
+    return $definitions;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/PlatformAdminSettingBase.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/PlatformAdminSettingBase.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\ys_core;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Base class for platform admin setting plugins.
+ */
+class PlatformAdminSettingBase extends PluginBase implements PlatformAdminSettingInterface, ContainerFactoryPluginInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Constructs a new PlatformAdminSettingBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config_factory, AccountInterface $current_user) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->configFactory = $config_factory;
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory'),
+      $container->get('current_user'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildSettings(array $form, FormStateInterface $form_state): array {
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateSettings(array &$form, FormStateInterface $form_state): void {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitSettings(array &$form, FormStateInterface $form_state): void {
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/PlatformAdminSettingInterface.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/PlatformAdminSettingInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\ys_core;
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Defines an interface for platform admin setting plugins.
+ *
+ * Each plugin contributes a self-contained section (build, validate, and save)
+ * to the platform-admin-only Platform Admin Settings form. The form owns
+ * discovery and ordering; each plugin owns its own configuration.
+ */
+interface PlatformAdminSettingInterface {
+
+  /**
+   * Builds this plugin's settings section.
+   *
+   * @param array $form
+   *   The section's form subtree (rendered with #tree set to TRUE).
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current form state.
+   *
+   * @return array
+   *   The render array of form elements for this section.
+   */
+  public function buildSettings(array $form, FormStateInterface $form_state): array;
+
+  /**
+   * Validates this plugin's settings section.
+   *
+   * @param array $form
+   *   The complete form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current form state.
+   */
+  public function validateSettings(array &$form, FormStateInterface $form_state): void;
+
+  /**
+   * Saves this plugin's settings section.
+   *
+   * @param array $form
+   *   The complete form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current form state.
+   */
+  public function submitSettings(array &$form, FormStateInterface $form_state): void;
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/PlatformAdminSettingManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/PlatformAdminSettingManager.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\ys_core;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\ys_core\Attribute\PlatformAdminSetting;
+
+/**
+ * Manages platform admin setting plugins.
+ */
+class PlatformAdminSettingManager extends DefaultPluginManager {
+
+  /**
+   * Constructs a PlatformAdminSettingManager object.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct('Plugin/PlatformAdminSetting', $namespaces, $module_handler, 'Drupal\ys_core\PlatformAdminSettingInterface', PlatformAdminSetting::class);
+    $this->setCacheBackend($cache_backend, 'ys_core_platform_admin_setting_plugins');
+    $this->alterInfo('ys_core_platform_admin_setting_info');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
@@ -54,6 +54,13 @@ ys_core.admin_google_tag_settings:
   route_name: entity.google_tag_container.single_form
   title: "Google Tag Settings"
   weight: 30
+# Platform-admin-only settings form.
+ys_core.platform_admin_settings:
+  description: "Platform-admin-only settings, such as authorizing integrations per site."
+  parent: ys_core.admin_yalesites
+  route_name: ys_core.platform_admin_settings
+  title: "Platform Admin Settings"
+  weight: 35
 # Menu interface
 ys_core.menu_interface:
   description: "Manage menus"

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.permissions.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.permissions.yml
@@ -2,3 +2,8 @@
 yalesites manage settings:
   title: 'Manage YaleSite Settings'
   description: 'Access the settings forms in the YaleSites section of the admin menu.'
+# Permission to reach the platform-admin-only settings page.
+administer platform admin settings:
+  title: 'Administer Platform Admin Settings'
+  description: 'Access the platform-admin-only settings page (for example, authorizing integrations such as Beacon per site).'
+  restrict access: true

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.routing.yml
@@ -46,6 +46,14 @@ ys_core.admin_views_settings:
     _title: 'Views Settings'
   requirements:
     _permission: 'yalesites manage settings'
+# Platform-admin-only settings form.
+ys_core.platform_admin_settings:
+  path: '/admin/yalesites/platform-admin-settings'
+  defaults:
+    _form: '\Drupal\ys_core\Form\PlatformAdminSettingsForm'
+    _title: 'Platform Admin Settings'
+  requirements:
+    _permission: 'administer platform admin settings'
 # Dynamic search page.
 ys_core.search_page:
   path: '/search'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.services.yml
@@ -39,4 +39,10 @@ services:
     arguments: ['@current_user', '@request_stack']
     tags:
       - { name: event_subscriber }
+  # Manages platform-admin-only settings sections (extensible plugin type).
+  ys_core.platform_admin_setting_manager:
+    class: Drupal\ys_core\PlatformAdminSettingManager
+    arguments: ['@container.namespaces', '@cache.default', '@module_handler']
+    tags:
+      - { name: 'default_plugin_manager' }
 


### PR DESCRIPTION
## [1339: Gate the Beacon Integration Behind a Platform Admin Settings Toggle](https://github.com/yalesites-org/YaleSites-Internal/issues/1339)

### Description of work
- Adds a new platform-admin-only **Platform Admin Settings** page at `/admin/yalesites/platform-admin-settings`, built as an extensible PHP-attribute plugin type (`PlatformAdminSetting`) in `ys_core` mirroring the `ys_integrations` `#[Integration]` pattern. Gated by a new `administer platform admin settings` permission (`restrict access: true`) granted only to `platform_admin`; the attribute carries a `weight` so future sections render in a controllable order.
- `ys_beacon` contributes a per-site **"Allow site admins to configure and use Beacon"** toggle through that framework, stored in `ys_beacon.settings:platform_authorized` (config_ignored, default **off**).
- `BeaconAuthorization` is the single source of truth for the flag. When it is **off**: the Beacon dashboard card shows "not configured" (`isTurnedOn()`); a new `_ys_beacon_authorized` access check denies the Beacon settings and system-instructions routes so their menu links hide; `YsBeaconConfigOverrides` forces `ys_beacon.settings:enable_chat` off at runtime so the chat widget, conversation API, and search index all stand down through the existing `enable_chat` paths (the site admin's saved value is untouched); and the content feed endpoint plus the de-index / PDF-extraction hooks bail out.
- `ys_beacon_update_10004()` grandfathers the flag **on** for any site already using Beacon (chat enabled, or the `ys_beacon` integration on), so no live site loses Beacon on deploy.
- The existing `ys_integrations.integration_settings:ys_beacon` flag and the Integration Settings management form are unchanged; the new flag is independent and additive.
- **Beyond the ticket's file list:** the AI Tester submodule routes are also gated with the same check. The tester makes live LLM calls through `BeaconAnswerService` and was reachable by `site_admin` regardless of chat state, which would otherwise violate the ticket's "no AI-related activity runs at all" criterion.
- Targets `551-beacon-drupalai` (the Beacon / Drupal-AI epic branch), **not** `develop`.

### Functional testing steps:
- [x] As a **platform admin**, visit `/admin/yalesites/platform-admin-settings` and confirm the "Beacon (AI Chat)" section with the "Allow site admins to configure and use Beacon" toggle (off by default).
- [x] As a **site admin** on a site where the toggle is **off**, confirm `/admin/config/yalesites/ys-beacon` is not reachable (Access denied) and the Beacon menu links are hidden.
- [x] With the toggle **off**, confirm the chat widget does not render, `POST /api/ys-beacon/v1/conversation` and `GET /api/ys-beacon/v1/content` return 403, and the Beacon dashboard card reads "not configured".
- [x] Turn the toggle **on** as a platform admin, then confirm a site admin can reach `/admin/config/yalesites/ys-beacon` and enable/configure Beacon exactly as before.
- [x] Confirm a site that already had Beacon in use before deploy keeps it (grandfather update hook), and a brand-new/unused site starts gated off.

References yalesites-org/YaleSites-Internal#1339

---
Created with AI
