### PR TITLE
1428: ys_views_content_resources: uninitialized $entityValue errors for a new/unsaved block

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/src/Plugin/Field/FieldWidget/ViewsContentResourcesDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/src/Plugin/Field/FieldWidget/ViewsContentResourcesDefaultWidget.php
@@ -109,7 +109,8 @@ class ViewsContentResourcesDefaultWidget extends WidgetBase implements Container
     Array &$form,
     FormStateInterface $formState,
   ) {
-    $decodedParams = json_decode($items[$delta]->params, TRUE);
+    $decodedParams = json_decode($items[$delta]->params ?? '', TRUE);
+    $entityValue = NULL;
     if (!empty($decodedParams['filters']['types'][0])) {
       $entityValue = $decodedParams['filters']['types'][0];
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/tests/src/Unit/Plugin/Field/FieldWidget/ViewsContentResourcesDefaultWidgetTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_content_resources/tests/src/Unit/Plugin/Field/FieldWidget/ViewsContentResourcesDefaultWidgetTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\ys_views_content_resources\Unit\Plugin\Field\FieldWidget;
 
-use PHPUnit\Framework\Error\Warning;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
@@ -191,9 +190,8 @@ class ViewsContentResourcesDefaultWidgetTest extends UnitTestCase {
   /**
    * A brand-new block defaults field_options to thumbnail + teaser text.
    *
-   * A content type is already selected (isolating this test from the
-   * separately documented GAP around an unset content type), but no
-   * field_options have been stored yet.
+   * A content type is already selected, but no field_options have been stored
+   * yet.
    *
    * @covers ::formElement
    */
@@ -345,40 +343,14 @@ class ViewsContentResourcesDefaultWidgetTest extends UnitTestCase {
   }
 
   /**
-   * Current behavior: reading an unset $entityValue fatals in strict tests.
+   * FormElement() builds without error when no content type is stored.
    *
-   * ViewsContentResourcesDefaultWidget::formElement() only assigns
-   * $entityValue inside `if (!empty($decodedParams['filters']['types'][0]))`,
-   * then unconditionally reads it a few lines later when calling
-   * getFormSelectors(). That is an "Undefined variable $entityValue" PHP
-   * warning whenever a block has no stored content type yet (e.g. a
-   * brand-new, unsaved block) -- which, under PHPUnit's strict
-   * warnings-as-errors handling, is fatal. In production Drupal the warning
-   * is only logged and execution continues with NULL; $entityValue is not
-   * even read by getFormSelectors() itself, so real users see no visible
-   * effect -- but it is still a real bug. Paired with
-   * testFormElementShouldNotErrorWithoutStoredContentType() -- delete once
-   * the GAP is fixed.
-   *
-   * @covers ::formElement
-   */
-  public function testFormElementCurrentBehaviorErrorsWithoutStoredContentType() {
-    $this->expectException(Warning::class);
-    $this->expectExceptionMessage('Undefined variable $entityValue');
-
-    $items = $this->createItemsWithParams(NULL);
-    $form = [];
-    $this->widget->formElement($items, 0, [], $form, $this->createFormState());
-  }
-
-  /**
-   * Paired with testFormElementCurrentBehaviorErrorsWithoutStoredContentType().
+   * $entityValue is initialized before use, so a brand-new/unsaved block (empty
+   * params) no longer triggers an "Undefined variable $entityValue" warning.
    *
    * @covers ::formElement
    */
   public function testFormElementShouldNotErrorWithoutStoredContentType() {
-    $this->markTestSkipped('GAP: ViewsContentResourcesDefaultWidget::formElement() reads $entityValue without initializing it when the stored params have no filters.types[0] (e.g. a brand-new, unsaved block) -- see ~/Documents/Claude/not_dave/module-tests-20260710/ys_views_content_resources.md');
-
     $items = $this->createItemsWithParams(NULL);
     $form = [];
     $element = $this->widget->formElement($items, 0, [], $form, $this->createFormState());


### PR DESCRIPTION
## [1428: ys_views_content_resources: uninitialized $entityValue errors for a new/unsaved block](https://github.com/yalesites-org/YaleSites-Internal/issues/1428)

### Description of work
- `ViewsContentResourcesDefaultWidget::formElement()` assigned `$entityValue` only inside `if (!empty($decodedParams['filters']['types'][0]))` but read it unconditionally when calling `getFormSelectors()`, producing an "Undefined variable $entityValue" warning for a brand-new/unsaved block with empty params. It now initializes `$entityValue = NULL;` before the guard.
- The same new-block path also passed `NULL` params to `json_decode()`, emitting a "Passing null to parameter #1" deprecation (confirmed in the test run). Guarded it with `?? ''` so a new block builds cleanly (no warning, no deprecation).
- Un-skips the paired GAP test and removes the characterization test.

**Reviewer notes (follow-ups, not fixed here):**
- **Dead plumbing:** `$entityValue` is forwarded as `getFormSelectors()`'s third argument, but that method never reads its third parameter — so the value has no effect. The issue explicitly prescribed the `$entityValue = NULL` initialization, so this PR keeps that minimal fix; a cleaner future refactor would drop the unused parameter and the `$entityValue` computation (touches the shared `ViewsContentResourcesManager`).
- **Pre-existing null-deref:** `formElement()` calls `->load('custom_vocab')->label()` with no null check; if that vocabulary is ever missing it would fatal the block edit form. Out of scope for this ticket (unchanged line), low likelihood (custom_vocab is standard).

### Functional testing steps:
- [ ] Place a new Content Resources block in Layout Builder (no content type selected yet) and open its form; confirm it builds with no PHP warning/notice in the log.
- [ ] Configure and save a Content Resources block with a content type, then confirm it still renders and edits correctly (no regression).

References yalesites-org/YaleSites-Internal#1428

---
Created with AI
