### PR TITLE
1396: ys_node_access unpublished-content access fixes (partial)

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/src/EventSubscriber/NodeAccessEventSubscriber.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/src/EventSubscriber/NodeAccessEventSubscriber.php
@@ -7,6 +7,7 @@ use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
  * Overrides the 403 response to perform a CAS redirect for specific pages.
@@ -53,7 +54,15 @@ class NodeAccessEventSubscriber extends HttpExceptionSubscriberBase {
          */
         if ($node->hasField('field_login_required')) {
           if ($node->isPublished() && $node->field_login_required->first()->getValue()['value']) {
-            $casRedirectUrl = Url::fromRoute('cas.login', ['destination' => $node->toUrl()->toString()])->toString();
+            try {
+              $casRedirectUrl = Url::fromRoute('cas.login', ['destination' => $node->toUrl()->toString()])->toString();
+            }
+            catch (RouteNotFoundException $e) {
+              // The 'cas' module is not installed (not a hard dependency), so
+              // there is no login route to redirect to. Leave the default 403
+              // response in place instead of fataling.
+              return;
+            }
             $returnResponse = new TrustedRedirectResponse($casRedirectUrl);
             $returnResponse->getCacheableMetadata()->setCacheMaxAge(0);
             $event->setResponse($returnResponse);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/tests/src/Kernel/NodeAccessEventSubscriberMissingCasDependencyTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/tests/src/Kernel/NodeAccessEventSubscriberMissingCasDependencyTest.php
@@ -13,20 +13,17 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
  * Tests NodeAccessEventSubscriber::on403() when the 'cas' module is absent.
  *
  * Ys_node_access.info.yml declares only "drupal:node" as a dependency, but
- * on403() unconditionally calls Url::fromRoute('cas.login', ...), a route
- * that only exists when the contrib 'cas' module is installed. On every
- * real YaleSites site 'cas' is enabled via config (core.extension.yml), so
- * this is latent rather than active -- but nothing in Drupal's dependency
- * system stops 'cas' from being disabled while ys_node_access stays
- * enabled. This test characterizes what happens if that were to occur.
- * Paired with testMissingCasRouteShouldDegradeGracefully() -- delete once
- * the GAP is fixed.
+ * on403() redirects to the 'cas.login' route, which only exists when the
+ * contrib 'cas' module is installed. On every real YaleSites site 'cas' is
+ * enabled via config (core.extension.yml), but nothing in Drupal's dependency
+ * system stops 'cas' from being disabled while ys_node_access stays enabled.
+ * on403() must degrade gracefully (leave the default 403 in place) rather than
+ * throw a RouteNotFoundException.
  *
  * @group yalesites
  * @group ys_node_access
@@ -46,12 +43,14 @@ class NodeAccessEventSubscriberMissingCasDependencyTest extends KernelTestBase {
   ];
 
   /**
-   * An anonymous visit to a gated node fatals when 'cas' is absent.
+   * On403() degrades gracefully when the 'cas' module is absent.
    *
-   * It throws a RouteNotFoundException instead of falling back to the default
-   * 403, because 'cas' (an undeclared dependency) is not installed.
+   * 'cas' is not a declared dependency of ys_node_access, so its login route
+   * may be unavailable. In that case on403() must leave the default 403 in
+   * place (set no redirect response) instead of throwing a
+   * RouteNotFoundException.
    */
-  public function testUncaughtExceptionWhenCasModuleAbsent() {
+  public function testMissingCasRouteShouldDegradeGracefully() {
     $this->installEntitySchema('node');
     $this->installEntitySchema('user');
     // Saving the node below runs ys_node_access_node_access_records(), which
@@ -89,15 +88,11 @@ class NodeAccessEventSubscriberMissingCasDependencyTest extends KernelTestBase {
     );
 
     $subscriber = new NodeAccessEventSubscriber(new AnonymousUserSession());
-    $this->expectException(RouteNotFoundException::class);
     $subscriber->on403($event);
-  }
 
-  /**
-   * GAP: on403() should not fatal when 'cas' is unavailable.
-   */
-  public function testMissingCasRouteShouldDegradeGracefully() {
-    $this->markTestSkipped('GAP: NodeAccessEventSubscriber::on403() calls Url::fromRoute(\'cas.login\', ...) unconditionally; if the \'cas\' module is ever disabled while ys_node_access stays enabled (nothing enforces this, since ys_node_access.info.yml does not declare cas as a dependency), an anonymous visit to a published, login-required node throws an uncaught RouteNotFoundException instead of a normal 403 -- see ~/Documents/Claude/not_dave/module-tests-20260710/ys_node_access.md');
+    // With 'cas' absent, no redirect response is set and the default 403
+    // response stands.
+    $this->assertNull($event->getResponse());
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/tests/src/Kernel/NodeAccessGrantsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/tests/src/Kernel/NodeAccessGrantsTest.php
@@ -184,14 +184,17 @@ class NodeAccessGrantsTest extends KernelTestBase {
   }
 
   /**
-   * Tests hook_node_access_records() for an unpublished, non-gated node.
+   * Tests hook_node_access_records() defers an unpublished node to core.
    *
-   * Unpublished status alone is enough to mark the node private, as long as
-   * the content type carries field_login_required.
+   * The module writes a grant_view = 0 record for unpublished nodes: this
+   * keeps its realm's record set non-empty (so core does not fall back to the
+   * default public "all" grant) while granting no view access itself, leaving
+   * unpublished-content access to Drupal core (owner + "view own/any
+   * unpublished content").
    *
    * @covers ::ys_node_access_node_access_records
    */
-  public function testNodeAccessRecordsPrivateWhenUnpublished() {
+  public function testNodeAccessRecordsUnpublishedDefersToCore() {
     $node = Node::create([
       'type' => 'protected_type',
       'title' => 'Unpublished',
@@ -199,7 +202,15 @@ class NodeAccessGrantsTest extends KernelTestBase {
       'status' => 0,
     ]);
 
-    $this->assertEquals(NodeAccessManager::YS_NODE_ACCESS_GRANT_ID_PRIVATE, ys_node_access_node_access_records($node)[0]['gid']);
+    $this->assertEquals([[
+      'realm' => NodeAccessManager::YS_NODE_ACCESS_REALM,
+      'gid' => NodeAccessManager::YS_NODE_ACCESS_GRANT_ID_PRIVATE,
+      'grant_view' => 0,
+      'grant_update' => 0,
+      'grant_delete' => 0,
+      'priority' => 0,
+    ],
+    ], ys_node_access_node_access_records($node));
   }
 
   /**
@@ -238,21 +249,14 @@ class NodeAccessGrantsTest extends KernelTestBase {
   }
 
   /**
-   * Any authenticated user can view another user's unpublished content.
+   * Unpublished-view access should require ownership or the permission.
    *
-   * Ys_node_access_node_access_records() marks a node private (grant ID
-   * PRIVATE) whenever it is unpublished, but ys_node_access_node_grants()
-   * hands every authenticated user both the PUBLIC and PRIVATE grant IDs --
-   * not only owners or accounts with "view own unpublished content" -- so
-   * any logged-in user can view any other user's unpublished draft, on any
-   * content type that carries field_login_required (page, post, event,
-   * profile, resource in production). This is broader than Drupal's normal
-   * unpublished-content protection and broader than this module's stated
-   * purpose of CAS-gating specific pages. Paired with
-   * testUnpublishedNodeAccessShouldRespectOwnershipAndPermission() -- delete
-   * once the GAP is fixed.
+   * GAP: it should still require ownership or the "view own unpublished
+   * content" permission, not just being logged in.
    */
-  public function testAnyAuthenticatedUserCanViewAnotherUsersUnpublishedNode() {
+  public function testUnpublishedNodeAccessShouldRespectOwnershipAndPermission() {
+    $access_handler = \Drupal::entityTypeManager()->getAccessControlHandler('node');
+
     $owner = User::create(['name' => 'owner', 'uid' => 3]);
     $owner->save();
 
@@ -265,48 +269,19 @@ class NodeAccessGrantsTest extends KernelTestBase {
     ]);
     $node->save();
 
-    // $this->authenticated owns nothing here and has no "view own
-    // unpublished content" permission, yet can still view the draft.
+    // A plain authenticated user who neither owns the draft nor holds "view
+    // own unpublished content" cannot view it.
     $this->assertFalse($this->authenticated->hasPermission('view own unpublished content'));
-    $this->assertTrue($node->access('view', $this->authenticated));
-  }
+    $this->assertFalse($node->access('view', $this->authenticated));
 
-  /**
-   * Unpublished-view access should require ownership or the permission.
-   *
-   * GAP: it should still require ownership or the "view own unpublished
-   * content" permission, not just being logged in.
-   */
-  public function testUnpublishedNodeAccessShouldRespectOwnershipAndPermission() {
-    $this->markTestSkipped('GAP: any authenticated user can view any other user\'s unpublished node on a content type with field_login_required, regardless of ownership or the "view own unpublished content" permission -- see ~/Documents/Claude/not_dave/module-tests-20260710/ys_node_access.md');
-  }
-
-  /**
-   * A content type without field_login_required stays public when unpublished.
-   *
-   * Ys_node_access_node_access_records() only marks a node private when
-   * $node->hasField('field_login_required') is true; if a content type
-   * never gets the field attached (e.g. a new type added through the
-   * Drupal UI, which nothing in this module or its .install hook prevents),
-   * $private stays FALSE regardless of publish status, so the node gets a
-   * PUBLIC grant record and is visible to anonymous users even while
-   * unpublished. In production every shipped content type (page, post,
-   * event, profile, resource) currently has the field, so this is latent
-   * rather than actively exploited today -- but it activates automatically
-   * for any new content type a site builder adds without attaching the
-   * field. Paired with testUnpublishedNodeWithoutFieldShouldStayPrivate()
-   * -- delete once the GAP is fixed.
-   */
-  public function testUnpublishedNodeWithoutLoginRequiredFieldIsPubliclyViewable() {
-    $node = Node::create([
-      'type' => 'unprotected_type',
-      'title' => 'Unpublished, no field',
-      'status' => 0,
-    ]);
-    $node->save();
-
-    $this->assertFalse($node->hasField('field_login_required'));
-    $this->assertTrue($node->access('view', $this->anonymous));
+    // Once "view own unpublished content" is granted, the owner can view their
+    // own draft, but a non-owner still cannot -- ownership is respected, not
+    // just login state.
+    Role::load(RoleInterface::AUTHENTICATED_ID)->grantPermission('view own unpublished content')->save();
+    $access_handler->resetCache();
+    $this->assertTrue($node->access('view', User::load($owner->id())));
+    $access_handler->resetCache();
+    $this->assertFalse($node->access('view', User::load($this->authenticated->id())));
   }
 
   /**
@@ -316,7 +291,17 @@ class NodeAccessGrantsTest extends KernelTestBase {
    * even while unpublished.
    */
   public function testUnpublishedNodeWithoutFieldShouldStayPrivate() {
-    $this->markTestSkipped('GAP: nodes on a content type that never received field_login_required are always granted a PUBLIC access record by ys_node_access_node_access_records(), so they are visible to anonymous users even while unpublished -- see ~/Documents/Claude/not_dave/module-tests-20260710/ys_node_access.md');
+    $node = Node::create([
+      'type' => 'unprotected_type',
+      'title' => 'Unpublished, no field',
+      'status' => 0,
+    ]);
+    $node->save();
+
+    // Even though the content type never received field_login_required, an
+    // unpublished node must not be exposed to anonymous users.
+    $this->assertFalse($node->hasField('field_login_required'));
+    $this->assertFalse($node->access('view', $this->anonymous));
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.install
@@ -13,3 +13,15 @@
 function ys_node_access_install() {
   node_access_rebuild();
 }
+
+/**
+ * Rebuild node access grants after the unpublished-content access fix.
+ *
+ * Ys_node_access_node_access_records() no longer grants view access to
+ * unpublished nodes, but existing nodes keep their previously-written grant
+ * records in the node_access table until a rebuild. Rebuild so the fix applies
+ * to content that already exists, not only to nodes saved after this deploy.
+ */
+function ys_node_access_update_10001() {
+  node_access_rebuild();
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.module
@@ -43,45 +43,49 @@ function ys_node_access_node_grants($account, $op) {
  */
 function ys_node_access_node_access_records($node) {
 
-  $private = FALSE;
-
   $nodeAccessManager = new NodeAccessManager();
-  // Saving a node, check login required field to set the appropriate grants.
+
+  // Unpublished nodes are left to Drupal core's unpublished-content access
+  // (the owner with "view own unpublished content", or "view any unpublished
+  // content"). This module only CAS-gates published pages, so it must not
+  // hand out a view grant for a draft. A grant_view = 0 record keeps this
+  // realm's record set non-empty -- so core does not add its default public
+  // "all" grant -- while granting nobody view access.
+  if (!$node->isPublished()) {
+    return [
+      [
+        'realm' => $nodeAccessManager::YS_NODE_ACCESS_REALM,
+        'gid' => $nodeAccessManager::YS_NODE_ACCESS_GRANT_ID_PRIVATE,
+        'grant_view' => 0,
+        'grant_update' => 0,
+        'grant_delete' => 0,
+        'priority' => 0,
+      ],
+    ];
+  }
+
+  // Published nodes: gate on field_login_required. Login-required pages get the
+  // PRIVATE grant (authenticated/CAS users only); everything else is PUBLIC.
+  $login_required = FALSE;
   if ($node->hasField('field_login_required')) {
     $login_required_value = $node->get('field_login_required')->getValue();
     $login_required = !empty($login_required_value) && $login_required_value[0]['value'] == 1;
-
-    if ($login_required || !$node->isPublished()) {
-      $private = TRUE;
-    }
-    else {
-      $private = FALSE;
-    }
   }
 
-  // Update the node_access table for this node with the correct grants.
-  if ($private) {
-    $grants[] = [
+  $gid = $login_required
+    ? $nodeAccessManager::YS_NODE_ACCESS_GRANT_ID_PRIVATE
+    : $nodeAccessManager::YS_NODE_ACCESS_GRANT_ID_PUBLIC;
+
+  return [
+    [
       'realm' => $nodeAccessManager::YS_NODE_ACCESS_REALM,
-      'gid' => $nodeAccessManager::YS_NODE_ACCESS_GRANT_ID_PRIVATE,
+      'gid' => $gid,
       'grant_view' => 1,
       'grant_update' => 0,
       'grant_delete' => 0,
       'priority' => 0,
-    ];
-  }
-  else {
-    $grants[] = [
-      'realm' => $nodeAccessManager::YS_NODE_ACCESS_REALM,
-      'gid' => $nodeAccessManager::YS_NODE_ACCESS_GRANT_ID_PUBLIC,
-      'grant_view' => 1,
-      'grant_update' => 0,
-      'grant_delete' => 0,
-      'priority' => 0,
-    ];
-  }
-
-  return $grants;
+    ],
+  ];
 }
 
 /**


### PR DESCRIPTION
## [1396: ys_node_access unpublished-content access fixes (partial)](https://github.com/yalesites-org/YaleSites-Internal/issues/1396)

> **Scope: PARTIAL.** This PR fixes only the **security-critical `ys_node_access` GAPs** from #1396 (3 of ~18 defects in that ticket). The remaining GAPs across 10 other modules are **not** in this PR — see "Remaining GAPs" below. The remaining GAPs are now filed as **per-module sub-issues of #1396** (#1419–#1429; see below) — each Bug / `tech-debt` / To Do — to be worked one at a time. This ticket is not fully resolved by this PR.

### Description of work
`ys_node_access_node_access_records()` conflated publish status with the module's CAS gating, causing two **confidentiality** issues:
- **Any authenticated user could view any other user's unpublished node.** Unpublished nodes were marked PRIVATE and every authenticated user holds the PRIVATE grant, so drafts were viewable regardless of ownership or the core `view own unpublished content` permission.
- **Unpublished nodes on a content type that never received `field_login_required` were granted a PUBLIC record**, so anonymous users could view them while unpublished.

Fixes:
- Unpublished nodes now get a `grant_view = 0` record, deferring to Drupal core's own unpublished-content access (owner + `view own/any unpublished content`). The empty grant keeps this realm's record set non-empty so core does not add its default public `all` grant, while granting no view access. Published nodes are gated purely on `field_login_required` (PRIVATE = authenticated/CAS only, PUBLIC = everyone), unchanged.
- Guarded `NodeAccessEventSubscriber::on403()` so a missing `cas` module (not a declared dependency) degrades to the default 403 instead of throwing `RouteNotFoundException`.
- Added `hook_update_10001()` calling `node_access_rebuild()` so the fix applies to **existing** content on deploy, not only to nodes saved afterward.
- Un-skipped the three paired GAP tests with real assertions; removed the obsolete characterization tests.

Verified: full `ys_node_access` suite **23 tests pass**; `phpcs` (Drupal + DrupalPractice) clean; security review clear.

### Functional testing steps:
- [ ] As a plain authenticated user (not the author, without `view own unpublished content`), you cannot view another user's **unpublished** node — 403.
- [ ] The node's **author**, with `view own unpublished content`, can still view their own unpublished node.
- [ ] An **anonymous** user cannot view an unpublished node on a content type without `field_login_required`.
- [ ] A **published** login-required page is still hidden from anonymous and shown to authenticated users (CAS gating unchanged); a published non-gated page is still public.
- [ ] After deploy, existing unpublished content is protected (the update hook rebuilds node access).

### Remaining GAPs from #1396 — now filed as per-module sub-issues
The other GAPs are **not** in this PR; each is now a per-module sub-issue of #1396 (type Bug, `tech-debt`, `To Do` on the board) so they can be worked one at a time. Each has a paired `...CurrentBehavior...` test to delete and a `...Should...` stub to un-skip/author:
- yalesites-org/YaleSites-Internal#1419 — **ys_toolbar**: off-canvas `#access` set to a permission *string* (always truthy) instead of a `hasPermission()` check.
- yalesites-org/YaleSites-Internal#1420 — **ys_dcn_field**: `"0"` identifier stripped by `empty()` + hidden by a truthiness check; also missing field-settings config schema (new file).
- yalesites-org/YaleSites-Internal#1421 — **ys_taxonomy_manager**: `type IN ()` query throws when no bundle references the vocabulary.
- yalesites-org/YaleSites-Internal#1422 — **ys_campus_groups**: `CampusGroupsConfig` reads `ys_campus_group.settings` (singular) vs the plural used everywhere else.
- yalesites-org/YaleSites-Internal#1423 — **ys_migrate**: `processImport()` silently drops rows where node creation returns NULL.
- yalesites-org/YaleSites-Internal#1424 — **ys_localist**: `getSourceData()` clobbers `$url` each paging iteration, compounding `&page=`.
- yalesites-org/YaleSites-Internal#1425 — **ys_embed** (5): missing `/s` regex modifiers (GoogleMaps, JWPlayer), `isVideo()` host false-positive, SoundCloud playlist endpoint, `loadPluginById()` NULL instead of Broken fallback.
- yalesites-org/YaleSites-Internal#1426 — **ys_views_basic**: missing `break;` (fall-through returns the wrong default).
- yalesites-org/YaleSites-Internal#1427 — **ys_layouts**: inverted bail condition renders event meta for every bundle.
- yalesites-org/YaleSites-Internal#1428 — **ys_views_content_resources**: uninitialized `$entityValue` for a new/unsaved block.
- yalesites-org/YaleSites-Internal#1429 — **ys_core**: dead `mailto` branch in `getUrlType()` (ordered after `isInternal()`).
- **ys_file_management** — the described GAP is **not a defect** (already fixed on develop, commit 8c099f0d7); no ticket.

References yalesites-org/YaleSites-Internal#1396

---
Created with AI

