### PR TITLE
1374: Hotfix: View: Multi Day Event Spacing -- MULTIDEV ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,5 @@ lando xdebug-off           # Disable Xdebug
 - **Custom Modules**: Use `ys_` prefix (e.g., `ys_core`, `ys_themes`)
 - **Branch Strategy**: `develop` (primary), `master` (releases), `YALB-XXX-description` (features)
 - **Semantic Release**: Automated versioning on master branch using conventional commits
+
+


### PR DESCRIPTION
## [1374: Hotfix: View: Multi Day Event Spacing](https://github.com/yalesites-org/YaleSites-Internal/issues/1374)

> **Do not merge** — this PR exists solely to spin up a multidev for verifying the fix in [component-library-twig#666](https://github.com/yalesites-org/component-library-twig/pull/666) inside Drupal.

### Description of work
- Fix is in: yalesites-org/component-library-twig#666
- This is a **hotfix** for a production issue; release cutting is handled separately.
- No atomic branch is pushed, so the multidev builds against the production-pinned atomic (v1.77.0) plus the matching-name CLT branch — i.e. "production + only this CLT fix."

### Functional testing steps
- [ ] Create (or open) an Event that spans multiple days, all day — start on one date and end on a later date, with no specific times (e.g. 7/1/2026 → 7/5/2026).
- [ ] View it in an event **card grid**, the **event list**, and the **condensed** view.
- [ ] Confirm each display shows a separator between the dates, e.g. `July 1, 2026—July 5, 2026 All day` (previously rendered as `July 1, 2026July 5, 2026 All day`).
- [ ] Confirm single-day all-day events still read `July 1, 2026 All day` (no stray dash), and timed events are unchanged.
