### PR TITLE
1431: ys_embed: allow authoring new SoundCloud playlist embeds (relax isTrack() gate)

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/Validation/Constraint/EmbedConstraintValidator.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/src/Plugin/Validation/Constraint/EmbedConstraintValidator.php
@@ -92,20 +92,25 @@ class EmbedConstraintValidator extends ConstraintValidator implements ContainerI
   }
 
   /**
-   * Check if the embed code matches a track.
+   * Check if the embed code is a supported SoundCloud audio embed.
+   *
+   * SoundCloud embeds are limited to single tracks and playlists (the two forms
+   * captured by SoundCloud::$pattern's track_or_playlist group); any other
+   * SoundCloud form is rejected. Non-SoundCloud embeds are unaffected.
    *
    * @param string $input
    *   The user provided embed code.
    *
    * @return bool
-   *   TRUE if the embed code matches a track.
+   *   TRUE if the embed code is a SoundCloud track or playlist, or is not a
+   *   SoundCloud embed at all.
    */
   protected function isTrack(string $input): bool {
     if (!$this->isSoundcloud($input)) {
       return TRUE;
     }
 
-    $p1 = "https:\/\/\S+.soundcloud.com\/tracks\S+";
+    $p1 = "https:\/\/\S+.soundcloud.com\/(?:tracks|playlists)\S+";
     $pattern = "/{$p1}/";
     return (bool) preg_match($pattern, $input, $matches);
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Unit/EmbedConstraintValidatorTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_embed/tests/src/Unit/EmbedConstraintValidatorTest.php
@@ -131,18 +131,36 @@ class EmbedConstraintValidatorTest extends UnitTestCase {
   }
 
   /**
+   * A SoundCloud playlist embed is accepted (no invalidAudioTrack violation).
+   *
    * @covers ::validate
    * @covers ::isTrack
    * @covers ::isSoundcloud
    */
-  public function testValidateAddsInvalidAudioTrackViolationForSoundcloudPlaylist(): void {
+  public function testValidateAddsNoViolationForValidSoundcloudPlaylist(): void {
+    $this->embedManager->method('isValid')->willReturn(TRUE);
+    $this->context->expects($this->never())->method('addViolation');
+
+    $this->validator->validate(
+      $this->mockValueForInput('https://api.soundcloud.com/playlists/123456'),
+      $this->constraint
+    );
+  }
+
+  /**
+   * A non-track, non-playlist SoundCloud embed still trips the violation.
+   *
+   * @covers ::validate
+   * @covers ::isTrack
+   */
+  public function testValidateAddsInvalidAudioTrackViolationForOtherSoundcloudForm(): void {
     $this->embedManager->method('isValid')->willReturn(TRUE);
     $this->context->expects($this->once())
       ->method('addViolation')
       ->with($this->constraint->invalidAudioTrack);
 
     $this->validator->validate(
-      $this->mockValueForInput('https://api.soundcloud.com/playlists/123456'),
+      $this->mockValueForInput('https://api.soundcloud.com/users/123456'),
       $this->constraint
     );
   }
@@ -239,8 +257,8 @@ class EmbedConstraintValidatorTest extends UnitTestCase {
   /**
    * @covers ::isTrack
    */
-  public function testIsTrackFalseForSoundcloudPlaylist(): void {
-    $this->assertFalse($this->invokeProtected('isTrack', 'https://api.soundcloud.com/playlists/1'));
+  public function testIsTrackTrueForSoundcloudPlaylist(): void {
+    $this->assertTrue($this->invokeProtected('isTrack', 'https://api.soundcloud.com/playlists/1'));
   }
 
   /**
@@ -248,6 +266,29 @@ class EmbedConstraintValidatorTest extends UnitTestCase {
    */
   public function testIsTrackTrueForSoundcloudTrack(): void {
     $this->assertTrue($this->invokeProtected('isTrack', 'https://api.soundcloud.com/tracks/1'));
+  }
+
+  /**
+   * A SoundCloud URL that is neither a track nor a playlist is still rejected.
+   *
+   * @covers ::isTrack
+   */
+  public function testIsTrackFalseForOtherSoundcloudForm(): void {
+    $this->assertFalse($this->invokeProtected('isTrack', 'https://api.soundcloud.com/users/1'));
+  }
+
+  /**
+   * IsTrack() accepts the real full-iframe embeds authors actually paste.
+   *
+   * The other isTrack tests use bare API URLs; these use the complete <iframe>
+   * embed code (the canonical SoundCloud examples), so a regex regression that
+   * only broke the real form would still be caught.
+   *
+   * @covers ::isTrack
+   */
+  public function testIsTrackAcceptsRealSoundcloudIframes(): void {
+    $this->assertTrue($this->invokeProtected('isTrack', SoundCloudTest::TRACK_EMBED));
+    $this->assertTrue($this->invokeProtected('isTrack', SoundCloudTest::PLAYLIST_EMBED));
   }
 
 }


### PR DESCRIPTION
## [1431: ys_embed: allow authoring new SoundCloud playlist embeds (relax isTrack() gate)](https://github.com/yalesites-org/YaleSites-Internal/issues/1431)

### Description of work
- Relax `EmbedConstraintValidator::isTrack()` so newly-authored SoundCloud **playlist** embeds are accepted. Its gate previously matched only `soundcloud.com/tracks`, so a new playlist embed tripped the `invalidAudioTrack` violation and could not be saved — even though rendering already worked for playlists.
- The SoundCloud plugin already captures and renders both tracks and playlists (the `track_or_playlist` group, from yalesites-org/yalesites-project#1382), so this aligns the authoring gate: the pattern now accepts `/tracks` and `/playlists`, scoped to those two forms only. Any other SoundCloud form is still rejected, and non-SoundCloud embeds are unaffected.
- The method keeps the name `isTrack` (per the issue acceptance criteria) with an updated docblock that describes the track-or-playlist behavior.

Implements the **2026-07-20 product decision** recorded on the issue that SoundCloud playlists are an officially supported embed type alongside single tracks.

### Verification
- Test-driven: inverted the two tests that asserted playlists are rejected (validate + `isTrack`); added guards that a non-track/non-playlist SoundCloud embed still trips `invalidAudioTrack`; and added a test that the real full-`<iframe>` track and playlist embeds (the canonical examples) pass the gate. Red on the old code, green after.
- Full `ys_embed` unit suite: **126 tests, 168 assertions, all passing** (baseline 123/164).
- `composer code-sniff` clean (exit 0).
- Independent review: no correctness or security findings — `isTrack` runs only after `isValid` (so nothing harmful is newly accepted), the render path rebuilds a safe URL from the captured numeric id, and ReDoS was ruled out by timing. `SoundCloudTest` already covers playlist support at the plugin level (from #1382), so it needed no change.

### Functional testing steps:
- [ ] In the rich text editor, add a SoundCloud embed using a **playlist** URL (Share -> Embed -> Code) and confirm it saves without the `invalidAudioTrack` error and renders.
- [ ] Confirm a single **track** embed still saves and renders (unchanged).
- [ ] Confirm an unrelated/invalid SoundCloud form (e.g. a user profile) is still rejected.

References yalesites-org/YaleSites-Internal#1431

---
Created with AI
