### PR TITLE
1410: Beacon AI Tester: link run-comparison citations and open them in a new window

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/Controller/AiTesterController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/Controller/AiTesterController.php
@@ -143,21 +143,9 @@ class AiTesterController extends ControllerBase {
         : $this->t('retrieved, not cited');
 
       // The title links to its source when a URL is present; the cited flag
-      // lets a tester evaluate citation quality at a glance. Only http(s)
-      // schemes become links: citation URLs come from server-side entity/file
-      // URLs today, but allowlisting the scheme keeps a javascript: URI from
-      // ever rendering as a live link if that ever changes.
-      $scheme = $url !== NULL ? strtolower((string) parse_url($url, PHP_URL_SCHEME)) : '';
-      $link = in_array($scheme, ['http', 'https'], TRUE)
-        ? [
-          '#type' => 'link',
-          '#title' => $title,
-          '#url' => Url::fromUri($url),
-        ]
-        : ['#markup' => htmlspecialchars($title, ENT_QUOTES)];
-
+      // lets a tester evaluate citation quality at a glance.
       $items[] = [
-        'link' => $link,
+        'link' => $this->citationLink($title, $url),
         'flag' => ['#markup' => ' — <em>' . $flag . '</em>'],
         'url' => ($url !== NULL && $url !== '')
           ? ['#markup' => '<br><small>' . htmlspecialchars($url, ENT_QUOTES) . '</small>']
@@ -168,6 +156,46 @@ class AiTesterController extends ControllerBase {
     return [
       '#theme' => 'item_list',
       '#items' => $items,
+    ];
+  }
+
+  /**
+   * Builds a citation link that opens its source in a new window.
+   *
+   * Only http(s) URLs become links; any other scheme (or an empty/absent URL)
+   * degrades to escaped plain text. Citation URLs come from server-side
+   * entity/file URLs today, but allowlisting the scheme keeps a javascript:
+   * URI from ever rendering as a live link if that changes. New-window links
+   * carry rel="noopener noreferrer" and a visually-hidden "(opens in new
+   * window)" cue so assistive-tech users are warned of the context switch
+   * (WCAG 2.1 AA, technique G201).
+   *
+   * @param string $title
+   *   The link text.
+   * @param string|null $url
+   *   The citation URL, or NULL when the source has none.
+   *
+   * @return array
+   *   A #type link render element, or a #markup text fallback when the URL is
+   *   empty or not an http(s) link.
+   */
+  protected function citationLink(string $title, ?string $url): array {
+    $scheme = $url !== NULL ? strtolower((string) parse_url($url, PHP_URL_SCHEME)) : '';
+    if (!in_array($scheme, ['http', 'https'], TRUE)) {
+      return ['#markup' => htmlspecialchars($title, ENT_QUOTES)];
+    }
+
+    return [
+      '#type' => 'link',
+      '#title' => Markup::create(
+        htmlspecialchars($title, ENT_QUOTES)
+        . '<span class="visually-hidden"> ' . $this->t('(opens in new window)') . '</span>'
+      ),
+      '#url' => Url::fromUri($url),
+      '#attributes' => [
+        'target' => '_blank',
+        'rel' => 'noopener noreferrer',
+      ],
     ];
   }
 
@@ -404,14 +432,21 @@ class AiTesterController extends ControllerBase {
 
     $unique = $pair['citation_overlap'][$key === 'a' ? 'only_a' : 'only_b'];
     if ($unique) {
-      $titles = array_map(
-        static fn (array $source): string => trim($source['title']) !== '' ? $source['title'] : $source['url'],
-        $unique
-      );
-      $cell['unique'] = $this->wrap('ys-compare-unique', $this->t(
-        'Sources only here: @list',
-        ['@list' => implode(', ', $titles)]
-      ));
+      // Each unique source renders as a new-window link (falling back to text
+      // when non-linkable) so a reviewer can open a source without losing the
+      // comparison; a comma joins them into the "Sources only here:" line.
+      $cell['unique'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['ys-compare-unique']],
+        'label' => ['#markup' => $this->t('Sources only here:') . ' '],
+      ];
+      foreach (array_values($unique) as $i => $source) {
+        if ($i > 0) {
+          $cell['unique']['sep_' . $i] = ['#markup' => ', '];
+        }
+        $title = trim($source['title']) !== '' ? $source['title'] : $source['url'];
+        $cell['unique']['link_' . $i] = $this->citationLink($title, $source['url']);
+      }
     }
 
     return $cell;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterCompareRenderTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterCompareRenderTest.php
@@ -134,4 +134,92 @@ class AiTesterCompareRenderTest extends UnitTestCase {
     $this->assertCount(4, $build['results']['#rows'][0]);
   }
 
+  /**
+   * The compare view renders unique sources as new-window citation links.
+   *
+   * @covers ::sideCell
+   * @covers ::citationLink
+   */
+  public function testCompareUniqueSourcesAreNewWindowLinks(): void {
+    $data = [
+      'run_a' => ['id' => 2, 'created' => 1000, 'yaml_filename' => 'a.yml', 'status' => 'complete'],
+      'run_b' => ['id' => 3, 'created' => 2000, 'yaml_filename' => 'b.yml', 'status' => 'complete'],
+      'pairs' => [
+        [
+          'question' => 'What is Yale?',
+          'status' => 'differs',
+          'a' => $this->side('Yale is a university.', 1, 2, FALSE),
+          'b' => $this->side('Yale is a private university.', 2, 2, FALSE),
+          'len_delta' => 7,
+          'citation_overlap' => [
+            'both' => [],
+            'only_a' => [
+              ['url' => 'https://a.example', 'title' => 'About A'],
+              ['url' => 'javascript:alert(1)', 'title' => 'Sneaky'],
+            ],
+            'only_b' => [['url' => 'https://news.yale.edu', 'title' => 'News']],
+          ],
+        ],
+      ],
+      'summary' => [
+        'total_compared' => 1,
+        'differ' => 1,
+        'identical' => 0,
+        'only_a' => 0,
+        'only_b' => 0,
+      ],
+    ];
+
+    $build = $this->controllerReturning($data)->compare(2, 3);
+    // Row 0, column index 2 is Run A's side cell; its 'unique' element lists
+    // the sources only Run A retrieved.
+    $unique = $build['results']['#rows'][0][2]['data']['unique'];
+
+    // The http(s) source becomes a link that opens in a new window, hardened
+    // with rel and carrying the visually-hidden a11y cue.
+    $link = $unique['link_0'];
+    $this->assertSame('link', $link['#type']);
+    $this->assertSame('_blank', $link['#attributes']['target']);
+    $this->assertSame('noopener noreferrer', $link['#attributes']['rel']);
+    $this->assertSame('https://a.example', $link['#url']->getUri());
+    $title = (string) $link['#title'];
+    $this->assertStringContainsString('About A', $title);
+    $this->assertStringContainsString('visually-hidden', $title);
+    $this->assertStringContainsString('opens in new window', $title);
+
+    // A non-http(s) URL never renders as a live link — it degrades to text.
+    $sneaky = $unique['link_1'];
+    $this->assertArrayNotHasKey('#type', $sneaky);
+    $this->assertArrayHasKey('#markup', $sneaky);
+    $this->assertStringNotContainsString('<a', (string) $sneaky['#markup']);
+  }
+
+  /**
+   * The single-run detail view links citations the same new-window way.
+   *
+   * @covers ::buildCitationsCell
+   * @covers ::citationLink
+   */
+  public function testDetailCitationsAreNewWindowLinks(): void {
+    $controller = $this->controllerReturning([]);
+    $method = new \ReflectionMethod($controller, 'buildCitationsCell');
+    $method->setAccessible(TRUE);
+
+    $cell = $method->invoke($controller, [
+      ['title' => 'Yale', 'url' => 'https://yale.edu', 'cited' => TRUE],
+      ['title' => 'No link', 'url' => 'mailto:x@example.com', 'cited' => FALSE],
+    ]);
+
+    $link = $cell['#items'][0]['link'];
+    $this->assertSame('link', $link['#type']);
+    $this->assertSame('_blank', $link['#attributes']['target']);
+    $this->assertSame('noopener noreferrer', $link['#attributes']['rel']);
+    $this->assertStringContainsString('opens in new window', (string) $link['#title']);
+
+    // Non-http(s) citation stays plain text.
+    $fallback = $cell['#items'][1]['link'];
+    $this->assertArrayNotHasKey('#type', $fallback);
+    $this->assertArrayHasKey('#markup', $fallback);
+  }
+
 }


### PR DESCRIPTION
## [1410: Beacon AI Tester: link run-comparison citations and open them in a new window](https://github.com/yalesites-org/YaleSites-Internal/issues/1410)

### Description of work
- Added a shared `citationLink(string $title, ?string $url): array` helper in `ys_ai_tester/src/Controller/AiTesterController.php` — the single source of truth for both views. It renders an http(s)-only `#type => link` with `target="_blank"` + `rel="noopener noreferrer"` and a visually-hidden "(opens in new window)" cue for assistive tech (WCAG 2.1 AA, technique G201; uses Gin's `.visually-hidden`, no custom CSS).
- `sideCell()` (compare view) now renders each run's unique sources as links via the helper instead of comma-joined plain text — preserving the "Sources only here: a, b" format and the `ys-compare-unique` wrapper.
- `buildCitationsCell()` (single-run detail view) now uses the same helper, so its existing links gain the new-window + `rel` + a11y treatment; both views behave identically.
- Safety preserved: non-http(s) schemes (e.g. `javascript:`, `mailto:`) and empty/absent URLs degrade gracefully to escaped plain text; titles are single-escaped and never inject markup.

### Functional testing steps:
- [ ] Open a run-comparison at `/admin/config/yalesites/ys-beacon/tester/compare/{run_a}/{run_b}` and confirm the "Sources only here" citations are now clickable links.
- [ ] Click a citation and confirm it opens in a new browser tab/window.
- [ ] Open a single-run detail view and confirm its citation links also open in a new window.
- [ ] With a screen reader (or by inspecting the markup), confirm each new-window link announces "(opens in new window)".
- [ ] Confirm a non-http(s) or empty source still renders as plain text (no link).

Automated: `AiTesterCompareRenderTest` extended (link type, target/rel attributes, a11y cue, https URL, and javascript:/mailto: degradation for both views); full `ys_ai_tester` unit suite 29 → 31 tests (98 assertions), 0 failures; `composer code-sniff` (Drupal + DrupalPractice) clean.

References yalesites-org/YaleSites-Internal#1410

---
Created with AI
