### PR TITLE
1432: ys_embed: EmbedSourceManager::loadAll() returns undefined $this->instance instead of $this->instances

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSourceManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/EmbedSourceManager.php
@@ -172,7 +172,7 @@ class EmbedSourceManager extends DefaultPluginManager {
     foreach ($this->getSources() as $plugin_id => $source) {
       $this->loadPluginById($plugin_id);
     }
-    return $this->instance;
+    return $this->instances;
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Kernel/EmbedSourceManagerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Kernel/EmbedSourceManagerTest.php
@@ -6,6 +6,7 @@ use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\ys_embed\Plugin\EmbedSource\Broken;
 use Drupal\ys_embed\Plugin\EmbedSource\Twitter;
+use Drupal\ys_embed\Plugin\EmbedSourceInterface;
 use Drupal\ys_embed\Plugin\EmbedSourceManager;
 
 /**
@@ -193,6 +194,23 @@ class EmbedSourceManagerTest extends KernelTestBase {
 
     $this->assertInstanceOf(Broken::class, $result);
     $this->assertSame([], $captured);
+  }
+
+  /**
+   * @covers ::loadAll
+   */
+  public function testLoadAllReturnsAnInstanceForEveryActiveSource(): void {
+    $instances = $this->manager->loadAll();
+
+    // loadAll() instantiates every active source and returns them keyed by
+    // plugin id -- not NULL, and not the inactive 'broken' source.
+    $this->assertIsArray($instances);
+    $this->assertEqualsCanonicalizing(
+      array_keys($this->manager->getSources()),
+      array_keys($instances)
+    );
+    $this->assertContainsOnlyInstancesOf(EmbedSourceInterface::class, $instances);
+    $this->assertInstanceOf(Twitter::class, $instances['twitter']);
   }
 
 }


### PR DESCRIPTION
## [1432: ys_embed: EmbedSourceManager::loadAll() returns undefined $this->instance instead of $this->instances](https://github.com/yalesites-org/YaleSites-Internal/issues/1432)

### Description of work
- `EmbedSourceManager::loadAll()` populated `$this->instances` (plural) via `loadPluginById()` in its loop, but then returned `$this->instance` (singular) -- a property that does not exist on the class. Reading the undefined property yields `NULL` (with an "Undefined property" warning), so `loadAll()` returned `NULL` instead of the array of loaded plugin instances it documents.
- Fixed the return to `$this->instances` -- the property the loop actually populates and that the rest of the class (`loadPluginById()`) uses.
- This method has no call sites in the codebase today, so the defect was **latent** -- a real correctness bug, but with no current user-facing impact.
- Added a Kernel test (`testLoadAllReturnsAnInstanceForEveryActiveSource`) covering `loadAll()`: it must return an instance of every active `EmbedSource` keyed by plugin id (previously uncovered).

### Functional testing steps:
This is a latent internal fix with no user-facing UI change; verify via the module's test suite:
- [ ] Run `EmbedSourceManagerTest` and confirm `testLoadAllReturnsAnInstanceForEveryActiveSource` passes (`loadAll()` returns an array of `EmbedSourceInterface` instances keyed by active plugin id, not `NULL`).
- [ ] Confirm the rest of `EmbedSourceManagerTest` still passes (no regressions).
- [ ] Read `EmbedSourceManager::loadAll()` and confirm it returns `$this->instances` (plural).

References yalesites-org/YaleSites-Internal#1432

---
Created with AI
