### PR TITLE
1427: ys_layouts: EventMetaBlock renders event meta for every bundle (inverted bail condition)

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/EventMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/EventMetaBlock.php
@@ -81,7 +81,7 @@ class EventMetaBlock extends BlockBase implements ContainerFactoryPluginInterfac
 
     /** @var \Drupal\node\NodeInterface $node */
     $node = $this->routeMatch->getParameter('node');
-    if (!($node instanceof NodeInterface || ($node && $node->bundle() !== 'event'))) {
+    if (!($node instanceof NodeInterface) || $node->bundle() !== 'event') {
       return [];
     }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/EventMetaBlockTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/EventMetaBlockTest.php
@@ -122,37 +122,19 @@ class EventMetaBlockTest extends UnitTestCase {
   }
 
   /**
-   * A non-event node still renders full event meta output (current bug).
-   *
-   * The bail condition in build() is
-   * `!($node instanceof NodeInterface || ($node && $node->bundle() !==
-   * 'event'))`. Because any NodeInterface makes the first half of the OR
-   * TRUE regardless of bundle, the negation is always FALSE for a real node
-   * -- so the block builds event meta data for ANY node bundle, not just
-   * 'event'. Paired with testBuildShouldReturnEmptyForNonEventNode() --
-   * delete once the GAP is fixed.
-   *
-   * @covers ::build
-   */
-  public function testBuildRendersEventDataForNonEventNode(): void {
-    $node = $this->createMock(NodeInterface::class);
-    $node->method('bundle')->willReturn('page');
-    $this->routeMatch->method('getParameter')->with('node')->willReturn($node);
-    $this->metaFieldsManager->method('getEventData')->with($node)->willReturn($this->eventFieldData);
-
-    $build = $this->buildBlock()->build();
-
-    $this->assertSame('ys_event_meta_block', $build['#theme']);
-    $this->assertSame('Fall Concert', $build['#event_title__heading']);
-  }
-
-  /**
    * A non-event node should render nothing.
    *
    * @covers ::build
    */
   public function testBuildShouldReturnEmptyForNonEventNode(): void {
-    $this->markTestSkipped('GAP: EventMetaBlock::build() builds full event meta output for any NodeInterface regardless of bundle -- see ~/Documents/Claude/not_dave/module-tests-20260710/ys_layouts.md');
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('bundle')->willReturn('page');
+    $this->routeMatch->method('getParameter')->with('node')->willReturn($node);
+    $this->metaFieldsManager->expects($this->never())->method('getEventData');
+
+    $build = $this->buildBlock()->build();
+
+    $this->assertSame([], $build);
   }
 
 }


### PR DESCRIPTION
## [1427: ys_layouts: EventMetaBlock renders event meta for every bundle (inverted bail condition)](https://github.com/yalesites-org/YaleSites-Internal/issues/1427)

### Description of work
- Fixed an inverted bail condition in `EventMetaBlock::build()` (`ys_layouts`). Because any real `NodeInterface` makes the first OR operand true, the negation was always false, so the block rendered full event meta for **every** node bundle instead of only events. Reordered to `!($node instanceof NodeInterface) || $node->bundle() !== 'event'`, which bails for a null/non-node (short-circuiting before `->bundle()`) and for any non-event bundle.
- Un-skipped the paired GAP unit test `testBuildShouldReturnEmptyForNonEventNode` and removed the obsolete `testBuildRendersEventDataForNonEventNode` that characterized the buggy behavior.

### Functional testing steps:
- [ ] On an event page, confirm the event meta (dates, Add to Calendar, location, etc.) still renders as before.
- [ ] Place the Event Meta block on a non-event page (e.g. a Page) via Layout Builder, save, and view it; confirm no event meta renders.
- [ ] Confirm existing event listings and pages show no regressions.

References yalesites-org/YaleSites-Internal#1427

---
Created with AI
