### PR TITLE
1447: Rename "Views Settings" admin page to "Search Settings"

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.coffee.inc
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.coffee.inc
@@ -184,7 +184,7 @@ function ys_core_coffee_commands() {
   // Add YaleSites settings commands.
   $commands[] = [
     'value' => Url::fromRoute('ys_core.admin_views_settings')->toString(),
-    'label' => 'Views Settings',
+    'label' => 'Search Settings',
     'command' => ':views_settings',
   ];
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
@@ -45,10 +45,10 @@ ys_core.admin_footer_settings:
   weight: 20
 # Views settings form.
 ys_core.admin_views_settings:
-  description: "Views settings."
+  description: "Site search settings."
   parent: ys_core.admin_yalesites
   route_name: ys_core.admin_views_settings
-  title: "Views Settings"
+  title: "Search Settings"
   weight: 25
 # Dashboard settings form.
 ys_core.admin_dashboard_settings:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.routing.yml
@@ -43,7 +43,7 @@ ys_core.admin_views_settings:
   path: '/admin/yalesites/views-settings'
   defaults:
     _form: '\Drupal\ys_core\Form\ViewsSettingsForm'
-    _title: 'Views Settings'
+    _title: 'Search Settings'
   requirements:
     _permission: 'yalesites manage settings'
 # Dashboard settings form.


### PR DESCRIPTION
## [1447: Rename "Views Settings" admin page to "Search Settings"](https://github.com/yalesites-org/YaleSites-Internal/issues/1447)

### Description of work
- Renames the display label of the `/admin/yalesites/views-settings` admin page (and its YaleSites admin menu item) from "Views Settings" to "Search Settings". Every setting on that page controls site search (the Content Type filter on the Search results page), so the old name was misleading — editors reported navigating there expecting Views-block settings and leaving confused.
- Updated in three places: the route `_title` (drives the page heading and browser title), the admin menu link title + description, and the Coffee quick-nav label.
- Machine names are intentionally left unchanged (route id `ys_core.admin_views_settings`, path `/admin/yalesites/views-settings`, form id `ys_core_views_settings_form`, config `ys_core.views_settings`, and the Coffee `:views_settings` command keyword) so bookmarks and config exports are unaffected. This is a display-label rename only.

### Functional testing steps:
- [ ] In the YaleSites admin menu (Manage settings), confirm the item previously labeled "Views Settings" now reads "Search Settings"
- [ ] Visit `/admin/yalesites/views-settings` and confirm the page heading and browser tab title both read "Search Settings"; confirm the URL is unchanged
- [ ] Open the Coffee quick-nav (admin quick search) and confirm the entry for this page is labeled "Search Settings"
- [ ] Confirm the settings on the page still save correctly (no functional change intended)

References yalesites-org/YaleSites-Internal#1447

---
Created with AI
