### PR TITLE
1434: Add updated_at (last-indexed) timestamp to Beacon search index chunks

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/VdbProvider/BeaconAzureAiSearchProvider.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/VdbProvider/BeaconAzureAiSearchProvider.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\ys_beacon\Plugin\VdbProvider;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
@@ -74,6 +75,7 @@ class BeaconAzureAiSearchProvider extends AzureAiSearchProvider {
     MessengerInterface $messenger,
     AzureAiSearch $azure_ai_search,
     protected BeaconIndexManager $beaconIndexManager,
+    protected TimeInterface $time,
   ) {
     parent::__construct(
       $pluginId,
@@ -101,6 +103,7 @@ class BeaconAzureAiSearchProvider extends AzureAiSearchProvider {
       $container->get('messenger'),
       $container->get('azure_ai_search.api'),
       $container->get('ys_beacon.index_manager'),
+      $container->get('datetime.time'),
     );
   }
 
@@ -233,7 +236,8 @@ class BeaconAzureAiSearchProvider extends AzureAiSearchProvider {
    * Prefixing drupal_long_id namespaces the Azure key the client derives from
    * it, so two sites' node/123 no longer share a key; prefixing
    * drupal_entity_id scopes the delete/fetch lookup; site_id records the key in
-   * a retrievable, filterable column.
+   * a retrievable, filterable column; updated_at records the index-write time
+   * in a filterable/sortable date column.
    *
    * @param array $data
    *   The document the ai_search backend assembled.
@@ -251,6 +255,9 @@ class BeaconAzureAiSearchProvider extends AzureAiSearchProvider {
       $data['drupal_entity_id'] = $prefix . $data['drupal_entity_id'];
     }
     $data['site_id'] = $site_id;
+    // The single insert path, so updated_at refreshes on every (re)index of
+    // the chunk, including cron reindex and reprovision.
+    $data['updated_at'] = gmdate('c', $this->time->getCurrentTime());
     return $data;
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/BeaconIndexManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/BeaconIndexManager.php
@@ -368,6 +368,20 @@ class BeaconIndexManager {
         // exist locally.
         $retrievable_field('citation_title'),
         $retrievable_field('citation_url'),
+        // Last-indexed timestamp, stamped on every insert (ISO 8601 UTC)
+        // by the beacon_azure_ai_search provider so chunks can be sorted
+        // and filtered by index freshness in the Azure portal
+        // (yalesites-org/YaleSites-Internal#1434).
+        [
+          'name' => 'updated_at',
+          'type' => 'Edm.DateTimeOffset',
+          'key' => FALSE,
+          'retrievable' => TRUE,
+          'searchable' => FALSE,
+          'filterable' => TRUE,
+          'sortable' => TRUE,
+          'facetable' => FALSE,
+        ],
         [
           'name' => 'vector',
           'type' => 'Collection(Edm.Single)',

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconAzureAiSearchProviderTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconAzureAiSearchProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\ys_beacon\Unit;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\TypedData\DataDefinitionInterface;
 use Drupal\ai_vdb_provider_azure_ai_search\AzureAiSearch;
 use Drupal\search_api\IndexInterface;
@@ -25,6 +26,14 @@ use Drupal\ys_beacon\Service\BeaconIndexManager;
  * @coversDefaultClass \Drupal\ys_beacon\Plugin\VdbProvider\BeaconAzureAiSearchProvider
  */
 class BeaconAzureAiSearchProviderTest extends UnitTestCase {
+
+  /**
+   * A fixed index-write time and its ISO 8601 UTC rendering.
+   *
+   * The clock is stubbed so updated_at is asserted against an exact value.
+   */
+  private const FIXED_TIME = 1700000000;
+  private const FIXED_TIME_ISO = '2023-11-14T22:13:20+00:00';
 
   /**
    * Namespacing makes two sites' node/1 distinct in a shared collection.
@@ -58,6 +67,30 @@ class BeaconAzureAiSearchProviderTest extends UnitTestCase {
     // Untouched fields pass through.
     $this->assertSame('Hello', $data['content']);
     $this->assertSame('ys_beacon', $data['index_id']);
+  }
+
+  /**
+   * Each written document is stamped with the current index-write time.
+   *
+   * Updated_at records when the chunk was last written to the index, as an
+   * ISO 8601 UTC string Azure stores in a filterable/sortable DateTimeOffset
+   * column (yalesites-org/YaleSites-Internal#1434). It is stamped here on the
+   * single insert path, so it refreshes on every (re)index of the chunk.
+   *
+   * @covers ::namespaceDocument
+   */
+  public function testNamespaceDocumentStampsUpdatedAt(): void {
+    $provider = $this->makeProvider('sitea');
+
+    $data = $this->invoke($provider, 'namespaceDocument', [
+      [
+        'drupal_long_id' => 'entity:node/1:en:0',
+        'drupal_entity_id' => 'entity:node/1:en',
+        'content' => 'Hello',
+      ],
+    ]);
+
+    $this->assertSame(self::FIXED_TIME_ISO, $data['updated_at']);
   }
 
   /**
@@ -306,6 +339,8 @@ class BeaconAzureAiSearchProviderTest extends UnitTestCase {
       'ys_beacon.settings' => ['query_entire_index' => $query_entire_index],
     ]));
 
+    $this->stubTime($provider);
+
     return $provider;
   }
 
@@ -333,6 +368,8 @@ class BeaconAzureAiSearchProviderTest extends UnitTestCase {
     $property = new \ReflectionProperty($provider, 'beaconIndexManager');
     $property->setAccessible(TRUE);
     $property->setValue($provider, $index_manager);
+
+    $this->stubTime($provider);
 
     return $provider;
   }
@@ -375,6 +412,20 @@ class BeaconAzureAiSearchProviderTest extends UnitTestCase {
     $query->method('getConditionGroup')->willReturn($group);
 
     return $query;
+  }
+
+  /**
+   * Stubs the injected time service on a provider to a fixed clock.
+   *
+   * @param object $provider
+   *   The provider under test whose protected time property to set.
+   */
+  private function stubTime(object $provider): void {
+    $time = $this->createMock(TimeInterface::class);
+    $time->method('getCurrentTime')->willReturn(self::FIXED_TIME);
+    $property = new \ReflectionProperty($provider, 'time');
+    $property->setAccessible(TRUE);
+    $property->setValue($provider, $time);
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconIndexManagerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconIndexManagerTest.php
@@ -290,6 +290,34 @@ class BeaconIndexManagerTest extends UnitTestCase {
   }
 
   /**
+   * The index schema carries a filterable, sortable updated_at date column.
+   *
+   * The last-indexed timestamp is stored as a typed Edm.DateTimeOffset (not a
+   * string attribute) so chunks can be sorted and filtered by index freshness
+   * directly in the Azure portal (yalesites-org/YaleSites-Internal#1434). It is
+   * freshness metadata, so it is retrievable but not full-text searched or
+   * faceted on.
+   *
+   * @covers ::buildIndexSchema
+   */
+  public function testBuildIndexSchemaIncludesUpdatedAt(): void {
+    $manager = $this->buildManagerWithSiteUuid('unused-uuid');
+    $method = new \ReflectionMethod($manager, 'buildIndexSchema');
+    $method->setAccessible(TRUE);
+
+    $schema = $method->invoke($manager, 'shared-index');
+    $fields = array_column($schema['fields'], NULL, 'name');
+
+    $this->assertArrayHasKey('updated_at', $fields);
+    $this->assertSame('Edm.DateTimeOffset', $fields['updated_at']['type']);
+    $this->assertTrue($fields['updated_at']['retrievable']);
+    $this->assertTrue($fields['updated_at']['filterable']);
+    $this->assertTrue($fields['updated_at']['sortable']);
+    $this->assertFalse($fields['updated_at']['searchable']);
+    $this->assertFalse($fields['updated_at']['facetable']);
+  }
+
+  /**
    * Re-provisioning drops an existing index before recreating it.
    *
    * @covers ::reprovision

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.install
@@ -423,3 +423,32 @@ function ys_beacon_update_10009() {
   }
   \Drupal::service('ys_beacon.index_manager')->reprovision();
 }
+
+/**
+ * Recreate the Beacon Azure index with the updated_at schema and reindex.
+ *
+ * Issue yalesites-org/YaleSites-Internal#1434 adds a typed updated_at
+ * (Edm.DateTimeOffset, filterable + sortable) field recording when each chunk
+ * was last written to the index, so chunks can be sorted and filtered by index
+ * freshness in the Azure portal. Azure never modifies an index in place, so an
+ * index provisioned by the earlier citation-field migration (update 10009) must
+ * be dropped and recreated with the current schema and fully reindexed, which
+ * also stamps updated_at onto every existing chunk. Only a site that owns a
+ * provisioned, writable index is touched; a fresh provision or a read-only
+ * borrower is left alone.
+ *
+ * As with the earlier schema migrations, a failure aborts the update rather
+ * than being swallowed: reprovision() checks indexExists() before any
+ * destructive delete, so a plain outage aborts without having touched the index
+ * and Drupal re-runs the update on the next deploy. The queued reindex runs
+ * afterwards on cron.
+ */
+function ys_beacon_update_10010() {
+  $settings = \Drupal::config('ys_beacon.settings');
+  // Only a site that owns a writable, provisioned index has one of its own to
+  // recreate. A read-only borrower must never write to the collection it reads.
+  if ((string) $settings->get('azure_index_name') === '' || (bool) $settings->get('read_only')) {
+    return;
+  }
+  \Drupal::service('ys_beacon.index_manager')->reprovision();
+}


### PR DESCRIPTION
## [1434: Add updated_at (last-indexed) timestamp to Beacon search index chunks](https://github.com/yalesites-org/YaleSites-Internal/issues/1434)

### Description of work
- Adds an `updated_at` field to each chunk written to the Beacon Azure AI Search index, set to the time the chunk is written to the index (index-write time), so chunks can be sorted and filtered by index freshness directly in the Azure portal. It is for debugging/index-freshness inspection only and is **not** consumed by DrupalAI retrieval (chat, citations, or the prompt).
- `BeaconIndexManager::buildIndexSchema()` declares `updated_at` as a typed `Edm.DateTimeOffset` field, filterable and sortable (unlike the string `attributes` fields), so the Azure portal can sort/filter by it.
- `BeaconAzureAiSearchProvider::namespaceDocument()` stamps `updated_at` as ISO 8601 UTC on every insert — the single write path that already stamps `site_id` — so the value refreshes on every (re)index, including cron reindex and reprovision. The clock is the injected `datetime.time` service.
- `ys_beacon_update_10010()` reprovisions owned, writable indexes since Azure cannot alter a schema in place; the queued reindex stamps `updated_at` onto every existing chunk. A read-only borrower or a fresh provision is left untouched.
- Mirrors how `citation_url` was added.

### Functional testing steps:
- [ ] Deploy on a site that owns a writable Beacon index; confirm `ys_beacon_update_10010()` drops/recreates the Azure index and queues a full reindex.
- [ ] After cron reindex, confirm each chunk in the Azure portal carries an `updated_at` value equal to its last index-write time, and that the field is sortable and filterable in the portal.
- [ ] Confirm the chat assistant still answers with citations and that `updated_at` does not appear in chat/citations/prompt output.
- [ ] Automated: `lando phpunit --group ys_beacon` — new tests `BeaconIndexManagerTest::testBuildIndexSchemaIncludesUpdatedAt` and `BeaconAzureAiSearchProviderTest::testNamespaceDocumentStampsUpdatedAt` pass.

Note: local Beacon uses a dummy Azure key, so a live index write cannot be exercised locally — final visual confirmation of the field in the Azure portal belongs on the multidev/QA environment.

References yalesites-org/YaleSites-Internal#1434

---
Created with AI
