### PR TITLE
1335: Index content immediately on save/delete instead of requiring a manual "Index now"

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/search_api.index.ys_beacon.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/search_api.index.ys_beacon.yml
@@ -117,6 +117,6 @@ tracker_settings:
     indexing_order: fifo
 options:
   cron_limit: 20
-  index_directly: false
+  index_directly: true
   track_changes_in_references: true
 server: ys_beacon

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
@@ -99,8 +99,28 @@ a new index must be provisioned, and all content re-indexed.
 
 ## Indexing operations
 
-- Content is indexed on cron (`index_directly` is off so entity saves never
-  block on embedding calls).
+- Content is indexed immediately on save (`index_directly` is on). Search API
+  runs the embedding calls after the response is sent (in `kernel.terminate`),
+  so the editor's save returns without waiting on them, and a freshly published
+  or edited page is answerable by the chat without a cron run or a manual
+  "Index now". Items are still tracked, so cron remains the backstop for
+  anything the request did not finish.
+- Deletes remove the item from the vector database synchronously during the
+  delete request, so removed content stops being cited promptly.
+- Bulk changes are indexed at the end of the request in `cron_limit`-sized
+  chunks; anything that does not finish before the request ends stays tracked
+  and is drained by the next cron run. Two cases produce a large end-of-request
+  batch: a single request that saves many nodes (a migration, Feeds/JSON:API
+  import, or a `drush` loop), and — because `track_changes_in_references` is on
+  — editing one entity that many indexed items reference (a taxonomy term,
+  menu, or shared media), which re-embeds every referencing item. Both run
+  after the response is sent, so the editor is not blocked, but they can occupy
+  a worker and drive embedding-API cost for the batch's duration. Batch-API
+  bulk operations already spread their saves across requests; a genuinely large
+  programmatic import should wrap its save loop in
+  `Index::startBatchTracking()`/`stopBatchTracking()` to defer indexing to
+  cron. (Immediate indexing is gated on the index being enabled, so nothing
+  runs while chat is off; see "Per-site configuration" above.)
 - Re-index everything: the button on the Beacon administration form, or
   `drush sapi-r ys_beacon && drush sapi-i ys_beacon`.
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconImmediateIndexingTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconImmediateIndexingTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Guards that the Beacon content index indexes items immediately on save.
+ *
+ * The chat answers about freshly published or edited content, so an editor's
+ * save must reach the vector index without waiting for cron or a manual
+ * "Index now" (issue #1335). Search API only indexes at the end of the request
+ * when the index carries `options.index_directly: true` (and is not read-only).
+ *
+ * The index ships from the profile config-sync directory rather than this
+ * module's config/install, so this test reads the synced YAML directly — the
+ * same fixture approach as BeaconConfigDefaultsTest.
+ *
+ * @group ys_beacon
+ */
+class BeaconImmediateIndexingTest extends UnitTestCase {
+
+  /**
+   * Returns the parsed synced config for the ys_beacon search index.
+   */
+  private function indexConfig(): array {
+    $path = dirname(__DIR__, 6) . '/config/sync/search_api.index.ys_beacon.yml';
+    $this->assertFileExists($path);
+    return Yaml::parseFile($path);
+  }
+
+  /**
+   * Saving eligible content indexes it immediately, not on the next cron run.
+   */
+  public function testIndexDirectlyIsEnabled(): void {
+    $this->assertTrue($this->indexConfig()['options']['index_directly']);
+  }
+
+  /**
+   * The index must be writable for immediate indexing to reach the server.
+   */
+  public function testIndexIsNotReadOnly(): void {
+    $this->assertFalse($this->indexConfig()['read_only']);
+  }
+
+}


### PR DESCRIPTION
## [1335: Index content immediately on save/delete instead of requiring a manual "Index now"](https://github.com/yalesites-org/YaleSites-Internal/issues/1335)

### Description of work
- Flip the `ys_beacon` Search API index from `index_directly: false` to `index_directly: true` (in `config/sync/search_api.index.ys_beacon.yml`). With Yale Chat on, eligible content is now indexed immediately: Search API embeds the changed items at the end of the request (in `kernel.terminate`, after the response is sent), on both insert and update — no cron wait and no manual "Index now".
- The editor's save is not blocked (indexing runs post-response), and items stay tracked, so cron remains the backstop for anything a request does not finish.
- Composition with existing gating/rules is unchanged and was verified on Lando:
  - The #1288 config override still forces the index status off when chat is disabled/unauthorized/has no Azure index name; Search API gates both tracking and immediate indexing on the index status, so nothing is indexed or embedded while chat is off.
  - The `ExcludeAiDisabled` + core `entity_status` processors still drop unpublished, anonymous-inaccessible (CAS/login), and `ai_disable_indexing` content on the immediate path; the entity-update hook still removes content that becomes non-indexable.
  - Deletes already removed items from the vector database synchronously in the delete request — unchanged by this flag.
- Deploy: the index config is non-config-ignored synced config, so `drush deploy`'s `config:import` applies the change to existing sites — no update hook needed.
- Docs + tests: `ys_beacon/README.md` "Indexing operations" now documents the immediate-on-save behavior, synchronous deletes, the cron backstop, and the end-of-request bulk/reference fan-out. Adds `BeaconImmediateIndexingTest` asserting the shipped index config requests immediate, writable indexing.

**Open question for reviewer (AC6 — bulk/fan-out):** Because `track_changes_in_references: true`, editing one entity that many indexed items reference (a taxonomy term, menu, or shared media) — or a single request that saves many nodes (migration/Feeds/JSON:API/`drush` loop) — now re-embeds all affected items at end-of-request. This runs post-response with cron as the backstop (no user-facing hang, no data loss), which matches the issue's "acceptable, documented" bulk behavior. I documented it and pointed at `Index::startBatchTracking()` for large programmatic imports rather than building custom throttling (out of scope). Flagging in case you'd prefer an explicit large-batch guard.

### Functional testing steps:
On a Beacon site with Yale Chat enabled (index enabled, Azure index name set):
- [ ] Create/publish a new eligible page; without clicking "Index now" or running cron, confirm the tracker's "remaining" does not grow (the item is indexed immediately) and the chatbot can cite it.
- [ ] Edit an existing indexed page; confirm its index entry updates immediately (no manual step).
- [ ] Delete an indexed page; confirm it is removed from the index promptly.
- [ ] Turn Yale Chat off, then save/delete content; confirm no indexing or embedding occurs (index status is forced off) and #1288 behavior is preserved.
- [ ] Confirm indexability rules still hold: an unpublished / `ai_disable_indexing` / login-required page is excluded (and removed on transition), not indexed.

References yalesites-org/YaleSites-Internal#1335

---
Created with AI
