### PR TITLE
Hotfix: 1381: RC: Bug - Reusable blocks (e.g. Grand Hero) fail required-field validation when applied to a page

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/GrandHeroReusableBlockFormAlterTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/GrandHeroReusableBlockFormAlterTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\block_content\Entity\BlockContentType;
+use Drupal\Core\Form\FormState;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests ys_core_form_alter() on reusable vs inline block placements.
+ *
+ * Regression test for the bug where adding a reusable (Custom Block Library)
+ * Grand Hero block to a page via Layout Builder failed on save with false
+ * "… field is required" errors and logged an "Undefined array key block_form"
+ * warning in ys_core_form_alter().
+ *
+ * For a reusable block placement (plugin id block_content:UUID) the entity
+ * subform lives at $form['block_form'], not $form['settings']['block_form']
+ * (that structure is only built for inline_block:* placements). The grand_hero
+ * customization and its ys_core_grand_hero_validate handler assume the inline
+ * settings.block_form structure, so they must not run for a reusable placement
+ * — otherwise the validator reads empty values from the wrong path and flags
+ * every required field as missing.
+ *
+ * @group ys_core
+ */
+class GrandHeroReusableBlockFormAlterTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'block_content',
+    'ys_core',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('block_content');
+    // ys_core_get_block_type() resolves a reusable placement's block type by
+    // loading the block_content entity and reading its bundle, so only the
+    // bundle needs to exist — no fields are required for this test.
+    BlockContentType::create([
+      'id' => 'grand_hero',
+      'label' => 'Grand Hero',
+    ])->save();
+  }
+
+  /**
+   * Builds a layout builder block form state for a given block plugin id.
+   *
+   * The block plugin id is read by ys_core_get_block_type() from build-info
+   * arg 3.
+   */
+  protected function blockFormState(string $plugin_id): FormState {
+    $form_state = new FormState();
+    $form_state->setBuildInfo(['args' => [NULL, NULL, NULL, $plugin_id]]);
+    return $form_state;
+  }
+
+  /**
+   * A reusable placement must not attach the inline-only grand_hero validator.
+   *
+   * Exercises both form IDs the guard governs (add + update block).
+   */
+  public function testReusablePlacementDoesNotAttachGrandHeroValidator(): void {
+    $block = BlockContent::create([
+      'type' => 'grand_hero',
+      'info' => 'Reusable Grand Hero',
+      'reusable' => 1,
+    ]);
+    $block->save();
+
+    foreach (['layout_builder_add_block', 'layout_builder_update_block'] as $form_id) {
+      // Reusable placement: no settings.block_form; the entity subform (when
+      // shown) lives at the top-level block_form key.
+      $form = [
+        'settings' => [
+          'label' => ['#default_value' => 'Grand Hero'],
+        ],
+        'block_form' => ['#block' => $block],
+      ];
+      $form_state = $this->blockFormState('block_content:' . $block->uuid());
+
+      // The grand_hero branch must actually be reached: the block type resolves
+      // to grand_hero, so it is the isset() guard — not a misclassification —
+      // that keeps the inline-only validator off a reusable placement.
+      $this->assertSame('grand_hero', ys_core_get_block_type($form, $form_state));
+
+      ys_core_form_alter($form, $form_state, $form_id);
+
+      $this->assertNotContains(
+        'ys_core_grand_hero_validate',
+        $form['#validate'] ?? [],
+        "The grand_hero validate handler must not be attached for a reusable placement ($form_id)."
+      );
+    }
+  }
+
+  /**
+   * An inline placement must still attach the grand_hero validator.
+   */
+  public function testInlinePlacementAttachesGrandHeroValidator(): void {
+    $block = BlockContent::create([
+      'type' => 'grand_hero',
+      'info' => 'Inline Grand Hero',
+      'reusable' => 0,
+    ]);
+    $block->save();
+
+    // Inline placement: the entity subform lives under settings.block_form.
+    $form = [
+      'settings' => [
+        'label' => ['#default_value' => 'Grand Hero'],
+        'block_form' => ['#block' => $block],
+      ],
+    ];
+    $form_state = $this->blockFormState('inline_block:grand_hero');
+
+    $this->assertSame('grand_hero', ys_core_get_block_type($form, $form_state));
+
+    ys_core_form_alter($form, $form_state, 'layout_builder_add_block');
+
+    $this->assertContains(
+      'ys_core_grand_hero_validate',
+      $form['#validate'] ?? [],
+      'The grand_hero validate handler must be attached for an inline block placement.'
+    );
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -101,7 +101,14 @@ function ys_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {
       }
     }
 
-    if ($block_type === 'grand_hero') {
+    // Only applies to inline block forms, where the entity subform lives at
+    // settings.block_form. Reusable (Custom Block Library) placements expose
+    // the subform at a different path, so these settings.block_form
+    // assumptions (including the ys_core_grand_hero_validate handler) must not
+    // run for them; otherwise the validator reads empty values from the wrong
+    // path and flags every required field as missing. See
+    // yalesites-org/YaleSites-Internal#1381.
+    if ($block_type === 'grand_hero' && isset($form['settings']['block_form'])) {
 
       // Get the block entity.
       $block = $form['settings']['block_form']['#block'];


### PR DESCRIPTION
## [1381: RC: Bug - Reusable blocks (e.g. Grand Hero) fail required-field validation when applied to a page](https://github.com/yalesites-org/YaleSites-Internal/issues/1381)

### Description of work
- Reusable (Custom Block Library) Grand Hero blocks could not be added to a page via Layout Builder — saving failed with false "… field is required" errors (Heading, Media, Style Color, Style Position, Media Size, Heading Level) and logged an "Undefined array key block_form" warning, even though those values were already set on the block.
- Root cause: for a reusable placement (`block_content:UUID`) the block entity subform is exposed at a different form path than for an inline placement, so `$form['settings']['block_form']` does not exist. The `grand_hero` branch of `ys_core_form_alter()` read that missing key (the warning) and attached `ys_core_grand_hero_validate`, which then read every required-field value from the missing `settings.block_form` path — all empty — and flagged each field as missing, blocking the save.
- Fix: guard the `grand_hero` customization on `isset($form['settings']['block_form'])` so it only runs for inline block forms (the same idiom `ys_themes` already uses). Reusable placements keep their native required-field validation, so no coverage is lost, and inline Grand Hero add/edit — including the Banner Overlay PNG behavior — is unchanged.
- Added a kernel test (`GrandHeroReusableBlockFormAlterTest`) covering reusable placements (validator not attached, for both the add and update block forms) and inline placements (validator attached).
- Scope: Grand Hero is the only block type that attaches custom Layout Builder validation, so it was the only one affected; a reusable Pull Quote and other reusable block types already save cleanly and are unchanged.

### Functional testing steps:
- [x] Create (or use an existing) reusable Grand Hero block in the Block Library with all required fields filled in.
- [x] Add a page, open Layout Builder, and add that reusable Grand Hero from the library into the banner section, then Save.
- [x] It should save with no "… field is required" errors and no "Undefined array key block_form" warning in the logs; the placed Grand Hero renders with its saved content/overlay.
- [x] Spot-check: add an inline (non-reusable) Grand Hero and confirm its required-field validation still works (clearing Heading/Media still blocks save on the inline edit form).
- [x] Spot-check: add a reusable Pull Quote (or another reusable block) and confirm it still saves normally.

References yalesites-org/YaleSites-Internal#1381

---
Created with AI
