### PR TITLE
1404: Pre-commit lint hooks fail on repo-wide pre-existing formatting debt, forcing --no-verify

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Deliberately-malformed test fixture (invalid JSON by design). Prettier throws a
+# SyntaxError on it, so exclude it from formatting checks.
+web/profiles/custom/yalesites_profile/modules/custom/ys_themes/tests/fixtures/tokens-fixture-malformed.json

--- a/package.json
+++ b/package.json
@@ -39,14 +39,14 @@
     "shelljs": "^0.8.5"
   },
   "lint-staged": {
-    "web/**/*.scss": [
-      "npm run lint:styles"
+    "{web/modules/custom,web/themes/contrib/atomic,web/themes/custom,web/profiles/custom}/**/*.scss": [
+      "stylelint --color"
     ],
-    "web/**/*.js": [
-      "npm run lint:js"
+    "{web/modules/custom,web/themes/custom,web/profiles/custom}/**/*.js": [
+      "eslint --color --no-error-on-unmatched-pattern --format stylish"
     ],
-    "web/**/*.{js,scss,php}": [
-      "npm run prettier"
+    "{.github,docs,web/profiles/custom,web/modules/custom,web/themes/contrib/atomic,web/themes/custom}/**/*.{json,md,js,html,scss}": [
+      "prettier --ignore-unknown --list-different"
     ]
   },
   "release": {


### PR DESCRIPTION
## [1404: Pre-commit lint hooks fail on repo-wide pre-existing formatting debt, forcing --no-verify](https://github.com/yalesites-org/YaleSites-Internal/issues/1404)

### Description of work
- The `lint-staged` config mapped file globs to the **repo-wide npm scripts** (`npm run lint:styles` / `lint:js` / `prettier`), and those scripts have hardcoded whole-tree globs. So lint-staged ignored the staged-file list and every commit re-linted the entire custom tree, failing on pre-existing formatting debt — forcing `git commit --no-verify`, which defeats the hook.
- **Fix (option a):** point `lint-staged` at the linters directly so it lints only the staged files that match each pattern, scoped to the same directories the scripts targeted:
  - `stylelint --color` (was `npm run lint:styles`)
  - `eslint --color --no-error-on-unmatched-pattern --format stylish` (was `npm run lint:js`)
  - `prettier --ignore-unknown --list-different` (was `npm run prettier`)
- Added a `.prettierignore` for the deliberately-malformed JSON test fixture (`tokens-fixture-malformed.json`), which made prettier hard-error (SyntaxError). This also unblocks the manual `npm run prettier`.
- The manual `npm run lint*` / `prettier` scripts are unchanged and still available for full-tree linting.
- **Out of scope (option b):** the one-time repo-wide formatting cleanup (`stylelint --fix` / `prettier --write` across the tree) is intentionally not done here — it's large, mechanical, and spans repos (including the `atomic` symlink), so it belongs in its own dedicated change. Consequence: editing a file that already carries pre-existing debt will still surface that file's own debt at commit time (unrelated files no longer do).

### Functional testing steps:
- [ ] Stage a small, well-formatted change in a linted dir and run `npx lint-staged` (or commit normally) — it passes, even though the repo still has pre-existing formatting debt elsewhere.
- [ ] Stage a badly-formatted file and run `npx lint-staged` — it fails (linting still catches real issues).
- [ ] Run `npm run prettier` — it no longer hard-errors on `tokens-fixture-malformed.json` (exits with the remaining formatting-debt list rather than a SyntaxError).
- [ ] Confirm the manual `npm run lint` still lints the whole custom tree as before.

References yalesites-org/YaleSites-Internal#1404

---
Created with AI
