### PR TITLE
1377: Unused CasHelper import on develop fails static_tests phpcs job on every new PR

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/EventSubscriber/CasUser1BypassSubscriber.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/EventSubscriber/CasUser1BypassSubscriber.php
@@ -3,7 +3,6 @@
 namespace Drupal\ys_core\EventSubscriber;
 
 use Drupal\cas\Event\CasPreRedirectEvent;
-use Drupal\cas\Service\CasHelper;
 use Drupal\Core\Session\AccountInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;


### PR DESCRIPTION
## [1377: Unused CasHelper import on develop fails static_tests phpcs job on every new PR](https://github.com/yalesites-org/YaleSites-Internal/issues/1377)

### Description of work
- Remove the dead `use Drupal\cas\Service\CasHelper;` import from `ys_core`'s `CasUser1BypassSubscriber.php`. Commit `72602cdf9` replaced `CasHelper::EVENT_PRE_REDIRECT` with the `CasPreRedirectEvent` class FQCN but left the now-unused import behind. The Drupal coder `Drupal.Classes.UnusedUseStatement` sniff (enforced by CI as of early July) flags it, failing the `static_tests` job with exit code 2 on every new PR even though the PR does not touch this file — observed on #1335, #1337, #1338, #1339.

### Functional testing steps:
- [x] CI `static_tests` job passes on this PR
- [x] `lando composer code-sniff` runs clean locally
- [ ] User 1 CAS forced-login bypass still works (no runtime impact — the removed import was unused)

References yalesites-org/YaleSites-Internal#1377
