### PR TITLE
1391: Beacon: cross-site citations - store title/URL on documents and cite without a local entity

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/ai_search.index.ys_beacon.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ai_search.index.ys_beacon.yml
@@ -16,3 +16,7 @@ indexing_options:
     indexing_option: main_content
   url:
     indexing_option: ignore
+  citation_title:
+    indexing_option: attributes
+  citation_url:
+    indexing_option: attributes

--- a/web/profiles/custom/yalesites_profile/config/sync/search_api.index.ys_beacon.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/search_api.index.ys_beacon.yml
@@ -23,6 +23,14 @@ field_settings:
     label: 'AI Tags'
     property_path: ys_beacon_ai_tags
     type: string
+  citation_title:
+    label: 'Citation title'
+    property_path: ys_beacon_citation_title
+    type: string
+  citation_url:
+    label: 'Citation URL'
+    property_path: ys_beacon_citation_url
+    type: string
   field_ai_pdf_text:
     label: 'AI extracted PDF text'
     datasource_id: 'entity:media'
@@ -111,6 +119,7 @@ processor_settings:
       u: 1.0
   rendered_item: {  }
   ys_beacon_ai_metadata: {  }
+  ys_beacon_citation_fields: {  }
   ys_beacon_exclude_ai_disabled: {  }
 tracker_settings:
   default:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/search_api/processor/CitationFields.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/search_api/processor/CitationFields.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Drupal\ys_beacon\Plugin\search_api\processor;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\search_api\Attribute\SearchApiProcessor;
