### PR TITLE
1318: Block authoring form — tabs + two-column field display

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-form-tabs.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-form-tabs.css
@@ -1,13 +1,15 @@
 /*
  * Listing block form tabs (#1299).
  *
- * Gin strips field_group's default horizontal-tab dividers/padding and applies
- * negative margins, so the tab labels collide (they read as one run of text).
- * Re-space them into clearly separated, padded tabs sitting on a shared
- * baseline. Loaded only on the listing block authoring forms (via the
- * ys_views_basic/listing-form-tabs library, attached in the tabs form_alter)
- * and scoped to the block configure form, so no other field_group tabs are
- * touched.
+ * In the Layout Builder modal, gin_lb tags each horizontal-tab button with
+ * .glb-claro-details, whose `margin: 0 -0.25em 0 -1.25em !important`
+ * (gin_lb/dist/css/gin_lb.css) pulls every tab ~20px left over its neighbour,
+ * so the labels collide (they read as one run of text). Re-space them into
+ * clearly separated, padded tabs sitting on a shared baseline; the margin reset
+ * needs !important to win against that rule. Loaded only on the listing block
+ * authoring forms (via the ys_views_basic/listing-form-tabs library, attached
+ * in the tabs form_alter) and scoped to the block configure form, so no other
+ * field_group tabs are touched.
  */
 .layout-builder-configure-block .horizontal-tabs-list {
   display: flex;
@@ -20,7 +22,7 @@
 
 .layout-builder-configure-block .horizontal-tabs-list .horizontal-tab-button {
   float: none;
-  margin: 0;
+  margin: 0 !important;
   padding: 0;
   border: 0;
   list-style: none;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-form-tabs.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-form-tabs.css
@@ -34,3 +34,22 @@
   white-space: nowrap;
   text-decoration: none;
 }
+
+/*
+ * Align the first tab's label with the panel's left edge. The tab bar's left
+ * edge already lines up with the pane content, but the button's 1rem left
+ * padding insets the first label ~16px past it; drop that padding on the first
+ * tab so its text sits flush with the fields below.
+ */
+.layout-builder-configure-block .horizontal-tabs-list .horizontal-tab-button:first-child a {
+  padding-left: 0;
+}
+
+/*
+ * Give the tab panes the same layer background the rest of the form uses. The
+ * panes wrapper is otherwise transparent, so in Gin dark mode it shows the
+ * near-black app background instead of the lighter gray form surface.
+ */
+.layout-builder-configure-block .horizontal-tabs-panes {
+  background: var(--gin-bg-layer, #fff);
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-form-tabs.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-form-tabs.css
@@ -1,0 +1,34 @@
+/*
+ * Listing block form tabs (#1299).
+ *
+ * Gin strips field_group's default horizontal-tab dividers/padding and applies
+ * negative margins, so the tab labels collide (they read as one run of text).
+ * Re-space them into clearly separated, padded tabs sitting on a shared
+ * baseline. Loaded only on the listing block authoring forms (via the
+ * ys_views_basic/listing-form-tabs library, attached in the tabs form_alter)
+ * and scoped to the block configure form, so no other field_group tabs are
+ * touched.
+ */
+.layout-builder-configure-block .horizontal-tabs-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin: 0;
+  padding: 0;
+  border-bottom: 1px solid var(--gin-border-color, #d3d4d9);
+}
+
+.layout-builder-configure-block .horizontal-tabs-list .horizontal-tab-button {
+  float: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  list-style: none;
+}
+
+.layout-builder-configure-block .horizontal-tabs-list .horizontal-tab-button a {
+  display: block;
+  padding: 0.5rem 1rem;
+  white-space: nowrap;
+  text-decoration: none;
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-form-tabs.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-form-tabs.css
@@ -10,13 +10,21 @@
  * authoring forms (via the ys_views_basic/listing-form-tabs library, attached
  * in the tabs form_alter) and scoped to the block configure form, so no other
  * field_group tabs are touched.
+ *
+ * Gin's tabs.css and field_group's horizontal-tabs.css both target
+ * `ul.horizontal-tabs-list li.horizontal-tab-button a`, which beats our
+ * class-only selectors on specificity (their ul/li tip the balance). Worse,
+ * field_group also has a `li.selected a` branch at the same specificity that
+ * wins the tie for the active tab only, giving it different (shorter)
+ * padding than inactive tabs. `!important` throughout this file is what
+ * makes our spacing win consistently across every tab state.
  */
 .layout-builder-configure-block .horizontal-tabs-list {
   display: flex;
   flex-wrap: wrap;
   gap: 0.25rem;
-  margin: 0;
-  padding: 0;
+  margin: 0 !important;
+  padding: 0 !important;
   border-bottom: 1px solid var(--gin-border-color, #d3d4d9);
 }
 
@@ -30,26 +38,115 @@
 
 .layout-builder-configure-block .horizontal-tabs-list .horizontal-tab-button a {
   display: block;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 1rem !important;
   white-space: nowrap;
   text-decoration: none;
 }
 
 /*
- * Align the first tab's label with the panel's left edge. The tab bar's left
- * edge already lines up with the pane content, but the button's 1rem left
- * padding insets the first label ~16px past it; drop that padding on the first
- * tab so its text sits flush with the fields below.
+ * Gin's tabs.css also draws its own underline via ::after on the tab list,
+ * offset up from the bottom edge by a fixed spacing value (inset-block-end:
+ * var(--gin-spacing-l)) calibrated for Gin's own, taller default tab height.
+ * Now that the tabs above are shorter, that fixed offset lands mid-label
+ * instead of at the bottom edge, showing as a stray line through the tab
+ * text. We already draw our own border-bottom on the list above, so this
+ * second underline is redundant as well as misplaced; hide it.
  */
-.layout-builder-configure-block .horizontal-tabs-list .horizontal-tab-button:first-child a {
-  padding-left: 0;
+.layout-builder-configure-block .horizontal-tabs-list::after {
+  display: none !important;
 }
 
 /*
- * Give the tab panes the same layer background the rest of the form uses. The
- * panes wrapper is otherwise transparent, so in Gin dark mode it shows the
- * near-black app background instead of the lighter gray form surface.
+ * Give the tab panes the same layer background and left/right alignment the
+ * rest of the form uses. Two separate gin_lb overrides fight this:
+ * - .glb-claro-details__wrapper gets `background: var(--gin-bg-app)
+ *   !important` (gin_lb.css) — the near-black app background, not the
+ *   lighter layer surface — and it sits *inside* .horizontal-tabs-panes, so
+ *   it paints over the background set below regardless of what that
+ *   resolves to.
+ * - The same selector also gets `padding-inline: 1.5em !important`, which
+ *   insets the pane content ~24px past the tab list's left edge, breaking
+ *   the alignment between the tab bar and the fields below it. We bring
+ *   that down to a small 0.5rem gutter instead of removing it outright, so
+ *   fields aren't flush against the panel edge, while staying close enough
+ *   to the tab bar's edge to still read as aligned.
+ * Both need !important overrides, scoped to this wrapper specifically, to
+ * win.
  */
 .layout-builder-configure-block .horizontal-tabs-panes {
   background: var(--gin-bg-layer, #fff);
+}
+
+.layout-builder-configure-block .horizontal-tabs-panes .glb-claro-details__wrapper {
+  padding-left: 0.5rem !important;
+  padding-right: 0.5rem !important;
+  background: var(--gin-bg-layer, #fff) !important;
+}
+
+/*
+ * The pane itself (not just its inner wrapper above) also carries
+ * .glb-claro-details, so it inherits that same class's `margin-left:
+ * -1.25em !important` (gin_lb.css) — meant to compensate the tab buttons'
+ * own indent, but here it just shifts the whole pane content 20px left of
+ * the tab bar above it. Zero it out for panes specifically.
+ */
+.layout-builder-configure-block .horizontal-tabs-panes .horizontal-tabs-pane {
+  margin: 0 !important;
+}
+
+/*
+ * Restore the icon-radio "card" styling (e.g. Event Time Period) for
+ * controls that now live inside the tab bar. ViewsBasicWidgetBase's
+ * initSelectionContainers() puts the styling hook class
+ * .views-basic--group-user-selection on the *outer* group_user_selection
+ * container, and views-basic.css keys the whole card treatment — hiding
+ * the native radio circle, the bordered label, the icon sizing, the
+ * flex-wrap layout — off that ancestor. But _ys_views_basic_listing_form_tabs()
+ * moves the entity_and_view_mode/filter_and_sort/options subgroups into the
+ * tab bar via Drupal's #group mechanism, which re-parents their rendered
+ * markup under .horizontal-tabs-panes, outside that outer container. So
+ * every .views-basic--group-user-selection-scoped rule silently stops
+ * matching for anything inside those groups. Re-declare the subset that
+ * applies to icon-radio controls here, scoped to the new ancestor, rather
+ * than changing the #group relocation itself.
+ */
+.layout-builder-configure-block .horizontal-tabs-panes .grouped-items input.form-radio {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.layout-builder-configure-block .horizontal-tabs-panes .grouped-items .glb-form-type--radio {
+  position: relative;
+}
+
+.layout-builder-configure-block .horizontal-tabs-panes .glb-form-type--radio label.glb-option {
+  display: flex !important;
+  align-items: center;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1 auto;
+  border: 2px solid;
+  aspect-ratio: 2/1;
+  text-align: left;
+  padding: 0.75rem 1rem;
+  color: var(--gin-color-text);
+  border-radius: 0.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.layout-builder-configure-block .horizontal-tabs-panes .grouped-items img {
+  width: auto;
+}
+
+.layout-builder-configure-block .horizontal-tabs-panes .form-boolean-group {
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+  flex-flow: row wrap;
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-preview.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-preview.css
@@ -158,3 +158,49 @@
 .vb-preview[data-view-mode='directory'] .vb-preview__image {
   height: 11rem;
 }
+
+/*
+ * Two-column layout for the "Field display & filters" tab on the block-create
+ * form (#1318): the field controls stack in a left column while the live
+ * preview sits in the right. Anchored with :has() to the tab that actually
+ * carries a preview, so it only takes effect on the create form (the preview
+ * is not built when reconfiguring an existing block), and gated behind a
+ * container query so the single-column stack is kept where two columns will
+ * not fit — e.g. the narrow (~460px) Layout Builder off-canvas tray. This rule
+ * is layout only (no colors), so it needs no separate dark-mode handling; the
+ * preview card's own colors already follow Gin's light/dark mode above.
+ */
+.views-basic--entity-view-mode:has(> .claro-details__wrapper > .vb-preview-wrapper) {
+  container-type: inline-size;
+}
+
+@container (min-width: 40rem) {
+  .views-basic--entity-view-mode:has(> .claro-details__wrapper > .vb-preview-wrapper) > .claro-details__wrapper {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(14rem, 18rem);
+    gap: 0 1.5rem;
+    align-items: start;
+  }
+
+  /* Field controls flow down the left column. */
+  .views-basic--entity-view-mode:has(> .claro-details__wrapper > .vb-preview-wrapper) > .claro-details__wrapper > * {
+    grid-column: 1;
+    min-width: 0;
+  }
+
+  /*
+   * Preview pinned to the top of the right column. The row span comfortably
+   * exceeds the handful of left-column controls so the preview shares — rather
+   * than owns — their rows, and so never forces one tall row that would gap the
+   * left column; align-self holds it at its natural height, and sticky keeps it
+   * in view while the taller left column scrolls.
+   */
+  .views-basic--entity-view-mode:has(> .claro-details__wrapper > .vb-preview-wrapper) > .claro-details__wrapper > .vb-preview-wrapper {
+    grid-column: 2;
+    grid-row: 1 / span 20;
+    align-self: start;
+    margin-top: 0;
+    position: sticky;
+    top: 0;
+  }
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-preview.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-preview.css
@@ -7,12 +7,23 @@
  * theme render — but it reflects the bundle's display mode (card, list,
  * condensed, directory) so the layout matches what the block will produce.
  *
- * Colors are bound to Gin's admin-theme custom properties (with light-mode
- * fallbacks) so the preview follows Gin's current color mode, including dark
- * mode, automatically.
+ * The card is pinned to light-mode colors regardless of the admin theme's mode:
+ * it represents front-facing content, which the live site always renders in
+ * light mode. Gin's color custom properties are re-declared with fixed light
+ * values on the wrapper below, so every var(--gin-*) usage inside resolves to
+ * those regardless of Gin's dark mode.
  */
 
 .vb-preview-wrapper {
+  /* Pin the preview to light mode — see file header. */
+  --gin-bg-app: #f7f7f7;
+  --gin-bg-layer: #fff;
+  --gin-bg-input: #e9edf2;
+  --gin-border-color: #b3b3b3;
+  --gin-border-color-layer: #d4d4d4;
+  --gin-color-title: #1b1b1b;
+  --gin-color-text: #1b1b1b;
+  --gin-color-text-light: #555;
   margin-top: 1rem;
   padding: 0.75rem;
   border: 1px dashed var(--gin-border-color, #b3b3b3);
@@ -168,7 +179,7 @@
  * container query so the single-column stack is kept where two columns will
  * not fit — e.g. the narrow (~460px) Layout Builder off-canvas tray. This rule
  * is layout only (no colors), so it needs no separate dark-mode handling; the
- * preview card's own colors already follow Gin's light/dark mode above.
+ * preview card's own colors are pinned to light mode above.
  */
 .views-basic--entity-view-mode:has(> .details-wrapper > .vb-preview-wrapper) {
   container-type: inline-size;
@@ -177,7 +188,7 @@
 @container (min-width: 40rem) {
   .views-basic--entity-view-mode:has(> .details-wrapper > .vb-preview-wrapper) > .details-wrapper {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(14rem, 18rem);
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: 0 1.5rem;
     align-items: start;
   }
@@ -189,18 +200,16 @@
   }
 
   /*
-   * Preview pinned to the top of the right column. The row span comfortably
-   * exceeds the handful of left-column controls so the preview shares — rather
-   * than owns — their rows, and so never forces one tall row that would gap the
-   * left column; align-self holds it at its natural height, and sticky keeps it
-   * in view while the taller left column scrolls.
+   * Preview occupies the right half, top-aligned with the first control. It
+   * spans the control rows (rather than owning a single row) so its height
+   * never forces one tall grid row that would gap the left column; align-self
+   * holds it at its natural height. No sticky positioning — it scrolls with the
+   * form instead of floating pinned to the corner.
    */
   .views-basic--entity-view-mode:has(> .details-wrapper > .vb-preview-wrapper) > .details-wrapper > .vb-preview-wrapper {
     grid-column: 2;
     grid-row: 1 / span 20;
     align-self: start;
     margin-top: 0;
-    position: sticky;
-    top: 0;
   }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-preview.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-preview.css
@@ -7,15 +7,65 @@
  * theme render — but it reflects the bundle's display mode (card, list,
  * condensed, directory) so the layout matches what the block will produce.
  *
+ * Only the card itself (.vb-preview) is styled as a "mockup" — a dashed-border
+ * stage (.vb-preview-wrapper__stage) around it signals it's a placeholder, not
+ * live content. The "Preview" label and its helper note above it
+ * (.vb-preview-wrapper__header) are plain form label/description text, not
+ * part of the mockup chrome.
+ *
  * The card is pinned to light-mode colors regardless of the admin theme's mode:
  * it represents front-facing content, which the live site always renders in
  * light mode. Gin's color custom properties are re-declared with fixed light
- * values on the wrapper below, so every var(--gin-*) usage inside resolves to
- * those regardless of Gin's dark mode.
+ * values on the stage below (not the outer wrapper), so every var(--gin-*)
+ * usage inside the card resolves to those regardless of Gin's dark mode. The
+ * header text sits outside that pin, on Gin's real background, so it keeps
+ * inheriting Gin's actual (theme-aware) color vars and stays readable in dark
+ * mode too.
  */
 
 .vb-preview-wrapper {
-  /* Pin the preview to light mode — see file header. */
+  margin-top: 1rem;
+}
+
+.vb-preview-wrapper__header {
+  margin-bottom: 0.75rem;
+}
+
+/*
+ * Label/note are qualified with the .vb-preview-wrapper__header ancestor
+ * (rather than left as bare classes) to outrank gin_lb's `.ui-dialog p {
+ * margin: 1em 0; }` — both are <p> tags, and that rule's extra specificity
+ * (one class + one type selector beats our one class) would otherwise
+ * override these margins with 1em of each element's own (much larger)
+ * font-size.
+ */
+.vb-preview-wrapper__header .vb-preview-wrapper__label {
+  margin: 0 0 0.25rem;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--gin-color-title, inherit);
+}
+
+.vb-preview-wrapper__header .vb-preview-wrapper__note {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--gin-color-text-light, #555);
+}
+
+/*
+ * --gin-color-text-light isn't reliably readable here: Gin's off-canvas
+ * dialog chrome re-declares it to a low-contrast value for this scope
+ * (unlike --gin-color-title, which does resolve correctly), so the note
+ * inherits a light-mode-tuned gray even in dark mode. Pin it explicitly to
+ * the color Gin's own .description text actually renders at in dark-mode
+ * dialogs, rather than trust the variable.
+ */
+.gin--dark-mode .vb-preview-wrapper__note {
+  color: #d2d3d3;
+}
+
+.vb-preview-wrapper__stage {
+  /* Pin the card mockup to light mode — see file header. */
   --gin-bg-app: #f7f7f7;
   --gin-bg-layer: #fff;
   --gin-bg-input: #e9edf2;
@@ -24,43 +74,51 @@
   --gin-color-title: #1b1b1b;
   --gin-color-text: #1b1b1b;
   --gin-color-text-light: #555;
-  margin-top: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 0.75rem;
   border: 1px dashed var(--gin-border-color, #b3b3b3);
   border-radius: 4px;
   background: var(--gin-bg-app, #f7f7f7);
 }
 
-.vb-preview-wrapper__label {
-  margin: 0 0 0.5rem;
-  font-size: 0.85rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  color: var(--gin-color-title, inherit);
-}
-
-.vb-preview-wrapper__note {
-  margin: 0 0 0.75rem;
-  font-size: 0.8rem;
-  color: var(--gin-color-text-light, #555);
-}
-
 .vb-preview {
   position: relative;
+  width: 100%;
   max-width: 22rem;
   padding: 0.75rem;
   border: 1px solid var(--gin-border-color-layer, #d4d4d4);
   border-radius: 4px;
   background: var(--gin-bg-layer, #fff);
   color: var(--gin-color-text, inherit);
+  font-family: "Mallory", sans-serif;
 }
 
+.vb-preview[data-font-pairing='mallory'] .vb-preview__title {
+  font-family: "Mallory", sans-serif;
+}
+
+.vb-preview:not([data-font-pairing='mallory']) .vb-preview__title {
+  font-family: "YaleNew", serif;
+}
+
+/*
+ * width: 100% needs !important here: the preview panel lives inside
+ * .grouped-items (ViewsBasicWidgetBase's styling hook, see views-basic.css),
+ * and views-basic-form-tabs.css sets `.grouped-items img { width: auto; }` to
+ * keep the Display Type tab's icon-radio images from stretching. That rule
+ * outweighs this one on specificity and also matches this placeholder image,
+ * collapsing it to the 1x1 GIF's natural size (aspect-ratio alone can't
+ * rescue it once width resolves to ~1px).
+ */
 .vb-preview__image {
   display: block;
-  width: 100%;
-  height: 90px;
-  margin-bottom: 0.5rem;
+  width: 100% !important;
+  aspect-ratio: 3 / 2;
+  height: auto;
+  /* Matches the real reference-card's image-to-content gap (--size-spacing-4). */
+  margin-bottom: 0.75rem;
   border-radius: 2px;
   background: var(--gin-bg-input, #dcdcdc);
   object-fit: cover;
@@ -79,38 +137,64 @@
   text-transform: uppercase;
 }
 
+/*
+ * Small-caps + lowercase + letter-spacing matches the real reference-card's
+ * overline/eyebrow treatment (_yds-reference-card.scss) — the mockup
+ * previously rendered this as plain bold text.
+ */
 .vb-preview__eyebrow {
   display: block;
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   font-weight: 700;
+  font-variant-caps: small-caps;
+  text-transform: lowercase;
+  letter-spacing: 0.5px;
   color: var(--gin-color-text-light, #555);
 }
 
-.vb-preview__title {
-  margin: 0.15rem 0;
-  font-size: 1rem;
+/*
+ * font-size/line-height copy the real reference-card heading's fluid scale
+ * (grid, non-featured variant, _yds-reference-card.scss) verbatim, so it
+ * scales the same way relative to the viewport. margin-top matches
+ * --size-spacing-3; font-family stays controlled by the data-font-pairing
+ * rules above.
+ *
+ * Qualified with the .vb-preview__body ancestor (rather than left bare) to
+ * outrank gin_lb's `.ui-dialog p { margin: 1em 0; }` — title is a <p> tag,
+ * and that rule's extra specificity would otherwise replace this margin
+ * with 1em of the title's own (much larger, fluid) font-size, which is what
+ * was pushing the title out of alignment with the list-view thumbnail.
+ */
+.vb-preview__body .vb-preview__title {
+  margin: 0.5rem 0 0;
+  font-size: clamp(1.3125rem, calc(0.49vw + 1.1377rem), 1.5625rem);
+  line-height: 1.14;
   font-weight: 700;
   color: var(--gin-color-title, inherit);
 }
 
 .vb-preview__meta {
+  display: block;
+  margin-top: 0.5rem;
   font-size: 0.8rem;
   color: var(--gin-color-text-light, #555);
 }
 
+/*
+ * Categories render as plain pipe-separated text, matching tags — the design
+ * system has no pill/badge treatment for either field. margin-top matches
+ * the real component's --size-spacing-3 snippet/list spacing.
+ */
 .vb-preview__category {
-  display: inline-block;
-  margin-top: 0.4rem;
-  padding: 0.1rem 0.4rem;
-  border-radius: 2px;
-  background: var(--gin-bg-input, #eef1f5);
-  color: var(--gin-color-text, inherit);
-  font-size: 0.72rem;
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--gin-color-text-light, #555);
 }
 
 .vb-preview__tags {
   display: block;
-  margin-top: 0.4rem;
+  margin-top: 0.5rem;
   font-size: 0.75rem;
   color: var(--gin-color-text-light, #555);
 }
@@ -141,9 +225,14 @@
   max-width: 26rem;
 }
 
+/*
+ * flex-basis sizes the thumbnail; height stays auto so the inherited
+ * aspect-ratio: 3/2 (base .vb-preview__image rule) computes it, rather than
+ * a fixed height that (at the old 5rem width) actually rendered closer to
+ * 5:4 than the real card_list_3_2 ratio.
+ */
 .vb-preview[data-view-mode='list_item'] .vb-preview__image {
-  flex: 0 0 5rem;
-  height: 4rem;
+  flex: 0 0 8rem;
   margin-bottom: 0;
 }
 
@@ -200,16 +289,27 @@
   }
 
   /*
-   * Preview occupies the right half, top-aligned with the first control. It
-   * spans the control rows (rather than owning a single row) so its height
-   * never forces one tall grid row that would gap the left column; align-self
-   * holds it at its natural height. No sticky positioning — it scrolls with the
-   * form instead of floating pinned to the corner.
+   * Preview occupies the right half. It spans the control rows (rather than
+   * owning a single row) so its height never forces one tall grid row that
+   * would gap the left column; align-self: stretch fills that full span so
+   * the card stage below can center itself within it. No sticky positioning —
+   * it scrolls with the form instead of floating pinned to the corner.
    */
   .views-basic--entity-view-mode:has(> .details-wrapper > .vb-preview-wrapper) > .details-wrapper > .vb-preview-wrapper {
+    display: flex;
+    flex-direction: column;
     grid-column: 2;
     grid-row: 1 / span 20;
-    align-self: start;
+    align-self: stretch;
     margin-top: 0;
+  }
+
+  /*
+   * The card stage grows to fill the stretched column and centers the card
+   * within it, so the mockup sits centered in the right half rather than
+   * pinned to the top (the header/label above it stays top-aligned).
+   */
+  .views-basic--entity-view-mode:has(> .details-wrapper > .vb-preview-wrapper) > .details-wrapper > .vb-preview-wrapper > .vb-preview-wrapper__stage {
+    flex: 1;
   }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-preview.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/assets/css/views-basic-preview.css
@@ -170,12 +170,12 @@
  * is layout only (no colors), so it needs no separate dark-mode handling; the
  * preview card's own colors already follow Gin's light/dark mode above.
  */
-.views-basic--entity-view-mode:has(> .claro-details__wrapper > .vb-preview-wrapper) {
+.views-basic--entity-view-mode:has(> .details-wrapper > .vb-preview-wrapper) {
   container-type: inline-size;
 }
 
 @container (min-width: 40rem) {
-  .views-basic--entity-view-mode:has(> .claro-details__wrapper > .vb-preview-wrapper) > .claro-details__wrapper {
+  .views-basic--entity-view-mode:has(> .details-wrapper > .vb-preview-wrapper) > .details-wrapper {
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(14rem, 18rem);
     gap: 0 1.5rem;
@@ -183,7 +183,7 @@
   }
 
   /* Field controls flow down the left column. */
-  .views-basic--entity-view-mode:has(> .claro-details__wrapper > .vb-preview-wrapper) > .claro-details__wrapper > * {
+  .views-basic--entity-view-mode:has(> .details-wrapper > .vb-preview-wrapper) > .details-wrapper > * {
     grid-column: 1;
     min-width: 0;
   }
@@ -195,7 +195,7 @@
    * left column; align-self holds it at its natural height, and sticky keeps it
    * in view while the taller left column scrolls.
    */
-  .views-basic--entity-view-mode:has(> .claro-details__wrapper > .vb-preview-wrapper) > .claro-details__wrapper > .vb-preview-wrapper {
+  .views-basic--entity-view-mode:has(> .details-wrapper > .vb-preview-wrapper) > .details-wrapper > .vb-preview-wrapper {
     grid-column: 2;
     grid-row: 1 / span 20;
     align-self: start;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicWidgetBase.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicWidgetBase.php
@@ -5,6 +5,7 @@ namespace Drupal\ys_views_basic\Plugin\Field\FieldWidget;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\InvokeCommand;
 use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
@@ -54,6 +55,13 @@ abstract class ViewsBasicWidgetBase extends WidgetBase implements ContainerFacto
   protected $entityTypeManager;
 
   /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * Memoized label of the custom_vocab vocabulary.
    *
    * @var string|null
@@ -77,6 +85,8 @@ abstract class ViewsBasicWidgetBase extends WidgetBase implements ContainerFacto
    *   The ViewsBasic management service.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
    */
   public function __construct(
     $plugin_id,
@@ -86,6 +96,7 @@ abstract class ViewsBasicWidgetBase extends WidgetBase implements ContainerFacto
     array $third_party_settings,
     ViewsBasicManager $views_basic_manager,
     EntityTypeManagerInterface $entity_type_manager,
+    ConfigFactoryInterface $config_factory,
   ) {
     parent::__construct(
       $plugin_id,
@@ -96,6 +107,7 @@ abstract class ViewsBasicWidgetBase extends WidgetBase implements ContainerFacto
     );
     $this->viewsBasicManager = $views_basic_manager;
     $this->entityTypeManager = $entity_type_manager;
+    $this->configFactory = $config_factory;
   }
 
   /**
@@ -114,7 +126,8 @@ abstract class ViewsBasicWidgetBase extends WidgetBase implements ContainerFacto
       $configuration['settings'],
       $configuration['third_party_settings'],
       $container->get('ys_views_basic.views_basic_manager'),
-      $container->get('entity_type.manager')
+      $container->get('entity_type.manager'),
+      $container->get('config.factory')
     );
   }
 
@@ -338,6 +351,11 @@ abstract class ViewsBasicWidgetBase extends WidgetBase implements ContainerFacto
       '#view_mode' => $this->getViewMode(),
       // 1x1 transparent GIF; the CSS shows the placeholder as a grey box.
       '#image_src' => 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+      // Mirrors the site's configured heading typeface (Site Settings > Font
+      // Pairing) so the mockup reads like the live front-end render. The
+      // webfonts themselves load via the ys_views_basic_preview library's
+      // dependency on ys_core/font_preview.
+      '#font_pairing' => $this->configFactory->get('ys_core.site')->get('font_pairing') ?? 'yalenew',
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/templates/views-basic-mockup-preview.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/templates/views-basic-mockup-preview.html.twig
@@ -15,22 +15,29 @@
  * - view_mode: The node view mode; feeds data-view-mode for the CSS layout
  *   variants (list_item/condensed/directory).
  * - image_src: Placeholder teaser image src (a 1x1 transparent GIF).
+ * - font_pairing: The site's configured Font Pairing (ys_core.site:
+ *   font_pairing — yalenew/mallory/yalenew-oldstyle); feeds data-font-pairing
+ *   so the card's heading typeface matches the live front-end render.
  */
 #}
 <div class="vb-preview-wrapper" role="group" aria-label="{{ 'Result preview'|t }}">
-  <p class="vb-preview-wrapper__label">{{ 'Preview'|t }}</p>
-  <p class="vb-preview-wrapper__note">{{ 'Example content that updates as you change the Field Display options. This is a mockup, not a live query.'|t }}</p>
-  <div class="vb-preview" data-content-type="{{ content_type }}" data-view-mode="{{ view_mode }}">
-    <span class="vb-preview__pinned" hidden>{{ 'Pinned'|t }}</span>
-    <img class="vb-preview__image" alt="{{ 'Example teaser image placeholder'|t }}" src="{{ image_src }}">
-    <div class="vb-preview__body">
-      {% if content_type == 'post' %}<span class="vb-preview__eyebrow">{{ 'Eyebrow'|t }}</span>{% endif %}
-      <p class="vb-preview__title">{{ 'Example Title'|t }}</p>
-      {% if content_type == 'event' %}<span class="vb-preview__meta">{{ 'Month 1, 2026 - 12:00 PM'|t }}</span>{% endif %}
-      {% if content_type == 'profile' %}<span class="vb-preview__meta">{{ 'Job Title'|t }}</span>{% endif %}
-      <span class="vb-preview__category">{{ 'Category Name'|t }}</span>
-      <span class="vb-preview__tags">{{ 'Tag A | Tag B'|t }}</span>
-      {% if content_type == 'event' %}<a class="vb-preview__calendar" href="#">{{ 'Add to Calendar'|t }}</a>{% endif %}
+  <div class="vb-preview-wrapper__header">
+    <p class="vb-preview-wrapper__label">{{ 'Preview'|t }}</p>
+    <p class="vb-preview-wrapper__note">{{ 'Example content that updates as you change the Field Display options. This is a mockup, not a live query.'|t }}</p>
+  </div>
+  <div class="vb-preview-wrapper__stage">
+    <div class="vb-preview" data-content-type="{{ content_type }}" data-view-mode="{{ view_mode }}" data-font-pairing="{{ font_pairing }}">
+      <span class="vb-preview__pinned" hidden>{{ 'Pinned'|t }}</span>
+      <img class="vb-preview__image" alt="{{ 'Example teaser image placeholder'|t }}" src="{{ image_src }}">
+      <div class="vb-preview__body">
+        {% if content_type == 'post' %}<span class="vb-preview__eyebrow">{{ 'Eyebrow'|t }}</span>{% endif %}
+        <p class="vb-preview__title">{{ 'Example Title'|t }}</p>
+        {% if content_type == 'event' %}<span class="vb-preview__meta">{{ 'Month 1, 2026 - 12:00 PM'|t }}</span>{% endif %}
+        {% if content_type == 'profile' %}<span class="vb-preview__meta">{{ 'Job Title'|t }}</span>{% endif %}
+        <span class="vb-preview__category">{{ 'Category A | Category B'|t }}</span>
+        <span class="vb-preview__tags">{{ 'Tag A | Tag B'|t }}</span>
+        {% if content_type == 'event' %}<a class="vb-preview__calendar" href="#">{{ 'Add to Calendar'|t }}</a>{% endif %}
+      </div>
     </div>
   </div>
 </div>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.info.yml
@@ -5,4 +5,5 @@ core_version_requirement: '^9 || ^10'
 package: YaleSites
 dependencies:
   - field
+  - field_group:field_group
   - views

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.libraries.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.libraries.yml
@@ -17,3 +17,8 @@ ys_views_basic_preview:
     - core/drupal
     - core/once
 
+listing_form_tabs:
+  css:
+    theme:
+      assets/css/views-basic-form-tabs.css: {}
+

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.libraries.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.libraries.yml
@@ -16,6 +16,7 @@ ys_views_basic_preview:
   dependencies:
     - core/drupal
     - core/once
+    - ys_core/font_preview
 
 listing_form_tabs:
   css:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -360,5 +360,12 @@ function _ys_views_basic_listing_form_tabs(array $element, FormStateInterface $f
     }
   }
 
+  // Those three groups now render inside the tab bar via #group (the event
+  // time-period control lives in the "options" group, so it moves into the
+  // Display options tab too). What remains directly under group_user_selection
+  // is only empty helper containers, so it renders as a stray empty <div>; drop
+  // the wrapper so nothing is emitted.
+  $element['group_user_selection']['#theme_wrappers'] = [];
+
   return $element;
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -73,6 +73,7 @@ function ys_views_basic_theme($existing, $type, $theme, $path): array {
         'content_type' => NULL,
         'view_mode' => NULL,
         'image_src' => NULL,
+        'font_pairing' => NULL,
       ],
     ],
   ];

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -5,7 +5,9 @@
  * Contains ys_views_basic.module functions.
  */
 
+use Drupal\block_content\BlockContentInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
 use Drupal\views\ViewExecutable;
 use Drupal\ys_views_basic\ViewsBasicManager;
@@ -221,4 +223,139 @@ function ys_views_basic_node_view(array &$build, NodeInterface $node, EntityView
   if (in_array($view_mode, $view_modes)) {
     $build['#cache']['max-age'] = 0;
   }
+}
+
+/**
+ * Implements hook_form_alter().
+ *
+ * Unifies the listing-block authoring form (Layout Builder add/update block)
+ * into a single horizontal tab bar: General | Field display & filters |
+ * Tags, sorting & pinned | Display options.
+ *
+ * The last three tabs are the field widget's own inner "details" groups
+ * (ViewsBasicWidgetBase::initSelectionContainers()); "General" collects the
+ * outer block fields (heading, heading links, padding, admin title, reusable).
+ * Because the widget groups live inside the field_view_params widget,
+ * field_group (which is driven by form-display config) cannot reach them, so
+ * the grouping is done here with core's #group mechanism instead.
+ *
+ * The tab set and the General group are built in a #process callback appended
+ * to the content-block subform, because the block fields do not exist until
+ * that subform's own #process (InlineBlock::processBlockForm()) has run. The
+ * root-level reusable/admin-title fields are attached to the General group
+ * here in the alter — before form processing begins — so their #group is set
+ * before their own #process runs, regardless of the order in which the form
+ * tree is processed. ys_layouts_form_alter() relabels those two fields; this
+ * hook only groups them, so the two do not conflict.
+ */
+function ys_views_basic_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  if ($form_id !== 'layout_builder_add_block' && $form_id !== 'layout_builder_update_block') {
+    return;
+  }
+
+  // The inline-block authoring form nests the content-block subform under
+  // 'settings'; a reusable (block_content) block places it at the top level.
+  if (isset($form['settings']['block_form'])) {
+    $block_form = &$form['settings']['block_form'];
+  }
+  elseif (isset($form['block_form'])) {
+    $block_form = &$form['block_form'];
+  }
+  else {
+    return;
+  }
+
+  // Only listing-view blocks get the tabbed layout.
+  $block = $block_form['#block'] ?? NULL;
+  if (!$block instanceof BlockContentInterface || !isset(ViewsBasicManager::LISTING_BUNDLES[$block->bundle()])) {
+    return;
+  }
+
+  // Attach the root-level reusable/admin-title fields (inline-block only) to
+  // the General tab. Weights place them below the content fields within it.
+  foreach (['info' => 20, 'reusable' => 21] as $key => $weight) {
+    if (isset($form[$key])) {
+      $form[$key]['#group'] = 'group_listing_general';
+      $form[$key]['#weight'] = $weight;
+    }
+  }
+
+  $block_form['#process'][] = '_ys_views_basic_listing_form_tabs';
+}
+
+/**
+ * Process callback: gathers the listing-block fields into one tab bar.
+ *
+ * Runs after the content-block subform is built, so the field widgets and the
+ * widget's inner group details are present. Adds a horizontal_tabs element and
+ * a "General" details, then attaches the four groups to the tab bar via
+ * #group. The widget's three details self-register as group members (details
+ * elements run RenderElement::processGroup()); the plain field wrappers do
+ * not, so they are moved into the General details instead. Their #parents were
+ * assigned at widget-build time and survive the move (FormBuilder only assigns
+ * #parents when unset), so the stored form values are unaffected.
+ *
+ * @param array $element
+ *   The content-block subform element.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The current state of the form.
+ * @param array $complete_form
+ *   The complete form structure.
+ *
+ * @return array
+ *   The processed subform element.
+ */
+function _ys_views_basic_listing_form_tabs(array $element, FormStateInterface $form_state, array &$complete_form): array {
+  // The widget's inner groups only exist once the entity form has been built.
+  if (!isset($element['group_user_selection'])) {
+    return $element;
+  }
+
+  $tabs = 'group_listing_tabs';
+  $general = 'group_listing_general';
+
+  // The single tab bar. An explicit #parents fixes the group identifier that
+  // member details reference via #group, independent of tree position.
+  $element[$tabs] = [
+    '#type' => 'horizontal_tabs',
+    '#parents' => [$tabs],
+    '#weight' => 1,
+  ];
+
+  // "General": the outer block fields. field_heading, field_heading_links and
+  // field_padding_options are moved in physically because field wrappers do
+  // not self-register with #group; reusable/info are attached by #group in the
+  // form alter above.
+  $element[$general] = [
+    '#type' => 'details',
+    '#title' => t('General'),
+    '#group' => $tabs,
+    '#parents' => [$general],
+    '#weight' => 0,
+    '#open' => TRUE,
+  ];
+  foreach (['field_heading', 'field_heading_links', 'field_padding_options'] as $field) {
+    if (isset($element[$field])) {
+      $element[$general][$field] = $element[$field];
+      unset($element[$field]);
+    }
+  }
+
+  // The remaining three tabs are the widget's existing inner details groups.
+  // Their keys, contents and #parents stay unchanged, so massageFormValues()'s
+  // fixed paths still resolve; only #group (and the active-tab #open flag) are
+  // set here.
+  // Weight the widget groups after General (#weight 0) so the bar reads
+  // General | Field display & filters | Tags, sorting & pinned |
+  // Display options.
+  $group_weight = 1;
+  foreach (['entity_and_view_mode', 'filter_and_sort', 'options'] as $group) {
+    if (isset($element['group_user_selection'][$group])) {
+      $element['group_user_selection'][$group]['#group'] = $tabs;
+      $element['group_user_selection'][$group]['#open'] = FALSE;
+      $element['group_user_selection'][$group]['#weight'] = $group_weight++;
+    }
+  }
+
+  return $element;
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -281,6 +281,9 @@ function ys_views_basic_form_alter(array &$form, FormStateInterface $form_state,
   }
 
   $block_form['#process'][] = '_ys_views_basic_listing_form_tabs';
+
+  // Space out the horizontal tab bar (Gin collapses the field_group defaults).
+  $form['#attached']['library'][] = 'ys_views_basic/listing_form_tabs';
 }
 
 /**


### PR DESCRIPTION
## [1318: Views Block: Live Mockup Preview in Authoring Form](https://github.com/yalesites-org/YaleSites-Internal/issues/1318)

Isolated, closeable PR for the block-authoring-form **tabs + two-column** rework (items #4 and #5 from the 2026-07-06 QA round on yalesites-org/yalesites-project#1299). Targets **`1318-views-rework`** (not `develop`) so it can be merged into that branch or **closed to discard the experiment** with zero impact on #1299.

### Description of work
- Convert the listing-block authoring form from stacked accordions to one horizontal tab bar: **General | Field display & filters | Tags, sorting & pinned | Display options**. A `hook_form_alter` + `#process` unites the outer block fields (heading, link, padding, admin title, reusable) with the widget's inner `details` groups via core `#group` + field_group `horizontal_tabs` (field_group can't reach inside a field widget, so it's done in code). Widget group keys and field `#parents` are unchanged, so saving is unaffected.
- Two-column **Field display & filters** tab: controls left, live preview right (CSS-only, create-form-scoped, stacks in a narrow dialog, Gin dark-mode safe).
- Declare the `field_group` dependency.

### Functional testing steps:
- [ ] Add a listing block ("Posts - Card Grid View") in Layout Builder — the config form shows one horizontal tab bar with General first/active.
- [ ] Confirm the four tab buttons are evenly spaced and do **not** overlap (fix for the ~20px overlap gin_lb's `.glb-claro-details !important` margin caused in the LB modal).
- [ ] General holds heading, link, padding, admin title, and the reusable toggle.
- [ ] Other tabs hold their controls (incl. Event Time Period under Display options for events); no stray/empty groups.
- [ ] The Field display tab shows fields left + preview right on a wide dialog, stacking on a narrow one; Gin dark mode OK.
- [ ] Save a block and confirm the listing renders with the chosen settings (params unchanged).
- [ ] Edit an existing listing block — tabs render (no preview/two-column on edit), saves correctly.

Known cosmetic follow-up: after the widget groups are tabbed out, the now-empty `group_user_selection` container renders as a stray empty `<div>` (harmless). A reusable "block form tabs" pattern was documented for applying this to other block forms later.


**Review rework (#1342) — verify the front-end fixes:**
- [ ] In Gin **dark mode**, open a listing block config form: the tab content area sits on the lighter gray form surface (not near-black), and the **General** tab label lines up with the fields' left edge below it.
- [ ] On **Field display & filters**, the live preview stays **light** (white card, dark text) even in dark mode, and the controls + preview form an even **50/50** split with the preview sitting in the right column (not floating pinned in the corner); the left controls have no large empty gap.
- [ ] No stray empty box remains below the tabbed groups; the block still saves, and for **event** blocks the Event Time Period control still appears under **Display options**.

References yalesites-org/YaleSites-Internal#1318


