### PR TITLE
1422: ys_campus_groups: CampusGroupsConfig reads the wrong (singular) config name

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/src/CampusGroupsConfig.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/src/CampusGroupsConfig.php
@@ -28,7 +28,7 @@ class CampusGroupsConfig implements ContainerInjectionInterface {
    *   The config factory service.
    */
   public function __construct(ConfigFactoryInterface $config_factory) {
-    $this->configFactory = $config_factory->getEditable('ys_campus_group.settings');
+    $this->configFactory = $config_factory->getEditable('ys_campus_groups.settings');
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/tests/src/Unit/CampusGroupsConfigTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_campus_groups/tests/src/Unit/CampusGroupsConfigTest.php
@@ -48,45 +48,24 @@ class CampusGroupsConfigTest extends UnitTestCase {
   }
 
   /**
-   * Locks in the current getConfig() behavior for the GAP.
+   * CampusGroupsConfig must read the same config the rest of the module uses.
    *
-   * Paired with testGetConfigShouldUseCampusGroupsSettingsName() -- delete
-   * once the GAP is fixed.
-   *
-   * CampusGroupsConfig requests the config object named
-   * "ys_campus_group.settings" (singular "group"), but every other class in
-   * this module -- CampusGroupsSettings, CampusGroupsIntegrationPlugin,
-   * RunMigrations, CampusGroupUrl, and the cron hook -- reads and writes
-   * "ys_campus_groups.settings" (plural). The service is not currently
-   * registered or used anywhere in the module, so this typo is latent rather
-   * than actively causing incorrect behavior today.
-   *
-   * @covers ::__construct
-   * @covers ::getConfig
-   */
-  public function testGetConfigUsesSingularConfigNameCurrentBehavior(): void {
-    $this->configFactory->expects($this->once())
-      ->method('getEditable')
-      ->with('ys_campus_group.settings')
-      ->willReturn($this->createMock(ImmutableConfig::class));
-
-    $service = new CampusGroupsConfig($this->configFactory);
-    $service->getConfig();
-  }
-
-  /**
-   * Paired with testGetConfigUsesSingularConfigNameCurrentBehavior().
-   *
-   * GAP: CampusGroupsConfig reads "ys_campus_group.settings" (singular)
-   * while the rest of the module reads and writes "ys_campus_groups.settings"
-   * (plural), so if this service is ever wired up it will silently see a
-   * different config object than the settings form saves to.
+   * Every other class in the module (CampusGroupsSettings,
+   * CampusGroupsIntegrationPlugin, RunMigrations, CampusGroupUrl) reads and
+   * writes "ys_campus_groups.settings" (plural), so CampusGroupsConfig must
+   * request that same object, not the singular "ys_campus_group.settings".
    *
    * @covers ::__construct
    * @covers ::getConfig
    */
   public function testGetConfigShouldUseCampusGroupsSettingsName(): void {
-    $this->markTestSkipped('GAP: CampusGroupsConfig::__construct() calls $config_factory->getEditable(\'ys_campus_group.settings\') (singular), but every other class in the module uses \'ys_campus_groups.settings\' (plural) -- see ~/Documents/Claude/not_dave/module-tests-20260710/ys_campus_groups.md');
+    $this->configFactory->expects($this->once())
+      ->method('getEditable')
+      ->with('ys_campus_groups.settings')
+      ->willReturn($this->createMock(ImmutableConfig::class));
+
+    $service = new CampusGroupsConfig($this->configFactory);
+    $service->getConfig();
   }
 
 }


### PR DESCRIPTION
## [1422: ys_campus_groups: CampusGroupsConfig reads the wrong (singular) config name](https://github.com/yalesites-org/YaleSites-Internal/issues/1422)

### Description of work
- `CampusGroupsConfig::__construct()` requested the config object named `ys_campus_group.settings` (singular), while every other class in the module -- the `CampusGroupsSettings` form that saves the values, `CampusGroupsIntegrationPlugin`, `RunMigrations`, and `CampusGroupUrl` -- reads and writes `ys_campus_groups.settings` (plural). Pointed the constructor at the plural name so it resolves the same config object the settings form writes to.
- This service is not yet wired into a service definition, so the defect was **latent** -- but if it were used it would silently read a different config object than the form saves to.
- Activated the paired GAP unit test `testGetConfigShouldUseCampusGroupsSettingsName` with a real assertion on the plural name, and removed the now-obsolete characterization test that locked in the singular behavior.

### Functional testing steps:
This is a latent internal fix with no user-facing UI change; verify via the module's test suite and config wiring:
- [ ] Run the module's unit tests and confirm `testGetConfigShouldUseCampusGroupsSettingsName` passes (it asserts the plural `ys_campus_groups.settings`).
- [ ] Confirm the full `ys_campus_groups` suite (Unit + Kernel) passes with no regressions (29 tests / 118 assertions locally).
- [ ] Grep the module to confirm `CampusGroupsConfig` now reads `ys_campus_groups.settings` (plural), matching `CampusGroupsSettings`, `CampusGroupsIntegrationPlugin`, `RunMigrations`, and `CampusGroupUrl`.

References yalesites-org/YaleSites-Internal#1422

---
Created with AI