+use Drupal\search_api\Datasource\DatasourceInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\search_api\Processor\ProcessorProperty;
+use Drupal\ys_beacon\Service\EntityCitationResolver;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Adds a retrievable citation title and URL to each indexed document.
+ *
+ * Storing the title and absolute URL on the document lets a site querying a
+ * shared collection cite content whose Drupal entity does not exist locally
+ * (see RagRetriever). The values match what RagRetriever derives from a live
+ * entity because both delegate to EntityCitationResolver.
+ */
+#[SearchApiProcessor(
+  id: 'ys_beacon_citation_fields',
+  label: new TranslatableMarkup('Beacon citation fields'),
+  description: new TranslatableMarkup('Adds a retrievable citation title and URL to each indexed document.'),
+  stages: [
+    'add_properties' => 0,
+  ],
+)]
+class CitationFields extends ProcessorPluginBase {
+
+  /**
+   * The entity citation resolver.
+   *
+   * @var \Drupal\ys_beacon\Service\EntityCitationResolver
+   */
+  protected EntityCitationResolver $citationResolver;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $processor = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $processor->citationResolver = $container->get('ys_beacon.entity_citation_resolver');
+    return $processor;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) {
+    $properties = [];
+
+    if (!$datasource) {
+      $properties['ys_beacon_citation_title'] = new ProcessorProperty([
+        'label' => $this->t('Citation title'),
+        'description' => $this->t('The title used when citing this item, stored so a shared collection can be cited without a local entity.'),
+        'type' => 'string',
+        'processor_id' => $this->getPluginId(),
+      ]);
+      $properties['ys_beacon_citation_url'] = new ProcessorProperty([
+        'label' => $this->t('Citation URL'),
+        'description' => $this->t('The absolute URL used when citing this item, stored so a shared collection can be cited without a local entity.'),
+        'type' => 'string',
+        'processor_id' => $this->getPluginId(),
+      ]);
+    }
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addFieldValues(ItemInterface $item) {
+    $entity = $item->getOriginalObject()?->getValue();
+    if (!$entity instanceof ContentEntityInterface) {
+      return;
+    }
+
+    $fields = $item->getFields(FALSE);
+    $this->addCitationValue($fields, 'ys_beacon_citation_title', $this->citationResolver->title($entity));
+    $this->addCitationValue($fields, 'ys_beacon_citation_url', $this->citationResolver->url($entity));
+  }
+
+  /**
+   * Fills the fields matching a citation property path with a value.
+   *
+   * @param \Drupal\search_api\Item\FieldInterface[] $fields
+   *   The item's fields.
+   * @param string $property_path
+   *   The processor property path to fill.
+   * @param string|null $value
+   *   The value to add; nothing is added when it is NULL or empty.
+   */
+  protected function addCitationValue(array $fields, string $property_path, ?string $value): void {
+    if ($value === NULL || $value === '') {
+      return;
+    }
+    foreach ($this->getFieldsHelper()->filterForPropertyPath($fields, NULL, $property_path) as $field) {
+      $field->addValue($value);
+    }
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/BeaconIndexManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/BeaconIndexManager.php
@@ -268,6 +268,19 @@ class BeaconIndexManager {
       'facetable' => TRUE,
     ];
 
+    // Retrievable-only string fields: stored and returned for citations, but
+    // not searched, filtered, sorted, or faceted on.
+    $retrievable_field = static fn (string $field_name): array => [
+      'name' => $field_name,
+      'type' => 'Edm.String',
+      'key' => FALSE,
+      'retrievable' => TRUE,
+      'searchable' => FALSE,
+      'filterable' => FALSE,
+      'sortable' => FALSE,
+      'facetable' => FALSE,
+    ];
+
     return [
       'name' => $name,
       'fields' => [
@@ -276,16 +289,12 @@ class BeaconIndexManager {
         $string_field('drupal_long_id'),
         $string_field('index_id'),
         $string_field('server_id'),
-        [
-          'name' => 'content',
-          'type' => 'Edm.String',
-          'key' => FALSE,
-          'retrievable' => TRUE,
-          'searchable' => FALSE,
-          'filterable' => FALSE,
-          'sortable' => FALSE,
-          'facetable' => FALSE,
-        ],
+        $retrievable_field('content'),
+        // Title and absolute URL stored per document so a site querying a
+        // shared collection can cite content whose Drupal entity does not
+        // exist locally.
+        $retrievable_field('citation_title'),
+        $retrievable_field('citation_url'),
         [
           'name' => 'vector',
           'type' => 'Collection(Edm.Single)',

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/EntityCitationResolver.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/EntityCitationResolver.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\ys_beacon\Service;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\media\MediaInterface;
+
+/**
+ * Derives the citation title and URL for a content entity.
+ *
+ * Shared by RagRetriever (query time, for the owning site's own content) and
+ * the CitationFields search processor (index time, so borrowing sites can cite
+ * from stored fields). Keeping the derivation in one place guarantees a
+ * document cited from stored fields links to the same place it would when
+ * cited via a live entity load.
+ */
+class EntityCitationResolver {
+
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
+  }
+
+  /**
+   * Builds the citation title for an entity.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to title.
+   *
+   * @return string
+   *   The entity label (node title or media name).
+   */
+  public function title(ContentEntityInterface $entity): string {
+    return (string) $entity->label();
+  }
+
+  /**
+   * Builds the citation URL for an entity.
+   *
+   * Media items link directly to their source file when possible, matching the
+   * legacy ai_engine feed behavior; everything else uses the canonical entity
+   * URL.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to link to.
+   *
+   * @return string|null
+   *   An absolute URL, or NULL when none can be generated.
+   */
+  public function url(ContentEntityInterface $entity): ?string {
+    try {
+      if ($entity instanceof MediaInterface) {
+        $fid = $entity->getSource()->getSourceFieldValue($entity);
+        if ($fid && is_numeric($fid)) {
+          $file = $this->entityTypeManager->getStorage('file')->load($fid);
+          if ($file) {
+            return $file->createFileUrl(FALSE);
+          }
+        }
+      }
+      if ($entity->hasLinkTemplate('canonical')) {
+        return $entity->toUrl('canonical', ['absolute' => TRUE])->toString();
+      }
+    }
+    catch (\Throwable $e) {
+      // Fall through to NULL: a citation without a link is still usable.
+    }
+    return NULL;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/RagRetriever.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/RagRetriever.php
@@ -5,8 +5,8 @@ namespace Drupal\ys_beacon\Service;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\media\MediaInterface;
 use Drupal\search_api\IndexInterface;
+use Drupal\search_api\Item\ItemInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -22,6 +22,7 @@ class RagRetriever {
     protected EntityTypeManagerInterface $entityTypeManager,
     protected ConfigFactoryInterface $configFactory,
     protected LoggerInterface $logger,
+    protected EntityCitationResolver $citationResolver,
   ) {
   }
 
@@ -45,11 +46,22 @@ class RagRetriever {
       return [];
     }
 
+    // A read-only site borrows another site's (shared) collection: the cited
+    // documents belong to other sites and have no local entity to load or
+    // access-check, so citations are built from the title and URL stored on
+    // each document instead. This is only safe because protected content is
+    // never written to the index (the Beacon indexing security hardening is the
+    // sole safeguard once per-visitor access is bypassed for shared retrieval).
+    $read_only = $index->isReadOnly();
+
     try {
       $query = $index->query([
         'limit' => (int) ($settings->get('top_k') ?: 5),
       ]);
       $query->setOption('search_api_ai_get_chunks_result', TRUE);
+      if ($read_only) {
+        $query->setOption('search_api_bypass_access', TRUE);
+      }
       $query->keys($question);
       $results = $query->execute();
     }
@@ -83,6 +95,57 @@ class RagRetriever {
       $items[] = $item;
     }
 
+    return $read_only
+      ? $this->buildStoredCitations($items)
+      : $this->buildEntityCitations($index, $items);
+  }
+
+  /**
+   * Builds citations from the title/URL stored on each document.
+   *
+   * Used for a read-only (shared/borrowed) index whose documents belong to
+   * other sites and cannot be loaded as local entities. Access is not
+   * re-checked here: the write-side invariant that protected content is never
+   * indexed is the only safeguard for shared retrieval.
+   *
+   * @param \Drupal\search_api\Item\ItemInterface[] $items
+   *   The filtered result items.
+   *
+   * @return array[]
+   *   Citation arrays.
+   */
+  protected function buildStoredCitations(array $items): array {
+    $citations = [];
+    foreach ($items as $item) {
+      $title = $this->decodeStoredValue((string) $item->getExtraData('citation_title'));
+      $url = $this->decodeStoredValue((string) $item->getExtraData('citation_url'));
+      $citations[] = $this->buildCitation(
+        $item,
+        // Fall back to a generic label only for documents indexed before the
+        // citation fields existed; a re-indexed corpus always stores a title.
+        $title !== '' ? $title : 'Source',
+        $url !== '' ? $url : NULL,
+      );
+    }
+    return $citations;
+  }
+
+  /**
+   * Builds citations by loading each chunk's local entity.
+   *
+   * Used for a site's own writable index, where the current visitor's view
+   * access is enforced per result and chunks whose entity has been deleted,
+   * unpublished, or access-restricted are dropped.
+   *
+   * @param \Drupal\search_api\IndexInterface $index
+   *   The Beacon index.
+   * @param \Drupal\search_api\Item\ItemInterface[] $items
+   *   The filtered result items.
+   *
+   * @return array[]
+   *   Citation arrays.
+   */
+  protected function buildEntityCitations(IndexInterface $index, array $items): array {
     $entities = $this->loadEntities($index, $items);
     $citations = [];
     foreach ($items as $item) {
@@ -95,19 +158,70 @@ class RagRetriever {
       if (!$entity || !$entity->access('view')) {
         continue;
       }
-      $citations[] = [
-        'content' => trim((string) $item->getExtraData('content')),
-        'id' => $item->getId(),
-        'title' => $entity->label(),
-        'filepath' => NULL,
-        'url' => $this->getEntityUrl($entity),
-        'metadata' => NULL,
-        'chunk_id' => $item->getId(),
-        'reindex_id' => NULL,
-      ];
+      $citations[] = $this->buildCitation(
+        $item,
+        $this->citationResolver->title($entity),
+        $this->citationResolver->url($entity),
+      );
     }
 
     return $citations;
+  }
+
+  /**
+   * Assembles a citation array from an item plus its title and URL.
+   *
+   * The shape is the contract consumed by the chat frontend and the AI tester
+   * (see retrieve()); keeping it in one place guarantees the stored-field and
+   * local-entity paths emit identically-shaped citations.
+   *
+   * @param \Drupal\search_api\Item\ItemInterface $item
+   *   The result item supplying content and ids.
+   * @param string $title
+   *   The citation title.
+   * @param string|null $url
+   *   The citation URL, or NULL when none is available.
+   *
+   * @return array
+   *   A citation array.
+   */
+  protected function buildCitation(ItemInterface $item, string $title, ?string $url): array {
+    return [
+      'content' => trim((string) $item->getExtraData('content')),
+      'id' => $item->getId(),
+      'title' => $title,
+      'filepath' => NULL,
+      'url' => $url,
+      'metadata' => NULL,
+      'chunk_id' => $item->getId(),
+      'reindex_id' => NULL,
+    ];
+  }
+
+  /**
+   * Reverses the escaping the ai_search indexer applies to stored attributes.
+   *
+   * Retrievable "attributes" fields (citation_title/citation_url) pass through
+   * the ai_search embedding strategy's HTML-to-Markdown converter at index time
+   * (EmbeddingBase::getValue), which backslash-escapes Markdown punctuation
+   * ("annual_report" -> "annual\_report") and HTML-encodes entities
+   * ("&" -> "&amp;"). Undo both so a stored citation title/URL matches the
+   * value the local-entity path derives live. (Removable once Beacon owns the
+   * write seam and can store these fields raw.)
+   *
+   * @param string $value
+   *   The stored (escaped) field value.
+   *
+   * @return string
+   *   The decoded value.
+   */
+  protected function decodeStoredValue(string $value): string {
+    if ($value === '') {
+      return '';
+    }
+    $value = html_entity_decode($value, ENT_QUOTES | ENT_HTML5);
+    // Strip a single backslash placed before any ASCII punctuation character.
+    return preg_replace('/\\\\([\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e])/', '$1', $value);
   }
 
   /**
@@ -145,40 +259,6 @@ class RagRetriever {
       ]);
     }
     return $entities;
-  }
-
-  /**
-   * Builds the citation URL for an entity.
-   *
-   * Media items link directly to their source file when possible, matching
-   * the legacy ai_engine feed behavior; everything else uses the canonical
-   * entity URL.
-   *
-   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
-   *   The entity to link to.
-   *
-   * @return string|null
-   *   An absolute URL, or NULL when none can be generated.
-   */
-  protected function getEntityUrl(ContentEntityInterface $entity): ?string {
-    try {
-      if ($entity instanceof MediaInterface) {
-        $fid = $entity->getSource()->getSourceFieldValue($entity);
-        if ($fid && is_numeric($fid)) {
-          $file = $this->entityTypeManager->getStorage('file')->load($fid);
-          if ($file) {
-            return $file->createFileUrl(FALSE);
-          }
-        }
-      }
-      if ($entity->hasLinkTemplate('canonical')) {
-        return $entity->toUrl('canonical', ['absolute' => TRUE])->toString();
-      }
-    }
-    catch (\Throwable $e) {
-      // Fall through to NULL: a citation without a link is still usable.
-    }
-    return NULL;
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconIndexManagerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconIndexManagerTest.php
@@ -50,6 +50,39 @@ class BeaconIndexManagerTest extends UnitTestCase {
   }
 
   /**
+   * The Azure schema declares retrievable citation title and URL fields.
+   *
+   * Cross-site citations read these back off each document, so both must exist
+   * and be retrievable (but not searchable/filterable — they are display data).
+   *
+   * @covers ::buildIndexSchema
+   */
+  public function testBuildIndexSchemaIncludesCitationFields(): void {
+    // All config lookups fall through to defaults (server id, dimensions).
+    $config = $this->createMock(Config::class);
+    $config->method('get')->willReturn(NULL);
+    $config_factory = $this->createMock(ConfigFactoryInterface::class);
+    $config_factory->method('get')->willReturn($config);
+
+    $manager = (new \ReflectionClass(BeaconIndexManager::class))->newInstanceWithoutConstructor();
+    $config_property = new \ReflectionProperty($manager, 'configFactory');
+    $config_property->setAccessible(TRUE);
+    $config_property->setValue($manager, $config_factory);
+
+    $method = new \ReflectionMethod($manager, 'buildIndexSchema');
+    $method->setAccessible(TRUE);
+    $schema = $method->invoke($manager, 'test-index');
+
+    $fields = array_column($schema['fields'], NULL, 'name');
+    $this->assertArrayHasKey('citation_title', $fields);
+    $this->assertArrayHasKey('citation_url', $fields);
+    $this->assertTrue($fields['citation_title']['retrievable']);
+    $this->assertTrue($fields['citation_url']['retrievable']);
+    $this->assertFalse($fields['citation_title']['searchable']);
+    $this->assertFalse($fields['citation_url']['filterable']);
+  }
+
+  /**
    * A read-only borrow persists the connection into real Search API config.
    *
    * The call writes the Azure index name onto the search server's database name

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/CitationFieldsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/CitationFieldsTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\TypedData\ComplexDataInterface;
+use Drupal\search_api\Item\FieldInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\Utility\FieldsHelperInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\Plugin\search_api\processor\CitationFields;
+use Drupal\ys_beacon\Service\EntityCitationResolver;
+
+/**
+ * Tests the Beacon citation-fields search processor.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Plugin\search_api\processor\CitationFields
+ */
+class CitationFieldsTest extends UnitTestCase {
+
+  /**
+   * Writes the resolved title and URL onto the item's citation fields.
+   *
+   * @covers ::addFieldValues
+   */
+  public function testWritesTitleAndUrl(): void {
+    $entity = $this->createMock(ContentEntityInterface::class);
+
+    $title_field = $this->createMock(FieldInterface::class);
+    $title_field->expects($this->once())->method('addValue')->with('Housing Guide');
+    $url_field = $this->createMock(FieldInterface::class);
+    $url_field->expects($this->once())->method('addValue')->with('https://owner.example.edu/housing');
+
+    $resolver = $this->createMock(EntityCitationResolver::class);
+    $resolver->method('title')->with($entity)->willReturn('Housing Guide');
+    $resolver->method('url')->with($entity)->willReturn('https://owner.example.edu/housing');
+
+    $item = $this->makeItem($entity);
+    $this->makeProcessor($resolver, $title_field, $url_field)->addFieldValues($item);
+  }
+
+  /**
+   * When no URL can be derived, only the title is written.
+   *
+   * @covers ::addFieldValues
+   */
+  public function testSkipsUrlWhenNull(): void {
+    $entity = $this->createMock(ContentEntityInterface::class);
+
+    $title_field = $this->createMock(FieldInterface::class);
+    $title_field->expects($this->once())->method('addValue')->with('Housing Guide');
+    $url_field = $this->createMock(FieldInterface::class);
+    $url_field->expects($this->never())->method('addValue');
+
+    $resolver = $this->createMock(EntityCitationResolver::class);
+    $resolver->method('title')->with($entity)->willReturn('Housing Guide');
+    $resolver->method('url')->with($entity)->willReturn(NULL);
+
+    $item = $this->makeItem($entity);
+    $this->makeProcessor($resolver, $title_field, $url_field)->addFieldValues($item);
+  }
+
+  /**
+   * A non-content object is ignored without touching the fields.
+   *
+   * @covers ::addFieldValues
+   */
+  public function testIgnoresNonContentEntity(): void {
+    $original = $this->createMock(ComplexDataInterface::class);
+    $original->method('getValue')->willReturn(NULL);
+
+    $item = $this->createMock(ItemInterface::class);
+    $item->method('getOriginalObject')->willReturn($original);
+    $item->expects($this->never())->method('getFields');
+
+    $resolver = $this->createMock(EntityCitationResolver::class);
+    $resolver->expects($this->never())->method('title');
+
+    $this->makeProcessor($resolver, $this->createMock(FieldInterface::class), $this->createMock(FieldInterface::class))
+      ->addFieldValues($item);
+  }
+
+  /**
+   * Builds a result item whose original object resolves to the given entity.
+   */
+  private function makeItem(ContentEntityInterface $entity): ItemInterface {
+    $original = $this->createMock(ComplexDataInterface::class);
+    $original->method('getValue')->willReturn($entity);
+
+    $item = $this->createMock(ItemInterface::class);
+    $item->method('getOriginalObject')->willReturn($original);
+    $item->method('getFields')->with(FALSE)->willReturn([]);
+    return $item;
+  }
+
+  /**
+   * Builds the processor with the resolver and a fields helper routing paths.
+   */
+  private function makeProcessor(EntityCitationResolver $resolver, FieldInterface $title_field, FieldInterface $url_field): CitationFields {
+    $fields_helper = $this->createMock(FieldsHelperInterface::class);
+    $fields_helper->method('filterForPropertyPath')->willReturnCallback(
+      fn (array $fields, $datasource_id, string $property_path): array => match ($property_path) {
+        'ys_beacon_citation_title' => [$title_field],
+        'ys_beacon_citation_url' => [$url_field],
+        default => [],
+      },
+    );
+
+    $processor = new CitationFields([], 'ys_beacon_citation_fields', []);
+    $processor->setFieldsHelper($fields_helper);
+    $resolver_property = new \ReflectionProperty($processor, 'citationResolver');
+    $resolver_property->setAccessible(TRUE);
+    $resolver_property->setValue($processor, $resolver);
+    return $processor;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/EntityCitationResolverTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/EntityCitationResolverTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Url;
+use Drupal\file\FileInterface;
+use Drupal\media\MediaInterface;
+use Drupal\media\MediaSourceInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\Service\EntityCitationResolver;
+
+/**
+ * Tests citation title/URL derivation shared by indexing and retrieval.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Service\EntityCitationResolver
+ */
+class EntityCitationResolverTest extends UnitTestCase {
+
+  /**
+   * The title is the entity label (node title or media name).
+   *
+   * @covers ::title
+   */
+  public function testTitleIsEntityLabel(): void {
+    $entity = $this->createMock(ContentEntityInterface::class);
+    $entity->method('label')->willReturn('Housing Guide');
+
+    $resolver = new EntityCitationResolver($this->createMock(EntityTypeManagerInterface::class));
+    $this->assertSame('Housing Guide', $resolver->title($entity));
+  }
+
+  /**
+   * A non-media entity links to its absolute canonical URL.
+   *
+   * @covers ::url
+   */
+  public function testUrlUsesCanonicalForNonMedia(): void {
+    $url = $this->createMock(Url::class);
+    $url->method('toString')->willReturn('https://site.example/node/1');
+
+    $entity = $this->createMock(ContentEntityInterface::class);
+    $entity->method('hasLinkTemplate')->with('canonical')->willReturn(TRUE);
+    $entity->method('toUrl')->with('canonical', ['absolute' => TRUE])->willReturn($url);
+
+    $resolver = new EntityCitationResolver($this->createMock(EntityTypeManagerInterface::class));
+    $this->assertSame('https://site.example/node/1', $resolver->url($entity));
+  }
+
+  /**
+   * A media entity links directly to its source file URL.
+   *
+   * @covers ::url
+   */
+  public function testUrlUsesSourceFileForMedia(): void {
+    $file = $this->createMock(FileInterface::class);
+    $file->method('createFileUrl')->with(FALSE)->willReturn('https://site.example/files/doc.pdf');
+
+    $file_storage = $this->createMock(EntityStorageInterface::class);
+    $file_storage->method('load')->with('42')->willReturn($file);
+
+    $etm = $this->createMock(EntityTypeManagerInterface::class);
+    $etm->method('getStorage')->with('file')->willReturn($file_storage);
+
+    $source = $this->createMock(MediaSourceInterface::class);
+    $media = $this->createMock(MediaInterface::class);
+    $media->method('getSource')->willReturn($source);
+    $source->method('getSourceFieldValue')->with($media)->willReturn('42');
+
+    $resolver = new EntityCitationResolver($etm);
+    $this->assertSame('https://site.example/files/doc.pdf', $resolver->url($media));
+  }
+
+  /**
+   * An entity with no canonical link yields no URL rather than an error.
+   *
+   * @covers ::url
+   */
+  public function testUrlIsNullWhenNoCanonicalLink(): void {
+    $entity = $this->createMock(ContentEntityInterface::class);
+    $entity->method('hasLinkTemplate')->with('canonical')->willReturn(FALSE);
+
+    $resolver = new EntityCitationResolver($this->createMock(EntityTypeManagerInterface::class));
+    $this->assertNull($resolver->url($entity));
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/RagRetrieverTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/RagRetrieverTest.php
@@ -2,16 +2,21 @@
 
 namespace Drupal\Tests\ys_beacon\Unit;
 
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\TypedData\ComplexDataInterface;
 use Drupal\search_api\IndexInterface;
+use Drupal\search_api\Item\ItemInterface;
 use Drupal\search_api\Query\QueryInterface;
+use Drupal\search_api\Query\ResultSetInterface;
 use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\Service\EntityCitationResolver;
 use Drupal\ys_beacon\Service\RagRetriever;
 use Psr\Log\LoggerInterface;
 
 /**
- * Tests Beacon RAG retrieval: failure logging, guards, and index resolution.
+ * Tests Beacon RAG retrieval: failure logging, guards, and citation building.
  *
  * @group ys_beacon
  * @coversDefaultClass \Drupal\ys_beacon\Service\RagRetriever
@@ -95,7 +100,7 @@ class RagRetrieverTest extends UnitTestCase {
       ],
     ]);
 
-    $retriever = new RagRetriever($entityTypeManager, $configFactory, $this->createMock(LoggerInterface::class));
+    $retriever = new RagRetriever($entityTypeManager, $configFactory, $this->createMock(LoggerInterface::class), $this->createMock(EntityCitationResolver::class));
     $this->assertSame([], $retriever->retrieve('hello'));
   }
 
@@ -121,14 +126,254 @@ class RagRetrieverTest extends UnitTestCase {
       'ys_beacon.settings' => ['top_k' => 5, 'score_threshold' => 0.0],
     ]);
 
-    $retriever = new RagRetriever($entityTypeManager, $configFactory, $this->createMock(LoggerInterface::class));
+    $retriever = new RagRetriever($entityTypeManager, $configFactory, $this->createMock(LoggerInterface::class), $this->createMock(EntityCitationResolver::class));
     $this->assertSame([], $retriever->retrieve('hello'));
   }
 
   /**
-   * Builds a RagRetriever wired to the given index and logger.
+   * A read-only (shared) index cites from stored fields, bypassing access.
+   *
+   * The cited document belongs to another site and has no local entity, so no
+   * entity is loaded and the query runs with access bypassed.
+   *
+   * @covers ::retrieve
+   * @covers ::buildStoredCitations
    */
-  private function makeRetriever(IndexInterface $index, LoggerInterface $logger): RagRetriever {
+  public function testReadOnlyIndexBuildsCitationsFromStoredFields(): void {
+    $item = $this->createMock(ItemInterface::class);
+    $item->method('getScore')->willReturn(0.9);
+    $item->method('getId')->willReturn('entity:node/501:0');
+    $item->method('getExtraData')->willReturnCallback(fn (string $key) => match ($key) {
+      'content' => 'Housing applications open in March.',
+      'citation_title' => 'Housing Guide',
+      'citation_url' => 'https://owner.example.edu/housing',
+      default => NULL,
+    });
+
+    $results = $this->createMock(ResultSetInterface::class);
+    $results->method('getResultItems')->willReturn([$item]);
+
+    $options = [];
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('setOption')->willReturnCallback(function (string $key, $value) use ($query, &$options) {
+      $options[$key] = $value;
+      return $query;
+    });
+    $query->method('keys')->willReturnSelf();
+    $query->method('execute')->willReturn($results);
+
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('status')->willReturn(TRUE);
+    $index->method('id')->willReturn('ys_beacon');
+    $index->method('isReadOnly')->willReturn(TRUE);
+    $index->method('query')->willReturn($query);
+    // A borrowed index must never load local entities for its citations.
+    $index->expects($this->never())->method('loadItemsMultiple');
+
+    // The resolver serves the entity path only; unused for shared content.
+    $resolver = $this->createMock(EntityCitationResolver::class);
+    $resolver->expects($this->never())->method('title');
+    $resolver->expects($this->never())->method('url');
+
+    $citations = $this->makeRetriever($index, $this->createMock(LoggerInterface::class), $resolver)
+      ->retrieve('How do I apply for housing?');
+
+    $this->assertCount(1, $citations);
+    $this->assertSame('Housing Guide', $citations[0]['title']);
+    $this->assertSame('https://owner.example.edu/housing', $citations[0]['url']);
+    $this->assertSame('Housing applications open in March.', $citations[0]['content']);
+    // Access is bypassed because shared documents have no local access grants.
+    $this->assertArrayHasKey('search_api_bypass_access', $options);
+    $this->assertTrue($options['search_api_bypass_access']);
+  }
+
+  /**
+   * A read-only citation keeps the chunk even when stored fields are missing.
+   *
+   * Documents indexed before the citation fields existed have no stored title;
+   * they must still surface (with a fallback title) rather than be dropped.
+   *
+   * @covers ::buildStoredCitations
+   */
+  public function testReadOnlyStoredCitationFallsBackWhenFieldsMissing(): void {
+    $item = $this->createMock(ItemInterface::class);
+    $item->method('getScore')->willReturn(0.7);
+    $item->method('getId')->willReturn('entity:node/777:0');
+    $item->method('getExtraData')->willReturnCallback(fn (string $key) => $key === 'content' ? 'Orphan chunk text.' : NULL);
+
+    $results = $this->createMock(ResultSetInterface::class);
+    $results->method('getResultItems')->willReturn([$item]);
+
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('setOption')->willReturnSelf();
+    $query->method('keys')->willReturnSelf();
+    $query->method('execute')->willReturn($results);
+
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('status')->willReturn(TRUE);
+    $index->method('id')->willReturn('ys_beacon');
+    $index->method('isReadOnly')->willReturn(TRUE);
+    $index->method('query')->willReturn($query);
+
+    $citations = $this->makeRetriever($index, $this->createMock(LoggerInterface::class))
+      ->retrieve('anything');
+
+    $this->assertCount(1, $citations);
+    $this->assertSame('Source', $citations[0]['title']);
+    $this->assertNull($citations[0]['url']);
+    $this->assertSame('Orphan chunk text.', $citations[0]['content']);
+  }
+
+  /**
+   * Stored title/URL are un-escaped from the ai_search markdown conversion.
+   *
+   * The ai_search indexer runs "attributes" fields through an HTML-to-Markdown
+   * converter, backslash-escaping punctuation and HTML-encoding entities. The
+   * read path must undo that so the citation URL is not corrupted (a stored
+   * "annual\_report" would otherwise 404).
+   *
+   * @covers ::buildStoredCitations
+   * @covers ::decodeStoredValue
+   */
+  public function testReadOnlyStoredCitationDecodesEscapedFields(): void {
+    $item = $this->createMock(ItemInterface::class);
+    $item->method('getScore')->willReturn(0.9);
+    $item->method('getId')->willReturn('entity:node/12:0');
+    $item->method('getExtraData')->willReturnCallback(fn (string $key) => match ($key) {
+      'content' => 'Chunk text.',
+      'citation_title' => 'R&amp;D Report\_final',
+      'citation_url' => 'https://owner.edu/files/annual\_report\_2024.pdf?a=1&amp;b=2',
+      default => NULL,
+    });
+
+    $results = $this->createMock(ResultSetInterface::class);
+    $results->method('getResultItems')->willReturn([$item]);
+
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('setOption')->willReturnSelf();
+    $query->method('keys')->willReturnSelf();
+    $query->method('execute')->willReturn($results);
+
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('status')->willReturn(TRUE);
+    $index->method('id')->willReturn('ys_beacon');
+    $index->method('isReadOnly')->willReturn(TRUE);
+    $index->method('query')->willReturn($query);
+
+    $citations = $this->makeRetriever($index, $this->createMock(LoggerInterface::class))
+      ->retrieve('report');
+
+    $this->assertCount(1, $citations);
+    $this->assertSame('R&D Report_final', $citations[0]['title']);
+    $this->assertSame('https://owner.edu/files/annual_report_2024.pdf?a=1&b=2', $citations[0]['url']);
+  }
+
+  /**
+   * A writable index cites from the loaded local entity via the resolver.
+   *
+   * @covers ::retrieve
+   * @covers ::buildEntityCitations
+   */
+  public function testWritableIndexBuildsCitationsFromEntity(): void {
+    $entity = $this->createMock(ContentEntityInterface::class);
+    $entity->method('access')->with('view')->willReturn(TRUE);
+
+    $typed = $this->createMock(ComplexDataInterface::class);
+    $typed->method('getValue')->willReturn($entity);
+
+    $item = $this->createMock(ItemInterface::class);
+    $item->method('getScore')->willReturn(0.8);
+    $item->method('getId')->willReturn('entity:node/9:0');
+    $item->method('getExtraData')->willReturnCallback(fn (string $key) => match ($key) {
+      'content' => 'Local chunk text.',
+      'drupal_entity_id' => 'entity:node/9',
+      default => NULL,
+    });
+
+    $results = $this->createMock(ResultSetInterface::class);
+    $results->method('getResultItems')->willReturn([$item]);
+
+    $options = [];
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('setOption')->willReturnCallback(function (string $key, $value) use ($query, &$options) {
+      $options[$key] = $value;
+      return $query;
+    });
+    $query->method('keys')->willReturnSelf();
+    $query->method('execute')->willReturn($results);
+
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('status')->willReturn(TRUE);
+    $index->method('id')->willReturn('ys_beacon');
+    $index->method('isReadOnly')->willReturn(FALSE);
+    $index->method('query')->willReturn($query);
+    $index->method('loadItemsMultiple')->with(['entity:node/9'])->willReturn(['entity:node/9' => $typed]);
+
+    $resolver = $this->createMock(EntityCitationResolver::class);
+    $resolver->method('title')->with($entity)->willReturn('My Page');
+    $resolver->method('url')->with($entity)->willReturn('https://site.example/my-page');
+
+    $citations = $this->makeRetriever($index, $this->createMock(LoggerInterface::class), $resolver)
+      ->retrieve('question');
+
+    $this->assertCount(1, $citations);
+    $this->assertSame('My Page', $citations[0]['title']);
+    $this->assertSame('https://site.example/my-page', $citations[0]['url']);
+    $this->assertSame('Local chunk text.', $citations[0]['content']);
+    // A writable index must NOT bypass access; the per-visitor check stays.
+    $this->assertArrayNotHasKey('search_api_bypass_access', $options);
+  }
+
+  /**
+   * A writable index never quotes content the current visitor cannot view.
+   *
+   * @covers ::buildEntityCitations
+   */
+  public function testWritableIndexDropsInaccessibleEntity(): void {
+    $entity = $this->createMock(ContentEntityInterface::class);
+    $entity->method('access')->with('view')->willReturn(FALSE);
+
+    $typed = $this->createMock(ComplexDataInterface::class);
+    $typed->method('getValue')->willReturn($entity);
+
+    $item = $this->createMock(ItemInterface::class);
+    $item->method('getScore')->willReturn(0.8);
+    $item->method('getId')->willReturn('entity:node/9:0');
+    $item->method('getExtraData')->willReturnCallback(fn (string $key) => match ($key) {
+      'content' => 'Restricted chunk text.',
+      'drupal_entity_id' => 'entity:node/9',
+      default => NULL,
+    });
+
+    $results = $this->createMock(ResultSetInterface::class);
+    $results->method('getResultItems')->willReturn([$item]);
+
+    $options = [];
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('setOption')->willReturnCallback(function (string $key, $value) use ($query, &$options) {
+      $options[$key] = $value;
+      return $query;
+    });
+    $query->method('keys')->willReturnSelf();
+    $query->method('execute')->willReturn($results);
+
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('status')->willReturn(TRUE);
+    $index->method('id')->willReturn('ys_beacon');
+    $index->method('isReadOnly')->willReturn(FALSE);
+    $index->method('query')->willReturn($query);
+    $index->method('loadItemsMultiple')->with(['entity:node/9'])->willReturn(['entity:node/9' => $typed]);
+
+    $citations = $this->makeRetriever($index, $this->createMock(LoggerInterface::class))->retrieve('question');
+    $this->assertSame([], $citations);
+    // Even while dropping content, the writable path never bypasses access.
+    $this->assertArrayNotHasKey('search_api_bypass_access', $options);
+  }
+
+  /**
+   * Builds a RagRetriever wired to the given index, logger, and resolver.
+   */
+  private function makeRetriever(IndexInterface $index, LoggerInterface $logger, ?EntityCitationResolver $resolver = NULL): RagRetriever {
     $storage = $this->createMock(EntityStorageInterface::class);
     $storage->method('load')->with('ys_beacon')->willReturn($index);
 
@@ -139,7 +384,7 @@ class RagRetrieverTest extends UnitTestCase {
       'ys_beacon.settings' => ['top_k' => 5, 'score_threshold' => 0.0],
     ]);
 
-    return new RagRetriever($entityTypeManager, $configFactory, $logger);
+    return new RagRetriever($entityTypeManager, $configFactory, $logger, $resolver ?? $this->createMock(EntityCitationResolver::class));
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.services.yml
@@ -3,12 +3,18 @@ services:
     parent: logger.channel_base
     arguments: ['ys_beacon']
 
+  ys_beacon.entity_citation_resolver:
+    class: Drupal\ys_beacon\Service\EntityCitationResolver
+    arguments:
+      - '@entity_type.manager'
+
   ys_beacon.rag_retriever:
     class: Drupal\ys_beacon\Service\RagRetriever
     arguments:
       - '@entity_type.manager'
       - '@config.factory'
       - '@logger.channel.ys_beacon'
+      - '@ys_beacon.entity_citation_resolver'
 
   ys_beacon.citation_formatter:
     class: Drupal\ys_beacon\Service\CitationFormatter


### PR DESCRIPTION
## [1391: Beacon: cross-site citations - store title/URL on documents and cite without a local entity](https://github.com/yalesites-org/YaleSites-Internal/issues/1391)

### Description of work
- A read-only (borrowed/shared) Beacon index returns documents whose `drupal_entity_id` belongs to another site, so the old local-entity load dropped every one and a borrowing site got **zero citations**. This stores a citation title + absolute URL on each indexed document and, when the index is read-only, builds citations from those stored fields instead of loading a local entity.
- New `EntityCitationResolver` service: single source for the citation title (entity label) and URL (media source file, else canonical absolute), reused by both the index-time processor and `RagRetriever`'s owning-site path so stored and live citations stay identical.
- New `CitationFields` Search API processor: emits retrievable `ys_beacon_citation_title` / `ys_beacon_citation_url` (tagged as the ai_search `attributes` option), wired into `search_api.index.ys_beacon` and `ai_search.index.ys_beacon`.
- `BeaconIndexManager::buildIndexSchema()`: declares `citation_title` / `citation_url` as retrievable Azure fields.
- `RagRetriever`: the read-only branch sets `search_api_bypass_access` and builds citations from the stored fields; the owning/writable path is unchanged (entity load + per-visitor `access('view')`). `decodeStoredValue()` reverses the HTML-to-Markdown escaping the ai_search `attributes` write path applies at index time, so stored URLs (e.g. underscores) and titles are not corrupted.

**Requires re-provisioning the Azure index (drop, recreate, full re-index).** `buildIndexSchema()` runs only at index creation, so an already-provisioned index must be dropped and recreated to gain the new fields — otherwise every document upload is rejected and indexing silently no-ops. Verified locally by deleting and regenerating the index.

**Depends on yalesites-org/YaleSites-Internal#1390 (hard prerequisite).** Cross-site retrieval bypasses per-visitor access at query time; that is safe only once #1390 guarantees protected content is never indexed, which must merge before go-live. Base branch is `551-beacon-drupalai` (the Beacon shared-index epic integration branch), which already carries the #1387 read-only foundation.

### Functional testing steps:
- [ ] With a site on its own writable index, ask the chat a question — citations still show the correct title + URL (unchanged behavior).
- [ ] Re-provision the Azure index (drop it, toggle the Beacon chat off/on to recreate it with the new schema, then re-index) and confirm content indexes without errors.
- [ ] Point a site at a populated shared collection (read-only) and confirm a question returns at least one citation carrying the owning site's title and URL (previously zero citations).
- [ ] Confirm a citation URL that contains an underscore (e.g. a media file such as `annual_report.pdf`) links correctly and does not 404.

References yalesites-org/YaleSites-Internal#1391

---
Created with AI
