### PR TITLE
1362: Wave 7: Global site chrome

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-footer-block.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-footer-block.html.twig
@@ -2,14 +2,15 @@
 {% set link_group__base_class = 'link-group' %}
 {% set school_logo_url = school_logo_url|default('/') %}
 
-{% embed "@organisms/site-footer/yds-site-footer.twig" with {
+{% embed "atomic:site-footer" with {
   site_footer__border_thickness: '8',
   site_footer__theme: getThemeSetting('footer_theme'),
   site_footer__accent: getThemeSetting('footer_accent'),
   site_footer__variation: footer_variation|default('basic'),
 }%}
-  {% block footer__inner %}
-    {% if site_footer__variation == 'mega'%}
+  {% block footer__content %}
+    {% set site_footer__base_class = 'site-footer' %}
+    {% if footer_variation|default('basic') == 'mega'%}
       {% embed "@organisms/site-footer/_site-footer-mega.twig" %}
         {% block site_footer__logos %}
           {% for logo in footer_logos %}


### PR DESCRIPTION
## [1362: Wave 7: Global site chrome](https://github.com/yalesites-org/YaleSites-Internal/issues/1362)

> Footer, skip-link, breadcrumbs, and all three navigations are done and verified. The **site header was split into its own ticket, yalesites-org/YaleSites-Internal#1413**, and is **not** part of this PR. One reviewer-side check remains: the "in this section" nav's on-page render needs a Book/Collection page (see the testing steps) — the local DB has none, so it was verified in isolation here.

### Description of work
Converts the global site chrome to Single Directory Components, following the thin-wrapper recipe. Stacked on the epic branch `1351-migrate-cl-to-sdc` (base of this PR). Chrome is theme-region / menu-block driven, not Layout Builder, so the render-path adapters are region/menu/block templates.
- Footer renders through a new `atomic:site-footer` SDC (adapter: `ys_core/templates/ys-footer-block.html.twig`). Byte-identical render.
- Skip-link renders the existing `atomic:link-skip` SDC (both the main-content and secondary-menu links).
- Breadcrumbs: corrected the stale "not yet wired" docstrings (it is wired via `ys-breadcrumb-block.html.twig`; the Layout Builder preview branch still uses the raw component-library template).
- Primary navigation renders through a new `atomic:primary-nav` SDC. Byte-identical.
- Utility navigation renders through a new `atomic:utility-nav` SDC. Byte-identical (desktop and mobile).
- "In this section" / secondary navigation renders through a new `atomic:in-this-section` SDC.
- The Drupal menu tree carries `\Drupal\Core\Url` objects that cannot cross an SDC prop boundary, so `atomic.theme` gains `_atomic_flatten_menu_items()` (called from `atomic_preprocess_menu` and a new `atomic_preprocess_book_tree`) that flattens the tree to string URLs; the nav SDCs render it with `menu__contextual: true`. Schema tests: `composer test:sdc` 47 to 51.
- The **site header** is tracked separately in yalesites-org/YaleSites-Internal#1413 and is **not** part of this PR — it is materially larger and higher-blast (every page) and has its own scope, review, and local-testing prerequisites.
- Other work completed in: yalesites-org/atomic#488

### Functional testing steps:
- [ ] On the front page and an interior page, the footer, skip-links, primary nav, and utility menu render identically to production; the primary-nav dropdown/mega toggles still work.
- [ ] With Twig debug on, View Source shows `Component start: atomic:site-footer`, `atomic:primary-nav`, `atomic:utility-nav`, and `atomic:link-skip` around the respective chrome.
- [ ] On a Book/Collection page, the "in this section" navigation renders identically and links work; View Source shows `Component start: atomic:in-this-section`.
- [ ] `lando composer test:sdc` is green (51).

References yalesites-org/YaleSites-Internal#1362
