### PR TITLE
1393: Beacon: fresh-site config:import crashes creating the Search API server (config-ignored database_name -> ai_search new-server subscriber TypeError)

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/BeaconConfigIgnoreCreateScopeTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/BeaconConfigIgnoreCreateScopeTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Kernel;
+
+use Drupal\config_ignore\ConfigIgnoreConfig;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests that the Beacon server database name is not config-ignored on create.
+ *
+ * The per-site Azure index (database) name is persisted onto
+ * search_api.server.ys_beacon by BeaconIndexManager::propagateConnection() and
+ * config-ignored so it survives config import on provisioned sites
+ * (yalesites-org/YaleSites-Internal#1387). config_ignore runs in simple mode,
+ * which applies every entry to create, update AND delete. On a brand-new site
+ * the server is created rather than updated, so the ignore strips database_name
+ * from the incoming config; ai_search's NewServerEventSubscriber then calls
+ * AzureAiSearchProvider::getCollections(NULL) and aborts the whole config
+ * import with a TypeError (yalesites-org/YaleSites-Internal#1393).
+ *
+ * ys_beacon_config_ignore_ignored_alter() scopes that one ignore away from the
+ * create operation on import, so a fresh import keeps the shipped empty default
+ * (present, harmless) while the import-update ignore still protects a
+ * provisioned site's persisted name on every later deploy and the export
+ * ignores are left intact. This test locks that scoping.
+ *
+ * @group ys_beacon
+ */
+class BeaconConfigIgnoreCreateScopeTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'config_ignore',
+  ];
+
+  /**
+   * The config-ignore entry protecting the per-site Azure database name.
+   */
+  private const DATABASE_NAME_ENTRY = 'search_api.server.ys_beacon:backend_config.database_settings.database_name';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    // The hook lives in a procedural .module file; ys_beacon itself is not
+    // installed here (its dependency tree is large and irrelevant to the
+    // config_ignore scoping under test), so load the file directly.
+    require_once dirname(__DIR__, 3) . '/ys_beacon.module';
+  }
+
+  /**
+   * The database-name ignore applies on update/delete but not import-create.
+   */
+  public function testDatabaseNameIgnoreIsScopedAwayFromImportCreate(): void {
+    // Simple mode broadcasts every entry to create, update and delete; this
+    // mirrors how config_ignore builds the object before invoking the alter.
+    $ignored = new ConfigIgnoreConfig('simple', [
+      self::DATABASE_NAME_ENTRY,
+      'ys_beacon*',
+    ]);
+
+    ys_beacon_config_ignore_ignored_alter($ignored);
+
+    $import_create = $ignored->getList('import', 'create');
+    $import_update = $ignored->getList('import', 'update');
+    $export_create = $ignored->getList('export', 'create');
+
+    // Dropped from create on import (the deploy path): a fresh import keeps the
+    // shipped empty default, so the new-server subscriber never gets a null.
+    $this->assertNotContains(self::DATABASE_NAME_ENTRY, $import_create);
+
+    // Still ignored on import-update: a provisioned site's persisted per-site
+    // name survives every later deploy exactly as before.
+    $this->assertContains(self::DATABASE_NAME_ENTRY, $import_update);
+
+    // Export is left untouched, so the per-site name never leaks into synced
+    // config on export.
+    $this->assertContains(self::DATABASE_NAME_ENTRY, $export_create);
+
+    // Unrelated Beacon config keeps its create-time protection untouched.
+    $this->assertContains('ys_beacon*', $import_create);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.module
@@ -5,6 +5,7 @@
  * Contains ys_beacon.module functions.
  */
 
+use Drupal\config_ignore\ConfigIgnoreConfig;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -177,6 +178,35 @@ function ys_beacon_entity_update(EntityInterface $entity) {
  */
 function ys_beacon_metatag_groups_alter(&$definitions) {
   unset($definitions['ai_engine']);
+}
+
+/**
+ * Implements hook_config_ignore_ignored_alter().
+ *
+ * The per-site Azure index (database) name persisted onto the Beacon search
+ * server is config-ignored so a provisioned site keeps it across deploys
+ * (yalesites-org/YaleSites-Internal#1387). config_ignore's simple mode applies
+ * that ignore to create as well as update, so on a brand-new site - where the
+ * server is created, not updated - the incoming database_name key is stripped.
+ * ai_search's NewServerEventSubscriber then reaches the vector-database backend
+ * with a null name and aborts the whole config import with a TypeError
+ * (yalesites-org/YaleSites-Internal#1393).
+ *
+ * Scope that ignore away from create on import (the deploy path) by dropping
+ * it from that one operation, so a fresh import keeps the shipped empty default
+ * (a harmless present value). The import-update ignore still protects a
+ * provisioned site's persisted name on every later deploy, and the export
+ * ignores are left untouched so the per-site name never leaks into synced
+ * config.
+ */
+function ys_beacon_config_ignore_ignored_alter(ConfigIgnoreConfig $ignored) {
+  $entry = 'search_api.server.ys_beacon:'
+    . 'backend_config.database_settings.database_name';
+  $create = $ignored->getList('import', 'create');
+  if (in_array($entry, $create, TRUE)) {
+    $create = array_values(array_diff($create, [$entry]));
+    $ignored->setList('import', 'create', $create);
+  }
 }
 
 /**


### PR DESCRIPTION
## [1393: Beacon: fresh-site config:import crashes creating the Search API server (config-ignored database_name -> ai_search new-server subscriber TypeError)](https://github.com/yalesites-org/YaleSites-Internal/issues/1393)

### Description of work
- The per-site Azure index (database) name persisted onto `search_api.server.ys_beacon` is config-ignored so it survives config import on provisioned sites (yalesites-org/YaleSites-Internal#1387). `config_ignore` runs in **simple mode**, which applies every entry to create as well as update — so on a cold site, where the server is *created* rather than updated, the ignore strips `database_name` from the incoming config. ai_search's `NewServerEventSubscriber` then calls `AzureAiSearchProvider::getCollections(null)` and aborts the whole `config:import` with a `TypeError`.
- Warm environments deploy as an *update* (the existing value is preserved), which is why the crash only surfaces on a fresh site — or any environment whose database lacks the server. It passed on yalesites-org/YaleSites-Internal#1387's own multidev (an update) but fails the first cold deploy (a create).
- Adds `hook_config_ignore_ignored_alter()` in `ys_beacon.module` that drops that one entry from the **import-create** operation only. A fresh import then keeps the shipped empty default (`database_name: ''`, a valid present value the new-server subscriber handles), while the import-update ignore still protects a provisioned site's persisted name on every later deploy and the export ignores are left intact so the per-site name never leaks into synced config.
- Keeps `config_ignore.settings.yml` in simple mode (no platform-wide advanced-mode conversion, no `DEFAULT` sentinel) and adds a kernel test locking the create/update scoping.
- Builds on the Beacon shared multi-tenant index epic (yalesites-org/YaleSites-Internal#1389, part of yalesites-org/YaleSites-Internal#551): this branch targets `551-beacon-drupalai` and should be reviewed/merged there rather than into `develop`.

### Functional testing steps:
- [ ] On an environment whose database does **not** already have `search_api.server.ys_beacon` (a fresh multidev/site), run `drush deploy` (or `drush config:import`) so the Beacon server is **created** — confirm it completes without a `TypeError` (previously the deploy aborted).
- [ ] Confirm the created server has `database_name` present and empty: `drush cget search_api.server.ys_beacon backend_config.database_settings.database_name` returns `''`.
- [ ] On a provisioned site (server already carries a per-site `database_name`), run `drush deploy` again and confirm the per-site name **survives** (is not reset to empty) — the update-time ignore still applies.

References yalesites-org/YaleSites-Internal#1393

---
Created with AI
