### PR TITLE
1387: Allow the Beacon search index to be marked read-only (config-survivable) so a site can safely borrow another site's index

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/config_ignore.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/config_ignore.settings.yml
@@ -17,6 +17,8 @@ ignored_config_entities:
   - key.key.azure_ai_search_url
   - key.key.portkey_embedding_api_key
   - key.key.portkey_llm_api_key
+  - 'search_api.index.ys_beacon:read_only'
+  - 'search_api.server.ys_beacon:backend_config.database_settings.database_name'
   - 'system.site*'
   - 'taxonomy.vocabulary.custom_vocab:name'
   - 'ys_ai_system_instructions*'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
@@ -66,39 +66,51 @@ The module is installed on every site and is off by default.
    `/admin/config/yalesites/ys-beacon` (also reachable from
    `/admin/integrations`).
 
-Per-site values are never overwritten by config imports: all `ys_beacon*`
-config and the four key entities are in `config_ignore`, and the index name
-and endpoint URL are layered onto the synced `search_api.server.ys_beacon`
-and `ai_vdb_provider_azure_ai_search.settings` config at runtime by
-`YsBeaconConfigOverrides`.
+Per-site values are never overwritten by config imports. All `ys_beacon*` config
+and the four key entities are in `config_ignore`. The per-site index name and
+read-only flag are persisted onto the real Search API config
+(`search_api.server.ys_beacon`'s Azure database name and
+`search_api.index.ys_beacon`'s `read_only` flag) by
+`BeaconIndexManager::propagateConnection()`, with those two keys config-ignored so
+the import keeps them. The Azure endpoint URL is still layered onto
+`ai_vdb_provider_azure_ai_search.settings` at runtime from a key entity by
+`YsBeaconConfigOverrides`, which also forces the index status off while chat is
+disabled or the site is unauthorized.
 
 ### Borrowing another site's index (read-only)
 
 A site can query another site's collection (for example a shared or parent
 corpus) instead of maintaining its own. Point the index name at that collection
-(`azure_index_name`) and turn on **Read-only** on the Beacon administration form
-(`ys_beacon.settings:read_only`). The borrowing site then answers from the
-shared collection but never writes to it: immediate indexing, cron indexing, the
-"Re-index all content" / "Index now" controls, `clear`, and delete-time document
-removal are all suppressed, because `YsBeaconConfigOverrides` sets the Search API
-index `read_only` flag at runtime and Search API gates those write paths on
-`IndexInterface::isReadOnly()`. The site-facing settings form hides the indexing
-controls and shows a note in this state. Like the index name, the flag lives in
-the config-ignored `ys_beacon.settings`, so it survives `drush deploy` /
-`drush cim` without config-ignoring a new `search_api.index.*` key.
+(`azure_index_name`) and turn on **Read-only** on the Beacon administration form.
+The borrowing site then answers from the shared collection but never writes to
+it: immediate indexing, cron indexing, the "Re-index all content" / "Index now"
+controls, `clear`, and delete-time document removal are all suppressed, because
+the form persists the Search API index `read_only` flag onto the index entity
+(`BeaconIndexManager::propagateConnection()`) and Search API gates those write
+paths on `IndexInterface::isReadOnly()`. Because the flag is persisted on the
+entity rather than only applied as a runtime override, Search API's own index
+admin UI reflects it too, so its "Index now" / clear / reindex actions stand down
+as well. The site-facing settings form hides the indexing controls and shows a
+note in this state.
 
-Because the flag is applied as a runtime config override rather than persisted on
-the index entity, Search API's own index admin UI - which loads the index
-override-free - does not reflect it, so its "Index now" / clear / reindex actions
-would still write to the collection. That UI requires the `administer search_api`
-permission, which no YaleSites role is granted (site administrators manage Beacon
-through `manage ys beacon settings`), so it is reachable only by a platform
-operator. If that path ever needs closing, persist `read_only` on the entity and
-config-ignore the `search_api.index.*:read_only` key instead.
+The read-only flag and the borrowed index name live in the config-ignored
+`ys_beacon.settings` as the site preference, and are written onto the synced
+`search_api.index.ys_beacon` (`read_only`) and `search_api.server.ys_beacon`
+(Azure database name) config. Those two keys are themselves config-ignored
+(`search_api.index.ys_beacon:read_only` and
+`search_api.server.ys_beacon:backend_config.database_settings.database_name`), so
+a per-site value survives `drush deploy` / `drush cim`. These `config_ignore`
+entries are keyed to the default `ys_beacon` index/server machine names; a site
+that overrides `search_index_id` / `search_server_id` (the multi-index
+capability) must add matching `config_ignore` keys for its names, or config
+import will reset the persisted database name and read-only flag.
 
 (A read-only index still tracks items locally in Search API, but tracking is
 local bookkeeping and never reaches the borrowed collection, so the owning
-site's data is untouched.)
+site's data is untouched. Retrieving and citing content that belongs to a
+*different* site's collection additionally requires the cross-site citation work
+tracked in the shared multi-tenant index epic; a same-content borrow - for
+example across environments of one site - works today.)
 
 ## Azure AI Search index provisioning
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
@@ -72,6 +72,34 @@ and endpoint URL are layered onto the synced `search_api.server.ys_beacon`
 and `ai_vdb_provider_azure_ai_search.settings` config at runtime by
 `YsBeaconConfigOverrides`.
 
