### PR TITLE
1411: Beacon: restrict the Beacon administration form to user 1 only

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -149,7 +149,6 @@ permissions:
   - 'administer users'
   - 'administer utility-drop-button-navigation menu items'
   - 'administer utility-navigation menu items'
-  - 'administer ys beacon'
   - 'assign contributor role'
   - 'assign editor role'
   - 'assign file_manager role'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
@@ -63,9 +63,12 @@ The module is installed on every site and is off by default.
    - `portkey_embedding_api_key` - Portkey API key for embeddings
    - `azure_ai_search_api_key` - Azure AI Search admin key
    - `azure_ai_search_url` - Azure AI Search endpoint URL
-2. A platform administrator sets the per-site Azure index name at
-   `/admin/config/yalesites/ys-beacon/admin`. Until this is set, the Beacon
-   search index stays disabled at runtime and no Azure traffic occurs.
+2. User 1 (the platform superadmin) sets the per-site Azure index name at
+   `/admin/config/yalesites/ys-beacon/admin`. This administration form is
+   restricted to user 1 only — no other role, however privileged, can reach it
+   (`\Drupal\ys_beacon\Access\BeaconAdminAccessCheck`). Until the index name is
+   set, the Beacon search index stays disabled at runtime and no Azure traffic
+   occurs.
 3. A site administrator enables the chat widget at
    `/admin/config/yalesites/ys-beacon` (also reachable from
    `/admin/integrations`).

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Access/BeaconAdminAccessCheck.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Access/BeaconAdminAccessCheck.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\ys_beacon\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Restricts the Beacon administration form to user 1 only.
+ *
+ * The administration form holds the most sensitive Beacon operator settings,
+ * so access is limited to the platform superadmin (user 1). No other role,
+ * however privileged, may reach it. User 1 bypasses permission checks but not
+ * custom access checks, so this returns an explicit AccessResult::forbidden()
+ * for everyone else (a neutral result would let another allowed check open the
+ * route) and an explicit AccessResult::allowed() for user 1 (a forbidden result
+ * would lock out user 1 too).
+ */
+class BeaconAdminAccessCheck implements AccessInterface {
+
+  /**
+   * Checks access to the Beacon administration form.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The currently logged in account.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(AccountInterface $account) {
+    if ((int) $account->id() === 1) {
+      return AccessResult::allowed()->cachePerUser();
+    }
+    return AccessResult::forbidden('The Beacon administration form is restricted to user 1.')
+      ->cachePerUser();
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconAdminSettings.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconAdminSettings.php
@@ -11,10 +11,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Platform-facing administration form for Beacon.
  *
- * Holds the sensitive, platform-operator settings restricted by the "administer
- * ys beacon" permission: the Azure AI Search index connection and the retrieval
- * and response tuning (sources per answer, relevance threshold, streaming, and
- * the fallback system prompt).
+ * Holds the sensitive, platform-operator settings restricted to user 1 only
+ * (see \Drupal\ys_beacon\Access\BeaconAdminAccessCheck): the Azure AI Search
+ * index connection and the retrieval and response tuning (sources per answer,
+ * relevance threshold, streaming, and the fallback system prompt).
  */
 class YsBeaconAdminSettings extends ConfigFormBase {
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconAdminAccessCheckTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconAdminAccessCheckTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Core\Cache\Context\CacheContextsManager;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\Access\BeaconAdminAccessCheck;
+
+/**
+ * Tests the Beacon administration form access check.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Access\BeaconAdminAccessCheck
+ */
+class BeaconAdminAccessCheckTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    // The access result adds the 'user' cache context via cachePerUser(), which
+    // validates the token against the cache_contexts_manager service.
+    $container = new ContainerBuilder();
+    $container->set('cache_contexts_manager', $this->createMock(CacheContextsManager::class));
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Builds an account stub with the given uid that grants every permission.
+   */
+  private function account(int $uid): AccountInterface {
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('id')->willReturn($uid);
+    $account->method('hasPermission')->willReturn(TRUE);
+    return $account;
+  }
+
+  /**
+   * User 1 is allowed, so the route resolves to 200 for the superadmin.
+   *
+   * @covers ::access
+   */
+  public function testAllowedForUserOne(): void {
+    $result = (new BeaconAdminAccessCheck())->access($this->account(1));
+    $this->assertTrue($result->isAllowed());
+  }
+
+  /**
+   * A non-user-1 account is forbidden even when it holds every permission.
+   *
+   * A privileged admin therefore receives 403 on the route: the forbid is
+   * explicit (not neutral) so it cannot be overridden by another access check.
+   *
+   * @covers ::access
+   */
+  public function testForbiddenForPrivilegedNonUserOne(): void {
+    $result = (new BeaconAdminAccessCheck())->access($this->account(2));
+    $this->assertTrue($result->isForbidden());
+  }
+
+  /**
+   * The anonymous user (uid 0) is forbidden.
+   *
+   * @covers ::access
+   */
+  public function testForbiddenForAnonymous(): void {
+    $result = (new BeaconAdminAccessCheck())->access($this->account(0));
+    $this->assertTrue($result->isForbidden());
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.permissions.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.permissions.yml
@@ -1,7 +1,3 @@
-administer ys beacon:
-  title: 'Administer YaleSites Beacon'
-  description: 'Enable services and change sensitive Beacon settings.'
-  restrict access: true
 manage ys beacon settings:
   title: 'Manage YaleSites Beacon settings'
   description: 'Set and update Beacon content and display settings.'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.routing.yml
@@ -29,7 +29,7 @@ ys_beacon.admin_settings:
     _form: '\Drupal\ys_beacon\Form\YsBeaconAdminSettings'
     _title: 'YaleSites Beacon administration'
   requirements:
-    _permission: 'administer ys beacon'
+    _ys_beacon_admin_access: 'TRUE'
 
 ys_beacon.instructions:
   path: '/admin/config/yalesites/ys-beacon/instructions'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.services.yml
@@ -109,6 +109,11 @@ services:
     tags:
       - { name: access_check, applies_to: _ys_beacon_authorized }
 
+  ys_beacon.admin_access_check:
+    class: Drupal\ys_beacon\Access\BeaconAdminAccessCheck
+    tags:
+      - { name: access_check, applies_to: _ys_beacon_admin_access }
+
   ys_beacon.config_overrides:
     class: Drupal\ys_beacon\Config\YsBeaconConfigOverrides
     arguments:


### PR DESCRIPTION
## [1411: Beacon: restrict the Beacon administration form to user 1 only](https://github.com/yalesites-org/YaleSites-Internal/issues/1411)

### Description of work
- New access check `BeaconAdminAccessCheck` (tagged `access_check`, requirement `_ys_beacon_admin_access`) on the `ys_beacon.admin_settings` route (`/admin/config/yalesites/ys-beacon/admin`): returns `AccessResult::allowed()` for uid 1 and an explicit `AccessResult::forbidden()` for everyone else. The forbid is explicit so no other access check can open the route; uid 1 is explicitly allowed because Drupal's superuser bypass does not cover custom access checks.
- The `ys_beacon.admin_settings` menu link derives access from the route, so it is hidden automatically for non-uid-1 users.
- Retired the `administer ys beacon` permission — this route was its only consumer. Removed from `ys_beacon.permissions.yml` and from the `platform_admin` role config (`config/sync/user.role.platform_admin.yml`).
- Updated the admin form docblock and operator README with the user-1-only restriction.
- Note: ticket #1407 relocates the guardrail supplement and "Re-index all" control onto this form, so after both tickets those become user-1-only; operators retain reindex/index via Platform Admin Settings (#1408). This PR changes only this route's access control.

### Functional testing steps:
- [ ] As user 1, visit `/admin/config/yalesites/ys-beacon/admin` and confirm the form loads (HTTP 200).
- [ ] As a non-uid-1 admin (e.g. a platform_admin holding all Beacon permissions), visit the same URL and confirm access is denied (HTTP 403).
- [ ] Confirm the Beacon administration menu link / local task is not visible to the non-uid-1 admin.
- [ ] Confirm no other Beacon functionality regressed by removing the `administer ys beacon` permission.

Automated: `BeaconAdminAccessCheckTest` (uid 1 allowed; non-uid-1 forbidden even holding every permission; anonymous forbidden); ys_beacon Unit suite 140 → 143, no regressions; `phpcs` Drupal + DrupalPractice clean; live HTTP confirmed uid 1 → 200, platform_admin → 403.

References yalesites-org/YaleSites-Internal#1411

---
Created with AI
