### PR TITLE
1439: Make Beacon index citation_title, citation_url, and content searchable/sortable in the Azure portal (debugging)

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/BeaconIndexManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/BeaconIndexManager.php
@@ -337,8 +337,9 @@ class BeaconIndexManager {
       'facetable' => TRUE,
     ];
 
-    // Retrievable-only string fields: stored and returned for citations, but
-    // not searched, filtered, sorted, or faceted on.
+    // Retrievable-only string field base: returned but not searched, filtered,
+    // sorted, or faceted on. content overrides searchable to TRUE (below) for
+    // portal keyword debugging.
     $retrievable_field = static fn (string $field_name): array => [
       'name' => $field_name,
       'type' => 'Edm.String',
@@ -362,12 +363,18 @@ class BeaconIndexManager {
         // beacon_azure_ai_search provider writes it on insert and scopes
         // reads/deletes by it so multiple sites can share one collection.
         $string_field('site_id'),
-        $retrievable_field('content'),
-        // Title and absolute URL stored per document so a site querying a
-        // shared collection can cite content whose Drupal entity does not
-        // exist locally.
-        $retrievable_field('citation_title'),
-        $retrievable_field('citation_url'),
+        // Chunk text: retrievable, and searchable so it can be keyword-searched
+        // in the Azure portal for debugging. Not filtered, sorted, or faceted;
+        // matching full chunk text is not useful.
+        // See yalesites-org/YaleSites-Internal#1439.
+        ['searchable' => TRUE] + $retrievable_field('content'),
+        // Title and absolute URL stored per document so a site querying
+        // a shared collection can cite content whose Drupal entity does
+        // not exist locally. Fully queryable (search/filter/sort/facet)
+        // so a page's chunks can be found and grouped in the Azure portal
+        // (yalesites-org/YaleSites-Internal#1439).
+        $string_field('citation_title'),
+        $string_field('citation_url'),
         // Last-indexed timestamp, stamped on every insert (ISO 8601 UTC)
         // by the beacon_azure_ai_search provider so chunks can be sorted
         // and filtered by index freshness in the Azure portal

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconIndexManagerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconIndexManagerTest.php
@@ -68,10 +68,12 @@ class BeaconIndexManagerTest extends UnitTestCase {
   }
 
   /**
-   * The Azure schema declares retrievable citation title and URL fields.
+   * The Azure schema declares queryable citation title and URL fields.
    *
-   * Cross-site citations read these back off each document, so both must exist
-   * and be retrievable (but not searchable/filterable — they are display data).
+   * Cross-site citations read these back off each document, so both must be
+   * retrievable; they are also searchable, filterable, and sortable so a page's
+   * chunks can be found, filtered, and grouped in the Azure portal for
+   * debugging (yalesites-org/YaleSites-Internal#1439).
    *
    * @covers ::buildIndexSchema
    */
@@ -94,10 +96,41 @@ class BeaconIndexManagerTest extends UnitTestCase {
     $fields = array_column($schema['fields'], NULL, 'name');
     $this->assertArrayHasKey('citation_title', $fields);
     $this->assertArrayHasKey('citation_url', $fields);
-    $this->assertTrue($fields['citation_title']['retrievable']);
-    $this->assertTrue($fields['citation_url']['retrievable']);
-    $this->assertFalse($fields['citation_title']['searchable']);
-    $this->assertFalse($fields['citation_url']['filterable']);
+    // Retrievable for citations and fully queryable (searchable, filterable,
+    // sortable) for portal debugging.
+    foreach (['citation_title', 'citation_url'] as $name) {
+      $this->assertTrue($fields[$name]['retrievable']);
+      $this->assertTrue($fields[$name]['searchable']);
+      $this->assertTrue($fields[$name]['filterable']);
+      $this->assertTrue($fields[$name]['sortable']);
+      $this->assertTrue($fields[$name]['facetable']);
+    }
+  }
+
+  /**
+   * The Azure schema makes content searchable for portal keyword debugging.
+   *
+   * Content stays retrievable and becomes searchable so chunk text can be
+   * keyword-searched in the Azure portal, but it is not filtered, sorted, or
+   * faceted on — matching on full chunk text is not useful
+   * (yalesites-org/YaleSites-Internal#1439).
+   *
+   * @covers ::buildIndexSchema
+   */
+  public function testBuildIndexSchemaContentIsSearchable(): void {
+    $manager = $this->buildManagerWithSiteUuid('unused-uuid');
+    $method = new \ReflectionMethod($manager, 'buildIndexSchema');
+    $method->setAccessible(TRUE);
+
+    $schema = $method->invoke($manager, 'shared-index');
+    $fields = array_column($schema['fields'], NULL, 'name');
+
+    $this->assertArrayHasKey('content', $fields);
+    $this->assertTrue($fields['content']['retrievable']);
+    $this->assertTrue($fields['content']['searchable']);
+    $this->assertFalse($fields['content']['filterable']);
+    $this->assertFalse($fields['content']['sortable']);
+    $this->assertFalse($fields['content']['facetable']);
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.install
@@ -452,3 +452,34 @@ function ys_beacon_update_10010() {
   }
   \Drupal::service('ys_beacon.index_manager')->reprovision();
 }
+
+/**
+ * Recreate the Beacon Azure index with searchable citation/content fields.
+ *
+ * Issue yalesites-org/YaleSites-Internal#1439 makes the content,
+ * citation_title, and citation_url fields queryable for debugging in the
+ * Azure portal: content becomes searchable, and citation_title and
+ * citation_url become searchable, filterable, and sortable (previously all
+ * three were retrievable-only). This is portal-only inspection and does not
+ * affect DrupalAI retrieval, which is a pure vector search. Azure cannot
+ * change a field's searchable/filterable/sortable attributes in place, so an
+ * index provisioned by the earlier updated_at migration (update 10010) must
+ * be dropped and recreated with the current schema and fully reindexed. Only
+ * a site that owns a provisioned, writable index is touched; a fresh
+ * provision or a read-only borrower is left alone.
+ *
+ * As with the earlier schema migrations, a failure aborts the update rather
+ * than being swallowed: reprovision() checks indexExists() before any
+ * destructive delete, so a plain outage aborts without having touched the
+ * index and Drupal re-runs the update on the next deploy. The queued reindex
+ * runs on cron.
+ */
+function ys_beacon_update_10011() {
+  $settings = \Drupal::config('ys_beacon.settings');
+  // Only a site that owns a writable, provisioned index has one of its own to
+  // recreate. A read-only borrower must never write to the collection it reads.
+  if ((string) $settings->get('azure_index_name') === '' || (bool) $settings->get('read_only')) {
+    return;
+  }
+  \Drupal::service('ys_beacon.index_manager')->reprovision();
+}


### PR DESCRIPTION
## [1439: Make Beacon index citation_title, citation_url, and content searchable/sortable in the Azure portal (debugging)](https://github.com/yalesites-org/YaleSites-Internal/issues/1439)

### Description of work
- Makes the Beacon Azure AI Search index's `content`, `citation_title`, and `citation_url` fields queryable in the Azure portal for debugging, so a reported title/content/URL can be searched for and a page's chunks can be sorted and grouped.
- Portal-only inspection: does **not** change DrupalAI retrieval. Beacon RAG is a pure vector search — the Azure query sends only a `vectorQueries` block plus an OData site filter, with no top-level full-text `search` term, so these fields' `searchable` attribute is never consulted for retrieval or scoring.
- `content` becomes searchable (stays retrievable; not filtered, sorted, or faceted, since matching on full chunk text is not useful).
- `citation_title` and `citation_url` become searchable + filterable + sortable + facetable (previously retrievable-only), so a page's chunks can be found and grouped by title or URL.
- `ys_beacon_update_10011()` reprovisions owned, writable indexes since Azure cannot change a field's attributes in place; the queued reindex rewrites every chunk under the new schema.
- Follows the pattern used for `updated_at` in yalesites-org/YaleSites-Internal#1434.

### Functional testing steps:
- [ ] Deploy on a site that owns a writable Beacon index; confirm `ys_beacon_update_10011()` drops/recreates the Azure index and queues a full reindex.
- [ ] After cron reindex, in the Azure portal full-text search `content`, `citation_title`, and `citation_url`, and sort/filter chunks by `citation_url` or `citation_title` (e.g. filter to one URL to see all its chunks).
- [ ] Confirm Beacon chat still answers with citations unchanged (retrieval is pure vector, unaffected).
- [ ] Automated: `lando phpunit --group ys_beacon` — `BeaconIndexManagerTest::testBuildIndexSchemaIncludesCitationFields` (citation fields searchable/filterable/sortable/facetable) and `BeaconIndexManagerTest::testBuildIndexSchemaContentIsSearchable` (content searchable, not sorted/faceted) pass.

Note: local Beacon uses a dummy Azure key, so live portal search cannot be exercised locally — final confirmation belongs on the multidev/QA environment.

References yalesites-org/YaleSites-Internal#1439

---
Created with AI
