### PR TITLE
Hotfix: 1379: Recurring event displays on incorrect overflow date in calendar month view

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Service/EventsCalendar.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Service/EventsCalendar.php
@@ -89,8 +89,11 @@ class EventsCalendar implements EventsCalendarInterface {
     $previousMonth = $previousMonthDate->format('m');
     $previousYear = $previousMonthDate->format('Y');
 
-    // Calculate the next month and year.
-    $nextMonthDate = clone $lastDayOfMonth;
+    // Calculate the next month and year. Anchor on the first of the month, not
+    // the last day: modifying a 31st by '+1 month' overflows when the following
+    // month is shorter (e.g. Aug 31 + 1 month lands on Oct 1), which would tag
+    // the trailing overflow cells with the wrong month.
+    $nextMonthDate = clone $firstDayOfMonth;
     $nextMonthDate->modify('+1 month');
     $nextMonth = $nextMonthDate->format('m');
     $nextYear = $nextMonthDate->format('Y');

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/tests/src/Unit/EventsCalendarTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/tests/src/Unit/EventsCalendarTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Drupal\Tests\ys_views_basic\Unit;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\path_alias\AliasManagerInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_views_basic\Service\EventsCalendar;
+
+/**
+ * Tests the month-grid date math in the events calendar service.
+ *
+ * Regression coverage for the bug (yalesites-org/YaleSites-Internal#1379) where
+ * the trailing overflow cells in the last row of a month grid were tagged with
+ * the wrong month. The next month was derived from the last day of the current
+ * month via DrupalDateTime::modify('+1 month'), which overflows for any 31-day
+ * month whose successor is shorter (e.g. 2026-08-31 + 1 month lands on
+ * 2026-10-01, not September). Those cells then rendered next-next-month dates
+ * and surfaced events from the wrong day. The next month must instead be
+ * derived from the first of the month, which is safe in every month.
+ *
+ * @coversDefaultClass \Drupal\ys_views_basic\Service\EventsCalendar
+ *
+ * @group ys_views_basic
+ */
+class EventsCalendarTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // DrupalDateTime's constructor reads the current language for its default
+    // langcode, so a minimal container with a language manager is required.
+    $language = $this->createMock(LanguageInterface::class);
+    $language->method('getId')->willReturn('en');
+    $languageManager = $this->createMock(LanguageManagerInterface::class);
+    $languageManager->method('getCurrentLanguage')->willReturn($language);
+
+    $container = new ContainerBuilder();
+    $container->set('language_manager', $languageManager);
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Trailing overflow cells belong to the month after the viewed one.
+   *
+   * @covers ::getCalendar
+   *
+   * @dataProvider trailingOverflowProvider
+   */
+  public function testTrailingOverflowMonth(string $month, string $year, string $expectedMonth, string $expectedYear): void {
+    $calendar = $this->buildService()->getCalendar($month, $year);
+    $lastRow = end($calendar);
+
+    // Trailing overflow cells are the last-row cells that fall outside the
+    // viewed month.
+    $overflow = array_values(array_filter(
+      $lastRow,
+      fn(array $cell): bool => $cell['date']['month'] !== $month
+    ));
+
+    // Independently derive how many trailing overflow cells this month should
+    // have (0 when the month ends on a Saturday) using a plain DateTime, so the
+    // assertions hold for any month instead of depending on the fixture only
+    // listing months whose last day is not a Saturday.
+    $lastWeekday = (int) (new \DateTime("$year-$month-01"))
+      ->modify('last day of this month')
+      ->format('w');
+    $this->assertCount(
+      6 - $lastWeekday,
+      $overflow,
+      "Unexpected number of trailing overflow cells for $month/$year."
+    );
+
+    foreach ($overflow as $cell) {
+      $this->assertSame(
+        $expectedMonth,
+        $cell['date']['month'],
+        "Trailing overflow cell for $month/$year should belong to month $expectedMonth, got {$cell['date']['month']}."
+      );
+      $this->assertSame(
+        $expectedYear,
+        $cell['date']['year'],
+        "Trailing overflow cell for $month/$year should belong to year $expectedYear, got {$cell['date']['year']}."
+      );
+    }
+  }
+
+  /**
+   * Provides viewed months and the month/year the trailing overflow belongs to.
+   *
+   * @return array
+   *   Each case: [viewed month, viewed year, expected overflow month, year].
+   */
+  public static function trailingOverflowProvider(): array {
+    return [
+      // Regression cases: 31-day month whose successor is shorter. Before the
+      // fix these overflowed two months ahead.
+      'August -> September' => ['08', '2026', '09', '2026'],
+      'January -> February' => ['01', '2025', '02', '2025'],
+      'March -> April' => ['03', '2026', '04', '2026'],
+      'May -> June' => ['05', '2026', '06', '2026'],
+      'October -> November' => ['10', '2025', '11', '2025'],
+
+      // Controls that must stay correct after the fix.
+      // December rolls the year over.
+      'December -> January (year rollover)' => ['12', '2026', '01', '2027'],
+      // July's successor (August) also has 31 days: never overflowed.
+      'July -> August' => ['07', '2026', '08', '2026'],
+      // February has fewer than 31 days: never overflowed.
+      'February -> March' => ['02', '2025', '03', '2025'],
+    ];
+  }
+
+  /**
+   * Builds the service with storage mocked to return no events.
+   *
+   * The date-grid math is independent of the loaded events, so the node query
+   * is stubbed to return nothing. This keeps the test a pure unit test with no
+   * database or container bootstrap.
+   */
+  private function buildService(): EventsCalendar {
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('accessCheck')->willReturnSelf();
+    $query->method('condition')->willReturnSelf();
+    $query->method('execute')->willReturn([]);
+
+    $nodeStorage = $this->createMock(EntityStorageInterface::class);
+    $nodeStorage->method('getQuery')->willReturn($query);
+    $nodeStorage->method('loadMultiple')->willReturn([]);
+
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $entityTypeManager->method('getStorage')->willReturn($nodeStorage);
+
+    $aliasManager = $this->createMock(AliasManagerInterface::class);
+
+    return new EventsCalendar($entityTypeManager, $aliasManager);
+  }
+
+}


