### PR TITLE
1425: ys_embed: five embed defects (multiline regex, isVideo host check, SoundCloud playlist, Broken fallback)

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/GoogleMaps.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/GoogleMaps.php
@@ -21,7 +21,7 @@ class GoogleMaps extends EmbedSourceBase implements EmbedSourceInterface {
   /**
    * {@inheritdoc}
    */
-  protected static $pattern = '/^<iframe.+src=\"https:\/\/www\.google\.com\/maps\/embed(?<map_params>\?.+?)\".*$/';
+  protected static $pattern = '/^<iframe[^>]*src=\"https:\/\/www\.google\.com\/maps\/embed(?<map_params>\?.+?)\".*$/s';
 
   /**
    * {@inheritdoc}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/JWPlayer.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/JWPlayer.php
@@ -21,7 +21,7 @@ class JWPlayer extends EmbedSourceBase implements EmbedSourceInterface {
   /**
    * {@inheritdoc}
    */
-  protected static $pattern = '/<iframe.+src="(?<url>https:\/\/(content|cdn).(jwplatform|jwplayer).com\/players\/[^"]+)"/';
+  protected static $pattern = '/<iframe.+src="(?<url>https:\/\/(content|cdn).(jwplatform|jwplayer).com\/players\/[^"]+)"/s';
   /**
    * {@inheritdoc}
    */

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/SoundCloud.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSource/SoundCloud.php
@@ -26,7 +26,7 @@ class SoundCloud extends EmbedSourceBase implements EmbedSourceInterface {
   /**
    * {@inheritdoc}
    */
-  protected static $template = '<iframe title="{{ title }}" width="100%" height="240px" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/{{ track_id }}&color=%02366900&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe>';
+  protected static $template = '<iframe title="{{ title }}" width="100%" height="240px" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/{{ track_or_playlist }}/{{ track_id }}&color=%02366900&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe>';
 
   /**
    * {@inheritdoc}
@@ -54,8 +54,9 @@ class SoundCloud extends EmbedSourceBase implements EmbedSourceInterface {
    * {@inheritdoc}
    */
   public function getUrl(array $params): string {
+    $type = $params['track_or_playlist'];
     $track_id = $params['track_id'];
-    return 'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/' . $track_id;
+    return 'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/' . $type . '/' . $track_id;
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSourceManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSourceManager.php
@@ -135,7 +135,7 @@ class EmbedSourceManager extends DefaultPluginManager {
    */
   public function loadPluginById($plugin_id) {
     if (!$this->isValidSourceId($plugin_id)) {
-      return $this->instances[static::BROKEN_ID];
+      $plugin_id = static::BROKEN_ID;
     }
     if (!empty($this->instances[$plugin_id])) {
       return $this->instances[$plugin_id];

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/Validation/Constraint/EmbedConstraintValidator.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/Validation/Constraint/EmbedConstraintValidator.php
@@ -78,11 +78,17 @@ class EmbedConstraintValidator extends ConstraintValidator implements ContainerI
    *   TRUE if the embed code matches one of the remote video providers.
    */
   protected function isVideo(string $input): bool {
-    $p1 = "^https:\/\/\S+.youtube.com\/\S+";
-    $p2 = "^https:\/\/youtu.be\/\S+";
-    $p3 = "^https:\/\/vimeo.com\/\S+";
-    $pattern = "/{$p1}|{$p2}|{$p3}/";
-    return (bool) preg_match($pattern, $input, $matches);
+    $host = parse_url(trim($input), PHP_URL_HOST);
+    if (!$host) {
+      return FALSE;
+    }
+    $host = strtolower($host);
+    foreach (['youtube.com', 'youtu.be', 'vimeo.com'] as $video_host) {
+      if ($host === $video_host || str_ends_with($host, '.' . $video_host)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Kernel/EmbedSourceManagerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Kernel/EmbedSourceManagerTest.php
@@ -169,25 +169,15 @@ class EmbedSourceManagerTest extends KernelTestBase {
   }
 
   /**
-   * Tests load plugin by id returns null instead of broken plugin for.
+   * LoadPluginById() returns the Broken plugin for an unregistered ID.
    *
-   * CHARACTERIZATION: loadPluginById() documents that an unrecognized plugin
-   * ID falls back to the Broken plugin, but the implementation reads
-   * $this->instances[static::BROKEN_ID] directly without ever populating it
-   * first. On a fresh manager (nothing has called loadPluginById('broken')
-   * yet), this returns NULL and raises an "Undefined array key" warning
-   * instead of the documented Broken plugin instance.
-   *
-   * This is reachable in production: EmbedDefaultFormatter::viewElements()
-   * calls loadPluginById($item->embed_source) with a value read directly
-   * from stored field data, which can be stale/legacy.
-   *
-   * Paired with testLoadPluginByIdShouldReturnBrokenPluginForUnregisteredId()
-   * -- delete once the GAP is fixed.
+   * LoadPluginById() lazily instantiates and returns the Broken plugin for an
+   * unregistered plugin ID (per its docblock) rather than returning NULL with
+   * an "Undefined array key" warning.
    *
    * @covers ::loadPluginById
    */
-  public function testLoadPluginByIdReturnsNullInsteadOfBrokenPluginForUnregisteredId(): void {
+  public function testLoadPluginByIdReturnsBrokenPluginForUnregisteredId(): void {
     $captured = [];
     set_error_handler(function (int $errno, string $errstr) use (&$captured): bool {
       $captured[] = $errstr;
@@ -201,21 +191,8 @@ class EmbedSourceManagerTest extends KernelTestBase {
       restore_error_handler();
     }
 
-    $this->assertNull($result);
-    $this->assertNotEmpty($captured);
-    $this->assertStringContainsString('Undefined array key', $captured[0]);
-  }
-
-  /**
-   * Tests load plugin by id should return broken plugin for unregistered id.
-   *
-   * GAP: loadPluginById() should lazily instantiate and return the Broken
-   * plugin for an unregistered plugin ID per its own docblock, instead of
-   * returning NULL with an "Undefined array key" warning -- see
-   * ~/Documents/Claude/not_dave/module-tests-20260710/ys_embed.md.
-   */
-  public function testLoadPluginByIdShouldReturnBrokenPluginForUnregisteredId(): void {
-    $this->markTestSkipped('GAP: EmbedSourceManager::loadPluginById() should return the cached Broken plugin instance for an unregistered plugin ID (per its own docblock) instead of returning NULL with an "Undefined array key" warning, because $this->instances[BROKEN_ID] is read without ever being populated -- see ~/Documents/Claude/not_dave/module-tests-20260710/ys_embed.md');
+    $this->assertInstanceOf(Broken::class, $result);
+    $this->assertSame([], $captured);
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Unit/EmbedConstraintValidatorTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Unit/EmbedConstraintValidatorTest.php
@@ -208,34 +208,16 @@ class EmbedConstraintValidatorTest extends UnitTestCase {
   }
 
   /**
-   * CHARACTERIZATION: isVideo() false-positives on a non-video URL.
+   * IsVideo() matches on the parsed host, not a substring.
    *
-   * It flags a URL as a video embed even when "youtube.com" merely appears
-   * elsewhere in the string, because $p1 uses an unescaped "." (matches any
-   * character, not a literal dot) and a leading "\S+" with no host
-   * anchoring. A legitimate non-video embed whose URL happens to contain
-   * that substring is wrongly rejected as "should use the Video component
-   * instead".
-   *
-   * Paired with testIsVideoShouldOnlyMatchTheActualHost() -- delete once the
-   * GAP is fixed.
+   * IsVideo() anchors on parse_url()'s host, so a non-video URL that merely
+   * contains "youtube.com" elsewhere in the string is not misclassified as a
+   * video embed.
    *
    * @covers ::isVideo
    */
-  public function testIsVideoFalsePositivesOnUnrelatedHostContainingYoutubeSubstring(): void {
-    $this->assertTrue($this->invokeProtected('isVideo', 'https://evil.com/redirect?to=youtube.com/x'));
-  }
-
-  /**
-   * GAP: isVideo() should anchor its match to the actual request host.
-   *
-   * It should anchor $p1 to the actual host (e.g. via parse_url()) and
-   * escape the literal "." in "youtube.com", instead of a bare
-   * "\S+.youtube.com" that matches the substring anywhere in the string --
-   * see ~/Documents/Claude/not_dave/module-tests-20260710/ys_embed.md.
-   */
-  public function testIsVideoShouldOnlyMatchTheActualHost(): void {
-    $this->markTestSkipped('GAP: EmbedConstraintValidator::isVideo() wrongly classifies a non-YouTube URL as a video embed because its regex is unanchored and its "." is unescaped -- see ~/Documents/Claude/not_dave/module-tests-20260710/ys_embed.md');
+  public function testIsVideoOnlyMatchesTheActualHost(): void {
+    $this->assertFalse($this->invokeProtected('isVideo', 'https://evil.com/redirect?to=youtube.com/x'));
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Unit/GoogleMapsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Unit/GoogleMapsTest.php
@@ -53,32 +53,31 @@ class GoogleMapsTest extends UnitTestCase {
   }
 
   /**
-   * CHARACTERIZATION: a multi-line Google Maps iframe fails to validate.
+   * A multi-line iframe (newline before src) validates.
    *
-   * The pattern omits the "s" (DOTALL) modifier that the sibling
-   * GoogleCalendar plugin uses for the same shape of iframe match, so any
-   * embed code copied from a source that wraps attributes onto separate
-   * lines is silently rejected.
-   *
-   * Paired with testMatchShouldAcceptMultilineIframe() -- delete once the
-   * GAP is fixed.
+   * $pattern uses "[^>]*" before src (like the sibling GoogleCalendar plugin),
+   * which spans newlines within the opening tag, so an embed copied from a
+   * source that wraps attributes onto separate lines is accepted.
    *
    * @covers ::isValid
    */
-  public function testIsValidRejectsIframeWithNewlineBeforeSrc(): void {
+  public function testMatchAcceptsMultilineIframe(): void {
     $multiline = "<iframe\nsrc=\"https://www.google.com/maps/embed?pb=abc\" width=\"600\"></iframe>";
-    $this->assertFalse(GoogleMaps::isValid($multiline));
+    $this->assertTrue(GoogleMaps::isValid($multiline));
   }
 
   /**
-   * GAP: GoogleMaps::isValid() should accept a multi-line iframe.
+   * A paste with a leading non-Google iframe is rejected, not silently trimmed.
    *
-   * It should match the same way GoogleCalendar::isValid() does, by adding
-   * the "s" (DOTALL) modifier to $pattern so "." matches across newlines --
-   * see ~/Documents/Claude/not_dave/module-tests-20260710/ys_embed.md.
+   * "[^>]*" before src cannot cross the ">" that closes a preceding element,
+   * so a multi-element paste does not match (and validation fails) rather than
+   * matching only the trailing Google Maps iframe and discarding the rest.
+   *
+   * @covers ::isValid
    */
-  public function testMatchShouldAcceptMultilineIframe(): void {
-    $this->markTestSkipped('GAP: GoogleMaps::isValid() rejects a multi-line iframe because $pattern is missing the "s" (DOTALL) modifier that GoogleCalendar uses -- see ~/Documents/Claude/not_dave/module-tests-20260710/ys_embed.md');
+  public function testIsValidRejectsMultiElementPasteWithLeadingIframe(): void {
+    $paste = "<iframe src=\"https://evil.com/x\"></iframe>\n<iframe src=\"https://www.google.com/maps/embed?pb=X\"></iframe>";
+    $this->assertFalse(GoogleMaps::isValid($paste));
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Unit/JWPlayerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Unit/JWPlayerTest.php
@@ -60,35 +60,17 @@ class JWPlayerTest extends UnitTestCase {
   }
 
   /**
-   * Tests is valid rejects own documented example.
+   * The plugin's own documented example validates.
    *
-   * CHARACTERIZATION: the plugin's own getExample() embed code does not
-   * actually validate, because the example wraps the "src" attribute onto a
-   * new line while $pattern has no "s" (DOTALL) modifier -- "." cannot cross
-   * the newline between "<iframe ...\n" and "src=...". An editor who copies
-   * the documented example verbatim gets a validation failure.
-   *
-   * Paired with testMatchShouldAcceptDocumentedExample() -- delete once the
-   * GAP is fixed.
+   * $pattern carries the "s" (DOTALL) modifier so "." spans the newline the
+   * multi-line $example wraps before its src attribute; an editor who copies
+   * the documented example verbatim gets a valid embed.
    *
    * @covers ::isValid
    * @covers ::getExample
    */
-  public function testIsValidRejectsOwnDocumentedExample(): void {
-    $this->assertFalse(JWPlayer::isValid(JWPlayer::getExample()));
-  }
-
-  /**
-   * Tests match should accept documented example.
-   *
-   * GAP: JWPlayer::getExample() should produce an embed code that
-   * JWPlayer::isValid() accepts, since it is shown to editors as the
-   * canonical example. Either add the "s" modifier to $pattern (matching how
-   * GoogleCalendar handles multi-line iframes) or reflow the example onto a
-   * single line. See the module's test log for details.
-   */
-  public function testMatchShouldAcceptDocumentedExample(): void {
-    $this->markTestSkipped('GAP: JWPlayer::getExample() embed code fails JWPlayer::isValid() because $pattern lacks the "s" (DOTALL) modifier needed for its multi-line src attribute -- see ~/Documents/Claude/not_dave/module-tests-20260710/ys_embed.md');
+  public function testMatchAcceptsDocumentedExample(): void {
+    $this->assertTrue(JWPlayer::isValid(JWPlayer::getExample()));
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Unit/SoundCloudTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Unit/SoundCloudTest.php
@@ -92,36 +92,19 @@ class SoundCloudTest extends UnitTestCase {
   }
 
   /**
-   * CHARACTERIZATION: getUrl() always reconstructs a tracks API URL.
+   * GetUrl() reconstructs the playlists endpoint for a playlist embed.
    *
-   * It rebuilds a "/tracks/{id}" URL even when the embed code matched as a
-   * playlist -- it captures "track_or_playlist" for validation but never
-   * reads it back out when building the URL. A playlist embed is
-   * re-pointed at the tracks API endpoint instead of the playlists one.
-   *
-   * Paired with testGetUrlShouldUsePlaylistsEndpointForPlaylistEmbeds() --
-   * delete once the GAP is fixed.
+   * GetUrl() reads the captured "track_or_playlist" group, so a playlist embed
+   * yields a "/playlists/{id}" URL rather than the tracks endpoint.
    *
    * @covers ::getUrl
    */
-  public function testGetUrlAlwaysBuildsTracksApiUrlRegardlessOfType(): void {
+  public function testGetUrlUsesPlaylistsEndpointForPlaylistEmbeds(): void {
     $params = $this->plugin->getParams(self::PLAYLIST_EMBED);
     $this->assertSame(
-      'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/123456',
+      'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/123456',
       $this->plugin->getUrl($params)
     );
-  }
-
-  /**
-   * Tests get url should use playlists endpoint for playlist embeds.
-   *
-   * GAP: getUrl() should reconstruct "/playlists/{id}" when the embed
-   * matched as a playlist, using the captured "track_or_playlist" group
-   * instead of hardcoding "tracks" -- see
-   * ~/Documents/Claude/not_dave/module-tests-20260710/ys_embed.md.
-   */
-  public function testGetUrlShouldUsePlaylistsEndpointForPlaylistEmbeds(): void {
-    $this->markTestSkipped('GAP: SoundCloud::getUrl() hardcodes "/tracks/" and ignores the captured "track_or_playlist" group, so a playlist embed is reconstructed with the wrong API endpoint -- see ~/Documents/Claude/not_dave/module-tests-20260710/ys_embed.md');
   }
 
   /**


### PR DESCRIPTION
## [1425: ys_embed: five embed defects (multiline regex, isVideo host check, SoundCloud playlist, Broken fallback)](https://github.com/yalesites-org/YaleSites-Internal/issues/1425)

### Description of work
Fixes five independent defects in the `ys_embed` module. Each defect's paired GAP test (already on develop) is un-skipped and its characterization test removed.

- **GoogleMaps / JWPlayer multi-line iframes** — the iframe validation patterns rejected an embed code whose `src` attribute wraps onto its own line. GoogleMaps now uses `[^>]*` before `src` (matching the sibling GoogleCalendar plugin), which spans newlines within the opening tag but cannot cross into a following element; JWPlayer gains the `s` (DOTALL) modifier.
- **`isVideo()` host check** — an unanchored regex with an unescaped dot classified any URL merely containing `youtube.com` as a video embed. It now parses the URL host and matches it against the allowed video hosts (youtube.com / youtu.be / vimeo.com).
- **SoundCloud playlists** — `getUrl()` and the plugin template hardcoded the `/tracks/` API endpoint, ignoring the captured `track_or_playlist` group, so playlist embeds were rebuilt against the wrong endpoint. Both now use the captured group.
- **Broken fallback** — `EmbedSourceManager::loadPluginById()` read `$instances[BROKEN_ID]` before it was populated, returning `NULL` with an "Undefined array key" warning; it now reassigns to `BROKEN_ID` and lazily instantiates the `Broken` plugin per its docblock.

**Reviewer note (SoundCloud playlists — product question):** the `getUrl`/template fix corrects the rendered endpoint for playlist embeds, which benefits any already-saved/legacy playlist embed. However, a **pre-existing** validation gate — `EmbedConstraintValidator::isTrack()` — still rejects **newly-authored** SoundCloud playlist embeds with an `invalidAudioTrack` violation (this gate and its asserting test predate this PR). So new playlist embeds still cannot be saved. Whether SoundCloud **playlists** should be allowed at all is a product decision outside this ticket's five named defects; if desired, that's a follow-up to relax `isTrack()` and update its test. Flagging so the playlist behavior isn't misread as fully enabled.

### Functional testing steps:
- [ ] Paste a multi-line Google Maps "Embed a map" iframe (with `src` on its own line); confirm it validates and renders.
- [ ] Paste the JW Player documented example embed (multi-line); confirm it validates.
- [ ] Confirm a valid single-line Google Maps / SoundCloud track embed still works (no regression).
- [ ] Confirm an existing SoundCloud track embed still renders correctly.
- [ ] Paste a bare YouTube/Vimeo URL and confirm the "use the Video component" guidance still appears; confirm a non-video URL that merely contains "youtube.com" is no longer misclassified as a video.

References yalesites-org/YaleSites-Internal#1425

---
Created with AI
