### PR TITLE
1433: ys_migrate: ProfileImportService row-number drift and generic error messages on import failures

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Service/CsvValidatorService.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Service/CsvValidatorService.php
@@ -115,6 +115,9 @@ class CsvValidatorService {
         continue;
       }
 
+      // Carry the true CSV line number so consumers report the real row rather
+      // than a compacted array offset (blank rows skipped above shift offsets).
+      $row_data['_row_number'] = $row_number;
       $data[] = $row_data;
     }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Service/ProfileImportService.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Service/ProfileImportService.php
@@ -130,8 +130,12 @@ class ProfileImportService {
    * @param array $data
    *   The profile data.
    *
-   * @return \Drupal\node\NodeInterface|null
-   *   The created node or null on failure.
+   * @return \Drupal\node\NodeInterface
+   *   The created node.
+   *
+   * @throws \Exception
+   *   If the node cannot be saved. The reason is logged and re-thrown so the
+   *   caller can surface it instead of a generic failure message.
    */
   public function createProfileNode(array $data) {
     $node = $this->entityTypeManager->getStorage('node')->create(
@@ -165,7 +169,9 @@ class ProfileImportService {
     }
     catch (\Exception $e) {
       $this->loggerFactory->get('ys_migrate')->error('Failed to create profile node: @error', ['@error' => $e->getMessage()]);
-      return NULL;
+      // Re-throw so processImport() can report the real reason to the user
+      // instead of a generic "could not create profile" message.
+      throw $e;
     }
   }
 
@@ -186,6 +192,10 @@ class ProfileImportService {
     $errors = [];
 
     foreach ($data as $index => $row) {
+      // Use the true CSV line threaded through by the validator, falling
+      // back to the array offset (+2 for header and 0-based index).
+      $row_number = $row['_row_number'] ?? ($index + 2);
+
       try {
         $profile_data = $this->prepareProfileData($row);
 
@@ -197,25 +207,15 @@ class ProfileImportService {
           }
         }
 
-        $node = $this->createProfileNode($profile_data);
-        if ($node) {
-          $created++;
-        }
-        else {
-          $errors[] = $this->t(
-            'Row @row: could not create profile @name.', [
-              // +2 because index starts at 0 and we skip header
-              '@row' => $index + 2,
-              '@name' => $profile_data['display_name'] ?? '',
-            ]
-          );
-        }
+        // createProfileNode() returns the node or throws with the real reason,
+        // which the catch below reports (never silently dropping the row).
+        $this->createProfileNode($profile_data);
+        $created++;
       }
       catch (\Exception $e) {
         $errors[] = $this->t(
           'Row @row: @error', [
-            // +2 because index starts at 0 and we skip header
-            '@row' => $index + 2,
+            '@row' => $row_number,
             '@error' => $e->getMessage(),
           ]
         );

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/CsvValidatorServiceTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/CsvValidatorServiceTest.php
@@ -83,7 +83,10 @@ class CsvValidatorServiceTest extends UnitTestCase {
       'last name' => 'Doe',
       'email' => 'jane@example.com',
       'teaser text' => 'Short bio text.',
+      '_row_number' => 2,
     ], $result['data'][0]);
+    // The second data row is CSV line 3 (header is line 1).
+    $this->assertSame(3, $result['data'][1]['_row_number']);
     $this->assertEquals([
       'display name' => 'Display Name',
       'first name' => 'First Name',
@@ -104,7 +107,7 @@ class CsvValidatorServiceTest extends UnitTestCase {
     $result = $this->csvValidator->validateCsvStructure($path);
 
     $this->assertTrue($result['valid']);
-    $this->assertEquals([['display name' => 'Jane Doe']], $result['data']);
+    $this->assertEquals([['display name' => 'Jane Doe', '_row_number' => 2]], $result['data']);
   }
 
   /**
@@ -231,6 +234,11 @@ class CsvValidatorServiceTest extends UnitTestCase {
 
     $this->assertTrue($result['valid']);
     $this->assertCount(2, $result['data']);
+    // The blank line 3 is skipped, so John is CSV line 4 -- the reported row
+    // number must reflect the true line, not the compacted array offset (which
+    // would give 3). This is the row-number-drift regression guard.
+    $this->assertSame(2, $result['data'][0]['_row_number']);
+    $this->assertSame(4, $result['data'][1]['_row_number']);
   }
 
   /**
@@ -251,6 +259,7 @@ class CsvValidatorServiceTest extends UnitTestCase {
     $this->assertEquals([
       'display name' => 'Jane Doe',
       'email' => 'jane@example.com',
+      '_row_number' => 2,
     ], $result['data'][0]);
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ProfileImportServiceTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ProfileImportServiceTest.php
@@ -260,11 +260,14 @@ class ProfileImportServiceTest extends UnitTestCase {
   }
 
   /**
-   * CreateProfileNode() logs and returns NULL when save() fails.
+   * CreateProfileNode() logs and re-throws when save() fails.
+   *
+   * The exception is re-thrown (after logging) rather than swallowed into a
+   * NULL return, so processImport() can surface the real failure reason.
    *
    * @covers ::createProfileNode
    */
-  public function testCreateProfileNodeSaveFails() {
+  public function testCreateProfileNodeSaveFailsLogsAndRethrows() {
     $node = $this->createMock(NodeInterface::class);
     $node->method('save')->willThrowException(new \Exception('Database error'));
     $this->nodeStorage->method('create')->willReturn($node);
@@ -285,9 +288,9 @@ class ProfileImportServiceTest extends UnitTestCase {
       'custom_vocab' => [],
     ];
 
-    $result = $this->profileImport->createProfileNode($data);
-
-    $this->assertNull($result);
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('Database error');
+    $this->profileImport->createProfileNode($data);
   }
 
   /**
@@ -348,26 +351,47 @@ class ProfileImportServiceTest extends UnitTestCase {
   }
 
   /**
-   * A failed node creation is reported in the errors list, not dropped.
+   * A failed node creation is reported with its real reason, not dropped.
    *
-   * When createProfileNode() returns NULL, processImport() records the row in
-   * the returned "errors" list instead of silently omitting it.
+   * When createProfileNode() throws, processImport() records the row in the
+   * returned "errors" list with the actual failure message instead of a
+   * generic "could not create profile" line.
    *
    * @covers ::processImport
    */
   public function testProcessImportShouldReportFailedNodeCreation() {
     $service = $this->partialProfileImport(['prepareProfileData', 'findExistingProfile', 'createProfileNode']);
     $service->method('prepareProfileData')->willReturn(['display_name' => 'Someone', 'email' => '']);
-    $service->method('createProfileNode')->willReturn(NULL);
+    $service->method('createProfileNode')->willThrowException(new \Exception('Field constraint violated'));
 
-    $result = $service->processImport([['row' => 1]], TRUE);
+    $result = $service->processImport([['_row_number' => 2]], TRUE);
 
     $this->assertSame(0, $result['created']);
     $this->assertCount(1, $result['errors']);
-    // The single data row is CSV row 2 (header + 1), and the message carries
-    // the profile's display name.
+    // The row is reported with its true CSV line and the real failure reason.
     $this->assertStringContainsString('Row 2', (string) $result['errors'][0]);
-    $this->assertStringContainsString('Someone', (string) $result['errors'][0]);
+    $this->assertStringContainsString('Field constraint violated', (string) $result['errors'][0]);
+  }
+
+  /**
+   * ProcessImport() reports the true CSV row threaded by the validator.
+   *
+   * The row number comes from the '_row_number' carried on each row (the true
+   * CSV line), not the array offset, so blank rows earlier in the file do not
+   * skew the reported line.
+   *
+   * @covers ::processImport
+   */
+  public function testProcessImportUsesThreadedRowNumber() {
+    $service = $this->partialProfileImport(['prepareProfileData', 'createProfileNode']);
+    $service->method('prepareProfileData')->willReturn(['display_name' => 'Someone', 'email' => '']);
+    $service->method('createProfileNode')->willThrowException(new \Exception('Save failed'));
+
+    // A single data row carrying its true CSV line (7), e.g. after blank rows.
+    $result = $service->processImport([['_row_number' => 7]], TRUE);
+
+    $this->assertCount(1, $result['errors']);
+    $this->assertStringContainsString('Row 7', (string) $result['errors'][0]);
   }
 
   /**


### PR DESCRIPTION
## [1433: ys_migrate: ProfileImportService row-number drift and generic error messages on import failures](https://github.com/yalesites-org/YaleSites-Internal/issues/1433)

### Description of work
Fix two error-reporting defects in the profile CSV importer (`ys_migrate`):

- **Row-number drift.** `CsvValidatorService` skips blank rows and reindexes its validated `data`, so `ProfileImportService::processImport()` derived each error's "Row N" from the array offset (`$index + 2`), under-reporting the true CSV line after any blank row. The true line number is now threaded through each validated row (`_row_number`) and reported instead.
- **Generic failure message.** `createProfileNode()` logged the save exception and returned `NULL`, so a node-creation failure surfaced only the generic "could not create profile &lt;name&gt;" line. It now logs **and re-throws**, letting `processImport()`'s existing catch report the real reason as "Row N: &lt;error&gt;". The generic `else` branch is removed; failed rows still can't be silently dropped — they flow through the catch and are recorded (preserving the yalesites-org/YaleSites-Internal#1423 guarantee).

### Verification
- Test-driven: unit tests updated/added to encode both bugs (blank-row true line number; real error message + threaded row), confirmed **red** on the old code and **green** after.
- Full `ys_migrate` unit suite: **44 tests, 116 assertions, all passing** (baseline 43/110).
- `composer code-sniff` clean (exit 0).
- Independent review confirmed the no-silent-drop guarantee still holds, `_row_number` does not leak into node fields or the preview, and the error output is escaped and shown only on the permission-gated import form (no XSS/info-leak).

### Note (intended tradeoff)
The failure message no longer includes the profile display name (old: "could not create profile Jane"); it now shows "Row N: &lt;real reason&gt;". The real reason plus a locatable row was prioritized per the issue; the display name can't be reliably included in the shared catch (`prepareProfileData()` may have thrown before it was computed). Flagging in case a combined "Row N: &lt;name&gt;: &lt;reason&gt;" is wanted as a follow-up.

### Functional testing steps:
- [ ] Import a CSV containing a blank line followed by a row that fails (e.g. a field-constraint violation); confirm the reported "Row N" matches the actual CSV line, not an offset shifted by the blank row.
- [ ] Trigger a node-creation failure and confirm the error message shows the real reason ("Row N: &lt;error&gt;"), not the generic "could not create profile" line.
- [ ] Confirm a failing row is still reported (never silently skipped) and the valid rows still import.

References yalesites-org/YaleSites-Internal#1433

---
Created with AI