### PR DESCRIPTION
## [1379: Recurring event displays on incorrect overflow date in calendar month view](https://github.com/yalesites-org/YaleSites-Internal/issues/1379)

### Description of work
- Fixes the events calendar month grid tagging the last row's trailing (next-month) overflow days with the wrong month. `EventsCalendar::getCalendar()` derived the next month from the **last day** of the current month, so `DrupalDateTime::modify('+1 month')` on a 31st overflowed whenever the following month is shorter (e.g. `2026-08-31` + 1 month lands on `2026-10-01`, not September). Every 31-day month whose successor has fewer days (Jan, Mar, May, Aug, Oct) mislabeled its trailing overflow cells two months ahead, so `getEvents()` looked up the wrong calendar date and a recurring series' later-month occurrence surfaced on a cell the visitor reads as the next month's first day. Because that cell now carried an event it also picked up event styling, masking the grayed "not current month" treatment.
- Anchors the next-month calculation on the **first** of the month (safe in every month, including the December→January year rollover), mirroring the already-correct previous-month block. The overflow cells now carry the correct month, so they pull the correct events (or none) for their actual date and render grayed like the leading overflow days.
- Adds a `ys_views_basic` unit test covering the affected months plus controls (year rollover, a same-length successor, and a sub-31-day month).

### Functional testing steps:
- [ ] Open a page with an events calendar that shows a recurring/weekly event which also has occurrences early in the following month.
- [ ] View a 31-day month whose last day is not a Saturday and whose successor is shorter — **August** is the clearest case (its grid's last row is where Sep 1–5 appear after Aug 31).
- [ ] Confirm the trailing overflow days (the next month's first days shown after the current month's last day) show the correct month's events, and the previously-appearing wrong-date event is gone (e.g. no event on the "1" cell that isn't actually in the series).
- [ ] Confirm those trailing overflow day numbers render grayed out ("not current month"), consistent with the leading overflow days at the start of the grid.
- [ ] Page forward to the following month and confirm events still land on their correct dates there too.

References yalesites-org/YaleSites-Internal#1379

---
Created with AI
