### PR TITLE
1394: Hotfix: Campus Groups event sync is non-functional — CampusGroupUrl fatals with ArgumentCountError

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,5 @@ lando xdebug-off           # Disable Xdebug
 - **Custom Modules**: Use `ys_` prefix (e.g., `ys_core`, `ys_themes`)
 - **Branch Strategy**: `develop` (primary), `master` (releases), `YALB-XXX-description` (features)
 - **Semantic Release**: Automated versioning on master branch using conventional commits
+
+

--- a/README.md
+++ b/README.md
@@ -110,5 +110,3 @@ lando xdebug-off           # Disable Xdebug
 - **Custom Modules**: Use `ys_` prefix (e.g., `ys_core`, `ys_themes`)
 - **Branch Strategy**: `develop` (primary), `master` (releases), `YALB-XXX-description` (features)
 - **Semantic Release**: Automated versioning on master branch using conventional commits
-
-

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/migrations/campus_groups_events.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/migrations/campus_groups_events.yml
@@ -119,44 +119,67 @@ process:
      from_format: 'Y-m-d\TH:i:s.0000000P'
      to_format: 'U'
   field_tags:
-    plugin: entity_generate
-    entity_type: taxonomy_term
-    value_key: name
-    bundle_key: vid
-    bundle: tags
-    source: event_tags
+    -
+      plugin: skip_on_empty
+      method: process
+      source: event_tags
+    -
+      plugin: entity_generate
+      entity_type: taxonomy_term
+      value_key: name
+      bundle_key: vid
+      bundle: tags
   field_localist_event_type:
-    plugin: entity_generate
-    entity_type: taxonomy_term
-    value_key: name
-    bundle_key: vid
-    bundle: localist_event_type
-    source: event_type
+    -
+      plugin: skip_on_empty
+      method: process
+      source: event_type
+    -
+      plugin: entity_generate
+      entity_type: taxonomy_term
+      value_key: name
+      bundle_key: vid
+      bundle: localist_event_type
   field_category:
-    plugin: entity_generate
-    entity_type: taxonomy_term
-    value_key: name
-    bundle_key: vid
-    bundle: event_category
-    source: event_category
+    -
+      plugin: skip_on_empty
+      method: process
+      source: event_category
+    -
+      plugin: entity_generate
+      entity_type: taxonomy_term
+      value_key: name
+      bundle_key: vid
+      bundle: event_category
   field_localist_group:
-    plugin: entity_generate
-    entity_type: taxonomy_term
-    value_key: name
-    bundle_key: vid
-    bundle: event_groups
-    source: event_group
+    -
+      plugin: skip_on_empty
+      method: process
+      source: event_group
+    -
+      plugin: entity_generate
+      entity_type: taxonomy_term
+      value_key: name
+      bundle_key: vid
+      bundle: event_groups
   field_event_status:
-    plugin: entity_generate
-    entity_type: taxonomy_term
-    value_key: name
-    bundle_key: vid
-    bundle: event_status
-    source: event_status  
+    -
+      plugin: skip_on_empty
+      method: process
+      source: event_status
+    -
+      plugin: entity_generate
+      entity_type: taxonomy_term
+      value_key: name
+      bundle_key: vid
+      bundle: event_status
   field_event_topics:
     -
-      plugin: explode
+      plugin: skip_on_empty
+      method: process
       source: event_topics