+### Borrowing another site's index (read-only)
+
+A site can query another site's collection (for example a shared or parent
+corpus) instead of maintaining its own. Point the index name at that collection
+(`azure_index_name`) and turn on **Read-only** on the Beacon administration form
+(`ys_beacon.settings:read_only`). The borrowing site then answers from the
+shared collection but never writes to it: immediate indexing, cron indexing, the
+"Re-index all content" / "Index now" controls, `clear`, and delete-time document
+removal are all suppressed, because `YsBeaconConfigOverrides` sets the Search API
+index `read_only` flag at runtime and Search API gates those write paths on
+`IndexInterface::isReadOnly()`. The site-facing settings form hides the indexing
+controls and shows a note in this state. Like the index name, the flag lives in
+the config-ignored `ys_beacon.settings`, so it survives `drush deploy` /
+`drush cim` without config-ignoring a new `search_api.index.*` key.
+
+Because the flag is applied as a runtime config override rather than persisted on
+the index entity, Search API's own index admin UI - which loads the index
+override-free - does not reflect it, so its "Index now" / clear / reindex actions
+would still write to the collection. That UI requires the `administer search_api`
+permission, which no YaleSites role is granted (site administrators manage Beacon
+through `manage ys beacon settings`), so it is reachable only by a platform
+operator. If that path ever needs closing, persist `read_only` on the entity and
+config-ignore the `search_api.index.*:read_only` key instead.
+
+(A read-only index still tracks items locally in Search API, but tracking is
+local bookkeeping and never reaches the borrowed collection, so the owning
+site's data is untouched.)
+
 ## Azure AI Search index provisioning
 
 Indexes are provisioned automatically by `BeaconIndexManager`:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/install/ys_beacon.settings.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/install/ys_beacon.settings.yml
@@ -11,6 +11,7 @@ search_index_id: ys_beacon
 search_server_id: ys_beacon
 azure_index_name: ''
 azure_search_url_key: ''
+read_only: false
 pdf_extraction_max_bytes: 20971520
 top_k: 5
 score_threshold: 0.0

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/schema/ys_beacon.schema.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/schema/ys_beacon.schema.yml
@@ -44,6 +44,9 @@ ys_beacon.settings:
     azure_search_url_key:
       type: string
       label: 'Key entity id holding the Azure AI Search endpoint URL'
+    read_only:
+      type: boolean
+      label: 'Query the search index but never write to it (borrow another site''s index)'
     pdf_extraction_max_bytes:
       type: integer
       label: 'Maximum PDF size in bytes to extract text from'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Config/YsBeaconConfigOverrides.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Config/YsBeaconConfigOverrides.php
@@ -15,8 +15,17 @@ use Drupal\Core\Config\StorageInterface;
  * live outside of synced config: the index name in ys_beacon.settings (which
  * is config_ignored) and the endpoint URL in a key entity backed by Pantheon
  * secrets. This override layers them in at runtime, so config imports never
- * overwrite them. Search API explicitly supports overrides on server
- * backend_config and index status.
+ * overwrite them. Search API honors overrides on the loaded index entity, so
+ * this class drives the index status and the read-only flag as well as the
+ * server backend_config.
+ *
+ * A site can borrow another site's collection by pointing its index name at
+ * that collection and turning on ys_beacon.settings:read_only. This override
+ * then marks the index read-only at runtime, so Search API's automatic write
+ * paths (indexing, cron, clear, delete-time removal) stand down and the site
+ * queries the shared collection without writing to it. Like the index name, the
+ * flag lives in the config-ignored ys_beacon.settings, so it survives config
+ * import.
  *
  * The index is also disabled at runtime whenever the chat widget is turned
  * off or a site has not configured its index name yet, so unconfigured or
@@ -120,7 +129,18 @@ class YsBeaconConfigOverrides implements ConfigFactoryOverrideInterface {
       // chat is disabled (including an unauthorized site) or no index name has
       // been configured yet.
       if (!$enable_chat || $index_name === '') {
-        $overrides[$index_config] = ['status' => FALSE];
+        $overrides[$index_config]['status'] = FALSE;
+      }
+      // A site borrowing another site's collection marks its index read-only so
+      // it queries the shared collection but never writes to it. This gates
+      // Search API's automatic write paths (immediate indexing, cron, the
+      // indexing batch helper, clear, and delete-time removal) and the Beacon
+      // site-facing indexing controls, all of which load the index with
+      // overrides applied. Search API's own index admin UI loads the index
+      // override-free, so it is not gated here; that UI requires "administer
+      // search_api", which no Beacon site role is granted.
+      if (!empty($settings['read_only'])) {
+        $overrides[$index_config]['read_only'] = TRUE;
       }
     }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Config/YsBeaconConfigOverrides.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Config/YsBeaconConfigOverrides.php
@@ -9,27 +9,24 @@ use Drupal\Core\Config\StorageInterface;
 /**
  * Injects per-site Beacon values into platform-managed configuration.
  *
- * The search server and vector database connection configuration are shipped
- * in the profile config sync directory so they deploy identically to every
- * site. The per-site values (the Azure AI Search index name and endpoint URL)
- * live outside of synced config: the index name in ys_beacon.settings (which
- * is config_ignored) and the endpoint URL in a key entity backed by Pantheon
- * secrets. This override layers them in at runtime, so config imports never
- * overwrite them. Search API honors overrides on the loaded index entity, so
- * this class drives the index status and the read-only flag as well as the
- * server backend_config.
+ * Two things are layered in at runtime rather than stored in synced config: the
+ * Azure AI Search endpoint URL (resolved from a key entity backed by Pantheon
+ * secrets) on the vector database connection config, and safety-net toggles on
+ * the search index status and the Beacon chat setting.
  *
- * A site can borrow another site's collection by pointing its index name at
- * that collection and turning on ys_beacon.settings:read_only. This override
- * then marks the index read-only at runtime, so Search API's automatic write
- * paths (indexing, cron, clear, delete-time removal) stand down and the site
- * queries the shared collection without writing to it. Like the index name, the
- * flag lives in the config-ignored ys_beacon.settings, so it survives config
- * import.
+ * The per-site index name and read-only flag are NOT overridden here: they are
+ * persisted directly onto the real Search API config (the server's Azure
+ * database name and the index's read_only flag) by
+ * BeaconIndexManager::propagateConnection(), and kept through config import by
+ * config-ignoring those keys. Persisting them - rather than overriding at
+ * runtime - keeps the Search API admin UI truthful and points the chat query at
+ * the configured collection.
  *
- * The index is also disabled at runtime whenever the chat widget is turned
- * off or a site has not configured its index name yet, so unconfigured or
- * disabled sites never attempt to reach Azure.
+ * The index status is forced off at runtime whenever the chat widget is turned
+ * off, the site is unauthorized, or no index name is configured yet, so
+ * unconfigured or disabled sites never reach Azure. Status is the one index
+ * value still derived at runtime because it depends on the platform
+ * authorization and chat toggle, which can change without a settings-form save.
  *
  * Finally, when a platform admin has not authorized Beacon for a site, this
  * override forces the chat off (ys_beacon.settings:enable_chat) so the site
@@ -42,10 +39,10 @@ class YsBeaconConfigOverrides implements ConfigFactoryOverrideInterface {
   /**
    * The vector-database connection config this class overrides.
    *
-   * The search server and index config names are not constants: their machine
-   * names are configurable (ys_beacon.settings:search_server_id /
-   * search_index_id, defaulting to "ys_beacon"), so they are resolved at
-   * runtime to support a second index without code changes.
+   * The search index config name is not a constant: its machine name is
+   * configurable (ys_beacon.settings:search_index_id, defaulting to
+   * "ys_beacon"), so it is resolved at runtime to support a second index
+   * without code changes.
    */
   protected const VDB_CONFIG = 'ai_vdb_provider_azure_ai_search.settings';
 
@@ -93,7 +90,6 @@ class YsBeaconConfigOverrides implements ConfigFactoryOverrideInterface {
     }
 
     $settings = $this->getSettings();
-    $server_config = $this->serverConfigName($settings);
     $index_config = $this->indexConfigName($settings);
     $index_name = $settings['azure_index_name'] ?? '';
 
@@ -112,16 +108,6 @@ class YsBeaconConfigOverrides implements ConfigFactoryOverrideInterface {
       $overrides[self::SETTINGS_CONFIG] = ['enable_chat' => FALSE];
     }
 
-    if (in_array($server_config, $names, TRUE) && $index_name !== '') {
-      $overrides[$server_config] = [
-        'backend_config' => [
-          'database_settings' => [
-            'database_name' => $index_name,
-          ],
-        ],
-      ];
-    }
-
     if (in_array($index_config, $names, TRUE)) {
       // The chat toggle is the primary driver of index status: the settings
       // form enables or disables the index explicitly in sync with it. This
@@ -130,17 +116,6 @@ class YsBeaconConfigOverrides implements ConfigFactoryOverrideInterface {
       // been configured yet.
       if (!$enable_chat || $index_name === '') {
         $overrides[$index_config]['status'] = FALSE;
-      }
-      // A site borrowing another site's collection marks its index read-only so
-      // it queries the shared collection but never writes to it. This gates
-      // Search API's automatic write paths (immediate indexing, cron, the
-      // indexing batch helper, clear, and delete-time removal) and the Beacon
-      // site-facing indexing controls, all of which load the index with
-      // overrides applied. Search API's own index admin UI loads the index
-      // override-free, so it is not gated here; that UI requires "administer
-      // search_api", which no Beacon site role is granted.
-      if (!empty($settings['read_only'])) {
-        $overrides[$index_config]['read_only'] = TRUE;
       }
     }
 
@@ -164,26 +139,13 @@ class YsBeaconConfigOverrides implements ConfigFactoryOverrideInterface {
    *   The config object name.
    *
    * @return bool
-   *   TRUE when the name is the VDB settings or a search server/index object.
+   *   TRUE when the name is the VDB settings, the Beacon settings, or a search
+   *   index object.
    */
   protected function mayBeRelevant(string $name): bool {
     return $name === self::VDB_CONFIG
       || $name === self::SETTINGS_CONFIG
-      || str_starts_with($name, 'search_api.server.')
       || str_starts_with($name, 'search_api.index.');
-  }
-
-  /**
-   * The search server config object name backing the chatbot.
-   *
-   * @param array $settings
-   *   The raw ys_beacon settings.
-   *
-   * @return string
-   *   The config object name.
-   */
-  protected function serverConfigName(array $settings): string {
-    return 'search_api.server.' . (($settings['search_server_id'] ?? '') ?: 'ys_beacon');
   }
 
   /**
@@ -281,7 +243,6 @@ class YsBeaconConfigOverrides implements ConfigFactoryOverrideInterface {
     $ours = [
       self::VDB_CONFIG,
       self::SETTINGS_CONFIG,
-      $this->serverConfigName($settings),
       $this->indexConfigName($settings),
     ];
     if (in_array($name, $ours, TRUE)) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconAdminSettings.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconAdminSettings.php
@@ -152,12 +152,14 @@ class YsBeaconAdminSettings extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $config = $this->config(self::CONFIG_NAME);
     $previous_index_name = $config->get('azure_index_name');
+    $previous_read_only = (bool) $config->get('read_only');
     $new_index_name = $form_state->getValue('azure_index_name');
     $read_only = (bool) $form_state->getValue('read_only');
 
-    // The index name is intentionally not saved here: provision() persists it
-    // only after the Azure index has been verified or created, so a failed
-    // provisioning never leaves the site pointing at a nonexistent index.
+    // The index name and read-only flag are intentionally not saved here:
+    // propagateConnection() below persists them onto both the Beacon settings
+    // and the real Search API config (server database name + index read-only
+    // flag), so they never drift and the admin UI stays truthful.
     // The chatbot requires the AI metadata fields, so an explicit "off" here is
     // overridden whenever chat is enabled.
     $enable_metadata_fields = (bool) $form_state->getValue('enable_metadata_fields')
@@ -169,30 +171,34 @@ class YsBeaconAdminSettings extends ConfigFormBase {
       ->set('streaming', (bool) $form_state->getValue('streaming'))
       ->set('fallback_system_prompt', $form_state->getValue('fallback_system_prompt'))
       ->set('enable_metadata_fields', $enable_metadata_fields)
-      ->set('read_only', $read_only)
       ->save();
 
-    if ($new_index_name !== $previous_index_name) {
-      if ($new_index_name && $read_only) {
-        // Borrowing another site's collection: point at it, do not provision.
-        // A read-only site must never create, write to, or queue content into
-        // the shared collection, so skip provision() (which would create a
-        // missing index and rebuild the tracker) and just persist the name.
-        $this->config(self::CONFIG_NAME)->set('azure_index_name', $new_index_name)->save();
+    // Provision when a writable site points at a NEW index, or switches an
+    // existing index from read-only (borrowed) back to writable: both need the
+    // Azure index verified/created and the Search API tracker (re)built so the
+    // site's content is queued. provision() persists the connection only after
+    // the Azure index is confirmed, so a failed provisioning never leaves the
+    // site pointing at a nonexistent index. Read-only borrows never provision.
+    if ($new_index_name && !$read_only
+      && ($new_index_name !== $previous_index_name || $previous_read_only)) {
+      try {
+        $this->indexManager->provision($new_index_name);
+        $this->messenger()->addStatus($this->t('All existing content has been queued for indexing into the Beacon vector database.'));
+      }
+      catch (\RuntimeException $e) {
+        $this->messenger()->addWarning($this->t('The index name was not saved: Azure AI Search could not be reached to verify or create the index. @message', ['@message' => $e->getMessage()]));
+      }
+    }
+    else {
+      // Everything else - borrowing another site's collection read-only,
+      // clearing the index name, or a save that only toggles read-only on the
+      // current index - writes the connection straight into the real config
+      // without provisioning. A read-only site must never create, write to, or
+      // queue content into the collection, so provision() (which would create a
+      // missing index and rebuild the tracker) is skipped.
+      $this->indexManager->propagateConnection($new_index_name, $read_only);
+      if ($new_index_name && $read_only && $new_index_name !== $previous_index_name) {
         $this->messenger()->addStatus($this->t('This site now reads from the shared, read-only index %name. Content indexing is managed by the owning site.', ['%name' => $new_index_name]));
-      }
-      elseif ($new_index_name) {
-        try {
-          $this->indexManager->provision($new_index_name);
-          $this->messenger()->addStatus($this->t('All existing content has been queued for indexing into the Beacon vector database.'));
-        }
-        catch (\RuntimeException $e) {
-          $this->messenger()->addWarning($this->t('The index name was not saved: Azure AI Search could not be reached to verify or create the index. @message', ['@message' => $e->getMessage()]));
-        }
-      }
-      else {
-        // Explicitly clearing the index name disables Beacon indexing.
-        $this->config(self::CONFIG_NAME)->set('azure_index_name', '')->save();
       }
     }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconAdminSettings.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconAdminSettings.php
@@ -83,6 +83,12 @@ class YsBeaconAdminSettings extends ConfigFormBase {
       ]),
       '#default_value' => $config->get('azure_search_url_key'),
     ];
+    $form['connection']['read_only'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Read-only (borrow another site’s index)'),
+      '#description' => $this->t('When enabled, this site queries the index above but never writes to it: no indexing, re-indexing, clearing, or delete-time removal. Use this when the index name points at a collection owned by another site, so that site’s data is never modified. Leave off for a site that owns and indexes its own content.'),
+      '#default_value' => (bool) $config->get('read_only'),
+    ];
 
     $form['retrieval'] = [
       '#type' => 'details',
@@ -147,6 +153,7 @@ class YsBeaconAdminSettings extends ConfigFormBase {
     $config = $this->config(self::CONFIG_NAME);
     $previous_index_name = $config->get('azure_index_name');
     $new_index_name = $form_state->getValue('azure_index_name');
+    $read_only = (bool) $form_state->getValue('read_only');
 
     // The index name is intentionally not saved here: provision() persists it
     // only after the Azure index has been verified or created, so a failed
@@ -162,10 +169,19 @@ class YsBeaconAdminSettings extends ConfigFormBase {
       ->set('streaming', (bool) $form_state->getValue('streaming'))
       ->set('fallback_system_prompt', $form_state->getValue('fallback_system_prompt'))
       ->set('enable_metadata_fields', $enable_metadata_fields)
+      ->set('read_only', $read_only)
       ->save();
 
     if ($new_index_name !== $previous_index_name) {
-      if ($new_index_name) {
+      if ($new_index_name && $read_only) {
+        // Borrowing another site's collection: point at it, do not provision.
+        // A read-only site must never create, write to, or queue content into
+        // the shared collection, so skip provision() (which would create a
+        // missing index and rebuild the tracker) and just persist the name.
+        $this->config(self::CONFIG_NAME)->set('azure_index_name', $new_index_name)->save();
+        $this->messenger()->addStatus($this->t('This site now reads from the shared, read-only index %name. Content indexing is managed by the owning site.', ['%name' => $new_index_name]));
+      }
+      elseif ($new_index_name) {
         try {
           $this->indexManager->provision($new_index_name);
           $this->messenger()->addStatus($this->t('All existing content has been queued for indexing into the Beacon vector database.'));

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconSettings.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconSettings.php
@@ -6,6 +6,7 @@ use Drupal\Component\Utility\Html;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\search_api\IndexInterface;
 use Drupal\search_api\SearchApiException;
@@ -185,26 +186,37 @@ class YsBeaconSettings extends ConfigFormBase {
       '#open' => TRUE,
       '#weight' => 30,
     ];
-    $form['indexing']['status'] = [
-      '#markup' => '<p>' . $this->indexStatusSummary() . '</p>',
-    ];
-    $form['indexing']['reindex'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Re-index all content'),
-      '#submit' => ['::reindexAll'],
-      '#limit_validation_errors' => [],
-    ];
-    $form['indexing']['index_now'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Index now'),
-      // Dedicated handler only: the main config submit must not run, so chat
-      // settings are not saved when the user just wants to flush the queue.
-      '#submit' => ['::indexNow'],
-      '#limit_validation_errors' => [],
-      // Disabled unless the Beacon index is enabled and has items waiting to be
-      // indexed. Mirrors Search API's own "Index now" disabled behaviour.
-      '#disabled' => $this->indexRemainingItems() < 1,
-    ];
+    $index = $this->loadBeaconIndex();
+    if ($index && $index->isReadOnly()) {
+      // This site borrows another site's collection: content indexing is owned
+      // by that site, so the local re-index / index-now controls are hidden and
+      // the status is replaced with a short explanatory note.
+      $form['indexing']['status'] = [
+        '#markup' => '<p>' . $this->readOnlyNotice() . '</p>',
+      ];
+    }
+    else {
+      $form['indexing']['status'] = [
+        '#markup' => '<p>' . $this->indexStatusSummary() . '</p>',
+      ];
+      $form['indexing']['reindex'] = [
+        '#type' => 'submit',
+        '#value' => $this->t('Re-index all content'),
+        '#submit' => ['::reindexAll'],
+        '#limit_validation_errors' => [],
+      ];
+      $form['indexing']['index_now'] = [
+        '#type' => 'submit',
+        '#value' => $this->t('Index now'),
+        // Dedicated handler only: the main config submit must not run, so chat
+        // settings are not saved when the user just wants to flush the queue.
+        '#submit' => ['::indexNow'],
+        '#limit_validation_errors' => [],
+        // Disabled unless the Beacon index is enabled and has items waiting to
+        // be indexed. Mirrors Search API's own "Index now" disabled behaviour.
+        '#disabled' => $this->indexRemainingItems() < 1,
+      ];
+    }
 
     // Link to the per-site system instructions when the user has access.
     $instructions_url = Url::fromRoute('ys_beacon.instructions');
@@ -266,7 +278,7 @@ class YsBeaconSettings extends ConfigFormBase {
     // Keep the Search API index status in sync with the chat toggle. The
     // config override forces the index off while chat is disabled, so the
     // explicit status changes only take effect for the matching transition.
-    $index = $this->entityTypeManager->getStorage('search_api_index')->load($this->searchIndexId());
+    $index = $this->loadBeaconIndex();
     if (!$index) {
       // Abort if the index does not exist; this should never happen.
       parent::submitForm($form, $form_state);
@@ -284,7 +296,7 @@ class YsBeaconSettings extends ConfigFormBase {
       // config override forces it off while no index name is set), so we never
       // enable an index with no Azure backing.
       if (!$previous_enable && $this->config(self::CONFIG_NAME)->get('azure_index_name')) {
-        $index->setStatus(TRUE)->save();
+        $this->saveIndexStatus(TRUE);
         // Rebuild the tracker so existing content is queued for indexing on
         // the freshly enabled index: reindex() only re-flags already-tracked
         // items and leaves a never-seeded tracker empty (issue #1383).
@@ -293,7 +305,7 @@ class YsBeaconSettings extends ConfigFormBase {
     }
     elseif ($previous_enable) {
       // Chat turned off: stop indexing.
-      $index->setStatus(FALSE)->save();
+      $this->saveIndexStatus(FALSE);
     }
 
     parent::submitForm($form, $form_state);
@@ -326,6 +338,10 @@ class YsBeaconSettings extends ConfigFormBase {
    */
   public function reindexAll(array &$form, FormStateInterface $form_state): void {
     $index = $this->loadBeaconIndex();
+    if ($index && $index->isReadOnly()) {
+      $this->messenger()->addWarning($this->readOnlyNotice());
+      return;
+    }
     if ($index && $index->status()) {
       // rebuildTracker() re-enumerates the datasources and marks every item
       // for indexing, so it repopulates a never-seeded tracker as well as
@@ -351,6 +367,10 @@ class YsBeaconSettings extends ConfigFormBase {
    */
   public function indexNow(array &$form, FormStateInterface $form_state): void {
     $index = $this->loadBeaconIndex();
+    if ($index && $index->isReadOnly()) {
+      $this->messenger()->addWarning($this->readOnlyNotice());
+      return;
+    }
     if (!$index || !$index->status()) {
       $this->messenger()->addWarning($this->t('The Beacon index is not enabled on this site. Enable the chat widget first.'));
       return;
@@ -411,6 +431,16 @@ class YsBeaconSettings extends ConfigFormBase {
   }
 
   /**
+   * The note shown when the Beacon index borrows another site's collection.
+   *
+   * Displayed in place of the indexing controls and returned by the indexing
+   * submit handlers when they are blocked, so the wording lives in one place.
+   */
+  protected function readOnlyNotice(): TranslatableMarkup {
+    return $this->t('This site uses a shared, read-only index; content indexing is managed by the owning site.');
+  }
+
+  /**
    * Loads the Search API index backing the Beacon chatbot.
    *
    * @return \Drupal\search_api\IndexInterface|null
@@ -418,6 +448,22 @@ class YsBeaconSettings extends ConfigFormBase {
    */
   protected function loadBeaconIndex(): ?IndexInterface {
     return $this->entityTypeManager->getStorage('search_api_index')->load($this->searchIndexId());
+  }
+
+  /**
+   * Persists the Beacon index enabled/disabled status.
+   *
+   * Saves an override-free copy of the index so the runtime status and
+   * read-only overrides layered on by YsBeaconConfigOverrides are never baked
+   * into the synced search_api.index config (which, unlike ys_beacon.settings,
+   * is written back by config import). Mirrors Search API's own CommandHelper,
+   * which reloads override-free before persisting a status change.
+   */
+  protected function saveIndexStatus(bool $status): void {
+    $index = $this->entityTypeManager->getStorage('search_api_index')->loadOverrideFree($this->searchIndexId());
+    if ($index) {
+      $index->setStatus($status)->save();
+    }
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/BeaconIndexManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/BeaconIndexManager.php
@@ -60,9 +60,9 @@ class BeaconIndexManager {
   public function provision(?string $name = NULL): string {
     $name = $this->ensureIndex($name);
 
-    $this->configFactory->getEditable('ys_beacon.settings')
-      ->set('azure_index_name', $name)
-      ->save();
+    // A provisioned index is owned and written by this site, so persist the
+    // connection into the real Search API config as writable (read-only off).
+    $this->propagateConnection($name, FALSE);
 
     // The Beacon search index stays disabled at runtime until an index name
     // exists, so Search API never initialized its tracker. Rebuild it now
@@ -73,6 +73,56 @@ class BeaconIndexManager {
     }
 
     return $name;
+  }
+
+  /**
+   * Persists the per-site index connection into the real Search API config.
+   *
+   * Writes the per-site Azure index name onto the search server's database name
+   * and the read-only flag onto the search index entity, both on an
+   * override-free load so the runtime overrides layered on by
+   * YsBeaconConfigOverrides are never baked into the synced config. Persisting
+   * (rather than only overriding at runtime) makes the real search_api config
+   * authoritative: the Search API admin UI reflects the read-only state, and
+   * the chat query targets the configured collection instead of an empty one.
+   * The values also live in the config-ignored ys_beacon.settings as the site
+   * preference; the search_api copies survive config import because the
+   * database-name and read-only keys are config-ignored.
+   *
+   * @param string $index_name
+   *   The Azure AI Search index (collection) name this site connects to. An
+   *   empty string clears the connection (Beacon indexing disabled).
+   * @param bool $read_only
+   *   TRUE when this site borrows the collection and must never write to it.
+   */
+  public function propagateConnection(string $index_name, bool $read_only): void {
+    // Each store is written only when its value actually changes: repeated
+    // no-op saves would needlessly invalidate config caches and re-fire the
+    // search server's save subscriber. Comparing the wanted value against the
+    // persisted one also self-heals drift (for example a manual edit through
+    // Search API's own admin UI) on the next save.
+    $settings = $this->configFactory->getEditable('ys_beacon.settings');
+    if ($settings->get('azure_index_name') !== $index_name
+      || (bool) $settings->get('read_only') !== $read_only) {
+      $settings->set('azure_index_name', $index_name)
+        ->set('read_only', $read_only)
+        ->save();
+    }
+
+    $server = $this->entityTypeManager->getStorage('search_api_server')->loadOverrideFree($this->searchServerId());
+    if ($server) {
+      $backend_config = $server->get('backend_config');
+      $current = $backend_config['database_settings']['database_name'] ?? NULL;
+      if ($current !== $index_name) {
+        $backend_config['database_settings']['database_name'] = $index_name;
+        $server->set('backend_config', $backend_config)->save();
+      }
+    }
+
+    $index = $this->entityTypeManager->getStorage('search_api_index')->loadOverrideFree($this->searchIndexId());
+    if ($index && $index->isReadOnly() !== $read_only) {
+      $index->set('read_only', $read_only)->save();
+    }
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/BeaconServerImportTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/BeaconServerImportTest.php
@@ -9,8 +9,10 @@ use Drupal\search_api\Entity\Server;
  * Tests that importing the Beacon search server on a fresh site is safe.
  *
  * The Beacon search server ships in synced config with an empty per-site index
- * name (`database_name: ''`); the real name is layered in at read time by
- * YsBeaconConfigOverrides. Saving a `search_api.server.*` config fires
+ * name (`database_name: ''`); the real name is written onto the server config
+ * per site by BeaconIndexManager::propagateConnection() when the index is
+ * provisioned or a borrowed collection is set, and a fresh site has it empty
+ * until then. Saving a `search_api.server.*` config fires
  * ai_search's NewServerEventSubscriber, which reaches into the configured
  * vector-database backend. On a brand-new site that has no Azure index yet,
  * that path must not throw an uncaught error and abort the whole config
@@ -86,7 +88,7 @@ class BeaconServerImportTest extends KernelTestBase {
     $this->assertSame(
       '',
       $loaded->getBackendConfig()['database_settings']['database_name'],
-      'The stored index name stays empty; the real value is supplied at read time by YsBeaconConfigOverrides.',
+      'A freshly imported server keeps the empty default; the per-site name is written later by BeaconIndexManager::propagateConnection().',
     );
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconConfigDefaultsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconConfigDefaultsTest.php
@@ -47,6 +47,13 @@ class BeaconConfigDefaultsTest extends UnitTestCase {
   }
 
   /**
+   * The index ships writable: read-only is opt-in per borrowing site.
+   */
+  public function testReadOnlyDefaultsToOff(): void {
+    $this->assertFalse($this->installSettings()['read_only']);
+  }
+
+  /**
    * The fallback prompt ships with the full YaleSites system instruction.
    */
   public function testFallbackPromptShipsYaleSitesInstruction(): void {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconIndexManagerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconIndexManagerTest.php
@@ -2,6 +2,12 @@
 
 namespace Drupal\Tests\ys_beacon\Unit;
 
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\Entity\ConfigEntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\search_api\IndexInterface;
+use Drupal\search_api\ServerInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\ys_beacon\Service\BeaconIndexManager;
 
@@ -41,6 +47,151 @@ class BeaconIndexManagerTest extends UnitTestCase {
         str_repeat('a', 127),
       ],
     ];
+  }
+
+  /**
+   * A read-only borrow persists the connection into real Search API config.
+   *
+   * The call writes the Azure index name onto the search server's database name
+   * and the read-only flag onto the index entity, both override-free, plus the
+   * ys_beacon.settings preference - so the real config (not just a runtime
+   * override) is authoritative and the chat query targets the collection.
+   *
+   * @covers ::propagateConnection
+   */
+  public function testPropagateConnectionWritesRealConfig(): void {
+    $captured = [];
+    // Currently a writable "old-name" site; borrow "borrowed-collection".
+    $manager = $this->buildManagerCapturing($captured, 'old-name', FALSE);
+
+    $manager->propagateConnection('borrowed-collection', TRUE);
+
+    // The Beacon settings preference is saved.
+    $this->assertSame('borrowed-collection', $captured['settings']['azure_index_name']);
+    $this->assertTrue($captured['settings']['read_only']);
+    // The server's Azure database name is updated; sibling backend_config keys
+    // are preserved (merged into the existing config, not replaced).
+    $this->assertSame('borrowed-collection', $captured['server']['backend_config']['database_settings']['database_name']);
+    $this->assertSame('portkey', $captured['server']['backend_config']['embeddings_engine']);
+    // The index read-only flag is persisted on the entity.
+    $this->assertTrue($captured['index']['read_only']);
+  }
+
+  /**
+   * A writable (non-borrow) connection sets the name and clears read-only.
+   *
+   * @covers ::propagateConnection
+   */
+  public function testPropagateConnectionWritableClearsReadOnly(): void {
+    $captured = [];
+    // Currently a read-only "old" borrow; switch to a writable "my-own-index".
+    $manager = $this->buildManagerCapturing($captured, 'old', TRUE);
+
+    $manager->propagateConnection('my-own-index', FALSE);
+
+    $this->assertSame('my-own-index', $captured['settings']['azure_index_name']);
+    $this->assertFalse($captured['settings']['read_only']);
+    $this->assertSame('my-own-index', $captured['server']['backend_config']['database_settings']['database_name']);
+    $this->assertFalse($captured['index']['read_only']);
+  }
+
+  /**
+   * An unchanged connection writes nothing (no redundant saves or subscribers).
+   *
+   * @covers ::propagateConnection
+   */
+  public function testPropagateConnectionSkipsUnchangedValues(): void {
+    $captured = [];
+    // Already read-only on "shared-idx"; re-save the identical values.
+    $manager = $this->buildManagerCapturing($captured, 'shared-idx', TRUE);
+
+    $manager->propagateConnection('shared-idx', TRUE);
+
+    // Nothing changed, so no store is written (a missing key means skipped).
+    $this->assertArrayNotHasKey('settings', $captured);
+    $this->assertArrayNotHasKey('server', $captured);
+    $this->assertArrayNotHasKey('index', $captured);
+  }
+
+  /**
+   * Builds a BeaconIndexManager whose config writes are captured by reference.
+   *
+   * @param array $captured
+   *   Populated with the values written to ys_beacon.settings ('settings'), the
+   *   search server ('server'), and the search index ('index'); a store absent
+   *   from the array means propagateConnection() skipped writing it.
+   * @param string $current_name
+   *   The index name currently persisted (settings + server database name), so
+   *   change-detection can decide whether a write is needed.
+   * @param bool $current_read_only
+   *   The read-only flag currently persisted (settings + index entity).
+   *
+   * @return \Drupal\ys_beacon\Service\BeaconIndexManager
+   *   The manager under test with only the two used dependencies wired.
+   */
+  private function buildManagerCapturing(
+    array &$captured,
+    string $current_name,
+    bool $current_read_only,
+  ): BeaconIndexManager {
+    $editable = $this->createMock(Config::class);
+    $editable->method('get')->willReturnCallback(fn (string $key) => match ($key) {
+      'azure_index_name' => $current_name,
+      'read_only' => $current_read_only,
+      default => NULL,
+    });
+    $editable->method('set')->willReturnCallback(function (string $key, $value) use (&$captured, $editable) {
+      $captured['settings'][$key] = $value;
+      return $editable;
+    });
+    $editable->method('save')->willReturnSelf();
+
+    $immutable = $this->createMock(Config::class);
+    $immutable->method('get')->willReturnCallback(
+      fn (string $key) => in_array($key, ['search_server_id', 'search_index_id'], TRUE) ? 'ys_beacon' : NULL,
+    );
+
+    $config_factory = $this->createMock(ConfigFactoryInterface::class);
+    $config_factory->method('getEditable')->with('ys_beacon.settings')->willReturn($editable);
+    $config_factory->method('get')->with('ys_beacon.settings')->willReturn($immutable);
+
+    $server = $this->createMock(ServerInterface::class);
+    $server->method('get')->with('backend_config')->willReturn([
+      'database_settings' => ['database_name' => $current_name],
+      'embeddings_engine' => 'portkey',
+    ]);
+    $server->method('set')->willReturnCallback(function (string $key, $value) use (&$captured, $server) {
+      $captured['server'][$key] = $value;
+      return $server;
+    });
+    $server->method('save')->willReturn(1);
+    $server_storage = $this->createMock(ConfigEntityStorageInterface::class);
+    $server_storage->method('loadOverrideFree')->with('ys_beacon')->willReturn($server);
+
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('isReadOnly')->willReturn($current_read_only);
+    $index->method('set')->willReturnCallback(function (string $key, $value) use (&$captured, $index) {
+      $captured['index'][$key] = $value;
+      return $index;
+    });
+    $index->method('save')->willReturn(1);
+    $index_storage = $this->createMock(ConfigEntityStorageInterface::class);
+    $index_storage->method('loadOverrideFree')->with('ys_beacon')->willReturn($index);
+
+    $etm = $this->createMock(EntityTypeManagerInterface::class);
+    $etm->method('getStorage')->willReturnCallback(
+      fn (string $type) => $type === 'search_api_server' ? $server_storage : $index_storage,
+    );
+
+    $manager = (new \ReflectionClass(BeaconIndexManager::class))->newInstanceWithoutConstructor();
+    $config_property = new \ReflectionProperty($manager, 'configFactory');
+    $config_property->setAccessible(TRUE);
+    $config_property->setValue($manager, $config_factory);
+    $etm_property = new \ReflectionProperty($manager, 'entityTypeManager');
+    $etm_property->setAccessible(TRUE);
+    $etm_property->setValue($manager, $etm);
+
+    return $manager;
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/IndexNowFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/IndexNowFormTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\ys_beacon\Unit;
 
+use Drupal\Core\Config\Entity\ConfigEntityStorageInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -261,6 +262,83 @@ class IndexNowFormTest extends UnitTestCase {
     $form = $this->buildForm($index, NULL, $messenger);
     $form_array = [];
     $form->reindexAll($form_array, $this->createMock(FormStateInterface::class));
+  }
+
+  /**
+   * A read-only index blocks re-index: it warns and never rebuilds the tracker.
+   *
+   * A borrowing site must never write to the shared collection, so the local
+   * "Re-index all content" control is a no-op guarded server-side.
+   *
+   * @covers ::reindexAll
+   */
+  public function testReindexAllBlockedWhenReadOnly(): void {
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('isReadOnly')->willReturn(TRUE);
+    // Enabled, so without the read-only guard it would rebuild the tracker;
+    // the guard must short-circuit before that.
+    $index->method('status')->willReturn(TRUE);
+    $index->expects($this->never())->method('rebuildTracker');
+    $messenger = $this->createMock(MessengerInterface::class);
+    $messenger->expects($this->once())->method('addWarning');
+    $messenger->expects($this->never())->method('addStatus');
+
+    $form = $this->buildForm($index, NULL, $messenger);
+    $form_array = [];
+    $form->reindexAll($form_array, $this->createMock(FormStateInterface::class));
+  }
+
+  /**
+   * A read-only index blocks "Index now": it warns and never starts a batch.
+   *
+   * @covers ::indexNow
+   */
+  public function testIndexNowBlockedWhenReadOnly(): void {
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('isReadOnly')->willReturn(TRUE);
+    // Enabled with items queued, so without the read-only guard it would start
+    // a batch; the guard must short-circuit before that.
+    $index->method('status')->willReturn(TRUE);
+    $tracker = $this->createMock(TrackerInterface::class);
+    $tracker->method('getRemainingItemsCount')->willReturn(5);
+    $index->method('getTrackerInstance')->willReturn($tracker);
+    $helper = $this->createMock(IndexingBatchHelperInterface::class);
+    $helper->expects($this->never())->method('createBatch');
+    $messenger = $this->createMock(MessengerInterface::class);
+    $messenger->expects($this->once())->method('addWarning');
+
+    $form = $this->buildForm($index, $helper, $messenger);
+    $form_array = [];
+    $form->indexNow($form_array, $this->createMock(FormStateInterface::class));
+  }
+
+  /**
+   * Status changes are persisted on an override-free copy of the index.
+   *
+   * The runtime config override (status and read_only) must never be baked into
+   * the synced search_api.index config, so the save loads the index
+   * override-free rather than through the overrides-applied load().
+   *
+   * @covers ::saveIndexStatus
+   */
+  public function testSaveIndexStatusUsesOverrideFreeLoad(): void {
+    $index = $this->createMock(IndexInterface::class);
+    $index->expects($this->once())->method('setStatus')->with(TRUE)->willReturnSelf();
+    $index->expects($this->once())->method('save');
+
+    $storage = $this->createMock(ConfigEntityStorageInterface::class);
+    $storage->expects($this->once())->method('loadOverrideFree')->with('ys_beacon')->willReturn($index);
+    $storage->expects($this->never())->method('load');
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->with('search_api_index')->willReturn($storage);
+
+    $form = (new \ReflectionClass(YsBeaconSettings::class))->newInstanceWithoutConstructor();
+    $this->setProtected($form, 'entityTypeManager', $entity_type_manager);
+    $this->setProtected($form, 'configFactory', $this->getConfigFactoryStub([
+      'ys_beacon.settings' => ['search_index_id' => 'ys_beacon'],
+    ]));
+
+    $this->invoke($form, 'saveIndexStatus', [TRUE]);
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/IndexNowFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/IndexNowFormTest.php
@@ -315,9 +315,9 @@ class IndexNowFormTest extends UnitTestCase {
   /**
    * Status changes are persisted on an override-free copy of the index.
    *
-   * The runtime config override (status and read_only) must never be baked into
-   * the synced search_api.index config, so the save loads the index
-   * override-free rather than through the overrides-applied load().
+   * The runtime status config override must never be baked into the synced
+   * search_api.index config, so the save loads the index override-free rather
+   * than through the overrides-applied load().
    *
    * @covers ::saveIndexStatus
    */

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/YsBeaconAdminSettingsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/YsBeaconAdminSettingsTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\Form\YsBeaconAdminSettings;
+use Drupal\ys_beacon\Service\BeaconIndexManager;
+
+/**
+ * Tests the read-only handling of the Beacon administration settings form.
+ *
+ * A read-only site borrows another site's collection, so entering the shared
+ * index name and checking Read-only must point at that collection WITHOUT
+ * provisioning it: provision() would create the index when missing, rebuild the
+ * tracker, and claim content was queued - all writes a borrowing site must
+ * never perform. A writable site keeps provisioning as before.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Form\YsBeaconAdminSettings
+ */
+class YsBeaconAdminSettingsTest extends UnitTestCase {
+
+  /**
+   * Builds the form with a config mock and a given index manager.
+   *
+   * @param \Drupal\ys_beacon\Service\BeaconIndexManager $index_manager
+   *   The index manager (with provision() expectations set by the caller).
+   * @param string $previous_index_name
+   *   The azure_index_name currently stored, to drive the change detection.
+   *
+   * @return array
+   *   The form under test and the editable config mock (keyed 'form','config').
+   */
+  private function buildForm(BeaconIndexManager $index_manager, string $previous_index_name): array {
+    $config = $this->createMock(Config::class);
+    $config->method('set')->willReturnSelf();
+    $config->method('save')->willReturnSelf();
+    $config->method('get')->willReturnCallback(fn (string $key) => $key === 'azure_index_name' ? $previous_index_name : NULL);
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('getEditable')->with('ys_beacon.settings')->willReturn($config);
+    $factory->method('get')->with('ys_beacon.settings')->willReturn($config);
+
+    $form = (new \ReflectionClass(YsBeaconAdminSettings::class))->newInstanceWithoutConstructor();
+    $this->setProtected($form, 'configFactory', $factory);
+    $this->setProtected($form, 'indexManager', $index_manager);
+    $this->setProtected($form, 'messenger', $this->createMock(MessengerInterface::class));
+    $this->setProtected($form, 'stringTranslation', $this->getStringTranslationStub());
+
+    return ['form' => $form, 'config' => $config];
+  }
+
+  /**
+   * Sets a protected/inherited property on an object via reflection.
+   */
+  private function setProtected(object $object, string $property, mixed $value): void {
+    $reflection = new \ReflectionProperty($object, $property);
+    $reflection->setAccessible(TRUE);
+    $reflection->setValue($object, $value);
+  }
+
+  /**
+   * A read-only borrow persists the index name without provisioning it.
+   *
+   * @covers ::submitForm
+   */
+  public function testReadOnlyBorrowSkipsProvisioning(): void {
+    $index_manager = $this->createMock(BeaconIndexManager::class);
+    $index_manager->expects($this->never())->method('provision');
+
+    $built = $this->buildForm($index_manager, '');
+
+    $form_state = new FormState();
+    $form_state->setValue('azure_index_name', 'other-site-live');
+    $form_state->setValue('read_only', 1);
+
+    $form_array = [];
+    $built['form']->submitForm($form_array, $form_state);
+  }
+
+  /**
+   * A writable site still provisions the index when the name changes.
+   *
+   * @covers ::submitForm
+   */
+  public function testWritableSiteProvisionsIndex(): void {
+    $index_manager = $this->createMock(BeaconIndexManager::class);
+    $index_manager->expects($this->once())
+      ->method('provision')
+      ->with('my-site-live');
+
+    $built = $this->buildForm($index_manager, '');
+
+    $form_state = new FormState();
+    $form_state->setValue('azure_index_name', 'my-site-live');
+    $form_state->setValue('read_only', 0);
+
+    $form_array = [];
+    $built['form']->submitForm($form_array, $form_state);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/YsBeaconAdminSettingsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/YsBeaconAdminSettingsTest.php
@@ -31,15 +31,25 @@ class YsBeaconAdminSettingsTest extends UnitTestCase {
    *   The index manager (with provision() expectations set by the caller).
    * @param string $previous_index_name
    *   The azure_index_name currently stored, to drive the change detection.
+   * @param bool $previous_read_only
+   *   The read_only flag currently stored, to drive the read-only transition.
    *
    * @return array
    *   The form under test and the editable config mock (keyed 'form','config').
    */
-  private function buildForm(BeaconIndexManager $index_manager, string $previous_index_name): array {
+  private function buildForm(
+    BeaconIndexManager $index_manager,
+    string $previous_index_name,
+    bool $previous_read_only = FALSE,
+  ): array {
     $config = $this->createMock(Config::class);
     $config->method('set')->willReturnSelf();
     $config->method('save')->willReturnSelf();
-    $config->method('get')->willReturnCallback(fn (string $key) => $key === 'azure_index_name' ? $previous_index_name : NULL);
+    $config->method('get')->willReturnCallback(fn (string $key) => match ($key) {
+      'azure_index_name' => $previous_index_name,
+      'read_only' => $previous_read_only,
+      default => NULL,
+    });
 
     $factory = $this->createMock(ConfigFactoryInterface::class);
     $factory->method('getEditable')->with('ys_beacon.settings')->willReturn($config);
@@ -71,12 +81,66 @@ class YsBeaconAdminSettingsTest extends UnitTestCase {
   public function testReadOnlyBorrowSkipsProvisioning(): void {
     $index_manager = $this->createMock(BeaconIndexManager::class);
     $index_manager->expects($this->never())->method('provision');
+    // The borrow is persisted straight into the real config, read-only on.
+    $index_manager->expects($this->once())
+      ->method('propagateConnection')
+      ->with('other-site-live', TRUE);
 
     $built = $this->buildForm($index_manager, '');
 
     $form_state = new FormState();
     $form_state->setValue('azure_index_name', 'other-site-live');
     $form_state->setValue('read_only', 1);
+
+    $form_array = [];
+    $built['form']->submitForm($form_array, $form_state);
+  }
+
+  /**
+   * Toggling read-only on the current index drives the flag, no provisioning.
+   *
+   * A save that only flips Read-only (the index name is unchanged) must still
+   * propagate the flag onto the real config, and must never provision.
+   *
+   * @covers ::submitForm
+   */
+  public function testReadOnlyToggleOnSameIndexPropagates(): void {
+    $index_manager = $this->createMock(BeaconIndexManager::class);
+    $index_manager->expects($this->never())->method('provision');
+    $index_manager->expects($this->once())
+      ->method('propagateConnection')
+      ->with('my-site-live', TRUE);
+
+    // Index name already stored; only Read-only changes.
+    $built = $this->buildForm($index_manager, 'my-site-live');
+
+    $form_state = new FormState();
+    $form_state->setValue('azure_index_name', 'my-site-live');
+    $form_state->setValue('read_only', 1);
+
+    $form_array = [];
+    $built['form']->submitForm($form_array, $form_state);
+  }
+
+  /**
+   * Switching a read-only borrow to writable on the same index re-provisions.
+   *
+   * The tracker of a borrowing site was never seeded, so flipping it writable
+   * must still provision() (verify the index + rebuild the tracker), even when
+   * the index name is unchanged.
+   *
+   * @covers ::submitForm
+   */
+  public function testReadOnlyToWritableSameIndexProvisions(): void {
+    $index_manager = $this->createMock(BeaconIndexManager::class);
+    $index_manager->expects($this->once())->method('provision')->with('shared-idx');
+
+    // Previously borrowing "shared-idx" read-only; now writable, same name.
+    $built = $this->buildForm($index_manager, 'shared-idx', TRUE);
+
+    $form_state = new FormState();
+    $form_state->setValue('azure_index_name', 'shared-idx');
+    $form_state->setValue('read_only', 0);
 
     $form_array = [];
     $built['form']->submitForm($form_array, $form_state);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/YsBeaconConfigOverridesTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/YsBeaconConfigOverridesTest.php
@@ -264,6 +264,71 @@ class YsBeaconConfigOverridesTest extends UnitTestCase {
   }
 
   /**
+   * A read-only site adds the read_only override to the index config.
+   *
+   * A borrowing site keeps its index enabled so the shared collection can be
+   * queried, but marks it read-only so Search API never writes to it.
+   *
+   * @covers ::loadOverrides
+   */
+  public function testReadOnlyOverridesIndexWhenSet(): void {
+    $override = $this->buildOverride(
+      [
+        'enable_chat' => TRUE,
+        'platform_authorized' => TRUE,
+        'azure_index_name' => 'other-site-live',
+        'read_only' => TRUE,
+      ],
+      [],
+    );
+
+    $index = $override->loadOverrides([self::INDEX_CONFIG])[self::INDEX_CONFIG];
+    $this->assertTrue($index['read_only']);
+    // The index stays enabled so the borrowed collection can still be queried.
+    $this->assertArrayNotHasKey('status', $index);
+  }
+
+  /**
+   * A writable site (the default) gets no read_only override.
+   *
+   * @covers ::loadOverrides
+   */
+  public function testNoReadOnlyOverrideWhenUnset(): void {
+    $unset = $this->buildOverride(
+      ['enable_chat' => TRUE, 'platform_authorized' => TRUE, 'azure_index_name' => 'my-site-live'],
+      [],
+    );
+    $this->assertArrayNotHasKey(self::INDEX_CONFIG, $unset->loadOverrides([self::INDEX_CONFIG]));
+
+    $explicit_false = $this->buildOverride(
+      [
+        'enable_chat' => TRUE,
+        'platform_authorized' => TRUE,
+        'azure_index_name' => 'my-site-live',
+        'read_only' => FALSE,
+      ],
+      [],
+    );
+    $this->assertArrayNotHasKey(self::INDEX_CONFIG, $explicit_false->loadOverrides([self::INDEX_CONFIG]));
+  }
+
+  /**
+   * Read-only composes with the chat-off status safety net.
+   *
+   * @covers ::loadOverrides
+   */
+  public function testReadOnlyComposesWithStatusOverride(): void {
+    $override = $this->buildOverride(
+      ['enable_chat' => FALSE, 'azure_index_name' => 'other-site-live', 'read_only' => TRUE],
+      [],
+    );
+
+    $index = $override->loadOverrides([self::INDEX_CONFIG])[self::INDEX_CONFIG];
+    $this->assertFalse($index['status']);
+    $this->assertTrue($index['read_only']);
+  }
+
+  /**
    * By default the override targets the "ys_beacon" server and index.
    *
    * @covers ::loadOverrides

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/YsBeaconConfigOverridesTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/YsBeaconConfigOverridesTest.php
@@ -264,14 +264,15 @@ class YsBeaconConfigOverridesTest extends UnitTestCase {
   }
 
   /**
-   * A read-only site adds the read_only override to the index config.
+   * The read-only flag is no longer applied as a runtime index override.
    *
-   * A borrowing site keeps its index enabled so the shared collection can be
-   * queried, but marks it read-only so Search API never writes to it.
+   * It is persisted onto the index entity by BeaconIndexManager instead, so a
+   * read-only site's index config carries no override here and stays enabled so
+   * the collection can still be queried.
    *
    * @covers ::loadOverrides
    */
-  public function testReadOnlyOverridesIndexWhenSet(): void {
+  public function testReadOnlyIsNotOverridden(): void {
     $override = $this->buildOverride(
       [
         'enable_chat' => TRUE,
@@ -282,86 +283,29 @@ class YsBeaconConfigOverridesTest extends UnitTestCase {
       [],
     );
 
-    $index = $override->loadOverrides([self::INDEX_CONFIG])[self::INDEX_CONFIG];
-    $this->assertTrue($index['read_only']);
-    // The index stays enabled so the borrowed collection can still be queried.
-    $this->assertArrayNotHasKey('status', $index);
+    // Chat is on, authorized, and an index is named, so no status override
+    // fires; and read_only is no longer overridden, so the index config is
+    // untouched entirely.
+    $this->assertArrayNotHasKey(self::INDEX_CONFIG, $override->loadOverrides([self::INDEX_CONFIG]));
   }
 
   /**
-   * A writable site (the default) gets no read_only override.
+   * The search server config is no longer overridden.
+   *
+   * The per-site Azure database name is persisted onto search_api.server by
+   * BeaconIndexManager, not layered on at runtime, so this class leaves server
+   * config alone and its name never even reaches the relevance check.
    *
    * @covers ::loadOverrides
+   * @covers ::mayBeRelevant
    */
-  public function testNoReadOnlyOverrideWhenUnset(): void {
-    $unset = $this->buildOverride(
-      ['enable_chat' => TRUE, 'platform_authorized' => TRUE, 'azure_index_name' => 'my-site-live'],
-      [],
-    );
-    $this->assertArrayNotHasKey(self::INDEX_CONFIG, $unset->loadOverrides([self::INDEX_CONFIG]));
-
-    $explicit_false = $this->buildOverride(
-      [
-        'enable_chat' => TRUE,
-        'platform_authorized' => TRUE,
-        'azure_index_name' => 'my-site-live',
-        'read_only' => FALSE,
-      ],
-      [],
-    );
-    $this->assertArrayNotHasKey(self::INDEX_CONFIG, $explicit_false->loadOverrides([self::INDEX_CONFIG]));
-  }
-
-  /**
-   * Read-only composes with the chat-off status safety net.
-   *
-   * @covers ::loadOverrides
-   */
-  public function testReadOnlyComposesWithStatusOverride(): void {
+  public function testServerConfigIsNotOverridden(): void {
     $override = $this->buildOverride(
-      ['enable_chat' => FALSE, 'azure_index_name' => 'other-site-live', 'read_only' => TRUE],
+      ['enable_chat' => TRUE, 'platform_authorized' => TRUE, 'azure_index_name' => 'site-live'],
       [],
     );
 
-    $index = $override->loadOverrides([self::INDEX_CONFIG])[self::INDEX_CONFIG];
-    $this->assertFalse($index['status']);
-    $this->assertTrue($index['read_only']);
-  }
-
-  /**
-   * By default the override targets the "ys_beacon" server and index.
-   *
-   * @covers ::loadOverrides
-   */
-  public function testDefaultServerAndIndexNames(): void {
-    $overrides = $this->overridesFor(['enable_chat' => TRUE, 'azure_index_name' => 'site-live'])
-      ->loadOverrides(['search_api.server.ys_beacon', 'search_api.index.ys_beacon']);
-
-    $this->assertSame(
-      'site-live',
-      $overrides['search_api.server.ys_beacon']['backend_config']['database_settings']['database_name'] ?? NULL,
-    );
-  }
-
-  /**
-   * A configured server/index id moves the overrides to the new config names.
-   *
-   * @covers ::loadOverrides
-   */
-  public function testConfigurableServerAndIndexNames(): void {
-    $service = $this->overridesFor([
-      'search_server_id' => 'internal',
-      'search_index_id' => 'internal',
-      'azure_index_name' => 'internal-live',
-    ]);
-
-    $server = $service->loadOverrides(['search_api.server.internal']);
-    $this->assertSame(
-      'internal-live',
-      $server['search_api.server.internal']['backend_config']['database_settings']['database_name'] ?? NULL,
-    );
-    // The old default name is no longer overridden.
-    $this->assertSame([], $service->loadOverrides(['search_api.server.ys_beacon']));
+    $this->assertSame([], $override->loadOverrides(['search_api.server.ys_beacon']));
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.install
@@ -312,3 +312,25 @@ function ys_beacon_update_10004() {
     || (bool) \Drupal::config('ys_integrations.integration_settings')->get('ys_beacon');
   $settings->set('platform_authorized', $in_use)->save();
 }
+
+/**
+ * Seed the Beacon index read-only flag on existing sites.
+ *
+ * The new ys_beacon.settings:read_only flag lets a site borrow another site's
+ * Azure collection and query it without ever writing to it. It ships off, so
+ * seed the explicit FALSE on existing sites for explicit exported config;
+ * runtime already treats an absent value as not-read-only. This runs in the
+ * updatedb phase before config:import; ys_beacon.settings is config_ignored,
+ * so a per-site read-only value set later survives the import.
+ */
+function ys_beacon_update_10005() {
+  $settings = \Drupal::configFactory()->getEditable('ys_beacon.settings');
+  // Only touch sites that actually have Beacon settings; never create the
+  // config object here.
+  if ($settings->isNew()) {
+    return;
+  }
+  if ($settings->get('read_only') === NULL) {
+    $settings->set('read_only', FALSE)->save();
+  }
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.install
@@ -334,3 +334,27 @@ function ys_beacon_update_10005() {
     $settings->set('read_only', FALSE)->save();
   }
 }
+
+/**
+ * Persist the per-site index connection into the real search_api config.
+ *
+ * The Azure index name and read-only flag were previously applied only as
+ * runtime config overrides. They are now written onto search_api.server
+ * (backend_config database_name) and search_api.index (read_only), with those
+ * keys config-ignored so they survive import, and the overrides removed.
+ * Backfill existing sites from their saved ys_beacon.settings so removing the
+ * overrides never leaves the search server pointing at an empty database. This
+ * runs in the updatedb phase before config:import; the config-ignore entries
+ * added in the same deploy then keep the written values through the import.
+ */
+function ys_beacon_update_10006() {
+  $settings = \Drupal::config('ys_beacon.settings');
+  $index_name = (string) $settings->get('azure_index_name');
+  // An unconfigured site has nothing to propagate; its server database stays
+  // empty and the index stays disabled by the status override.
+  if ($index_name === '') {
+    return;
+  }
+  \Drupal::service('ys_beacon.index_manager')
+    ->propagateConnection($index_name, (bool) $settings->get('read_only'));
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.module
@@ -141,7 +141,10 @@ function ys_beacon_entity_update(EntityInterface $entity) {
   try {
     $index_id = \Drupal::config('ys_beacon.settings')->get('search_index_id') ?: 'ys_beacon';
     $index = Index::load($index_id);
-    if (!$index || !$index->status() || !$index->isServerEnabled()) {
+    // A read-only site borrows another site's collection and must never write
+    // to it, so skip the immediate removal just as Search API's own
+    // Index::trackItemsDeleted() skips the server delete for a read-only index.
+    if (!$index || !$index->status() || $index->isReadOnly() || !$index->isServerEnabled()) {
       return;
     }
     $datasource_id = 'entity:' . $entity->getEntityTypeId();


### PR DESCRIPTION
## [1387: Allow the Beacon search index to be marked read-only (config-survivable) so a site can safely borrow another site's index](https://github.com/yalesites-org/YaleSites-Internal/issues/1387)

> **Builds on** the `551-beacon-drupalai` Beacon epic branch. This PR is stacked on it and targets `551-beacon-drupalai` (not `develop`), so the diff shows only this issue's changes. It depends on the immediate-indexing work (yalesites-org/YaleSites-Internal#1335) already on that branch and should be reviewed/merged after it; GitHub will auto-retarget this PR to `develop` once `551-beacon-drupalai` merges.

### Description of work
- Add a per-site `read_only` flag to `ys_beacon.settings` (default `false`), config-ignored via the existing `ys_beacon*` wildcard so a per-site value survives `drush deploy` / `drush cim` without adding a new config-ignore surface.
- `YsBeaconConfigOverrides` marks the Search API index read-only at runtime when the flag is set (composed with the existing status override). Search API gates its automatic write paths — immediate indexing, cron, the indexing batch helper, `clear`, and delete-time removal — on the loaded index's `isReadOnly()`, so the override alone makes writes stand down while queries still work.
- Guard `ys_beacon_entity_update`'s immediate delete-on-unpublish (which calls the search server backend directly, bypassing Search API's own read-only guard) with `isReadOnly()`, so a borrowing site never deletes the owning site's chunks from the shared collection.
- Platform admin form (`administer ys beacon`) adds a **Read-only** toggle next to the index name; when set, it points at the borrowed collection without provisioning it (no index creation, no content queued).
- Site-facing form (`manage ys beacon settings`) hides the "Re-index all content" / "Index now" controls and guards their submit handlers when the index is read-only, showing a short note instead.
- `saveIndexStatus()` persists index status changes on an override-free load so the runtime `read_only` / `status` overrides are never baked into the synced (non-config-ignored) `search_api.index` config.
- Update hook `ys_beacon_update_10005` seeds `read_only: false` on existing sites for explicit exported config.
- Coverage: unit tests for the override (read_only present/absent, composition with status), the default, the read-only form guards, the override-free status save, and the admin provision-skip. Existing `BeaconImmediateIndexingTest` (shipped-YAML `read_only: false`) stays valid.

**Known limitation (accepted trade-off):** because `read_only` is applied as a runtime config override rather than persisted on the index entity, Search API's own index admin UI (which loads the index override-free) does not reflect it, so its actions could still write to the collection. That UI requires the `administer search_api` permission, which no YaleSites role holds (site admins use `manage ys beacon settings`), so it is reachable only by a platform operator. If that path ever needs closing, persist `read_only` on the entity and config-ignore `search_api.index.*:read_only` instead.

### Functional testing steps:
- [ ] As a platform admin (`administer ys beacon`) at `/admin/config/yalesites/ys-beacon/admin`, set the Azure index name to another site's collection, check **Read-only**, and save. Confirm the status message says the site reads from a shared, read-only index and there is no "content queued" message.
- [ ] As a site admin at `/admin/config/yalesites/ys-beacon`, confirm the Indexing section shows the shared/read-only note and the "Re-index all content" / "Index now" buttons are hidden.
- [ ] With Read-only on and chat enabled, unpublish (or AI-disable) a node/media item and confirm no delete is issued to the borrowed collection (the owning site's data is untouched).
- [ ] Turn Read-only off for a site using its own index and confirm the indexing controls return and content indexes normally (regression-safe default).
- [ ] Run `drush deploy` / `drush cim` and confirm a per-site `read_only: true` is not reset to `false`.

References yalesites-org/YaleSites-Internal#1387

---
Created with AI


---

### Rework testing steps (config now persisted, not runtime-only)

- As a platform admin at `/admin/config/yalesites/ys-beacon/admin`, set the Azure index name to another collection, check **Read-only**, and save. Then open the Search API index page (`/admin/config/search/search-api/index/ys_beacon`) and confirm it now shows the index **read-only** and the server's database name set to the entered name - **without** setting anything by hand.
- Uncheck **Read-only** on that same index and save; confirm the index returns to writable and content is queued for indexing (the tracker is rebuilt).
- Run `drush deploy` (or `drush cim`) and confirm a per-site `read_only: true` and the persisted `database_name` are not reset. (Note: the `config_ignore` protection is keyed to the default `ys_beacon` index/server machine names; a site overriding `search_index_id`/`search_server_id` must add matching keys.)
- Save the admin form changing only a tuning field (e.g. Sources per answer) with the index name and Read-only unchanged; confirm the search server/index entities are not re-saved needlessly (change-detection).
