### PR TITLE
1408: Beacon: add Re-index, Index, and Enable chat widget controls to Platform Admin Settings

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
@@ -70,6 +70,18 @@ The module is installed on every site and is off by default.
    `/admin/config/yalesites/ys-beacon` (also reachable from
    `/admin/integrations`).
 
+Platform operators can also drive Beacon for a site from the **Beacon (AI Chat)**
+section of the Platform Admin Settings page (`/admin/yalesites/platform-admin-settings`,
+contributed by the `BeaconPlatformAdminSetting` plugin) without opening the
+per-site forms. Besides the "Allow site admins to configure and use Beacon"
+authorization flag, that section exposes an **Enable chat widget** toggle and
+**Re-index all content** / **Index now** buttons. These reuse the site settings
+form's handlers verbatim (via the class resolver) and the same
+`ys_beacon.settings:enable_chat` flag, so toggling or indexing from either place
+stays consistent. The indexing buttons follow the same guards as the site form:
+they are hidden with an explanatory note when the site borrows a read-only index,
+and "Index now" is disabled when nothing is queued.
+
 Secret values are never stored in Drupal config: the four key entities are
 Pantheon pointers (created by `config:import` as `key.key.*` config) whose
 values resolve live at read time. Per-site `ys_beacon*` config stays in
@@ -167,8 +179,9 @@ a new index must be provisioned, and all content re-indexed.
   `Index::startBatchTracking()`/`stopBatchTracking()` to defer indexing to
   cron. (Immediate indexing is gated on the index being enabled, so nothing
   runs while chat is off; see "Per-site configuration" above.)
-- Re-index everything: the button on the Beacon administration form, or
-  `drush sapi-r ys_beacon && drush sapi-i ys_beacon`.
+- Re-index everything: the button on the Beacon administration form, the same
+  "Re-index all content" / "Index now" buttons in the Platform Admin Settings
+  Beacon (AI Chat) section, or `drush sapi-r ys_beacon && drush sapi-i ys_beacon`.
 
 > The `drush` commands below use `ys_beacon`, the default Search API index id.
 > If a site overrides `ys_beacon.settings:search_index_id`, substitute that id.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/PlatformAdminSetting/BeaconPlatformAdminSetting.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/PlatformAdminSetting/BeaconPlatformAdminSetting.php
@@ -2,18 +2,39 @@
 
 namespace Drupal\ys_beacon\Plugin\PlatformAdminSetting;
 
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\search_api\IndexInterface;
 use Drupal\ys_beacon\BeaconAuthorization;
+use Drupal\ys_beacon\Form\YsBeaconSettings;
+use Drupal\ys_beacon\Service\BeaconIndexManager;
 use Drupal\ys_core\Attribute\PlatformAdminSetting;
 use Drupal\ys_core\PlatformAdminSettingBase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Platform admin toggle authorizing Beacon for the site.
+ * Platform admin Beacon (AI Chat) section.
  *
- * Contributes the per-site Beacon authorization flag to the Platform Admin
- * Settings page. Only platform admins reach that page, so this is where Beacon
- * is switched on for a site; site admins then configure it as usual.
+ * Contributes the per-site Beacon controls to the Platform Admin Settings page.
+ * Only platform admins reach that page, so this is where Beacon is switched on
+ * for a site (the authorization flag), where the chat widget is toggled, and
+ * where indexing can be driven without navigating into the per-site Beacon
+ * forms.
+ *
+ * The indexing actions reuse the site settings form verbatim: the "Re-index all
+ * content" and "Index now" buttons delegate to
+ * YsBeaconSettings::reindexAll() / ::indexNow() through the class resolver, so
+ * the tracker-rebuild and search_api.indexing_batch_helper batch paths (and
+ * their read-only / disabled / empty-queue guards) are shared, not duplicated.
+ * The chat toggle reads and writes the same ys_beacon.settings:enable_chat flag
+ * as the site control and mirrors its on/off index side effects via
+ * BeaconIndexManager, so toggling from either place stays consistent.
  */
 #[PlatformAdminSetting(
   id: 'ys_beacon',
