### PR TITLE
1430: Beacon: Restrict Beacon chat enable + indexing to platform admins (remove controls from the site-admin settings form)

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/BeaconIndexingControlsTrait.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/BeaconIndexingControlsTrait.php
@@ -175,6 +175,23 @@ trait BeaconIndexingControlsTrait {
   }
 
   /**
+   * The index status text for a read-only display.
+   *
+   * Returns the shared-collection notice when this site borrows a read-only
+   * index, otherwise the "@indexed of @total items indexed" summary. Used where
+   * the status is shown without the indexing controls (the site settings form).
+   *
+   * @return string
+   *   The status text.
+   */
+  protected function indexStatusMarkup(): string {
+    $index = $this->loadBeaconIndex();
+    return $index && $index->isReadOnly()
+      ? (string) $this->readOnlyNotice()
+      : $this->indexStatusSummary();
+  }
+
+  /**
    * Counts tracked items not yet indexed into the Beacon vector database.
    *
    * Returns 0 when the index is missing or disabled so the "Index now" button

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconSettings.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconSettings.php
@@ -5,16 +5,16 @@ namespace Drupal\ys_beacon\Form;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
-use Drupal\ys_beacon\Service\BeaconIndexManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Site-facing settings form for the Beacon chat widget.
  *
- * Mirrors the editor-facing options of the legacy ai_engine chat settings so
- * site administrators keep a familiar experience. Turning the chat on for the
- * first time provisions the site's Azure AI Search index automatically when
- * none is configured yet.
+ * Site administrators manage the chat widget's presentation here - the floating
+ * button, initial prompts, disclaimer, and footer. Whether the chat widget is
+ * enabled and the content indexing that backs it are platform-admin actions
+ * (managed on the Platform Admin Settings page), so this form surfaces them
+ * only as a read-only status.
  */
 class YsBeaconSettings extends ConfigFormBase {
 
@@ -39,18 +39,15 @@ class YsBeaconSettings extends ConfigFormBase {
   const FLOATING_BUTTON_ICON = 'fa-sparkles';
 
   /**
-   * The Beacon index manager.
-   *
-   * @var \Drupal\ys_beacon\Service\BeaconIndexManager
-   */
-  protected BeaconIndexManager $indexManager;
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
     $instance = parent::create($container);
-    $instance->indexManager = $container->get('ys_beacon.index_manager');
+    // The entity type manager and indexing batch helper back the shared
+    // indexing trait: the Platform Admin Settings page delegates its "Re-index
+    // all content" / "Index now" buttons to a class-resolved instance of this
+    // form, so the wiring must stay even though this form no longer renders
+    // those controls.
     $instance->entityTypeManager = $container->get('entity_type.manager');
     $instance->indexingBatchHelper = $container->get('search_api.indexing_batch_helper');
     return $instance;
@@ -76,21 +73,24 @@ class YsBeaconSettings extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config(self::CONFIG_NAME);
 
-    if (!$config->get('azure_index_name')) {
-      $form['not_configured'] = [
-        '#markup' => '<p>' . $this->t('No search index is assigned to this site yet. One will be created automatically (named %name) the first time the chat widget is enabled.', [
-          '%name' => $this->indexManager->getDefaultIndexName(),
-        ]) . '</p>',
-        '#weight' => -20,
-      ];
-    }
-
-    $form['enable_chat'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Enable chat widget'),
-      '#default_value' => $config->get('enable_chat') ?? FALSE,
-      '#description' => $this->t('Enable or disable the chat service across the site. Chat can be launched by using href="#launch-chat" on any link.'),
+    // Enabling the chat widget and indexing its content are platform-admin
+    // actions (managed on the Platform Admin Settings page), so show them here
+    // only as a read-only status for context.
+    $form['beacon_status'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Beacon status'),
       '#weight' => -10,
+    ];
+    $form['beacon_status']['chat_state'] = [
+      '#type' => 'item',
+      '#title' => $this->t('Chat widget'),
+      '#markup' => $config->get('enable_chat') ? $this->t('Enabled') : $this->t('Disabled'),
+      '#description' => $this->t('Managed by a platform administrator; it cannot be changed here.'),
+    ];
+    $form['beacon_status']['index_status'] = [
+      '#type' => 'item',
+      '#title' => $this->t('Content index'),
+      '#markup' => $this->indexStatusMarkup(),
     ];
 
     $form['floating_button'] = [
@@ -138,12 +138,6 @@ class YsBeaconSettings extends ConfigFormBase {
       '#rows' => 2,
     ];
 
-    // "Index now" is always mirrored here. The re-index control primarily
-    // lives on the Beacon administration form; the site form mirrors it only
-    // in the initial "0 of 0" state so an administrator can seed indexing
-    // right after enabling the chat widget. See shouldMirrorReindex().
-    $form['indexing'] = $this->buildIndexingControls($this->shouldMirrorReindex());
-
     // Link to the per-site system instructions when the user has access.
     $instructions_url = Url::fromRoute('ys_beacon.instructions');
     if ($instructions_url->access($this->currentUser())) {
@@ -166,172 +160,21 @@ class YsBeaconSettings extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function validateForm(array &$form, FormStateInterface $form_state) {
-    parent::validateForm($form, $form_state);
-
-    // Never allow two chat widgets at once: the legacy ai_engine chat must be
-    // turned off before Beacon chat is enabled.
-    if ($form_state->getValue('enable_chat') && ys_beacon_legacy_chat_active()) {
-      $form_state->setErrorByName('enable_chat', $this->t('The legacy AI Engine chat widget is currently enabled. Disable it before enabling Beacon chat so visitors only see one chat widget.'));
-    }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $enable_chat = (bool) $form_state->getValue('enable_chat');
-    $config = $this->config(self::CONFIG_NAME);
-    // Capture the previously saved toggle before the config is mutated so the
-    // index status is only changed on an actual on/off transition.
-    $previous_enable = (bool) $config->getOriginal('enable_chat');
-    // The AI metadata fields are always shown while the chatbot is on; their
-    // visibility is otherwise a platform-admin setting and is not editable on
-    // this form.
-    $enable_metadata_fields = $enable_chat || (bool) $config->get('enable_metadata_fields');
-    $config
-      ->set('enable_chat', $enable_chat)
+    // Only the presentation settings are editable here. Whether the chat widget
+    // is enabled (enable_chat) and its metadata fields (enable_metadata_fields)
+    // are platform-admin concerns, so this form never writes them: config save
+    // leaves unset keys - and the platform admin's values - untouched.
+    $this->config(self::CONFIG_NAME)
       ->set('floating_button', (bool) $form_state->getValue('floating_button'))
       ->set('floating_button_text', $form_state->getValue('floating_button_text'))
       ->set('floating_button_icon', self::FLOATING_BUTTON_ICON)
       ->set('prompts', array_values(array_filter($form_state->getValue('prompts'))))
       ->set('disclaimer', $form_state->getValue('disclaimer'))
       ->set('footer', $form_state->getValue('footer'))
-      ->set('enable_metadata_fields', $enable_metadata_fields)
       ->save();
 
-    // Keep the Search API index status in sync with the chat toggle. The
-    // config override forces the index off while chat is disabled, so the
-    // explicit status changes only take effect for the matching transition.
-    $index = $this->loadBeaconIndex();
-    if (!$index) {
-      // Abort if the index does not exist; this should never happen.
-      parent::submitForm($form, $form_state);
-      return;
-    }
-
-    if ($enable_chat) {
-      // Ensure the assigned index actually exists in Azure, creating it if it
-      // does not: first enable (no name yet), a retry after a failed provision,
-      // or an index that was deleted or whose configured name was changed to
-      // one not yet created. An already-existing index is left untouched.
-      if ($this->configuredIndexMissing()) {
-        $this->provisionIndex();
-      }
-      // Enable indexing and queue content when chat turns on, but only once an
-      // index actually exists: a failed provision leaves the index off (the
-      // config override forces it off while no index name is set), so we never
-      // enable an index with no Azure backing.
-      if (!$previous_enable && $this->config(self::CONFIG_NAME)->get('azure_index_name')) {
-        $this->saveIndexStatus(TRUE);
-        // Rebuild the tracker so existing content is queued for indexing on
-        // the freshly enabled index: reindex() only re-flags already-tracked
-        // items and leaves a never-seeded tracker empty (issue #1383).
-        $index->rebuildTracker();
-      }
-    }
-    elseif ($previous_enable) {
-      // Chat turned off: stop indexing.
-      $this->saveIndexStatus(FALSE);
-    }
-
     parent::submitForm($form, $form_state);
-  }
-
-  /**
-   * Whether the site form should mirror the "Re-index all content" control.
-   *
-   * That control primarily lives on the Beacon administration form. The site
-   * settings form surfaces it only in the initial state - the index enabled but
-   * with nothing tracked yet (the "0 of 0" state right after the chat widget is
-   * first turned on) - so a site administrator can seed indexing from here.
-   * Once any content is tracked, re-indexing belongs on the administration form
-   * and the control is hidden here. A read-only borrower never writes its
-   * collection, so it is never offered either.
-   *
-   * @return bool
-   *   TRUE when the re-index control should appear on the site settings form.
-   */
-  protected function shouldMirrorReindex(): bool {
-    $index = $this->loadBeaconIndex();
-    if (!$index || !$index->status() || $index->isReadOnly()) {
-      return FALSE;
-    }
-    try {
-      return $index->getTrackerInstance()->getTotalItemsCount() === 0;
-    }
-    catch (\Throwable $e) {
-      return FALSE;
-    }
-  }
-
-  /**
-   * Provisions the site's search index, creating it when it does not exist.
-   *
-   * Targets the configured Azure index name, falling back to the per-site
-   * default when none is assigned yet, and creates it only when it is missing,
-   * then stores its name and queues existing content for indexing.
-   */
-  protected function provisionIndex(): void {
-    // Provision the index this site is configured to use so a custom or shared
-    // name is (re)created, not just the per-site default.
-    $configured = (string) $this->config(self::CONFIG_NAME)->get('azure_index_name');
-    try {
-      $index_name = $this->indexManager->provision($configured ?: NULL);
-    }
-    catch (\RuntimeException $e) {
-      $this->logger('ys_beacon')->error('Automatic index provisioning failed: @message', ['@message' => $e->getMessage()]);
-      $this->messenger()->addWarning($this->t('The chat widget is enabled, but the search index could not be created automatically. The assistant will not find site content until the index is configured in the Beacon administration settings.'));
-      return;
-    }
-    $this->messenger()->addStatus($this->t('The search index %name is ready and site content has been queued for indexing.', ['%name' => $index_name]));
-  }
-
-  /**
-   * Whether the configured Azure index still needs to be created.
-   *
-   * TRUE when this site is writable and either has no index name assigned yet
-   * or the assigned index no longer exists in Azure (deleted, or a newly chosen
-   * name). A read-only borrower never provisions the collection it reads, and
-   * an unreachable endpoint returns FALSE so a transient outage neither blocks
-   * the save nor triggers a doomed provision on every re-save.
-   *
-   * @return bool
-   *   TRUE when provisioning should run.
-   */
-  protected function configuredIndexMissing(): bool {
-    $config = $this->config(self::CONFIG_NAME);
-    // A read-only borrower must never create or write the collection it reads.
-    if ($config->get('read_only')) {
-      return FALSE;
-    }
-    $name = (string) $config->get('azure_index_name');
-    if ($name === '') {
-      return TRUE;
-    }
-    try {
-      return !$this->indexManager->indexExists($name);
-    }
-    catch (\RuntimeException $e) {
-      // Azure unreachable: don't block the save or attempt a doomed provision.
-      return FALSE;
-    }
-  }
-
-  /**
-   * Persists the Beacon index enabled/disabled status.
-   *
-   * Saves an override-free copy of the index so the runtime status and
-   * read-only overrides layered on by YsBeaconConfigOverrides are never baked
-   * into the synced search_api.index config (which, unlike ys_beacon.settings,
-   * is written back by config import). Mirrors Search API's own CommandHelper,
-   * which reloads override-free before persisting a status change.
-   */
-  protected function saveIndexStatus(bool $status): void {
-    $index = $this->entityTypeManager->getStorage('search_api_index')->loadOverrideFree($this->searchIndexId());
-    if ($index) {
-      $index->setStatus($status)->save();
-    }
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/PlatformAdminSetting/BeaconPlatformAdminSetting.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/PlatformAdminSetting/BeaconPlatformAdminSetting.php
@@ -158,6 +158,12 @@ class BeaconPlatformAdminSetting extends PlatformAdminSettingBase {
       ];
     }
     else {
+      // Show the "X of Y items indexed" count with the controls so platform
+      // admins can tell whether indexing succeeded, mirroring the read-only
+      // status the per-site settings form shows site admins.
+      $form['indexing']['status'] = [
+        '#markup' => '<p>' . $this->indexStatusSummary($index) . '</p>',
+      ];
       $form['indexing']['reindex'] = [
         '#type' => 'submit',
         '#name' => 'ys_beacon_reindex_all',
@@ -366,6 +372,37 @@ class BeaconPlatformAdminSetting extends PlatformAdminSettingBase {
    */
   protected function loadBeaconIndex(): ?IndexInterface {
     return $this->entityTypeManager->getStorage('search_api_index')->load($this->searchIndexId());
+  }
+
+  /**
+   * Builds a short indexing status summary for the platform admin display.
+   *
+   * Mirrors the per-site settings form's read-only status (via
+   * BeaconIndexingControlsTrait::indexStatusSummary()) so platform admins see
+   * the same "@indexed of @total items indexed" count next to the indexing
+   * controls. Kept as a parallel copy because this plugin extends
+   * PlatformAdminSettingBase, not the ConfigFormBase the trait requires.
+   *
+   * @param \Drupal\search_api\IndexInterface|null $index
+   *   The Beacon index, or NULL when it does not exist.
+   *
+   * @return string
+   *   The status text.
+   */
+  protected function indexStatusSummary(?IndexInterface $index): string {
+    if (!$index || !$index->status()) {
+      return (string) $this->t('The Beacon index is currently disabled. It enables automatically once the chat widget is turned on.');
+    }
+    try {
+      $tracker = $index->getTrackerInstance();
+      return (string) $this->t('@indexed of @total items indexed.', [
+        '@indexed' => $tracker->getIndexedItemsCount(),
+        '@total' => $tracker->getTotalItemsCount(),
+      ]);
+    }
+    catch (\Throwable $e) {
+      return (string) $this->t('Index status unavailable.');
+    }
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/PlatformAdminSetting/BeaconPlatformAdminSetting.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/PlatformAdminSetting/BeaconPlatformAdminSetting.php
@@ -32,9 +32,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * YsBeaconSettings::reindexAll() / ::indexNow() through the class resolver, so
  * the tracker-rebuild and search_api.indexing_batch_helper batch paths (and
  * their read-only / disabled / empty-queue guards) are shared, not duplicated.
- * The chat toggle reads and writes the same ys_beacon.settings:enable_chat flag
- * as the site control and mirrors its on/off index side effects via
- * BeaconIndexManager, so toggling from either place stays consistent.
+ * The chat toggle writes ys_beacon.settings:enable_chat - the flag the chat
+ * widget reads across the site - and manages its on/off index side effects via
+ * BeaconIndexManager. It is the only place the widget is enabled or disabled;
+ * the per-site settings form shows that state read-only.
  */
 #[PlatformAdminSetting(
   id: 'ys_beacon',
@@ -140,7 +141,7 @@ class BeaconPlatformAdminSetting extends PlatformAdminSettingBase {
     $form['enable_chat'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Enable chat widget'),
-      '#description' => $this->t('Turn the Beacon chat widget on or off for this site. This is the same setting as the site-level Enable chat widget control and stays in sync with it.'),
+      '#description' => $this->t('Turn the Beacon chat widget on or off for this site.'),
       '#default_value' => (bool) $settings->get('enable_chat'),
     ];
 
@@ -207,11 +208,18 @@ class BeaconPlatformAdminSetting extends PlatformAdminSettingBase {
     $previous_enable = (bool) $settings->get('enable_chat');
     $settings
       ->set(BeaconAuthorization::FLAG, $authorized)
-      ->set('enable_chat', $enable_chat)
-      ->save();
+      ->set('enable_chat', $enable_chat);
+    // The AI metadata fields (AI Description/Tags and the per-page index
+    // exclusion) back the live chatbot, so enabling chat forces them on -
+    // preserving the invariant the site settings form enforced before enabling
+    // moved here. Their visibility is otherwise a platform-admin concern.
+    if ($enable_chat) {
+      $settings->set('enable_metadata_fields', TRUE);
+    }
+    $settings->save();
 
-    // Keep the Search API index in sync with the chat toggle so enabling or
-    // disabling from this page behaves like the site settings form.
+    // Keep the Search API index in sync with the chat toggle: enable and seed
+    // it on turn-on, disable it on turn-off.
     if ($enable_chat && !$previous_enable) {
       $this->enableIndex($settings);
     }
@@ -262,10 +270,9 @@ class BeaconPlatformAdminSetting extends PlatformAdminSettingBase {
   /**
    * Enables the Beacon index in sync with the chat toggle turning on.
    *
-   * Mirrors YsBeaconSettings::submitForm()'s enable path so this page behaves
-   * exactly like the site form: provision only when the configured index is
-   * actually missing, then enable indexing and queue existing content once an
-   * index name exists. Provisioning is gated on configuredIndexMissing() -
+   * Provisions the index only when the configured index is actually missing,
+   * then enables indexing and queues existing content once an index name
+   * exists. Provisioning is gated on configuredIndexMissing() -
    * which treats an unreachable endpoint as "not missing" - so a transient
    * Azure outage on re-enable keeps an existing index enabled for cron to
    * catch up rather than disabling it. A read-only borrower never provisions
@@ -309,9 +316,9 @@ class BeaconPlatformAdminSetting extends PlatformAdminSettingBase {
   /**
    * Whether the configured Azure index still needs to be created.
    *
-   * Mirrors YsBeaconSettings::configuredIndexMissing(): TRUE when the site has
-   * no index name assigned yet or the assigned index no longer exists in Azure
-   * (deleted, or a newly chosen name). An unreachable endpoint returns FALSE so
+   * TRUE when the site has no index name assigned yet or the assigned index no
+   * longer exists in Azure (deleted, or a newly chosen name). An unreachable
+   * endpoint returns FALSE so
    * a transient outage neither triggers a doomed provision nor disables an
    * existing index. The caller guarantees a writable (non-read-only) site.
    *
@@ -339,7 +346,7 @@ class BeaconPlatformAdminSetting extends PlatformAdminSettingBase {
    *
    * Loads the index override-free so the runtime status/read-only overrides
    * layered on by YsBeaconConfigOverrides are never baked into the synced
-   * search_api.index config, matching YsBeaconSettings::saveIndexStatus().
+   * search_api.index config.
    *
    * @param bool $status
    *   The index status to persist.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconPlatformAdminSettingTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconPlatformAdminSettingTest.php
@@ -93,14 +93,16 @@ class BeaconPlatformAdminSettingTest extends UnitTestCase {
   }
 
   /**
-   * Builds an index mock with the given read-only, status and remaining count.
+   * Builds an index mock with the given read-only, status and item counts.
    */
-  private function indexMock(bool $read_only, bool $enabled, int $remaining): IndexInterface {
+  private function indexMock(bool $read_only, bool $enabled, int $remaining, int $indexed = 0, int $total = 0): IndexInterface {
     $index = $this->createMock(IndexInterface::class);
     $index->method('isReadOnly')->willReturn($read_only);
     $index->method('status')->willReturn($enabled);
     $tracker = $this->createMock(TrackerInterface::class);
     $tracker->method('getRemainingItemsCount')->willReturn($remaining);
+    $tracker->method('getIndexedItemsCount')->willReturn($indexed);
+    $tracker->method('getTotalItemsCount')->willReturn($total);
     $index->method('getTrackerInstance')->willReturn($tracker);
     return $index;
   }
@@ -199,6 +201,44 @@ class BeaconPlatformAdminSettingTest extends UnitTestCase {
     $this->assertArrayHasKey('read_only_notice', $form['indexing']);
     $this->assertArrayNotHasKey('reindex', $form['indexing']);
     $this->assertArrayNotHasKey('index_now', $form['indexing']);
+    // The count status belongs with the controls, not the read-only note.
+    $this->assertArrayNotHasKey('status', $form['indexing']);
+  }
+
+  /**
+   * An enabled index shows the "X of Y items indexed" count with the controls.
+   *
+   * Mirrors the read-only status site admins see on the Beacon settings form
+   * so platform admins can tell whether indexing succeeded, next to the
+   * Re-index / Index now buttons.
+   *
+   * @covers ::buildSettings
+   * @covers ::indexStatusSummary
+   */
+  public function testIndexStatusShowsCountWhenWritable(): void {
+    $factory = $this->getConfigFactoryStub(['ys_beacon.settings' => ['search_index_id' => 'ys_beacon']]);
+    $plugin = $this->plugin($factory, $this->entityTypeManagerWithIndex($this->indexMock(FALSE, TRUE, 48, 3, 51)));
+
+    $form = $plugin->buildSettings([], new FormState());
+
+    $this->assertArrayHasKey('status', $form['indexing']);
+    $this->assertStringContainsString('3 of 51 items indexed.', (string) $form['indexing']['status']['#markup']);
+  }
+
+  /**
+   * A disabled index shows the "index disabled" note instead of a count.
+   *
+   * @covers ::buildSettings
+   * @covers ::indexStatusSummary
+   */
+  public function testIndexStatusShowsDisabledMessageWhenIndexDisabled(): void {
+    $factory = $this->getConfigFactoryStub(['ys_beacon.settings' => ['search_index_id' => 'ys_beacon']]);
+    $plugin = $this->plugin($factory, $this->entityTypeManagerWithIndex($this->indexMock(FALSE, FALSE, 0)));
+
+    $form = $plugin->buildSettings([], new FormState());
+
+    $this->assertArrayHasKey('status', $form['indexing']);
+    $this->assertStringContainsString('currently disabled', (string) $form['indexing']['status']['#markup']);
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconPlatformAdminSettingTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconPlatformAdminSettingTest.php
@@ -237,6 +237,56 @@ class BeaconPlatformAdminSettingTest extends UnitTestCase {
   }
 
   /**
+   * Enabling the chat widget forces the AI metadata fields on.
+   *
+   * The site settings form used to guarantee "chat on implies AI metadata
+   * fields on"; with enabling now only on this page, it must preserve that
+   * invariant so editors keep the AI Description/Tags fields the live chatbot
+   * relies on, even if the fields were previously turned off.
+   *
+   * @covers ::submitSettings
+   */
+  public function testEnableForcesMetadataFieldsOn(): void {
+    $settings = [
+      'enable_chat' => FALSE,
+      'enable_metadata_fields' => FALSE,
+      'read_only' => FALSE,
+      'azure_index_name' => 'my-index',
+      'search_index_id' => 'ys_beacon',
+    ];
+    $config = $this->createMock(Config::class);
+    $config->method('get')->willReturnCallback(fn (string $key) => $settings[$key] ?? NULL);
+    $set = [];
+    $config->method('set')->willReturnCallback(function (string $key, $value) use (&$set, $config) {
+      $set[$key] = $value;
+      return $config;
+    });
+    $config->method('save')->willReturnSelf();
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('getEditable')->with('ys_beacon.settings')->willReturn($config);
+    $factory->method('get')->with('ys_beacon.settings')->willReturn($config);
+
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('setStatus')->willReturnSelf();
+    $entity_type_manager = $this->entityTypeManagerWithWritableIndex($index);
+
+    $index_manager = $this->createMock(BeaconIndexManager::class);
+    $index_manager->method('indexExists')->with('my-index')->willReturn(TRUE);
+
+    $plugin = $this->plugin($factory, $entity_type_manager, $index_manager);
+
+    $form_state = new FormState();
+    $form_state->setValue(['ys_beacon', 'platform_authorized'], 1);
+    $form_state->setValue(['ys_beacon', 'enable_chat'], 1);
+    $form = [];
+    $plugin->submitSettings($form, $form_state);
+
+    $this->assertTrue($set['enable_metadata_fields']);
+    $this->assertTrue($set['enable_chat']);
+  }
+
+  /**
    * A first enable provisions the missing index and queues content.
    *
    * @covers ::submitSettings

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/IndexNowFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/IndexNowFormTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\ys_beacon\Unit;
 
-use Drupal\Core\Config\Entity\ConfigEntityStorageInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -318,119 +317,37 @@ class IndexNowFormTest extends UnitTestCase {
   }
 
   /**
-   * Status changes are persisted on an override-free copy of the index.
+   * The read-only status shows item counts for a writable, enabled index.
    *
-   * The runtime status config override must never be baked into the synced
-   * search_api.index config, so the save loads the index override-free rather
-   * than through the overrides-applied load().
-   *
-   * @covers ::saveIndexStatus
+   * @covers ::indexStatusMarkup
    */
-  public function testSaveIndexStatusUsesOverrideFreeLoad(): void {
-    $index = $this->createMock(IndexInterface::class);
-    $index->expects($this->once())->method('setStatus')->with(TRUE)->willReturnSelf();
-    $index->expects($this->once())->method('save');
-
-    $storage = $this->createMock(ConfigEntityStorageInterface::class);
-    $storage->expects($this->once())->method('loadOverrideFree')->with('ys_beacon')->willReturn($index);
-    $storage->expects($this->never())->method('load');
-    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
-    $entity_type_manager->method('getStorage')->with('search_api_index')->willReturn($storage);
-
-    $form = (new \ReflectionClass(YsBeaconSettings::class))->newInstanceWithoutConstructor();
-    $this->setProtected($form, 'entityTypeManager', $entity_type_manager);
-    $this->setProtected($form, 'configFactory', $this->getConfigFactoryStub([
-      'ys_beacon.settings' => ['search_index_id' => 'ys_beacon'],
-    ]));
-
-    $this->invoke($form, 'saveIndexStatus', [TRUE]);
-  }
-
-  /**
-   * The shared builder omits "Re-index all" when told not to include it.
-   *
-   * The re-index control primarily lives on the Beacon administration form; the
-   * site settings form only mirrors it in the initial "0 of 0" state (see
-   * ::shouldMirrorReindex), passing FALSE otherwise. This asserts the trait
-   * honours that flag.
-   *
-   * @covers ::buildIndexingControls
-   */
-  public function testBuildIndexingControlsOmitsReindexOnSiteForm(): void {
+  public function testIndexStatusMarkupShowsCountsWhenEnabled(): void {
     $form = $this->buildForm($this->indexMock(TRUE, 5));
-    $element = $this->invoke($form, 'buildIndexingControls', [FALSE]);
-    $this->assertArrayNotHasKey('reindex', $element);
-    $this->assertArrayHasKey('index_now', $element);
+    $this->assertStringContainsString('items indexed', $this->invoke($form, 'indexStatusMarkup'));
   }
 
   /**
-   * The site form mirrors "Re-index all" in the initial "0 of 0" state.
+   * A disabled index reports the disabled status rather than item counts.
    *
-   * That is the index enabled but with nothing tracked yet, right after the
-   * chat widget is first turned on.
-   *
-   * @covers ::shouldMirrorReindex
+   * @covers ::indexStatusMarkup
    */
-  public function testMirrorsReindexWhenEnabledAndNothingTracked(): void {
-    $form = $this->buildForm($this->indexMock(TRUE, 0));
-    $this->assertTrue($this->invoke($form, 'shouldMirrorReindex'));
-  }
-
-  /**
-   * Once any content is tracked, the site form hides "Re-index all".
-   *
-   * @covers ::shouldMirrorReindex
-   */
-  public function testHidesReindexWhenContentTracked(): void {
-    $form = $this->buildForm($this->indexMock(TRUE, 6));
-    $this->assertFalse($this->invoke($form, 'shouldMirrorReindex'));
-  }
-
-  /**
-   * A disabled index never offers re-index and never consults the tracker.
-   *
-   * @covers ::shouldMirrorReindex
-   */
-  public function testHidesReindexWhenIndexDisabled(): void {
+  public function testIndexStatusMarkupShowsDisabledStatus(): void {
     $index = $this->createMock(IndexInterface::class);
     $index->method('status')->willReturn(FALSE);
-    $index->expects($this->never())->method('getTrackerInstance');
     $form = $this->buildForm($index);
-    $this->assertFalse($this->invoke($form, 'shouldMirrorReindex'));
+    $this->assertStringContainsString('disabled', strtolower($this->invoke($form, 'indexStatusMarkup')));
   }
 
   /**
-   * A missing index never offers re-index.
+   * A read-only borrow shows the shared-collection notice, not item counts.
    *
-   * @covers ::shouldMirrorReindex
+   * @covers ::indexStatusMarkup
    */
-  public function testHidesReindexWhenIndexMissing(): void {
-    $form = $this->buildForm(NULL);
-    $this->assertFalse($this->invoke($form, 'shouldMirrorReindex'));
-  }
-
-  /**
-   * A read-only borrower never offers re-index, without reading the tracker.
-   *
-   * @covers ::shouldMirrorReindex
-   */
-  public function testHidesReindexWhenReadOnly(): void {
+  public function testIndexStatusMarkupShowsReadOnlyNotice(): void {
     $index = $this->createMock(IndexInterface::class);
-    $index->method('status')->willReturn(TRUE);
     $index->method('isReadOnly')->willReturn(TRUE);
-    $index->expects($this->never())->method('getTrackerInstance');
     $form = $this->buildForm($index);
-    $this->assertFalse($this->invoke($form, 'shouldMirrorReindex'));
-  }
-
-  /**
-   * A tracker error degrades to hiding the control rather than crashing.
-   *
-   * @covers ::shouldMirrorReindex
-   */
-  public function testHidesReindexOnTrackerError(): void {
-    $form = $this->buildForm($this->indexMock(TRUE, NULL));
-    $this->assertFalse($this->invoke($form, 'shouldMirrorReindex'));
+    $this->assertStringContainsString('read-only', strtolower($this->invoke($form, 'indexStatusMarkup')));
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/YsBeaconSettingsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/YsBeaconSettingsTest.php
@@ -4,18 +4,19 @@ namespace Drupal\Tests\ys_beacon\Unit;
 
 use Drupal\Core\Config\Config;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\ys_beacon\Form\YsBeaconSettings;
-use Drupal\ys_beacon\Service\BeaconIndexManager;
 
 /**
- * Tests the site Beacon settings form's create-if-missing provisioning.
+ * Tests the site Beacon settings form's submit handler.
  *
- * Enabling the chat widget must (re)create the index this site is configured to
- * use whenever it does not actually exist - first enable, a failed retry, a
- * deleted index, or a newly chosen name - while leaving an existing index and a
- * read-only borrow untouched.
+ * Enabling the chat widget and driving indexing moved to the platform admin
+ * settings page (yalesites-org/YaleSites-Internal#1430), so the site form now
+ * persists only the presentation settings. It must never write enable_chat -
+ * doing so would overwrite the value a platform admin set - nor the
+ * platform-admin-managed enable_metadata_fields.
  *
  * @group ys_beacon
  * @coversDefaultClass \Drupal\ys_beacon\Form\YsBeaconSettings
@@ -23,124 +24,84 @@ use Drupal\ys_beacon\Service\BeaconIndexManager;
 class YsBeaconSettingsTest extends UnitTestCase {
 
   /**
-   * A read-only borrow never provisions the collection it reads.
+   * The form saves the presentation settings the site admin can edit.
    *
-   * @covers ::configuredIndexMissing
+   * @covers ::submitForm
    */
-  public function testReadOnlyBorrowIsNeverMissing(): void {
-    $index_manager = $this->createMock(BeaconIndexManager::class);
-    $index_manager->expects($this->never())->method('indexExists');
-    $form = $this->makeForm($index_manager, ['read_only' => TRUE, 'azure_index_name' => 'shared-idx']);
+  public function testSubmitSavesPresentationSettings(): void {
+    $saved = $this->submit([
+      'floating_button' => TRUE,
+      'floating_button_text' => 'Ask Beacon',
+      'prompts' => ['One', '', 'Two'],
+      'disclaimer' => 'Be careful.',
+      'footer' => 'Footer text.',
+    ]);
 
-    $this->assertFalse($this->invoke($form, 'configuredIndexMissing'));
+    $this->assertTrue($saved['floating_button']);
+    $this->assertSame('Ask Beacon', $saved['floating_button_text']);
+    $this->assertSame(YsBeaconSettings::FLOATING_BUTTON_ICON, $saved['floating_button_icon']);
+    // Empty prompts are filtered out and the list is re-indexed.
+    $this->assertSame(['One', 'Two'], $saved['prompts']);
+    $this->assertSame('Be careful.', $saved['disclaimer']);
+    $this->assertSame('Footer text.', $saved['footer']);
   }
 
   /**
-   * A site with no index name assigned yet needs provisioning.
+   * The form never writes the platform-admin-managed chat/indexing settings.
    *
-   * @covers ::configuredIndexMissing
+   * Enable_chat is owned by the platform admin settings page; writing it here
+   * would overwrite the platform admin's value. enable_metadata_fields is
+   * likewise a platform-admin concern and must be left untouched.
+   *
+   * @covers ::submitForm
    */
-  public function testUnassignedIndexIsMissing(): void {
-    $index_manager = $this->createMock(BeaconIndexManager::class);
-    $index_manager->expects($this->never())->method('indexExists');
-    $form = $this->makeForm($index_manager, ['read_only' => FALSE, 'azure_index_name' => '']);
+  public function testSubmitDoesNotWritePlatformAdminSettings(): void {
+    $saved = $this->submit([
+      'floating_button' => FALSE,
+      'floating_button_text' => 'Beacon Chat',
+      'prompts' => [],
+      'disclaimer' => '',
+      'footer' => '',
+    ]);
 
-    $this->assertTrue($this->invoke($form, 'configuredIndexMissing'));
+    $this->assertArrayNotHasKey('enable_chat', $saved);
+    $this->assertArrayNotHasKey('enable_metadata_fields', $saved);
   }
 
   /**
-   * An assigned index that exists in Azure needs no provisioning.
+   * Submits the form with the given values and returns the saved config map.
    *
-   * @covers ::configuredIndexMissing
+   * @param array $values
+   *   Submitted form values keyed by element name.
+   *
+   * @return array
+   *   The keys written to ys_beacon.settings mapped to their saved values.
    */
-  public function testExistingIndexIsNotMissing(): void {
-    $index_manager = $this->createMock(BeaconIndexManager::class);
-    $index_manager->expects($this->once())->method('indexExists')->with('my-index')->willReturn(TRUE);
-    $form = $this->makeForm($index_manager, ['read_only' => FALSE, 'azure_index_name' => 'my-index']);
-
-    $this->assertFalse($this->invoke($form, 'configuredIndexMissing'));
-  }
-
-  /**
-   * An assigned index deleted from Azure is missing and must be provisioned.
-   *
-   * @covers ::configuredIndexMissing
-   */
-  public function testDeletedIndexIsMissing(): void {
-    $index_manager = $this->createMock(BeaconIndexManager::class);
-    $index_manager->expects($this->once())->method('indexExists')->with('my-index')->willReturn(FALSE);
-    $form = $this->makeForm($index_manager, ['read_only' => FALSE, 'azure_index_name' => 'my-index']);
-
-    $this->assertTrue($this->invoke($form, 'configuredIndexMissing'));
-  }
-
-  /**
-   * An unreachable Azure endpoint neither blocks the save nor forces a retry.
-   *
-   * @covers ::configuredIndexMissing
-   */
-  public function testUnreachableAzureIsTreatedAsNotMissing(): void {
-    $index_manager = $this->createMock(BeaconIndexManager::class);
-    $index_manager->method('indexExists')->willThrowException(new \RuntimeException('unreachable'));
-    $form = $this->makeForm($index_manager, ['read_only' => FALSE, 'azure_index_name' => 'my-index']);
-
-    $this->assertFalse($this->invoke($form, 'configuredIndexMissing'));
-  }
-
-  /**
-   * Provisioning targets the configured index name, not the per-site default.
-   *
-   * @covers ::provisionIndex
-   */
-  public function testProvisionIndexUsesConfiguredName(): void {
-    $index_manager = $this->createMock(BeaconIndexManager::class);
-    $index_manager->expects($this->once())->method('provision')->with('special-idx')->willReturn('special-idx');
-    $form = $this->makeForm($index_manager, ['read_only' => FALSE, 'azure_index_name' => 'special-idx']);
-
-    $this->invoke($form, 'provisionIndex');
-  }
-
-  /**
-   * With no name assigned, provisioning falls back to the per-site default.
-   *
-   * @covers ::provisionIndex
-   */
-  public function testProvisionIndexFallsBackToDefault(): void {
-    $index_manager = $this->createMock(BeaconIndexManager::class);
-    // A NULL argument makes BeaconIndexManager::provision() use the default.
-    $index_manager->expects($this->once())->method('provision')->with(NULL)->willReturn('site-default');
-    $form = $this->makeForm($index_manager, ['read_only' => FALSE, 'azure_index_name' => '']);
-
-    $this->invoke($form, 'provisionIndex');
-  }
-
-  /**
-   * Builds the form with a config mock and index manager, sans constructor.
-   *
-   * @param \Drupal\ys_beacon\Service\BeaconIndexManager $index_manager
-   *   The index manager double.
-   * @param array $settings
-   *   The ys_beacon.settings values keyed by name (read_only,
-   *   azure_index_name).
-   *
-   * @return \Drupal\ys_beacon\Form\YsBeaconSettings
-   *   The form under test.
-   */
-  private function makeForm(BeaconIndexManager $index_manager, array $settings): YsBeaconSettings {
+  private function submit(array $values): array {
+    $saved = [];
     $config = $this->createMock(Config::class);
-    $config->method('get')->willReturnCallback(fn (string $key) => $settings[$key] ?? NULL);
+    $config->method('set')->willReturnCallback(function (string $key, $value) use (&$saved, $config) {
+      $saved[$key] = $value;
+      return $config;
+    });
+    $config->method('save')->willReturnSelf();
 
     $factory = $this->createMock(ConfigFactoryInterface::class);
     $factory->method('get')->willReturn($config);
     $factory->method('getEditable')->willReturn($config);
 
+    $form_state = $this->createMock(FormStateInterface::class);
+    $form_state->method('getValue')->willReturnCallback(fn (string $key) => $values[$key] ?? NULL);
+
     $form = (new \ReflectionClass(YsBeaconSettings::class))->newInstanceWithoutConstructor();
     $this->setProtected($form, 'configFactory', $factory);
-    $this->setProtected($form, 'indexManager', $index_manager);
     $this->setProtected($form, 'messenger', $this->createMock(MessengerInterface::class));
     $this->setProtected($form, 'stringTranslation', $this->getStringTranslationStub());
 
-    return $form;
+    $form_array = [];
+    $form->submitForm($form_array, $form_state);
+
+    return $saved;
   }
 
   /**
@@ -150,15 +111,6 @@ class YsBeaconSettingsTest extends UnitTestCase {
     $reflection = new \ReflectionProperty($object, $property);
     $reflection->setAccessible(TRUE);
     $reflection->setValue($object, $value);
-  }
-
-  /**
-   * Invokes a protected method via reflection.
-   */
-  private function invoke(object $object, string $method): mixed {
-    $reflection = new \ReflectionMethod($object, $method);
-    $reflection->setAccessible(TRUE);
-    return $reflection->invoke($object);
   }
 
 }


### PR DESCRIPTION
## [1430: Beacon: Restrict Beacon chat enable + indexing to platform admins (remove controls from the site-admin settings form)](https://github.com/yalesites-org/YaleSites-Internal/issues/1430)

### Description of work
- Removed the "Enable chat widget" checkbox and the indexing controls (Re-index all content / Index now) from the site-admin Beacon settings form (`/admin/config/yalesites/ys-beacon`); site admins can no longer toggle chat or drive indexing there.
- Replaced them with a read-only "Beacon status" indicator showing the current chat state ("Enabled"/"Disabled", managed by a platform administrator) and the current index status ("X of Y items indexed").
- Kept the site form's editable presentation settings: floating chat button + text, initial prompts, disclaimer, footer, and the System Instructions link.
- The site form no longer writes `enable_chat` or `enable_metadata_fields`, so saving it cannot overwrite the platform admin's values.
- Enabling/disabling chat and all indexing (create-index-on-enable, re-index all, index now) continue to work from the Platform Admin Settings page. Enabling chat there now also forces the AI metadata fields on, preserving the "chat on implies AI metadata fields on" invariant the site form previously enforced (the platform-admin path did not set it before).

### Functional testing steps:
- [ ] As a site admin, go to Configuration > YaleSites Beacon settings (`/admin/config/yalesites/ys-beacon`). Confirm there is no "Enable chat widget" checkbox and no "Re-index all content" / "Index now" buttons.
- [ ] Confirm the read-only "Beacon status" shows the current chat state and "X of Y items indexed", and that the floating button + text, initial prompts, disclaimer, footer, and System Instructions link are still editable and save correctly.
- [ ] As a platform admin, go to Platform Admin Settings and confirm the Beacon section still has "Enable chat widget", "Re-index all content", and "Index now".
- [ ] As a platform admin, confirm the Beacon section on Platform Admin Settings now shows the "X of Y items indexed" count alongside the "Re-index all content" / "Index now" buttons (mirroring the read-only count site admins see on the Beacon settings form), and that the count reflects the tracker state (e.g. "80 of 90 items indexed."). A disabled index shows the "index is currently disabled" note instead, and a borrowed read-only index keeps its "shared, read-only index" notice.
- [ ] End-to-end: on a site with Beacon authorized but chat off, enable the chat widget from Platform Admin Settings (the index is created if missing), click "Re-index all content", then "Index now", and confirm indexing completes and the site form's read-only status reflects the counts.
- [ ] Regression: on a site where the AI metadata fields were previously turned off, enable chat from Platform Admin Settings and confirm the AI Description / AI Tags fields reappear on node and media forms.

References yalesites-org/YaleSites-Internal#1430

---
Created with AI

