### PR TITLE
1426: ys_views_basic: missing break; in getDefaultParamValue() falls through for show_current_entity

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -781,6 +781,8 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
 
       case 'show_current_entity':
         $defaultParam = (empty($paramsDecoded['show_current_entity'])) ? 0 : $paramsDecoded['show_current_entity'];
+        break;
+
       case 'pinned_to_top':
         $defaultParam = (empty($paramsDecoded['pinned_to_top'])) ? FALSE : (bool) $paramsDecoded['pinned_to_top'];
         break;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/tests/src/Unit/ViewsBasicManagerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/tests/src/Unit/ViewsBasicManagerTest.php
@@ -456,47 +456,15 @@ class ViewsBasicManagerTest extends UnitTestCase {
   }
 
   /**
-   * Tests get default param value show current entity actually returns.
+   * GetDefaultParamValue('show_current_entity', ...) returns its own value.
    *
-   * CURRENT (buggy) behavior: 'show_current_entity' falls through to
-   * 'pinned_to_top' and returns the pinned_to_top value instead.
-   *
-   * The switch case for 'show_current_entity' at ViewsBasicManager.php:782
-   * is missing a `break;` statement, so execution falls through into the
-   * adjacent 'pinned_to_top' case and $defaultParam is overwritten before
-   * being returned. Calling getDefaultParamValue('show_current_entity', ...)
-   * therefore never returns the show_current_entity value at all -- it
-   * always returns the (bool) pinned_to_top default instead. Paired with
-   * testGetDefaultParamValueShowCurrentEntityShouldReturnItsOwnValue() --
-   * delete once the GAP is fixed.
+   * With the `break;` after the show_current_entity case, execution no longer
+   * falls through into pinned_to_top, so the show_current_entity default is
+   * returned as-is rather than being overwritten by the pinned_to_top value.
    *
    * @covers ::getDefaultParamValue
    */
-  public function testGetDefaultParamValueShowCurrentEntityActuallyReturnsPinnedToTopValue() {
-    // show_current_entity is truthy, pinned_to_top is unset (=> FALSE):
-    // the fallthrough clobbers the show_current_entity result with FALSE.
-    $params = json_encode(['show_current_entity' => 1]);
-    $this->assertFalse($this->manager->getDefaultParamValue('show_current_entity', $params));
-
-    // show_current_entity is unset, pinned_to_top is TRUE: fallthrough
-    // returns TRUE, not the expected show_current_entity default of 0.
-    $params = json_encode(['pinned_to_top' => TRUE]);
-    $this->assertTrue($this->manager->getDefaultParamValue('show_current_entity', $params));
-  }
-
-  /**
-   * Tests get default param value show current entity should return its own.
-   *
-   * GAP: missing `break;` after the 'show_current_entity' case in
-   * getDefaultParamValue() (ViewsBasicManager.php:782) makes it fall through
-   * to 'pinned_to_top' and return the wrong value -- see
-   * ~/Documents/Claude/not_dave/module-tests-20260710/ys_views_basic.md.
-   *
-   * @covers ::getDefaultParamValue
-   */
-  public function testGetDefaultParamValueShowCurrentEntityShouldReturnItsOwnValue() {
-    $this->markTestSkipped('GAP: missing `break;` after the show_current_entity case in ViewsBasicManager::getDefaultParamValue() makes it fall through to pinned_to_top and return the wrong value -- see ~/Documents/Claude/not_dave/module-tests-20260710/ys_views_basic.md');
-
+  public function testGetDefaultParamValueShowCurrentEntityReturnsItsOwnValue() {
     $params = json_encode(['show_current_entity' => 1, 'pinned_to_top' => FALSE]);
     $this->assertEquals(1, $this->manager->getDefaultParamValue('show_current_entity', $params));
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/tests/src/Unit/ViewsBasicManagerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/tests/src/Unit/ViewsBasicManagerTest.php
@@ -465,8 +465,22 @@ class ViewsBasicManagerTest extends UnitTestCase {
    * @covers ::getDefaultParamValue
    */
   public function testGetDefaultParamValueShowCurrentEntityReturnsItsOwnValue() {
+    // A stored value is returned as-is, not overwritten by pinned_to_top.
     $params = json_encode(['show_current_entity' => 1, 'pinned_to_top' => FALSE]);
-    $this->assertEquals(1, $this->manager->getDefaultParamValue('show_current_entity', $params));
+    $this->assertSame(1, $this->manager->getDefaultParamValue('show_current_entity', $params));
+
+    // An unset value falls back to the case's own 0 default.
+    $this->assertSame(0, $this->manager->getDefaultParamValue('show_current_entity', json_encode([])));
+  }
+
+  /**
+   * GetDefaultParamValue('pinned_to_top', ...) returns its boolean default.
+   *
+   * @covers ::getDefaultParamValue
+   */
+  public function testGetDefaultParamValuePinnedToTopReturnsBoolean() {
+    $this->assertTrue($this->manager->getDefaultParamValue('pinned_to_top', json_encode(['pinned_to_top' => TRUE])));
+    $this->assertFalse($this->manager->getDefaultParamValue('pinned_to_top', json_encode([])));
   }
 
   /**


### PR DESCRIPTION
## [1426: ys_views_basic: missing break; in getDefaultParamValue() falls through for show_current_entity](https://github.com/yalesites-org/YaleSites-Internal/issues/1426)

### Description of work
- `ViewsBasicManager::getDefaultParamValue()`'s `show_current_entity` switch case was missing a `break;`, so execution fell through into the adjacent `pinned_to_top` case and overwrote `$defaultParam`. `getDefaultParamValue('show_current_entity', ...)` therefore always returned the `pinned_to_top` value instead of its own — e.g. the "show current entity" checkbox default in the listing-block widget (`ViewsBasicDefaultWidget`) mirrored `pinned_to_top`. Added the `break;` so each case returns its own default.
- Un-skips the paired GAP test and removes the characterization test that asserted the fall-through behavior.

**Reviewer note:** the automated `/code-review` pass could not complete its verification stage (a session/rate limit was hit mid-run), so please re-run `/code-review` on this PR before merge. The fix is nonetheless a one-line, issue-prescribed `break;`, independently verified by TDD (red → green), the full `ys_views_basic` regression suite (71 tests, no regressions), `composer code-sniff` (exit 0), and `/simplify`.

### Functional testing steps:
- [ ] In a listing block (ys_views_basic), enable "Show current entity" and save; reopen the block form and confirm the checkbox reflects the saved value rather than the pinned-to-top value.
- [ ] Confirm "Pinned to top" and the other listing options still behave correctly.

References yalesites-org/YaleSites-Internal#1426

---
Created with AI
