### PR TITLE
1390: Beacon: validate that CAS-protected and unpublished content stays out of the shared index

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/BeaconImmediateRemovalTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/BeaconImmediateRemovalTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\search_api\Entity\Index;
+use Drupal\search_api\Entity\Server;
+use Drupal\search_api\Utility\Utility;
+use Drupal\ys_beacon\BeaconAuthorization;
+use Drupal\ys_beacon\Service\BeaconIndexability;
+
+/**
+ * Proves content is removed from the index the moment it stops being indexable.
+ *
+ * When an already-indexed node transitions from indexable to non-indexable
+ * (published -> unpublished, public -> CAS-protected, AI indexing enabled ->
+ * disabled), ys_beacon_entity_update() deletes its chunks from the search
+ * server immediately rather than waiting for the next cron run, so protected
+ * content cannot linger in the shared index. This drives that hook directly
+ * against a real Search API index backed by the contrib search_api_test backend
+ * (which records deletes). The full ys_beacon module is not enabled because its
+ * dependency graph is heavy, so the hook file is included and invoked directly,
+ * with the indexability and authorization services doubled to script each
+ * transition. The per-state indexability decisions are proven separately in
+ * BeaconIndexabilityAccessTest; here the concern is the removal dispatch.
+ *
+ * @group ys_beacon
+ */
+class BeaconImmediateRemovalTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'node',
+    'field',
+    'search_api',
+    'search_api_test',
+  ];
+
+  /**
+   * The Search API state key holding the test backend's indexed item ids.
+   */
+  private const INDEXED_STATE = 'search_api_test.backend.indexed.ys_beacon';
+
+  /**
+   * An unrelated indexed item that must survive any scoped removal.
+   */
+  private const UNRELATED_ITEM = 'entity:node/999999:en';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    // Saving a node writes its default node-access grant row.
+    $this->installSchema('node', ['node_access']);
+    $this->installSchema('search_api', ['search_api_item']);
+    $this->installEntitySchema('search_api_task');
+    $this->installConfig('search_api');
+
+    NodeType::create(['type' => 'page', 'name' => 'Page'])->save();
+
+    // The hook reads ys_beacon.settings directly. That config's schema ships
+    // with the (here-disabled) ys_beacon module, so write it straight to the
+    // config storage rather than through the schema-validating save path.
+    \Drupal::service('config.storage')->write('ys_beacon.settings', [
+      'azure_index_name' => 'test-index',
+      'search_index_id' => 'ys_beacon',
+    ]);
+    \Drupal::configFactory()->reset('ys_beacon.settings');
+
+    Server::create([
+      'id' => 'test',
+      'name' => 'Test server',
+      'status' => TRUE,
+      'backend' => 'search_api_test',
+    ])->save();
+
+    // The hook is a function on the (unenabled) module file; load it so it can
+    // be invoked directly. The file has no include-time side effects.
+    require_once dirname(__DIR__, 3) . '/ys_beacon.module';
+  }
+
+  /**
+   * A node that becomes non-indexable is deleted from the index immediately.
+   */
+  public function testTransitionToNonIndexableRemovesItem(): void {
+    $this->assertTrue(
+      $this->runRemovalHook(newIndexable: FALSE, originalIndexable: TRUE),
+      'A node that transitions indexable -> non-indexable is removed from the shared index.',
+    );
+  }
+
+  /**
+   * A node that is still indexable is left in the index.
+   */
+  public function testStillIndexableItemIsKept(): void {
+    $this->assertFalse(
+      $this->runRemovalHook(newIndexable: TRUE, originalIndexable: TRUE),
+      'Content that remains indexable must not be removed.',
+    );
+  }
+
+  /**
+   * A node that was already non-indexable triggers no delete.
+   */
+  public function testAlreadyNonIndexableItemIsUntouched(): void {
+    $this->assertFalse(
+      $this->runRemovalHook(newIndexable: FALSE, originalIndexable: FALSE),
+      'Only the indexable -> non-indexable transition removes an item.',
+    );
+  }
+
+  /**
+   * A read-only (borrowed) index is never written to, even on a transition.
+   */
+  public function testReadOnlyIndexIsNeverWritten(): void {
+    $this->assertFalse(
+      $this->runRemovalHook(newIndexable: FALSE, originalIndexable: TRUE, readOnly: TRUE),
+      'A read-only index borrows another site collection and must never be written to.',
+    );
+  }
+
+  /**
+   * An unauthorized site performs no index writes.
+   */
+  public function testUnauthorizedSiteDoesNothing(): void {
+    $this->assertFalse(
+      $this->runRemovalHook(newIndexable: FALSE, originalIndexable: TRUE, authorized: FALSE),
+      'A site where Beacon is not authorized must not touch the index.',
+    );
+  }
+
+  /**
+   * Runs the removal hook for a scripted transition and reports the delete.
+   *
+   * Seeds the test backend as if the node were already indexed, doubles the
+   * indexability/authorization services to script the transition, invokes the
+   * real hook, and reports whether the node's items were removed.
+   *
+   * @param bool $newIndexable
+   *   Whether isIndexable() returns TRUE for the saved (current) node.
+   * @param bool $originalIndexable
+   *   Whether isIndexable() returns TRUE for the pre-save ($node->original).
+   * @param bool $authorized
+   *   Whether Beacon is authorized on the site.
+   * @param bool $readOnly
+   *   Whether the Beacon index is read-only.
+   *
+   * @return bool
+   *   TRUE when every one of the node's item ids was deleted from the index.
+   */
+  private function runRemovalHook(bool $newIndexable, bool $originalIndexable, bool $authorized = TRUE, bool $readOnly = FALSE): bool {
+    $this->createBeaconIndex($readOnly);
+
+    $node = Node::create(['type' => 'page', 'title' => 'Removal test', 'status' => 1]);
+    $node->save();
+    $node->original = clone $node;
+
+    $item_ids = [];
+    foreach (array_keys($node->getTranslationLanguages()) as $langcode) {
+      $item_ids[] = Utility::createCombinedId('entity:node', $node->id() . ':' . $langcode);
+    }
+    // Pretend the node is already embedded in the index, alongside an unrelated
+    // item that must never be touched: removal must be scoped to this node.
+    $indexed = array_fill_keys($item_ids, []);
+    $indexed[self::UNRELATED_ITEM] = [];
+    \Drupal::state()->set(self::INDEXED_STATE, $indexed);
+
+    $indexability = $this->createMock(BeaconIndexability::class);
+    $indexability->method('isIndexable')->willReturnCallback(
+      fn ($entity) => $entity === $node ? $newIndexable : $originalIndexable,
+    );
+    $this->container->set('ys_beacon.indexability', $indexability);
+
+    $authorization = $this->createMock(BeaconAuthorization::class);
+    $authorization->method('isAuthorized')->willReturn($authorized);
+    $this->container->set('ys_beacon.authorization', $authorization);
+
+    ys_beacon_entity_update($node);
+
+    $remaining = array_keys(\Drupal::state()->get(self::INDEXED_STATE, []));
+    $this->assertContains(
+      self::UNRELATED_ITEM,
+      $remaining,
+      'Removal must be scoped; an unrelated indexed item must survive.',
+    );
+    return array_intersect($item_ids, $remaining) === [];
+  }
+
+  /**
+   * Creates the Beacon index on the test server.
+   */
+  private function createBeaconIndex(bool $readOnly): void {
+    Index::create([
+      'id' => 'ys_beacon',
+      'name' => 'Beacon',
+      'status' => TRUE,
+      'read_only' => $readOnly,
+      'server' => 'test',
+      'datasource_settings' => ['entity:node' => []],
+      'tracker_settings' => ['default' => []],
+    ])->save();
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/BeaconIndexabilityAccessTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/BeaconIndexabilityAccessTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Kernel;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\metatag\MetatagManager;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\node\NodeInterface;
+use Drupal\user\Entity\Role;
+use Drupal\user\RoleInterface;
+use Drupal\ys_beacon\Service\BeaconIndexability;
+
+/**
+ * Proves protected content is never eligible for the shared Beacon index.
+ *
+ * The shared/cross-tenant vector index is queried on behalf of visitors whose
+ * access another site cannot re-check, so the only guarantee against leaking
+ * private content is that it is never written to the index. isIndexable() is
+ * the single gate every write path consults (the ExcludeAiDisabled processor,
+ * the immediate-removal hook, and the content feed), so this test exercises it
+ * against the REAL YaleSites access chain - ys_node_access's node grants for
+ * CAS-protected (field_login_required) and unpublished content - rather than a
+ * mock. The metatag manager is mocked because the ai_disable_indexing rule has
+ * its own unit coverage (BeaconIndexabilityTest); here it only supplies the
+ * "not disabled" / "disabled" resolved value so the access and publish gates
+ * are what drive the result.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Service\BeaconIndexability
+ */
+class BeaconIndexabilityAccessTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'node', 'field', 'ys_node_access'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    // The node_access table backs the grant checks ys_node_access writes.
+    $this->installSchema('node', ['node_access']);
+
+    NodeType::create(['type' => 'page', 'name' => 'Page'])->save();
+
+    // Mirror the real content type: the CAS "Login Required" boolean field is
+    // what ys_node_access reads to write a PRIVATE (anonymous-denied) grant.
+    FieldStorageConfig::create([
+      'field_name' => 'field_login_required',
+      'entity_type' => 'node',
+      'type' => 'boolean',
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_login_required',
+      'entity_type' => 'node',
+      'bundle' => 'page',
+      'label' => 'CAS Login Required',
+    ])->save();
+
+    // isIndexable() asks a fresh AnonymousUserSession whether it may view the
+    // node; anonymous needs 'access content' for a public node to be viewable
+    // at all, on top of the ys_node_access grant.
+    Role::create([
+      'id' => RoleInterface::ANONYMOUS_ID,
+      'label' => 'Anonymous',
+    ])->grantPermission('access content')->save();
+  }
+
+  /**
+   * A published, non-CAS page is anonymously viewable and indexable.
+   *
+   * @covers ::isIndexable
+   */
+  public function testPublishedPublicNodeIsIndexable(): void {
+    $node = $this->createPage(published: TRUE, loginRequired: FALSE);
+    $this->assertTrue($this->indexability()->isIndexable($node));
+  }
+
+  /**
+   * An unpublished node is never indexable.
+   *
+   * @covers ::isIndexable
+   */
+  public function testUnpublishedNodeIsNotIndexable(): void {
+    $node = $this->createPage(published: FALSE, loginRequired: FALSE);
+    $this->assertFalse($this->indexability()->isIndexable($node));
+  }
+
+  /**
+   * A CAS-protected (field_login_required) node is never indexable.
+   *
+   * @covers ::isIndexable
+   */
+  public function testCasProtectedNodeIsNotIndexable(): void {
+    $node = $this->createPage(published: TRUE, loginRequired: TRUE);
+    $this->assertFalse(
+      $this->indexability()->isIndexable($node),
+      'A published page marked CAS Login Required must be excluded: anonymous visitors cannot view it, so it must never reach the shared index.',
+    );
+  }
+
+  /**
+   * Content opted out via the ai_disable_indexing metatag is not indexable.
+   *
+   * @covers ::isIndexable
+   */
+  public function testAiDisabledNodeIsNotIndexable(): void {
+    $node = $this->createPage(published: TRUE, loginRequired: FALSE);
+    $indexability = $this->indexability(['ai_disable_indexing' => 'disabled']);
+    $this->assertFalse($indexability->isIndexable($node));
+  }
+
+  /**
+   * Creates and reloads a page node, refreshing node-access grants.
+   */
+  private function createPage(bool $published, bool $loginRequired): NodeInterface {
+    $node = Node::create([
+      'type' => 'page',
+      'title' => 'Test page',
+      'status' => (int) $published,
+      'field_login_required' => (int) $loginRequired,
+    ]);
+    $node->save();
+    // Populate the node_access table from ys_node_access's records so the
+    // anonymous view check reflects the CAS/publish grant.
+    node_access_rebuild(FALSE);
+    return Node::load($node->id());
+  }
+
+  /**
+   * Builds the service with a metatag manager stubbed to the given tag values.
+   */
+  private function indexability(array $tags = []): BeaconIndexability {
+    $manager = $this->createMock(MetatagManager::class);
+    $manager->method('tagsFromEntityWithDefaults')->willReturn($tags);
+    $manager->method('generateTokenValues')->willReturnArgument(0);
+    return new BeaconIndexability($manager);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/ExcludeAiDisabledProcessorTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/ExcludeAiDisabledProcessorTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\TypedData\ComplexDataInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\Plugin\search_api\processor\ExcludeAiDisabled;
+use Drupal\ys_beacon\Service\BeaconIndexability;
+
+/**
+ * Proves the Search API processor drops non-indexable items before indexing.
+ *
+ * ExcludeAiDisabled is the write-path gate: Search API collects tracked items
+ * and this processor removes any whose entity fails BeaconIndexability, so a
+ * protected or AI-disabled entity is never embedded into the shared vector
+ * database. This isolates the processor's own drop logic; the indexability
+ * decision itself is covered by BeaconIndexabilityAccessTest and
+ * BeaconIndexabilityTest.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Plugin\search_api\processor\ExcludeAiDisabled
+ */
+class ExcludeAiDisabledProcessorTest extends UnitTestCase {
+
+  /**
+   * Non-indexable items are removed; indexable items are kept.
+   *
+   * @covers ::alterIndexedItems
+   */
+  public function testNonIndexableItemsAreDropped(): void {
+    $indexable = $this->createMock(EntityInterface::class);
+    $notIndexable = $this->createMock(EntityInterface::class);
+
+    $indexability = $this->createMock(BeaconIndexability::class);
+    $indexability->method('isIndexable')
+      ->willReturnCallback(fn ($entity) => $entity === $indexable);
+
+    $items = [
+      'keep' => $this->item($indexable),
+      'drop' => $this->item($notIndexable),
+    ];
+
+    $this->processor($indexability)->alterIndexedItems($items);
+
+    $this->assertArrayHasKey('keep', $items, 'The indexable item survives.');
+    $this->assertArrayNotHasKey('drop', $items, 'The non-indexable item is removed before it reaches the backend.');
+  }
+
+  /**
+   * An item with no original entity is left untouched (not an entity to gate).
+   *
+   * @covers ::alterIndexedItems
+   */
+  public function testItemWithoutEntityIsKept(): void {
+    $indexability = $this->createMock(BeaconIndexability::class);
+    $indexability->expects($this->never())->method('isIndexable');
+
+    $item = $this->createMock(ItemInterface::class);
+    $item->method('getOriginalObject')->willReturn(NULL);
+    $items = ['orphan' => $item];
+
+    $this->processor($indexability)->alterIndexedItems($items);
+
+    $this->assertArrayHasKey('orphan', $items);
+  }
+
+  /**
+   * Wraps an entity in a Search API item, as the processor receives it.
+   */
+  private function item(EntityInterface $entity): ItemInterface {
+    $original = $this->createMock(ComplexDataInterface::class);
+    $original->method('getValue')->willReturn($entity);
+    $item = $this->createMock(ItemInterface::class);
+    $item->method('getOriginalObject')->willReturn($original);
+    return $item;
+  }
+
+  /**
+   * Builds the processor with the indexability service injected.
+   */
+  private function processor(BeaconIndexability $indexability): ExcludeAiDisabled {
+    $processor = (new \ReflectionClass(ExcludeAiDisabled::class))->newInstanceWithoutConstructor();
+    $property = new \ReflectionProperty(ExcludeAiDisabled::class, 'indexability');
+    $property->setValue($processor, $indexability);
+    return $processor;
+  }
+
+}


### PR DESCRIPTION
## [1390: Beacon: validate that CAS-protected and unpublished content stays out of the shared index](https://github.com/yalesites-org/YaleSites-Internal/issues/1390)

### Description of work
- Adds automated tests that lock down the Beacon shared-index access invariant: content that is unpublished, CAS-protected (`field_login_required`), or AI-disabled must never be written to the shared vector index, and content that transitions to inaccessible is removed from it. Because a cross-tenant consumer of the shared index cannot re-check per-visitor access at query time, write-time exclusion is the only guarantee against leaking protected content. This is a hard prerequisite for cross-site retrieval.
- `BeaconIndexabilityAccessTest` (Kernel) - proves `BeaconIndexability::isIndexable()`, the single gate every write path consults, excludes unpublished and CAS-protected nodes (exercising the real `ys_node_access` node-grant chain) and AI-disabled content, and includes normal published public content.
- `ExcludeAiDisabledProcessorTest` (Unit) - proves the Search API processor (`ExcludeAiDisabled`) drops non-indexable items before they reach the backend.
- `BeaconImmediateRemovalTest` (Kernel) - proves `ys_beacon_entity_update()` deletes an item from the index the moment it transitions from indexable to non-indexable, and does not delete otherwise (still-indexable, already-excluded, read-only/borrowed index, or unauthorized site).
- No production code changes - validation only. Existing `BeaconImmediateIndexingTest` already covers index-immediately-on-save timing (`index_directly: true`, index not read-only).
- Scope note: route-level CAS `forced_login.paths` protection and media inheriting a node's protection are explicitly out of scope (see the issue). YaleSites protects pages via the `field_login_required` node field, and media AI indexing is a deliberate editor opt-in.
- Builds on yalesites-org/YaleSites-Internal#551 (PR yalesites-org/yalesites-project#1300) - this branch is stacked on the Beacon shared multi-tenant index work and targets `551-beacon-drupalai`; please review/merge that first. GitHub will auto-retarget this PR to `develop` once #1300 merges.

### Functional testing steps:
- [ ] Run the ys_beacon suite: `lando ssh -c "env SIMPLETEST_DB=mysql://pantheon:pantheon@database/pantheon php /app/vendor/bin/phpunit -c /app/phpunit.xml /app/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests --testdox"` and confirm it is green.
- [ ] Confirm the three new tests are present and pass: `BeaconIndexabilityAccessTest`, `ExcludeAiDisabledProcessorTest`, `BeaconImmediateRemovalTest`.
- [ ] `lando composer code-sniff` passes (Drupal + DrupalPractice).

References yalesites-org/YaleSites-Internal#1390

---
Created with AI