+    -
+      plugin: explode
       delimiter: ','
     -
       plugin: callback

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/src/Controller/RunMigrations.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/src/Controller/RunMigrations.php
@@ -18,6 +18,20 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class RunMigrations extends ControllerBase implements ContainerInjectionInterface {
 
   /**
+   * Marker for the spurious legacy-database warning to strip from the screen.
+   *
+   * Whenever migration definitions are rebuilt, core's
+   * migrate_drupal_migration_plugins_alter() probes the unrelated system_site
+   * migration (whose source is the "variable" plugin) to detect a legacy
+   * Drupal source database. This platform has none, so that probe fails and
+   * core queues a "Failed to connect to your database server" messenger error
+   * containing this text -- even though the Campus Groups sync (an HTTP feed,
+   * not a database source) succeeded. It is harmless noise, unrelated to
+   * Campus Groups. See yalesites-org/YaleSites-Internal#1394.
+   */
+  const SPURIOUS_MIGRATE_DB_WARNING = 'No database connection configured for source plugin variable';
+
+  /**
    * Configuration Factory.
    *
    * @var \Drupal\Core\Config\ConfigFactoryInterface
@@ -99,6 +113,7 @@ class RunMigrations extends ControllerBase implements ContainerInjectionInterfac
   public function runAllMigrations() {
     if ($this->campusGroupsConfig->get('enable_campus_groups_sync')) {
       $messageData = $this->campusGroupsManager->runAllMigrations();
+      $this->removeSpuriousMigrateDatabaseWarning();
       if ($messageData) {
         $eventsImported = $messageData['campus_groups_events']['imported'];
         $message = "Synchronized $eventsImported events.";
@@ -129,6 +144,30 @@ class RunMigrations extends ControllerBase implements ContainerInjectionInterfac
     }
 
     return $referer;
+  }
+
+  /**
+   * Removes the harmless legacy-database warning core queues during sync.
+   *
+   * See self::SPURIOUS_MIGRATE_DB_WARNING for why the message appears. The
+   * match is intentionally narrow (that one message only): if core ever
+   * rewords it we simply stop matching and the still-harmless message
+   * reappears, which is safer than a broad filter that could hide a genuinely
+   * different database error. All other errors are preserved.
+   */
+  private function removeSpuriousMigrateDatabaseWarning(): void {
+    $messenger = $this->messenger();
+    $errors = $messenger->messagesByType(MessengerInterface::TYPE_ERROR);
+    if (!$errors) {
+      return;
+    }
+
+    $messenger->deleteByType(MessengerInterface::TYPE_ERROR);
+    foreach ($errors as $error) {
+      if (!str_contains((string) $error, self::SPURIOUS_MIGRATE_DB_WARNING)) {
+        $messenger->addError($error);
+      }
+    }
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/src/Plugin/migrate/source/CampusGroupUrl.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/src/Plugin/migrate/source/CampusGroupUrl.php
@@ -3,6 +3,7 @@
 namespace Drupal\ys_campus_groups\Plugin\migrate\source;
 
 use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate_plus\DataParserPluginManager;
 use Drupal\migrate_plus\Plugin\migrate\source\Url;
 use Drupal\Core\Url as UrlObject;
 
@@ -20,7 +21,7 @@ class CampusGroupUrl extends Url {
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration, DataParserPluginManager $parserPluginManager) {
     $config = \Drupal::configFactory()->getEditable('ys_campus_groups.settings');
 
     $url = $config->get('campus_groups_endpoint');
@@ -47,7 +48,7 @@ class CampusGroupUrl extends Url {
       }
     }
 
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $migration);
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $migration, $parserPluginManager);
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/tests/src/Unit/CampusGroupUrlTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/tests/src/Unit/CampusGroupUrlTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Drupal\Tests\ys_campus_groups\Unit;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Utility\UnroutedUrlAssemblerInterface;
+use Drupal\key\KeyInterface;
+use Drupal\key\KeyRepositoryInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate_plus\DataParserPluginManager;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_campus_groups\Plugin\migrate\source\CampusGroupUrl;
+
+/**
+ * Unit tests for the CampusGroupUrl migrate source plugin.
+ *
+ * @coversDefaultClass \Drupal\ys_campus_groups\Plugin\migrate\source\CampusGroupUrl
+ *
+ * @group ys_campus_groups
+ * @group yalesites
+ */
+class CampusGroupUrlTest extends UnitTestCase {
+
+  /**
+   * The plugin instantiates and builds its source URL from configuration.
+   *
+   * Regression coverage for the hotfix: CampusGroupUrl::__construct() must
+   * accept and forward migrate_plus Url::__construct()'s fifth argument
+   * ($parserPluginManager). Before the fix every instantiation threw a fatal
+   * ArgumentCountError, so the campus_groups_events migration could not run.
+   *
+   * @covers ::__construct
+   */
+  public function testConstructShouldSucceedWithConfiguredEndpoint(): void {
+    // The group ID is a fabricated placeholder, never a real production value.
+    $config_factory = $this->getConfigFactoryStub([
+      'ys_campus_groups.settings' => [
+        'campus_groups_endpoint' => 'https://example.com/events',
+        'campus_groups_api_key' => 'campus_groups_key',
+        'campus_groups_groupids' => '12345',
+      ],
+    ]);
+
+    // No key is resolved, so no auth header is added -- keeps this test focused
+    // on constructor argument forwarding.
+    $key_repository = $this->createMock(KeyRepositoryInterface::class);
+    $key_repository->method('getKey')->willReturn(NULL);
+
+    // Url::toString() resolves external URLs through this service.
+    $assembler = $this->createMock(UnroutedUrlAssemblerInterface::class);
+    $assembler->method('assemble')->willReturnCallback(
+      function ($uri, array $options = []) {
+        return $uri . '?' . http_build_query($options['query'] ?? []);
+      }
+    );
+
+    $container = new ContainerBuilder();
+    $container->set('config.factory', $config_factory);
+    $container->set('key.repository', $key_repository);
+    $container->set('unrouted_url_assembler', $assembler);
+    \Drupal::setContainer($container);
+
+    $migration = $this->createMock(MigrationInterface::class);
+    $parser_plugin_manager = $this->createMock(DataParserPluginManager::class);
+
+    $plugin = new CampusGroupUrl(
+      ['urls' => 'test.xml', 'fields' => [], 'ids' => []],
+      'campus_groups_url',
+      [],
+      $migration,
+      $parser_plugin_manager
+    );
+
+    $this->assertInstanceOf(CampusGroupUrl::class, $plugin);
+
+    // The configured endpoint and query parameters drive the source URL
+    // (Url::__toString() returns the built source URLs).
+    $source_url = (string) $plugin;
+    $this->assertStringContainsString('https://example.com/events', $source_url);
+    $this->assertStringContainsString('future_day_range=365', $source_url);
+    $this->assertStringContainsString('group_ids=12345', $source_url);
+  }
+
+  /**
+   * A resolved API key is injected as the x-cg-api-secret request header.
+   *
+   * Covers the constructor's key-present branch: the campus_groups_events
+   * migration authenticates to the Campus Groups API via this header, so a
+   * regression that dropped or renamed it would otherwise pass unnoticed.
+   *
+   * @covers ::__construct
+   */
+  public function testConstructInjectsApiKeyHeaderWhenKeyPresent(): void {
+    // The group ID is a fabricated placeholder, never a real production value.
+    $config_factory = $this->getConfigFactoryStub([
+      'ys_campus_groups.settings' => [
+        'campus_groups_endpoint' => 'https://example.com/events',
+        'campus_groups_api_key' => 'campus_groups_key',
+        'campus_groups_groupids' => '12345',
+      ],
+    ]);
+
+    $key = $this->createMock(KeyInterface::class);
+    $key->method('getKeyValue')->willReturn('secret-value');
+    $key_repository = $this->createMock(KeyRepositoryInterface::class);
+    $key_repository->method('getKey')->with('campus_groups_key')->willReturn($key);
+
+    $assembler = $this->createMock(UnroutedUrlAssemblerInterface::class);
+    $assembler->method('assemble')->willReturnCallback(
+      function ($uri, array $options = []) {
+        return $uri . '?' . http_build_query($options['query'] ?? []);
+      }
+    );
+
+    $container = new ContainerBuilder();
+    $container->set('config.factory', $config_factory);
+    $container->set('key.repository', $key_repository);
+    $container->set('unrouted_url_assembler', $assembler);
+    \Drupal::setContainer($container);
+
+    $migration = $this->createMock(MigrationInterface::class);
+    $parser_plugin_manager = $this->createMock(DataParserPluginManager::class);
+
+    $plugin = new CampusGroupUrl(
+      ['urls' => 'test.xml', 'fields' => [], 'ids' => []],
+      'campus_groups_url',
+      [],
+      $migration,
+      $parser_plugin_manager
+    );
+
+    $property = new \ReflectionProperty($plugin, 'configuration');
+    $property->setAccessible(TRUE);
+    $configuration = $property->getValue($plugin);
+
+    $this->assertSame('secret-value', $configuration['headers']['x-cg-api-secret']);
+  }
+
+  /**
+   * GetApiKeyFromKeysModule() returns the key value when the key exists.
+   *
+   * Constructed via reflection so the leaf key-lookup logic can be exercised
+   * without standing up the full migrate source plugin.
+   *
+   * @covers ::getApiKeyFromKeysModule
+   */
+  public function testGetApiKeyFromKeysModuleReturnsValueWhenKeyExists(): void {
+    $key = $this->createMock(KeyInterface::class);
+    $key->method('getKeyValue')->willReturn('secret-value');
+
+    $key_repository = $this->createMock(KeyRepositoryInterface::class);
+    $key_repository->method('getKey')->with('campus_groups_key')->willReturn($key);
+
+    $container = new ContainerBuilder();
+    $container->set('key.repository', $key_repository);
+    \Drupal::setContainer($container);
+
+    $plugin = (new \ReflectionClass(CampusGroupUrl::class))->newInstanceWithoutConstructor();
+    $method = new \ReflectionMethod($plugin, 'getApiKeyFromKeysModule');
+    $method->setAccessible(TRUE);
+
+    $this->assertSame('secret-value', $method->invoke($plugin, 'campus_groups_key'));
+  }
+
+  /**
+   * GetApiKeyFromKeysModule() returns NULL when the key does not exist.
+   *
+   * @covers ::getApiKeyFromKeysModule
+   */
+  public function testGetApiKeyFromKeysModuleReturnsNullWhenKeyMissing(): void {
+    $key_repository = $this->createMock(KeyRepositoryInterface::class);
+    $key_repository->method('getKey')->with('missing_key')->willReturn(NULL);
+
+    $container = new ContainerBuilder();
+    $container->set('key.repository', $key_repository);
+    \Drupal::setContainer($container);
+
+    $plugin = (new \ReflectionClass(CampusGroupUrl::class))->newInstanceWithoutConstructor();
+    $method = new \ReflectionMethod($plugin, 'getApiKeyFromKeysModule');
+    $method->setAccessible(TRUE);
+
+    $this->assertNull($method->invoke($plugin, 'missing_key'));
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/tests/src/Unit/CampusGroupsEventsNullGuardTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/tests/src/Unit/CampusGroupsEventsNullGuardTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Drupal\Tests\ys_campus_groups\Unit;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Plugin\migrate\process\SkipOnEmpty;
+use Drupal\migrate\Row;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Guards the campus_groups_events migration against null taxonomy lookups.
+ *
+ * Regression coverage for yalesites-org/YaleSites-Internal#1394. A null or
+ * empty source value flowing into one of the entity_generate/entity_lookup
+ * steps reaches EntityLookup::query(), whose entity-query condition calls
+ * Connection::escapeLike() -- which emits "addcslashes(): Passing null to
+ * parameter #1" (a deprecation today, a hard TypeError on a future PHP). Each
+ * affected field is guarded with a leading skip_on_empty (method: process) so
+ * an empty value stops that field's pipeline before the lookup ever runs.
+ *
+ * @group ys_campus_groups
+ * @group yalesites
+ */
+class CampusGroupsEventsNullGuardTest extends UnitTestCase {
+
+  /**
+   * Guarded event fields in campus_groups_events.yml keyed to their source.
+   */
+  const GUARDED_FIELDS = [
+    'field_tags' => 'event_tags',
+    'field_localist_event_type' => 'event_type',
+    'field_category' => 'event_category',
+    'field_localist_group' => 'event_group',
+    'field_event_status' => 'event_status',
+    'field_event_topics' => 'event_topics',
+  ];
+
+  /**
+   * Every guarded field leads with skip_on_empty (method: process).
+   *
+   * This is the wiring that keeps a null value from reaching the lookup. If a
+   * guard is dropped or reordered, the deprecated escapeLike(null) path becomes
+   * reachable again and this test fails.
+   *
+   * @covers \Drupal\ys_campus_groups
+   */
+  public function testGuardedFieldsLeadWithSkipOnEmpty(): void {
+    $migration = Yaml::parseFile(__DIR__ . '/../../../migrations/campus_groups_events.yml');
+    $process = $migration['process'];
+
+    foreach (self::GUARDED_FIELDS as $field => $source) {
+      $this->assertIsArray($process[$field], "$field must be defined in the process pipeline");
+      $this->assertTrue(
+        array_is_list($process[$field]),
+        "$field must be a sequence of steps (an unguarded single-plugin mapping is the regression)"
+      );
+      $first = $process[$field][0];
+      $this->assertSame('skip_on_empty', $first['plugin'], "$field must guard with skip_on_empty first");
+      $this->assertSame('process', $first['method'], "$field skip_on_empty must use method: process");
+      $this->assertSame($source, $first['source'], "$field must guard its own source, $source");
+      // A lookup/transform step must follow the guard.
+      $this->assertArrayHasKey(1, $process[$field], "$field must run a step after the guard");
+    }
+  }
+
+  /**
+   * An empty source value stops the pipeline before the taxonomy lookup runs.
+   *
+   * @dataProvider emptyValues
+   */
+  public function testEmptyValueStopsPipelineBeforeLookup($value): void {
+    $plugin = new SkipOnEmpty(['method' => 'process'], 'skip_on_empty', []);
+
+    $result = $plugin->transform(
+      $value,
+      $this->createMock(MigrateExecutableInterface::class),
+      new Row(),
+      'field_category'
+    );
+
+    $this->assertNull($result);
+    $this->assertTrue($plugin->isPipelineStopped(), 'The lookup step is skipped for an empty value.');
+  }
+
+  /**
+   * A real source value passes through unchanged to the lookup.
+   *
+   * Confirms the guard is behavior-preserving: non-empty values are migrated
+   * exactly as before.
+   */
+  public function testNonEmptyValuePassesThroughToLookup(): void {
+    $plugin = new SkipOnEmpty(['method' => 'process'], 'skip_on_empty', []);
+
+    $result = $plugin->transform(
+      'Lecture',
+      $this->createMock(MigrateExecutableInterface::class),
+      new Row(),
+      'field_category'
+    );
+
+    $this->assertSame('Lecture', $result);
+    $this->assertFalse($plugin->isPipelineStopped(), 'A real value continues to the lookup.');
+  }
+
+  /**
+   * Empty source values that would otherwise hit escapeLike(null).
+   *
+   * A missing XML element decodes to NULL; a present-but-empty one to ''.
+   *
+   * @return array<string, array<int, mixed>>
+   *   Test cases.
+   */
+  public static function emptyValues(): array {
+    return [
+      'null (missing element)' => [NULL],
+      'empty string (present but empty)' => [''],
+    ];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/tests/src/Unit/RunMigrationsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/tests/src/Unit/RunMigrationsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Drupal\Tests\ys_campus_groups\Unit;
+
+use Drupal\Core\Messenger\Messenger;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\PageCache\ResponsePolicy\KillSwitch;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_campus_groups\CampusGroupsManager;
+use Drupal\ys_campus_groups\Controller\RunMigrations;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
+
+/**
+ * Unit tests for the Campus Groups "Sync now" controller.
+ *
+ * @coversDefaultClass \Drupal\ys_campus_groups\Controller\RunMigrations
+ *
+ * @group ys_campus_groups
+ * @group yalesites
+ */
+class RunMigrationsTest extends UnitTestCase {
+
+  /**
+   * The exact core warning that decorates a successful sync (see #1394).
+   *
+   * Core's migrate_drupal module probes the unrelated system_site migration
+   * (source plugin "variable") during migration-definition discovery; with no
+   * legacy source database it queues this messenger error even though the
+   * Campus Groups sync succeeded.
+   */
+  const NOISE_WARNING = 'Failed to connect to your database server. The server reports the following message: No database connection configured for source plugin variable.';
+
+  /**
+   * Builds the controller with a real in-memory messenger under test.
+   *
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger the controller and the (mocked) manager share.
+   * @param bool $enabled
+   *   Whether Campus Groups syncing is enabled in config.
+   *
+   * @return \Drupal\ys_campus_groups\Controller\RunMigrations
+   *   The controller instance.
+   */
+  private function buildController(MessengerInterface $messenger, bool $enabled): RunMigrations {
+    $config_factory = $this->getConfigFactoryStub([
+      'ys_campus_groups.settings' => ['enable_campus_groups_sync' => $enabled],
+    ]);
+
+    // The manager "runs" the sync: it reports 8 imported events and, like the
+    // real core probe, queues the spurious database warning while doing so.
+    $manager = $this->createMock(CampusGroupsManager::class);
+    $manager->method('runAllMigrations')->willReturnCallback(
+      function () use ($messenger) {
+        $messenger->addError(self::NOISE_WARNING);
+        return ['campus_groups_events' => ['imported' => 8]];
+      }
+    );
+
+    // A referer keeps getRedirectUrl() off the (container-backed) route path.
+    $request = Request::create('/admin/yalesites/campus_groups/sync');
+    $request->server->set('HTTP_REFERER', 'https://example.com/admin/yalesites/campus_groups');
+    $request_stack = new RequestStack();
+    $request_stack->push($request);
+
+    return new RunMigrations($config_factory, $manager, $messenger, $request_stack);
+  }
+
+  /**
+   * Casts the messenger's messages of a type to plain strings.
+   *
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger to read.
+   * @param string $type
+   *   A MessengerInterface::TYPE_* constant.
+   *
+   * @return string[]
+   *   The messages as strings.
+   */
+  private function messages(MessengerInterface $messenger, string $type): array {
+    return array_map('strval', $messenger->messagesByType($type));
+  }
+
+  /**
+   * The spurious database warning is stripped, real messages are preserved.
+   *
+   * @covers ::runAllMigrations
+   */
+  public function testSpuriousDatabaseWarningIsRemovedFromSyncScreen(): void {
+    $messenger = new Messenger(new FlashBag(), new KillSwitch());
+
+    // A pre-existing unrelated error and a *different* source-plugin error must
+    // both survive -- the filter is deliberately narrow to that one message.
+    $messenger->addError('Something else went wrong.');
+    $messenger->addError('No database connection configured for source plugin foo_bar');
+
+    $controller = $this->buildController($messenger, TRUE);
+    $controller->runAllMigrations();
+
+    $errors = $this->messages($messenger, MessengerInterface::TYPE_ERROR);
+    foreach ($errors as $error) {
+      $this->assertStringNotContainsString('source plugin variable', $error);
+    }
+    $this->assertContains('Something else went wrong.', $errors);
+    $this->assertContains('No database connection configured for source plugin foo_bar', $errors);
+
+    $status = $this->messages($messenger, MessengerInterface::TYPE_STATUS);
+    $this->assertContains('Synchronized 8 events.', $status);
+  }
+
+}


### PR DESCRIPTION
## [1394: Hotfix: Campus Groups event sync is non-functional — CampusGroupUrl fatals with ArgumentCountError](https://github.com/yalesites-org/YaleSites-Internal/issues/1394)

### Description of work
- `CampusGroupUrl::__construct()` now accepts and forwards the 5th `DataParserPluginManager $parserPluginManager` argument to migrate_plus's `Url::__construct()`, matching its required signature. This fixes the fatal `ArgumentCountError` that stopped the `campus_groups_url` source plugin from instantiating.
- Because the fatal was raised during migration source-plugin discovery, it had disabled Campus Groups event sync (cron and manual import) **and** aborted `drush migrate:status` for every migration on any site with `ys_campus_groups` enabled. Both now work.
- Added PHPUnit unit coverage for the source plugin (`CampusGroupUrlTest`): successful construction with a configured endpoint, injection of the `x-cg-api-secret` auth header when a key is resolved, and the key-lookup helper.

**Review-round fixes (@miketullo95 multidev findings):**
- **Sync-screen database warning:** the "Sync now" controller (`RunMigrations`) now strips the harmless, unrelated core `migrate_drupal` legacy-database warning ("No database connection configured for source plugin variable") that was decorating an otherwise-successful sync. The match is narrow to that one message on that one screen — all other errors, and every other migrate location (dashboard, drush, cron), are untouched. Covered by `RunMigrationsTest`.
- **`addcslashes(): Passing null` deprecation:** each taxonomy lookup step in `campus_groups_events.yml` (`field_tags`, `field_localist_event_type`, `field_category`, `field_localist_group`, `field_event_status`, `field_event_topics`) now leads with a `skip_on_empty` (`method: process`) guard, so an empty/missing source value no longer reaches `EntityLookup::query()` → `Connection::escapeLike(null)`. Behavior-preserving for imported content; also prevents a possible whole-row failure when `event_topics` is missing. Covered by `CampusGroupsEventsNullGuardTest`.

### Functional testing steps:
- [ ] On an environment with `ys_campus_groups` enabled, run `drush migrate:status` — it lists migrations (including `campus_groups_events`) with **no fatal** (previously threw `ArgumentCountError`).
- [ ] Trigger the Campus Groups sync (cron or the manual import) — the `campus_groups_events` migration runs instead of fataling.
- [ ] On the Campus Groups settings page, click **Sync now** — you get the "Synchronized N events." success message and **no** "Failed to connect to your database server… No database connection configured for source plugin variable" error beside it.
- [ ] Confirm events still import (`drush migrate:status campus_groups_events` shows the imported count), including events whose feed omits category / group / status / tags / topics — those fields are simply left unset, and no `addcslashes(): Passing null` / `escapeLike` deprecation is logged.
- [ ] Run the module's unit tests — 9 tests pass:
  `vendor/bin/phpunit -c /app/phpunit.xml --group ys_campus_groups web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/tests`

### Notes
- **Base branch:** this PR targets **`master`** (hotfix), not `develop`. Note that `build_deploy_and_test.yml` has `branches-ignore: master`, so automated CI (unit tests, static analysis, multidev deploy) does not run on this PR; the review-round changes were verified locally (PHPUnit green, `phpcs` Drupal + DrupalPractice clean).
- **Test-file overlap with #1354 (expected, trivial reconcile):** open PR yalesites-org/yalesites-project#1354 also adds this same `CampusGroupUrlTest.php` (on `develop`) with the earlier "GAP" tests that deliberately lock in the current bug. Once this hotfix forward-merges to `develop`, #1354 should drop its version of that file in favor of this one — its own comments already say to delete the bug-locking test once the fix lands.

References yalesites-org/YaleSites-Internal#1394

---
Created with AI
