### PR TITLE
1383: Beacon chatbot shows "0 of 0 pages indexed" - existing content is never added to the Search API tracker

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconSettings.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconSettings.php
@@ -285,7 +285,10 @@ class YsBeaconSettings extends ConfigFormBase {
       // enable an index with no Azure backing.
       if (!$previous_enable && $this->config(self::CONFIG_NAME)->get('azure_index_name')) {
         $index->setStatus(TRUE)->save();
-        $index->reindex();
+        // Rebuild the tracker so existing content is queued for indexing on
+        // the freshly enabled index: reindex() only re-flags already-tracked
+        // items and leaves a never-seeded tracker empty (issue #1383).
+        $index->rebuildTracker();
       }
     }
     elseif ($previous_enable) {
@@ -299,8 +302,9 @@ class YsBeaconSettings extends ConfigFormBase {
   /**
    * Provisions the site's search index when chat is first enabled.
    *
-   * Creates the per-site Azure AI Search index only when it does not exist
-   * yet, stores its name, and queues all site content for indexing.
+   * Creates the per-site Azure AI Search index only when it does not exist yet
+   * and stores its name. The caller enables the index and rebuilds its tracker
+   * to queue existing content once provisioning has succeeded.
    */
   protected function provisionIndex(): void {
     try {
@@ -323,7 +327,11 @@ class YsBeaconSettings extends ConfigFormBase {
   public function reindexAll(array &$form, FormStateInterface $form_state): void {
     $index = $this->loadBeaconIndex();
     if ($index && $index->status()) {
-      $index->reindex();
+      // rebuildTracker() re-enumerates the datasources and marks every item
+      // for indexing, so it repopulates a never-seeded tracker as well as
+      // re-queueing tracked content; reindex() would only do the latter
+      // (issue #1383).
+      $index->rebuildTracker();
       $this->messenger()->addStatus($this->t('All content has been queued for re-indexing into the Beacon vector database.'));
     }
     else {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/BeaconMigration.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/BeaconMigration.php
@@ -90,9 +90,9 @@ class BeaconMigration {
     }
 
     // Ensure the per-site Azure index exists. provision() persists the index
-    // name and rebuilds Search API tracking; on a connection failure it throws,
-    // and we defer to the next run rather than tearing the legacy widget down
-    // before Beacon can actually answer.
+    // name; on a connection failure it throws, and we defer to the next run
+    // rather than tearing the legacy widget down before Beacon can actually
+    // answer.
     if (!$settings->get('azure_index_name')) {
       try {
         $this->indexManager->provision();
@@ -114,7 +114,11 @@ class BeaconMigration {
     if (!$index->status()) {
       $index->setStatus(TRUE)->save();
     }
-    $index->reindex();
+    // Rebuild the tracker so existing content is queued for indexing;
+    // reindex() only re-flags already-tracked items and cannot seed an empty
+    // tracker (issue #1383). Under update-mode deploys the enumeration is
+    // deferred to the next cron run.
+    $index->rebuildTracker();
 
     // Beacon is live and indexing. Retire the legacy ai_engine chat, embedding,
     // and metadata so the two assistants never run together.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconMigrationTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconMigrationTest.php
@@ -213,7 +213,10 @@ class BeaconMigrationTest extends UnitTestCase {
     $index->method('status')->willReturn(FALSE);
     $index->expects($this->once())->method('setStatus')->with(TRUE)->willReturnSelf();
     $index->expects($this->once())->method('save');
-    $index->expects($this->once())->method('reindex');
+    // The tracker is rebuilt (not just re-flagged) so existing content is
+    // enumerated into a freshly enabled index (issue #1383).
+    $index->expects($this->once())->method('rebuildTracker');
+    $index->expects($this->never())->method('reindex');
 
     $migration = new BeaconMigration(
       $factory,
@@ -333,9 +336,10 @@ class BeaconMigrationTest extends UnitTestCase {
 
     $index = $this->createMock(IndexInterface::class);
     $index->method('status')->willReturn(TRUE);
-    // Already enabled, so the status is not rewritten; only re-queued.
+    // Already enabled, so the status is not rewritten; the tracker is rebuilt.
     $index->expects($this->never())->method('setStatus');
-    $index->expects($this->once())->method('reindex');
+    $index->expects($this->once())->method('rebuildTracker');
+    $index->expects($this->never())->method('reindex');
 
     $migration = new BeaconMigration(
       $factory,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/IndexNowFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/IndexNowFormTest.php
@@ -222,6 +222,48 @@ class IndexNowFormTest extends UnitTestCase {
   }
 
   /**
+   * Re-index all content rebuilds the tracker so existing content is queued.
+   *
+   * Uses rebuildTracker(), not reindex(): reindex() only re-flags items already
+   * in the tracker and cannot populate one that was never seeded, which is the
+   * "0 of 0 pages indexed" defect in issue #1383.
+   *
+   * @covers ::reindexAll
+   */
+  public function testReindexAllRebuildsTrackerWhenEnabled(): void {
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('status')->willReturn(TRUE);
+    $index->expects($this->once())->method('rebuildTracker');
+    $index->expects($this->never())->method('reindex');
+    $messenger = $this->createMock(MessengerInterface::class);
+    $messenger->expects($this->once())->method('addStatus');
+    $messenger->expects($this->never())->method('addWarning');
+
+    $form = $this->buildForm($index, NULL, $messenger);
+    $form_array = [];
+    $form->reindexAll($form_array, $this->createMock(FormStateInterface::class));
+  }
+
+  /**
+   * Re-index all content on a disabled index warns and never rebuilds.
+   *
+   * @covers ::reindexAll
+   */
+  public function testReindexAllWarnsWhenDisabled(): void {
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('status')->willReturn(FALSE);
+    $index->expects($this->never())->method('rebuildTracker');
+    $index->expects($this->never())->method('reindex');
+    $messenger = $this->createMock(MessengerInterface::class);
+    $messenger->expects($this->once())->method('addWarning');
+    $messenger->expects($this->never())->method('addStatus');
+
+    $form = $this->buildForm($index, NULL, $messenger);
+    $form_array = [];
+    $form->reindexAll($form_array, $this->createMock(FormStateInterface::class));
+  }
+
+  /**
    * A locked/failed batch surfaces a warning instead of a fatal error.
    *
    * @covers ::indexNow


### PR DESCRIPTION
## [1383: Beacon chatbot shows "0 of 0 pages indexed" - existing content is never added to the Search API tracker](https://github.com/yalesites-org/YaleSites-Internal/issues/1383)

### Description of work
- Enabling the Beacon chatbot, clicking "Re-index all content", or the legacy-to-Beacon cutover left the `ys_beacon` Search API index reporting "0 of 0 pages indexed" even when published pages existed — only newly created nodes (which self-register via the entity-insert hook) were ever counted.
- Root cause: these paths called `$index->reindex()`, which only re-flags items already in the tracker and so can never populate one that was never seeded. On first enable the index is still disabled when `BeaconIndexManager::provision()` runs (`YsBeaconConfigOverrides` forces the index status off until an Azure index name is set), so `provision()`'s status-guarded `rebuildTracker()` is skipped and `reindex()` then has nothing to re-flag.
- Fix: call `$index->rebuildTracker()` instead, after the index is enabled, on the three reachable paths — `YsBeaconSettings::submitForm` (first enable), `YsBeaconSettings::reindexAll` ("Re-index all content"), and `BeaconMigration::migrate` (deploy cutover). `rebuildTracker()` re-enumerates the datasources and queues every item, so the tracker is seeded with existing content and the index reports an accurate total.
- The platform admin-settings path (`YsBeaconAdminSettings`, changing the index name on an already-enabled site) is unchanged: `provision()`'s own status-guarded rebuild already covers it.
- Behavior note: "Re-index all content" and first-enable now run a Search API indexing batch to seed the tracker (the same mechanism the admin-settings form already used); the tracker is briefly emptied and repopulated. Under update-mode deploys the enumeration is deferred to the next cron run.
- Added unit coverage for `reindexAll` and updated the migration cutover tests to expect `rebuildTracker()`.
- Targets `551-beacon-drupalai` (the Beacon epic branch where `ys_beacon` lives), not `develop`.

### Functional testing steps:
- [ ] On a site with published pages where the Beacon index has not been seeded, enable the Beacon chat widget (Manage Settings → Yale Chat). Confirm the `ys_beacon` index status reports the full page count (e.g. "0 of 42 items indexed"), not "0 of 0".
- [ ] Run "Index now" (or cron) and confirm existing pages index into the Beacon vector database.
- [ ] Click "Re-index all content" and confirm every eligible node/media item is re-queued (total reflects all existing content, not just newly created nodes).
- [ ] Verify a fresh legacy-to-Beacon cutover (deploy) seeds existing content into the tracker rather than leaving it empty.

References yalesites-org/YaleSites-Internal#1383

---
Created with AI
