### PR TITLE
1372: re-remove ys_servicenow from active core.extension on stuck sites

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
@@ -1365,3 +1365,66 @@ function ys_core_update_10016() {
     '@what' => implode(', ', $cleaned),
   ]);
 }
+
+/**
+ * Re-repair sites still carrying ys_servicenow in active core.extension.
+ *
+ * Update 10016 removes ys_servicenow from the active core.extension, but a
+ * hook_update_N runs only once per site. Some existing sites still list
+ * ys_servicenow in active core.extension even though 10016 is recorded as run:
+ * a `drush deploy` whose synced config still referenced the (now file-less)
+ * module made the config importer try to install ys_servicenow, and
+ * ModuleInstaller::install() writes the module into active core.extension
+ * before it fails resolving the missing files. That left the module in
+ * core.extension while ys_core's schema had already advanced past 10016, so
+ * 10016 never runs again to clean it up.
+ *
+ * On those sites every later deploy dies in config import: installing any new
+ * module rebuilds the full module list from active core.extension
+ * (ModuleInstaller::install()), and getPath('ys_servicenow') throws
+ * UnknownExtensionException because the files are gone. Synced config no longer
+ * references ys_servicenow, so the only remaining fix is to strip it from
+ * active core.extension again under a fresh schema number. updatedb runs before
+ * config import, so this clears the module first and the import then succeeds.
+ * Idempotent: a no-op on sites already clean.
+ */
+function ys_core_update_10018() {
+  $module = 'ys_servicenow';
+  $cleaned = [];
+
+  // Remove from the active core.extension module list. The module's files are
+  // gone, so this direct edit stands in for ModuleInstaller::uninstall().
+  $extension = \Drupal::configFactory()->getEditable('core.extension');
+  $modules = $extension->get('module') ?? [];
+  if (array_key_exists($module, $modules)) {
+    unset($modules[$module]);
+    $extension->set('module', $modules)->save();
+    $cleaned[] = 'core.extension';
+  }
+
+  // Defensively clear any orphaned system.schema entry too.
+  $schema_exists = \Drupal::database()
+    ->select('key_value', 'kv')
+    ->fields('kv', ['name'])
+    ->condition('collection', 'system.schema')
+    ->condition('name', $module)
+    ->execute()
+    ->fetchField();
+  if ($schema_exists) {
+    \Drupal::database()
+      ->delete('key_value')
+      ->condition('collection', 'system.schema')
+      ->condition('name', $module)
+      ->execute();
+    $cleaned[] = 'system.schema';
+  }
+
+  if (empty($cleaned)) {
+    return t('@module already fully removed; nothing to do.', ['@module' => $module]);
+  }
+
+  return t('Uninstalled @module (cleaned: @what).', [
+    '@module' => $module,
+    '@what' => implode(', ', $cleaned),
+  ]);
+}


### PR DESCRIPTION
## [1372: Remove unused ys_servicenow module (tech debt)](https://github.com/yalesites-org/YaleSites-Internal/issues/1372)

### Description of work

`ys_servicenow` was deleted from the codebase in #1372, but it is still listed as installed in the **active** `core.extension` on existing sites. Because its files are gone, any `drush deploy` whose config import installs a new module crashes: `ModuleInstaller::install()` rebuilds the full module list from active `core.extension` and calls `getPath('ys_servicenow')`, which throws `UnknownExtensionException: The module ys_servicenow does not exist`.

- PR #1360 added `ys_core_update_10016()` to strip `ys_servicenow` from active `core.extension` during `updatedb`. That fixes sites whose `ys_core` schema is still below 10016 — but a `hook_update_N` runs only once. Sites whose schema has already advanced past 10016 while still carrying `ys_servicenow` (e.g. the pr-1300 multidev, now at schema 10017) never get cleaned, so their deploys keep failing during config import.
- This adds `ys_core_update_10018()`, which re-applies the same removal (and defensively clears any orphaned `system.schema` entry) under a fresh schema number so it runs again on those stuck sites. `updatedb` runs before config import, so `ys_servicenow` is cleared before the import installs anything. Idempotent — a no-op on sites already clean.
- Numbered **10018** (not 10017) to leave 10017 for the incoming Beacon update hook on the `551-beacon-drupalai` branch, so merges into `develop` stay conflict-free in either order.

Root cause was traced through Drupal core (`ModuleInstaller::install()` lines 222–236 → `ExtensionList::getPath()`) and the failing deploy trace on run 29507104455 (pr-1300). The `ys_servicenow` reference is confirmed still present in active `core.extension` on that multidev: the "module is marked as installed ... but it is missing" requirements error fires on every deploy, including a green re-run — that re-run only passed because the earlier failed deploy had already installed the new modules, so its config import had no module-install step left to trip the crash. The landmine remains until the module is stripped from active `core.extension`.

`php -l` clean; `phpcs` clean on the Drupal and DrupalPractice standards.

### Functional testing steps:
- [ ] On a site whose `ys_core` schema is already >= 10016 and that still lists `ys_servicenow` in active `core.extension`, run `drush deploy` and confirm it completes without the `The module ys_servicenow does not exist` config-import error.
- [ ] Confirm `ys_servicenow` is gone from active `core.extension` and from the `system.schema` key_value collection afterward.
- [ ] Site returns 200.

References yalesites-org/YaleSites-Internal#1372
Follows up #1360
