### PR TITLE
1421: ys_taxonomy_manager: AddTermsToNodesForm throws InvalidQueryException when no bundle references the vocabulary

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_taxonomy_manager/src/Form/AddTermsToNodesForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_taxonomy_manager/src/Form/AddTermsToNodesForm.php
@@ -107,13 +107,18 @@ class AddTermsToNodesForm extends FormBase {
       }
     }
 
-    // Get nodes of the relevant bundles.
-    $query = $this->nodeStorage->getQuery()
-      ->condition('status', 1)
-      ->condition('type', array_unique($relevantBundles), 'IN')
-      ->accessCheck(TRUE);
+    // Get nodes of the relevant bundles. Only query when a bundle references
+    // the vocabulary; an empty $relevantBundles would build an invalid
+    // `type IN ()` condition and throw InvalidQueryException.
+    $nids = [];
+    if (!empty($relevantBundles)) {
+      $query = $this->nodeStorage->getQuery()
+        ->condition('status', 1)
+        ->condition('type', array_unique($relevantBundles), 'IN')
+        ->accessCheck(TRUE);
 
-    $nids = $query->execute();
+      $nids = $query->execute();
+    }
 
     // If no nodes are found, show a message and return.
     if (empty($nids)) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_taxonomy_manager/tests/src/Kernel/AddTermsToNodesFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_taxonomy_manager/tests/src/Kernel/AddTermsToNodesFormTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\ys_taxonomy_manager\Kernel;
 
-use Drupal\Core\Database\InvalidQueryException;
 use Drupal\Core\Form\FormState;
 use Drupal\Core\Url;
 use Drupal\field\Entity\FieldConfig;
@@ -114,36 +113,15 @@ class AddTermsToNodesFormTest extends KernelTestBase {
   }
 
   /**
-   * Locks in that buildForm() throws for a vocabulary no bundle references.
+   * Shows "No nodes found" when no bundle references the vocabulary.
    *
-   * Paired with
-   * testBuildFormShouldShowMessageWhenNoBundleReferencesVocabulary() -- delete
-   * once the GAP is fixed. When no node bundle has an entity_reference field
-   * targeting the vocabulary, $relevantBundles is empty and the node query
-   * builds an invalid `type IN ()` condition, so buildForm() throws instead of
-   * showing the "No nodes found" message it intends to.
-   *
-   * @covers ::buildForm
-   */
-  public function testBuildFormThrowsWhenNoBundleReferencesVocabulary() {
-    $empty_vocabulary = Vocabulary::create(['vid' => 'empty_vocab', 'name' => 'Empty Vocab']);
-    $empty_vocabulary->save();
-
-    $form_state = new FormState();
-    $this->expectException(InvalidQueryException::class);
-    $this->form->buildForm([], $form_state, $empty_vocabulary);
-  }
-
-  /**
-   * Should show "No nodes found" when no bundle references the vocabulary.
-   *
-   * Paired with testBuildFormThrowsWhenNoBundleReferencesVocabulary().
+   * With the empty-bundles guard in buildForm(), a vocabulary that no content
+   * type references yields the "No nodes found" message instead of throwing an
+   * invalid-query exception.
    *
    * @covers ::buildForm
    */
   public function testBuildFormShouldShowMessageWhenNoBundleReferencesVocabulary() {
-    $this->markTestSkipped('GAP: AddTermsToNodesForm::buildForm() builds an empty "type IN ()" node query when no node bundle references the vocabulary, throwing InvalidQueryException instead of showing the intended "No nodes found" message -- see ~/Documents/Claude/not_dave/module-tests-20260710/ys_taxonomy_manager.md');
-
     $empty_vocabulary = Vocabulary::create(['vid' => 'empty_vocab', 'name' => 'Empty Vocab']);
     $empty_vocabulary->save();
 


### PR DESCRIPTION
## [1421: ys_taxonomy_manager: AddTermsToNodesForm throws InvalidQueryException when no bundle references the vocabulary](https://github.com/yalesites-org/YaleSites-Internal/issues/1421)

### Description of work
- `AddTermsToNodesForm::buildForm()` built a `type IN ()` node query when no node bundle references the selected vocabulary (`$relevantBundles` was empty), so `$query->execute()` threw `InvalidQueryException` (white screen) before the intended empty-result "No nodes found" message could be reached. It now only runs the query when at least one bundle references the vocabulary; otherwise it falls into the existing "No nodes found" message and returns the form.
- Un-skips the paired GAP test and removes the characterization test that expected the exception.

**Reviewer note (pre-existing, follow-up):** `buildForm()` dereferences its nullable `$taxonomy_vocabulary` parameter (`->id()`) with no null guard, so a NULL vocabulary would fatal. This is pre-existing and out of scope for this ticket; in practice it is gated by the route's entity upcasting (a missing vocabulary 404s before `buildForm()` runs). Flagging as a follow-up.

### Functional testing steps:
- [ ] Create a vocabulary that no content type references (no term-reference field targets it), open its "Add terms to nodes" form, and confirm it shows "No nodes found with fields that reference the selected vocabulary." instead of a white-screen error.
- [ ] For a vocabulary that IS referenced by a content type, confirm the form still lists terms and matching nodes as before.

References yalesites-org/YaleSites-Internal#1421

---
Created with AI