@@ -23,19 +44,141 @@ use Drupal\ys_core\PlatformAdminSettingBase;
 class BeaconPlatformAdminSetting extends PlatformAdminSettingBase {
 
   /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The Beacon index manager.
+   *
+   * @var \Drupal\ys_beacon\Service\BeaconIndexManager
+   */
+  protected BeaconIndexManager $indexManager;
+
+  /**
+   * The Beacon logger channel.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected LoggerInterface $logger;
+
+  /**
+   * Constructs a BeaconPlatformAdminSetting object.
+   *
+   * @param array $configuration
+   *   The plugin configuration.
+   * @param string $plugin_id
+   *   The plugin id.
+   * @param mixed $plugin_definition
+   *   The plugin definition.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\ys_beacon\Service\BeaconIndexManager $index_manager
+   *   The Beacon index manager.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The Beacon logger channel.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    ConfigFactoryInterface $config_factory,
+    AccountInterface $current_user,
+    EntityTypeManagerInterface $entity_type_manager,
+    BeaconIndexManager $index_manager,
+    MessengerInterface $messenger,
+    LoggerInterface $logger,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $config_factory, $current_user);
+    $this->entityTypeManager = $entity_type_manager;
+    $this->indexManager = $index_manager;
+    $this->messenger = $messenger;
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory'),
+      $container->get('current_user'),
+      $container->get('entity_type.manager'),
+      $container->get('ys_beacon.index_manager'),
+      $container->get('messenger'),
+      $container->get('logger.channel.ys_beacon'),
+    );
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function buildSettings(array $form, FormStateInterface $form_state): array {
-    $authorized = (bool) $this->configFactory
-      ->get(BeaconAuthorization::CONFIG_NAME)
-      ->get(BeaconAuthorization::FLAG);
+    // Read the site's own saved values override-free so the toggles reflect
+    // the stored state: the config override forces enable_chat off at runtime
+    // for an unauthorized site, which would otherwise misreport the value.
+    $settings = $this->configFactory->getEditable(BeaconAuthorization::CONFIG_NAME);
 
     $form['platform_authorized'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Allow site admins to configure and use Beacon'),
       '#description' => $this->t('When enabled, site administrators can turn on and configure the Beacon AI chat for this site. When disabled, all Beacon features are hidden and inactive for this site.'),
-      '#default_value' => $authorized,
+      '#default_value' => (bool) $settings->get(BeaconAuthorization::FLAG),
     ];
+
+    $form['enable_chat'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable chat widget'),
+      '#description' => $this->t('Turn the Beacon chat widget on or off for this site. This is the same setting as the site-level Enable chat widget control and stays in sync with it.'),
+      '#default_value' => (bool) $settings->get('enable_chat'),
+    ];
+
+    $form['indexing'] = [
+      '#type' => 'container',
+    ];
+    $index = $this->loadBeaconIndex();
+    if ($index && $index->isReadOnly()) {
+      // A borrowing site's content indexing is owned by the site it borrows
+      // from, so the local indexing controls are hidden and replaced with a
+      // short explanatory note, matching the site settings form.
+      $form['indexing']['read_only_notice'] = [
+        '#markup' => '<p>' . $this->t('This site uses a shared, read-only index; content indexing is managed by the owning site.') . '</p>',
+      ];
+    }
+    else {
+      $form['indexing']['reindex'] = [
+        '#type' => 'submit',
+        '#name' => 'ys_beacon_reindex_all',
+        '#value' => $this->t('Re-index all content'),
+        // Reuse the site form's handler; a dedicated #submit isolates the
+        // action so the shared host-form config save does not run (see the
+        // static handler docblock), and empty validation lets it run without
+        // touching the other platform-admin sections on the page.
+        '#submit' => [[static::class, 'reindexAllSubmit']],
+        '#limit_validation_errors' => [],
+      ];
+      $form['indexing']['index_now'] = [
+        '#type' => 'submit',
+        '#name' => 'ys_beacon_index_now',
+        '#value' => $this->t('Index now'),
+        '#submit' => [[static::class, 'indexNowSubmit']],
+        '#limit_validation_errors' => [],
+        // Disabled unless the index is enabled and has items waiting, mirroring
+        // Search API's own "Index now" and the site settings form.
+        '#disabled' => $this->indexRemainingItems($index) < 1,
+      ];
+    }
 
     return $form;
   }
@@ -43,12 +186,211 @@ class BeaconPlatformAdminSetting extends PlatformAdminSettingBase {
   /**
    * {@inheritdoc}
    */
+  public function validateSettings(array &$form, FormStateInterface $form_state): void {
+    // Never allow two chat widgets at once: mirror the site settings form and
+    // block enabling Beacon chat while the legacy ai_engine chat is still on.
+    if ($form_state->getValue([$this->getPluginId(), 'enable_chat']) && ys_beacon_legacy_chat_active()) {
+      $form_state->setErrorByName($this->getPluginId() . '][enable_chat', $this->t('The legacy AI Engine chat widget is currently enabled. Disable it before enabling Beacon chat so visitors only see one chat widget.'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function submitSettings(array &$form, FormStateInterface $form_state): void {
-    $value = (bool) $form_state->getValue([$this->getPluginId(), 'platform_authorized']);
-    $this->configFactory
-      ->getEditable(BeaconAuthorization::CONFIG_NAME)
-      ->set(BeaconAuthorization::FLAG, $value)
+    $authorized = (bool) $form_state->getValue([$this->getPluginId(), 'platform_authorized']);
+    $enable_chat = (bool) $form_state->getValue([$this->getPluginId(), 'enable_chat']);
+
+    $settings = $this->configFactory->getEditable(BeaconAuthorization::CONFIG_NAME);
+    // Capture the stored toggle before the config is mutated so the index
+    // status only changes on an actual on/off transition.
+    $previous_enable = (bool) $settings->get('enable_chat');
+    $settings
+      ->set(BeaconAuthorization::FLAG, $authorized)
+      ->set('enable_chat', $enable_chat)
       ->save();
+
+    // Keep the Search API index in sync with the chat toggle so enabling or
+    // disabling from this page behaves like the site settings form.
+    if ($enable_chat && !$previous_enable) {
+      $this->enableIndex($settings);
+    }
+    elseif (!$enable_chat && $previous_enable) {
+      $this->setIndexStatus(FALSE);
+    }
+  }
+
+  /**
+   * Reuses the site form's re-index handler.
+   *
+   * Static because a plugin-contributed button cannot own an instance
+   * `#submit` handler (Form API resolves `::method` against the host form
+   * object, which is Beacon-agnostic). The class resolver builds a fully wired
+   * YsBeaconSettings instance whose reindexAll() operates on config and
+   * services - not the passed form/state - so the tracker-rebuild path and its
+   * read-only / disabled guards are shared verbatim rather than reimplemented
+   * here.
+   *
+   * @param array $form
+   *   The complete form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current form state.
+   */
+  public static function reindexAllSubmit(array &$form, FormStateInterface $form_state): void {
+    // phpcs:ignore DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
+    \Drupal::classResolver(YsBeaconSettings::class)->reindexAll($form, $form_state);
+  }
+
+  /**
+   * Reuses the site form's "Index now" handler.
+   *
+   * See reindexAllSubmit() for why this is static and delegates through the
+   * class resolver. The delegated handler runs the
+   * search_api.indexing_batch_helper batch; Drupal's Form API processes the
+   * queued batch and returns the user to this page.
+   *
+   * @param array $form
+   *   The complete form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current form state.
+   */
+  public static function indexNowSubmit(array &$form, FormStateInterface $form_state): void {
+    // phpcs:ignore DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
+    \Drupal::classResolver(YsBeaconSettings::class)->indexNow($form, $form_state);
+  }
+
+  /**
+   * Enables the Beacon index in sync with the chat toggle turning on.
+   *
+   * Mirrors YsBeaconSettings::submitForm()'s enable path so this page behaves
+   * exactly like the site form: provision only when the configured index is
+   * actually missing, then enable indexing and queue existing content once an
+   * index name exists. Provisioning is gated on configuredIndexMissing() -
+   * which treats an unreachable endpoint as "not missing" - so a transient
+   * Azure outage on re-enable keeps an existing index enabled for cron to
+   * catch up rather than disabling it. A read-only borrower never provisions
+   * or writes the collection it reads; it just enables the local index to
+   * query it.
+   *
+   * @param \Drupal\Core\Config\Config $settings
+   *   The editable ys_beacon.settings config.
+   */
+  protected function enableIndex(Config $settings): void {
+    if ($settings->get('read_only')) {
+      $this->setIndexStatus(TRUE);
+      return;
+    }
+    $name = (string) $settings->get('azure_index_name');
+    if ($this->configuredIndexMissing($settings)) {
+      try {
+        $name = $this->indexManager->provision($name ?: NULL);
+        $this->messenger->addStatus($this->t('The search index %name is ready and site content has been queued for indexing.', ['%name' => $name]));
+      }
+      catch (\RuntimeException $e) {
+        // Creation failed: no index name is persisted, so the config override
+        // keeps the index off. The chat flag stays set (matching the site
+        // control); warn the operator and stop before enabling a backing-less
+        // index.
+        $this->logger->error('Automatic index provisioning failed: @message', ['@message' => $e->getMessage()]);
+        $this->messenger->addWarning($this->t('The chat widget is enabled, but the search index could not be created automatically. The assistant will not find site content until the index is configured in the Beacon administration settings.'));
+        return;
+      }
+    }
+    // Enable indexing and queue existing content once an index name exists (a
+    // failed first-time provision leaves none). rebuildTracker() re-enumerates
+    // the datasources so a never-seeded tracker is populated, not just
+    // re-flagged (issue #1383), matching the site settings form.
+    if ($name !== '') {
+      $this->setIndexStatus(TRUE);
+      $this->loadBeaconIndex()?->rebuildTracker();
+    }
+  }
+
+  /**
+   * Whether the configured Azure index still needs to be created.
+   *
+   * Mirrors YsBeaconSettings::configuredIndexMissing(): TRUE when the site has
+   * no index name assigned yet or the assigned index no longer exists in Azure
+   * (deleted, or a newly chosen name). An unreachable endpoint returns FALSE so
+   * a transient outage neither triggers a doomed provision nor disables an
+   * existing index. The caller guarantees a writable (non-read-only) site.
+   *
+   * @param \Drupal\Core\Config\Config $settings
+   *   The ys_beacon.settings config.
+   *
+   * @return bool
+   *   TRUE when provisioning should run.
+   */
+  protected function configuredIndexMissing(Config $settings): bool {
+    $name = (string) $settings->get('azure_index_name');
+    if ($name === '') {
+      return TRUE;
+    }
+    try {
+      return !$this->indexManager->indexExists($name);
+    }
+    catch (\RuntimeException $e) {
+      return FALSE;
+    }
+  }
+
+  /**
+   * Persists the Beacon index enabled/disabled status override-free.
+   *
+   * Loads the index override-free so the runtime status/read-only overrides
+   * layered on by YsBeaconConfigOverrides are never baked into the synced
+   * search_api.index config, matching YsBeaconSettings::saveIndexStatus().
+   *
+   * @param bool $status
+   *   The index status to persist.
+   */
+  protected function setIndexStatus(bool $status): void {
+    $index = $this->entityTypeManager->getStorage('search_api_index')->loadOverrideFree($this->searchIndexId());
+    if ($index instanceof IndexInterface) {
+      $index->setStatus($status)->save();
+    }
+  }
+
+  /**
+   * Loads the Search API index backing the Beacon chatbot.
+   *
+   * @return \Drupal\search_api\IndexInterface|null
+   *   The index entity, or NULL when it does not exist.
+   */
+  protected function loadBeaconIndex(): ?IndexInterface {
+    return $this->entityTypeManager->getStorage('search_api_index')->load($this->searchIndexId());
+  }
+
+  /**
+   * Counts tracked items not yet indexed into the Beacon vector database.
+   *
+   * @param \Drupal\search_api\IndexInterface|null $index
+   *   The Beacon index, or NULL when it does not exist.
+   *
+   * @return int
+   *   The remaining item count, or 0 when the index is missing, disabled, or
+   *   unavailable.
+   */
+  protected function indexRemainingItems(?IndexInterface $index): int {
+    if (!$index || !$index->status()) {
+      return 0;
+    }
+    try {
+      return (int) $index->getTrackerInstance()->getRemainingItemsCount();
+    }
+    catch (\Throwable $e) {
+      return 0;
+    }
+  }
+
+  /**
+   * The Search API index machine name backing the chatbot.
+   *
+   * @return string
+   *   The index machine name.
+   */
+  protected function searchIndexId(): string {
+    return $this->configFactory->get(BeaconAuthorization::CONFIG_NAME)->get('search_index_id') ?: 'ys_beacon';
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconPlatformAdminSettingTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconPlatformAdminSettingTest.php
@@ -4,17 +4,37 @@ namespace Drupal\Tests\ys_beacon\Unit;
 
 use Drupal\Core\Config\Config;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\Entity\ConfigEntityStorageInterface;
+use Drupal\Core\DependencyInjection\ClassResolverInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormState;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\search_api\IndexInterface;
+use Drupal\search_api\Tracker\TrackerInterface;
 use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\Form\YsBeaconSettings;
 use Drupal\ys_beacon\Plugin\PlatformAdminSetting\BeaconPlatformAdminSetting;
+use Drupal\ys_beacon\Service\BeaconIndexManager;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Tests the Beacon platform admin setting plugin.
  *
- * The toggle that authorizes Beacon for the site, contributed to the Platform
- * Admin Settings page: its checkbox reflects the stored flag and its submit
- * saves the flag back to ys_beacon.settings.
+ * The Beacon (AI Chat) section on the Platform Admin Settings page: the
+ * authorization flag, the Enable chat widget toggle, and the Re-index / Index
+ * now buttons. The buttons reuse the site settings form's handlers verbatim
+ * through the class resolver, so this test asserts the delegation and the
+ * render state (read-only guard, empty-queue disable) rather than re-testing
+ * the shared tracker-rebuild / batch paths (covered by IndexNowFormTest).
+ *
+ * The validateSettings() legacy-chat guard's positive branch calls the
+ * procedural ys_beacon_legacy_chat_active() and is verified manually on Lando;
+ * the negative branch (nothing to validate when the toggle is off) is covered
+ * here.
  *
  * @group ys_beacon
  * @coversDefaultClass \Drupal\ys_beacon\Plugin\PlatformAdminSetting\BeaconPlatformAdminSetting
@@ -22,68 +42,576 @@ use Drupal\ys_beacon\Plugin\PlatformAdminSetting\BeaconPlatformAdminSetting;
 class BeaconPlatformAdminSettingTest extends UnitTestCase {
 
   /**
-   * Builds the plugin against a read-only config factory stub.
+   * Builds the plugin with the given collaborators.
    */
-  private function pluginForRead(array $settings): BeaconPlatformAdminSetting {
+  private function plugin(
+    ConfigFactoryInterface $config_factory,
+    ?EntityTypeManagerInterface $entity_type_manager = NULL,
+    ?BeaconIndexManager $index_manager = NULL,
+    ?MessengerInterface $messenger = NULL,
+    ?LoggerInterface $logger = NULL,
+  ): BeaconPlatformAdminSetting {
     $plugin = new BeaconPlatformAdminSetting(
       [],
       'ys_beacon',
       [],
-      $this->getConfigFactoryStub(['ys_beacon.settings' => $settings]),
+      $config_factory,
       $this->createMock(AccountInterface::class),
+      $entity_type_manager ?? $this->createMock(EntityTypeManagerInterface::class),
+      $index_manager ?? $this->createMock(BeaconIndexManager::class),
+      $messenger ?? $this->createMock(MessengerInterface::class),
+      $logger ?? $this->createMock(LoggerInterface::class),
     );
     $plugin->setStringTranslation($this->getStringTranslationStub());
     return $plugin;
   }
 
   /**
-   * The checkbox default value reflects the stored authorization flag.
-   *
-   * @covers ::buildSettings
+   * An entity type manager whose search_api_index storage loads $index.
    */
-  public function testCheckboxDefaultReflectsFlag(): void {
-    $form_state = new FormState();
-
-    $on = $this->pluginForRead(['platform_authorized' => TRUE])
-      ->buildSettings([], $form_state);
-    $this->assertTrue((bool) $on['platform_authorized']['#default_value']);
-    $this->assertSame('checkbox', $on['platform_authorized']['#type']);
-
-    $off = $this->pluginForRead([])->buildSettings([], $form_state);
-    $this->assertFalse((bool) $off['platform_authorized']['#default_value']);
+  private function entityTypeManagerWithIndex(?IndexInterface $index): EntityTypeManagerInterface {
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $storage->method('load')->with('ys_beacon')->willReturn($index);
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->with('search_api_index')->willReturn($storage);
+    return $entity_type_manager;
   }
 
   /**
-   * Submitting saves the checkbox value to ys_beacon.settings.
+   * An entity type manager returning $index for both load paths.
+   *
+   * Stubs both the override-free load (setIndexStatus) and the regular load
+   * (tracker rebuild) to return $index.
+   */
+  private function entityTypeManagerWithWritableIndex(IndexInterface $index): EntityTypeManagerInterface {
+    $storage = $this->createMock(ConfigEntityStorageInterface::class);
+    $storage->method('load')->with('ys_beacon')->willReturn($index);
+    $storage->method('loadOverrideFree')->with('ys_beacon')->willReturn($index);
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->with('search_api_index')->willReturn($storage);
+    return $entity_type_manager;
+  }
+
+  /**
+   * Builds an index mock with the given read-only, status and remaining count.
+   */
+  private function indexMock(bool $read_only, bool $enabled, int $remaining): IndexInterface {
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('isReadOnly')->willReturn($read_only);
+    $index->method('status')->willReturn($enabled);
+    $tracker = $this->createMock(TrackerInterface::class);
+    $tracker->method('getRemainingItemsCount')->willReturn($remaining);
+    $index->method('getTrackerInstance')->willReturn($tracker);
+    return $index;
+  }
+
+  /**
+   * The toggles reflect the stored authorization and chat-enable flags.
+   *
+   * @covers ::buildSettings
+   */
+  public function testTogglesReflectStoredValues(): void {
+    $factory = $this->getConfigFactoryStub([
+      'ys_beacon.settings' => [
+        'platform_authorized' => TRUE,
+        'enable_chat' => TRUE,
+        'search_index_id' => 'ys_beacon',
+      ],
+    ]);
+    $plugin = $this->plugin($factory, $this->entityTypeManagerWithIndex($this->indexMock(FALSE, TRUE, 3)));
+
+    $form = $plugin->buildSettings([], new FormState());
+
+    $this->assertSame('checkbox', $form['platform_authorized']['#type']);
+    $this->assertTrue((bool) $form['platform_authorized']['#default_value']);
+    $this->assertSame('checkbox', $form['enable_chat']['#type']);
+    $this->assertTrue((bool) $form['enable_chat']['#default_value']);
+  }
+
+  /**
+   * The off state reflects unset flags.
+   *
+   * @covers ::buildSettings
+   */
+  public function testTogglesReflectUnsetValues(): void {
+    $factory = $this->getConfigFactoryStub(['ys_beacon.settings' => ['search_index_id' => 'ys_beacon']]);
+    $plugin = $this->plugin($factory, $this->entityTypeManagerWithIndex($this->indexMock(FALSE, TRUE, 0)));
+
+    $form = $plugin->buildSettings([], new FormState());
+
+    $this->assertFalse((bool) $form['platform_authorized']['#default_value']);
+    $this->assertFalse((bool) $form['enable_chat']['#default_value']);
+  }
+
+  /**
+   * A writable index renders both indexing buttons wired to shared handlers.
+   *
+   * @covers ::buildSettings
+   */
+  public function testIndexingButtonsRenderedWhenWritable(): void {
+    $factory = $this->getConfigFactoryStub(['ys_beacon.settings' => ['search_index_id' => 'ys_beacon']]);
+    $plugin = $this->plugin($factory, $this->entityTypeManagerWithIndex($this->indexMock(FALSE, TRUE, 5)));
+
+    $form = $plugin->buildSettings([], new FormState());
+
+    $this->assertArrayNotHasKey('read_only_notice', $form['indexing']);
+    $this->assertSame('submit', $form['indexing']['reindex']['#type']);
+    $this->assertSame(
+      [[BeaconPlatformAdminSetting::class, 'reindexAllSubmit']],
+      $form['indexing']['reindex']['#submit']
+    );
+    $this->assertSame([], $form['indexing']['reindex']['#limit_validation_errors']);
+    $this->assertSame('submit', $form['indexing']['index_now']['#type']);
+    $this->assertSame(
+      [[BeaconPlatformAdminSetting::class, 'indexNowSubmit']],
+      $form['indexing']['index_now']['#submit']
+    );
+    // Items are queued, so "Index now" is enabled.
+    $this->assertFalse($form['indexing']['index_now']['#disabled']);
+  }
+
+  /**
+   * The "Index now" button is disabled when nothing is queued.
+   *
+   * @covers ::buildSettings
+   * @covers ::indexRemainingItems
+   */
+  public function testIndexNowDisabledWhenQueueEmpty(): void {
+    $factory = $this->getConfigFactoryStub(['ys_beacon.settings' => ['search_index_id' => 'ys_beacon']]);
+    $plugin = $this->plugin($factory, $this->entityTypeManagerWithIndex($this->indexMock(FALSE, TRUE, 0)));
+
+    $form = $plugin->buildSettings([], new FormState());
+
+    $this->assertTrue($form['indexing']['index_now']['#disabled']);
+  }
+
+  /**
+   * A read-only index hides the indexing buttons and shows the borrow note.
+   *
+   * @covers ::buildSettings
+   */
+  public function testIndexingButtonsHiddenWhenReadOnly(): void {
+    $factory = $this->getConfigFactoryStub(['ys_beacon.settings' => ['search_index_id' => 'ys_beacon']]);
+    $plugin = $this->plugin($factory, $this->entityTypeManagerWithIndex($this->indexMock(TRUE, TRUE, 5)));
+
+    $form = $plugin->buildSettings([], new FormState());
+
+    $this->assertArrayHasKey('read_only_notice', $form['indexing']);
+    $this->assertArrayNotHasKey('reindex', $form['indexing']);
+    $this->assertArrayNotHasKey('index_now', $form['indexing']);
+  }
+
+  /**
+   * Submitting saves the authorization flag and the chat toggle together.
    *
    * @covers ::submitSettings
    */
-  public function testSubmitSavesFlag(): void {
+  public function testSubmitSavesFlags(): void {
     $config = $this->createMock(Config::class);
-    $config->expects($this->once())
-      ->method('set')
-      ->with('platform_authorized', TRUE)
-      ->willReturnSelf();
+    // No prior chat-enable value, and the submitted toggle stays off, so no
+    // index transition side effects run.
+    $config->method('get')->willReturnCallback(fn (string $key) => NULL);
+    $set = [];
+    $config->method('set')->willReturnCallback(function (string $key, $value) use (&$set, $config) {
+      $set[$key] = $value;
+      return $config;
+    });
     $config->expects($this->once())->method('save')->willReturnSelf();
 
     $factory = $this->createMock(ConfigFactoryInterface::class);
     $factory->method('getEditable')->with('ys_beacon.settings')->willReturn($config);
 
-    $plugin = new BeaconPlatformAdminSetting(
-      [],
-      'ys_beacon',
-      [],
-      $factory,
-      $this->createMock(AccountInterface::class),
-    );
-    $plugin->setStringTranslation($this->getStringTranslationStub());
+    $index_manager = $this->createMock(BeaconIndexManager::class);
+    $index_manager->expects($this->never())->method('provision');
+
+    $plugin = $this->plugin($factory, NULL, $index_manager);
 
     $form_state = new FormState();
-    // The section is rendered with #tree under the plugin id, so the value is
-    // nested under 'ys_beacon'.
     $form_state->setValue(['ys_beacon', 'platform_authorized'], 1);
+    $form_state->setValue(['ys_beacon', 'enable_chat'], 0);
     $form = [];
     $plugin->submitSettings($form, $form_state);
+
+    $this->assertTrue($set['platform_authorized']);
+    $this->assertFalse($set['enable_chat']);
+  }
+
+  /**
+   * A first enable provisions the missing index and queues content.
+   *
+   * @covers ::submitSettings
+   * @covers ::enableIndex
+   * @covers ::configuredIndexMissing
+   * @covers ::setIndexStatus
+   */
+  public function testEnableTransitionProvisionsIndex(): void {
+    $settings = [
+      'enable_chat' => FALSE,
+      'read_only' => FALSE,
+      'azure_index_name' => 'my-index',
+      'search_index_id' => 'ys_beacon',
+    ];
+    $config = $this->createMock(Config::class);
+    $config->method('get')->willReturnCallback(fn (string $key) => $settings[$key] ?? NULL);
+    $config->method('set')->willReturnSelf();
+    $config->method('save')->willReturnSelf();
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('getEditable')->with('ys_beacon.settings')->willReturn($config);
+    $factory->method('get')->with('ys_beacon.settings')->willReturn($config);
+
+    $index = $this->createMock(IndexInterface::class);
+    $index->expects($this->once())->method('setStatus')->with(TRUE)->willReturnSelf();
+    $index->expects($this->once())->method('save');
+    $index->expects($this->once())->method('rebuildTracker');
+    $entity_type_manager = $this->entityTypeManagerWithWritableIndex($index);
+
+    $index_manager = $this->createMock(BeaconIndexManager::class);
+    // The configured index does not exist yet, so it is provisioned.
+    $index_manager->expects($this->once())->method('indexExists')->with('my-index')->willReturn(FALSE);
+    $index_manager->expects($this->once())->method('provision')->with('my-index')->willReturn('my-index');
+
+    $messenger = $this->createMock(MessengerInterface::class);
+    $messenger->expects($this->once())->method('addStatus');
+    $messenger->expects($this->never())->method('addWarning');
+
+    $plugin = $this->plugin($factory, $entity_type_manager, $index_manager, $messenger);
+
+    $form_state = new FormState();
+    $form_state->setValue(['ys_beacon', 'platform_authorized'], 1);
+    $form_state->setValue(['ys_beacon', 'enable_chat'], 1);
+    $form = [];
+    $plugin->submitSettings($form, $form_state);
+  }
+
+  /**
+   * Re-enabling with an existing index enables it without re-provisioning.
+   *
+   * @covers ::submitSettings
+   * @covers ::enableIndex
+   * @covers ::configuredIndexMissing
+   */
+  public function testEnableWithExistingIndexSkipsProvision(): void {
+    $settings = [
+      'enable_chat' => FALSE,
+      'read_only' => FALSE,
+      'azure_index_name' => 'my-index',
+      'search_index_id' => 'ys_beacon',
+    ];
+    $config = $this->createMock(Config::class);
+    $config->method('get')->willReturnCallback(fn (string $key) => $settings[$key] ?? NULL);
+    $config->method('set')->willReturnSelf();
+    $config->method('save')->willReturnSelf();
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('getEditable')->with('ys_beacon.settings')->willReturn($config);
+    $factory->method('get')->with('ys_beacon.settings')->willReturn($config);
+
+    $index = $this->createMock(IndexInterface::class);
+    $index->expects($this->once())->method('setStatus')->with(TRUE)->willReturnSelf();
+    $index->expects($this->once())->method('save');
+    $index->expects($this->once())->method('rebuildTracker');
+    $entity_type_manager = $this->entityTypeManagerWithWritableIndex($index);
+
+    $index_manager = $this->createMock(BeaconIndexManager::class);
+    // The index already exists, so it must never be re-provisioned.
+    $index_manager->expects($this->once())->method('indexExists')->with('my-index')->willReturn(TRUE);
+    $index_manager->expects($this->never())->method('provision');
+
+    $messenger = $this->createMock(MessengerInterface::class);
+    $messenger->expects($this->never())->method('addStatus');
+    $messenger->expects($this->never())->method('addWarning');
+
+    $plugin = $this->plugin($factory, $entity_type_manager, $index_manager, $messenger);
+
+    $form_state = new FormState();
+    $form_state->setValue(['ys_beacon', 'platform_authorized'], 1);
+    $form_state->setValue(['ys_beacon', 'enable_chat'], 1);
+    $form = [];
+    $plugin->submitSettings($form, $form_state);
+  }
+
+  /**
+   * A transient Azure outage on re-enable keeps an existing index enabled.
+   *
+   * The indexExists() check throws when the endpoint is unreachable, so the
+   * enable path must treat that as "not missing": it never disables a healthy
+   * existing index or shows a misleading "could not be created" warning,
+   * matching the site form.
+   *
+   * @covers ::submitSettings
+   * @covers ::enableIndex
+   * @covers ::configuredIndexMissing
+   */
+  public function testEnableDuringTransientOutageKeepsIndexEnabled(): void {
+    $settings = [
+      'enable_chat' => FALSE,
+      'read_only' => FALSE,
+      'azure_index_name' => 'my-index',
+      'search_index_id' => 'ys_beacon',
+    ];
+    $config = $this->createMock(Config::class);
+    $config->method('get')->willReturnCallback(fn (string $key) => $settings[$key] ?? NULL);
+    $config->method('set')->willReturnSelf();
+    $config->method('save')->willReturnSelf();
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('getEditable')->with('ys_beacon.settings')->willReturn($config);
+    $factory->method('get')->with('ys_beacon.settings')->willReturn($config);
+
+    $index = $this->createMock(IndexInterface::class);
+    $index->expects($this->once())->method('setStatus')->with(TRUE)->willReturnSelf();
+    $index->expects($this->once())->method('save');
+    $index->expects($this->once())->method('rebuildTracker');
+    $entity_type_manager = $this->entityTypeManagerWithWritableIndex($index);
+
+    $index_manager = $this->createMock(BeaconIndexManager::class);
+    $index_manager->method('indexExists')->with('my-index')
+      ->willThrowException(new \RuntimeException('unreachable'));
+    // A transient outage must not trigger a doomed re-provision.
+    $index_manager->expects($this->never())->method('provision');
+
+    $messenger = $this->createMock(MessengerInterface::class);
+    $messenger->expects($this->never())->method('addWarning');
+
+    $plugin = $this->plugin($factory, $entity_type_manager, $index_manager, $messenger);
+
+    $form_state = new FormState();
+    $form_state->setValue(['ys_beacon', 'platform_authorized'], 1);
+    $form_state->setValue(['ys_beacon', 'enable_chat'], 1);
+    $form = [];
+    $plugin->submitSettings($form, $form_state);
+  }
+
+  /**
+   * Disabling the chat toggle disables the index without provisioning.
+   *
+   * @covers ::submitSettings
+   * @covers ::setIndexStatus
+   */
+  public function testDisableTransitionDisablesIndex(): void {
+    $settings = ['enable_chat' => TRUE, 'search_index_id' => 'ys_beacon'];
+    $config = $this->createMock(Config::class);
+    $config->method('get')->willReturnCallback(fn (string $key) => $settings[$key] ?? NULL);
+    $config->method('set')->willReturnSelf();
+    $config->method('save')->willReturnSelf();
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('getEditable')->with('ys_beacon.settings')->willReturn($config);
+    $factory->method('get')->with('ys_beacon.settings')->willReturn($config);
+
+    $index = $this->createMock(IndexInterface::class);
+    $index->expects($this->once())->method('setStatus')->with(FALSE)->willReturnSelf();
+    $index->expects($this->once())->method('save');
+    $storage = $this->createMock(ConfigEntityStorageInterface::class);
+    $storage->method('loadOverrideFree')->with('ys_beacon')->willReturn($index);
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->with('search_api_index')->willReturn($storage);
+
+    $index_manager = $this->createMock(BeaconIndexManager::class);
+    $index_manager->expects($this->never())->method('provision');
+
+    $plugin = $this->plugin($factory, $entity_type_manager, $index_manager);
+
+    $form_state = new FormState();
+    $form_state->setValue(['ys_beacon', 'platform_authorized'], 1);
+    $form_state->setValue(['ys_beacon', 'enable_chat'], 0);
+    $form = [];
+    $plugin->submitSettings($form, $form_state);
+  }
+
+  /**
+   * No on/off change leaves the index untouched.
+   *
+   * @covers ::submitSettings
+   */
+  public function testNoTransitionLeavesIndexUntouched(): void {
+    $settings = ['enable_chat' => FALSE, 'search_index_id' => 'ys_beacon'];
+    $config = $this->createMock(Config::class);
+    $config->method('get')->willReturnCallback(fn (string $key) => $settings[$key] ?? NULL);
+    $config->method('set')->willReturnSelf();
+    $config->method('save')->willReturnSelf();
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('getEditable')->with('ys_beacon.settings')->willReturn($config);
+    $factory->method('get')->with('ys_beacon.settings')->willReturn($config);
+
+    // The storage must never be touched when there is no transition.
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->expects($this->never())->method('getStorage');
+
+    $index_manager = $this->createMock(BeaconIndexManager::class);
+    $index_manager->expects($this->never())->method('provision');
+
+    $plugin = $this->plugin($factory, $entity_type_manager, $index_manager);
+
+    $form_state = new FormState();
+    $form_state->setValue(['ys_beacon', 'platform_authorized'], 1);
+    $form_state->setValue(['ys_beacon', 'enable_chat'], 0);
+    $form = [];
+    $plugin->submitSettings($form, $form_state);
+  }
+
+  /**
+   * A read-only borrow enables the index but never provisions or writes it.
+   *
+   * @covers ::submitSettings
+   * @covers ::enableIndex
+   */
+  public function testReadOnlyEnableSkipsProvision(): void {
+    $settings = ['enable_chat' => FALSE, 'read_only' => TRUE, 'search_index_id' => 'ys_beacon'];
+    $config = $this->createMock(Config::class);
+    $config->method('get')->willReturnCallback(fn (string $key) => $settings[$key] ?? NULL);
+    $config->method('set')->willReturnSelf();
+    $config->method('save')->willReturnSelf();
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('getEditable')->with('ys_beacon.settings')->willReturn($config);
+    $factory->method('get')->with('ys_beacon.settings')->willReturn($config);
+
+    $index = $this->createMock(IndexInterface::class);
+    $index->expects($this->once())->method('setStatus')->with(TRUE)->willReturnSelf();
+    $storage = $this->createMock(ConfigEntityStorageInterface::class);
+    $storage->method('loadOverrideFree')->with('ys_beacon')->willReturn($index);
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->with('search_api_index')->willReturn($storage);
+
+    $index_manager = $this->createMock(BeaconIndexManager::class);
+    $index_manager->expects($this->never())->method('provision');
+
+    $plugin = $this->plugin($factory, $entity_type_manager, $index_manager);
+
+    $form_state = new FormState();
+    $form_state->setValue(['ys_beacon', 'platform_authorized'], 1);
+    $form_state->setValue(['ys_beacon', 'enable_chat'], 1);
+    $form = [];
+    $plugin->submitSettings($form, $form_state);
+  }
+
+  /**
+   * A failed first-time provision leaves the index off and warns the user.
+   *
+   * With no index name yet, a provision failure persists no name, so the config
+   * override keeps the index disabled; the status is never set on and never
+   * needs a rollback.
+   *
+   * @covers ::submitSettings
+   * @covers ::enableIndex
+   * @covers ::configuredIndexMissing
+   */
+  public function testProvisionFailureLeavesIndexOffAndWarns(): void {
+    $settings = [
+      'enable_chat' => FALSE,
+      'read_only' => FALSE,
+      'azure_index_name' => '',
+      'search_index_id' => 'ys_beacon',
+    ];
+    $config = $this->createMock(Config::class);
+    $config->method('get')->willReturnCallback(fn (string $key) => $settings[$key] ?? NULL);
+    $config->method('set')->willReturnSelf();
+    $config->method('save')->willReturnSelf();
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('getEditable')->with('ys_beacon.settings')->willReturn($config);
+    $factory->method('get')->with('ys_beacon.settings')->willReturn($config);
+
+    // The index is never touched: provisioning fails before any status change.
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->expects($this->never())->method('getStorage');
+
+    $index_manager = $this->createMock(BeaconIndexManager::class);
+    $index_manager->method('provision')->willThrowException(new \RuntimeException('unreachable'));
+
+    $messenger = $this->createMock(MessengerInterface::class);
+    $messenger->expects($this->once())->method('addWarning');
+    $messenger->expects($this->never())->method('addStatus');
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())->method('error');
+
+    $plugin = $this->plugin($factory, $entity_type_manager, $index_manager, $messenger, $logger);
+
+    $form_state = new FormState();
+    $form_state->setValue(['ys_beacon', 'platform_authorized'], 1);
+    $form_state->setValue(['ys_beacon', 'enable_chat'], 1);
+    $form = [];
+    // Must not throw: the handler catches the provisioning failure.
+    $plugin->submitSettings($form, $form_state);
+  }
+
+  /**
+   * Validation is skipped when the toggle is off.
+   *
+   * @covers ::validateSettings
+   */
+  public function testValidateSkipsWhenToggleOff(): void {
+    $factory = $this->getConfigFactoryStub(['ys_beacon.settings' => []]);
+    $plugin = $this->plugin($factory);
+
+    $form_state = $this->createMock(FormStateInterface::class);
+    $form_state->method('getValue')->with(['ys_beacon', 'enable_chat'])->willReturn(0);
+    $form_state->expects($this->never())->method('setErrorByName');
+
+    $form = [];
+    $plugin->validateSettings($form, $form_state);
+  }
+
+  /**
+   * The Re-index button delegates to the site form's reindexAll() handler.
+   *
+   * @covers ::reindexAllSubmit
+   */
+  public function testReindexAllSubmitDelegates(): void {
+    $form = [];
+    $form_state = $this->createMock(FormStateInterface::class);
+
+    $settings_form = $this->createMock(YsBeaconSettings::class);
+    $settings_form->expects($this->once())->method('reindexAll');
+    $settings_form->expects($this->never())->method('indexNow');
+
+    $this->setContainerWithResolver($settings_form);
+
+    BeaconPlatformAdminSetting::reindexAllSubmit($form, $form_state);
+  }
+
+  /**
+   * The Index now button delegates to the site form's indexNow() handler.
+   *
+   * @covers ::indexNowSubmit
+   */
+  public function testIndexNowSubmitDelegates(): void {
+    $form = [];
+    $form_state = $this->createMock(FormStateInterface::class);
+
+    $settings_form = $this->createMock(YsBeaconSettings::class);
+    $settings_form->expects($this->once())->method('indexNow');
+    $settings_form->expects($this->never())->method('reindexAll');
+
+    $this->setContainerWithResolver($settings_form);
+
+    BeaconPlatformAdminSetting::indexNowSubmit($form, $form_state);
+  }
+
+  /**
+   * Installs a container whose class resolver returns the given settings form.
+   */
+  private function setContainerWithResolver(YsBeaconSettings $settings_form): void {
+    $resolver = $this->createMock(ClassResolverInterface::class);
+    $resolver->method('getInstanceFromDefinition')
+      ->with(YsBeaconSettings::class)
+      ->willReturn($settings_form);
+
+    $container = $this->createMock(ContainerInterface::class);
+    $container->method('get')->with('class_resolver')->willReturn($resolver);
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    parent::tearDown();
+    // Reset the global container set by the delegation tests.
+    \Drupal::unsetContainer();
   }
 
 }


### PR DESCRIPTION
## [1408: Beacon: add Re-index, Index, and Enable chat widget controls to Platform Admin Settings](https://github.com/yalesites-org/YaleSites-Internal/issues/1408)

### Description of work
- Add a "Re-index all content" button, an "Index now" button, and an "Enable chat widget" toggle to the Beacon (AI Chat) section of the org-wide Platform Admin Settings page (`/admin/yalesites/platform-admin-settings`).
- All additions live in the ys_beacon plugin `BeaconPlatformAdminSetting` (contributed via the `PlatformAdminSetting` plugin pattern, `buildSettings()` / `submitSettings()`); the generic ys_core host form stays Beacon-agnostic.
- Re-index / Index now delegate to the existing `YsBeaconSettings::reindexAll()` / `indexNow()` behavior (tracker rebuild + `search_api.indexing_batch_helper` batch); the buttons use static `#submit` handlers so they run correctly within the shared host-form submit flow. The "Enable chat widget" toggle reads/writes the same `ys_beacon.settings:enable_chat` flag the per-site enable control uses, staying consistent in both directions.
- Respect the borrowed/read-only-index guard (indexing buttons hidden/disabled when the index is borrowed read-only). Toggle and buttons are native, keyboard-operable controls with clear labels and AT-exposed state (WCAG 2.1 AA).
- Fixed two defects found during verification (the resumed WIP had never been run): a fatal typed `$messenger` property redeclaration colliding with core's MessengerTrait, and an `enableIndex()` path that called `provision()` unconditionally — now guarded by `configuredIndexMissing()` + an explicit `rebuildTracker()`, so a transient Azure outage on a chat re-enable no longer disables a healthy index.

### Functional testing steps:
- [ ] On `/admin/yalesites/platform-admin-settings`, confirm the Beacon (AI Chat) section shows the "Enable chat widget" toggle (reflecting current state), "Re-index all content", and "Index now".
- [ ] Toggle "Enable chat widget" and Save; confirm the per-site Beacon enable state changes to match (and toggling from the site form is reflected here).
- [ ] Click "Re-index all content" and confirm content is queued/rebuilt as on the site form.
- [ ] Confirm "Index now" is disabled when nothing is queued and runs the batch when items are queued.
- [ ] With a borrowed/read-only index, confirm the indexing buttons are hidden/disabled.
- [ ] Confirm keyboard operation and that the toggle's on/off state is announced by assistive tech.

Automated: ys_beacon Unit — 138 existing unchanged + 16 new plugin tests (42 assertions), all green, 0 failures; `phpcs` Drupal + DrupalPractice clean; playwright screenshot of the Beacon (AI Chat) section.

References yalesites-org/YaleSites-Internal#1408

---
Created with AI
