### PR TITLE
1449: Ability to decouple a reusable block (make it non-reusable again)

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/css/detach-reusable-block.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/css/detach-reusable-block.css
@@ -1,0 +1,13 @@
+/**
+ * @file
+ * Styling for the "Make non-reusable" (detach) off-canvas confirm dialog.
+ *
+ * gin_lb applies its confirm-dialog top spacing only to core's own remove form
+ * IDs (.layout-builder-remove-block / -remove-section). Extend the same spacing
+ * to this module's detach confirm form so its description sits below the
+ * off-canvas header with matching padding instead of cramped against it.
+ */
+
+#drupal-off-canvas .ys-layouts-detach-reusable-block {
+  padding-top: 40px;
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Access/DetachReusableBlockAccessCheck.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Access/DetachReusableBlockAccessCheck.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_layouts\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\layout_builder\SectionStorageInterface;
+use Drupal\ys_layouts\ReusableBlockDetacher;
+
+/**
+ * Restricts the detach route to placed reusable content blocks.
+ *
+ * Layout Builder filters contextual links by route access, so gating the detach
+ * route here is what keeps the "Make non-reusable" link from appearing on
+ * inline blocks (which have nothing to detach).
+ */
+class DetachReusableBlockAccessCheck implements AccessInterface {
+
+  public function __construct(
+    protected ReusableBlockDetacher $detacher,
+  ) {}
+
+  /**
+   * Checks that the targeted component is a placed reusable content block.
+   *
+   * @param \Drupal\layout_builder\SectionStorageInterface $section_storage
+   *   The section storage, upcast from the route.
+   * @param mixed $delta
+   *   The section delta.
+   * @param string $uuid
+   *   The uuid of the component being acted on.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   Allowed only when the component places a reusable block.
+   */
+  public function access(SectionStorageInterface $section_storage, $delta, string $uuid): AccessResultInterface {
+    try {
+      $component = $section_storage->getSection((int) $delta)->getComponent($uuid);
+    }
+    catch (\Exception) {
+      // An unresolvable delta/uuid means there is nothing to detach here.
+      return AccessResult::forbidden()->setCacheMaxAge(0);
+    }
+    // The result depends on live, per-request layout state (which block is
+    // placed where), so it must not be cached.
+    return AccessResult::allowedIf($this->detacher->isReusableBlockComponent($component))
+      ->setCacheMaxAge(0);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Access/DetachReusableBlockAccessCheck.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Access/DetachReusableBlockAccessCheck.php
@@ -7,8 +7,10 @@ namespace Drupal\ys_layouts\Access;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\layout_builder\LayoutTempstoreRepositoryInterface;
 use Drupal\layout_builder\SectionStorageInterface;
 use Drupal\ys_layouts\ReusableBlockDetacher;
+use Psr\Log\LoggerInterface;
 
 /**
  * Restricts the detach route to placed reusable content blocks.
@@ -21,6 +23,8 @@ class DetachReusableBlockAccessCheck implements AccessInterface {
 
   public function __construct(
     protected ReusableBlockDetacher $detacher,
+    protected LoggerInterface $logger,
+    protected LayoutTempstoreRepositoryInterface $layoutTempstore,
   ) {}
 
   /**
@@ -38,10 +42,28 @@ class DetachReusableBlockAccessCheck implements AccessInterface {
    */
   public function access(SectionStorageInterface $section_storage, $delta, string $uuid): AccessResultInterface {
     try {
+      // Judge the layout actually being edited. Layout Builder swaps in the
+      // tempstore copy from a route enhancer (LayoutTempstoreRouteEnhancer),
+      // which runs only while routing a real request - not from
+      // AccessManager::checkNamedRoute(), which is how the contextual link
+      // system evaluates this route. Without resolving it here the check would
+      // judge the saved layout and keep offering the action on a placement
+      // already detached in this editing session. Returns the argument
+      // unchanged when the layout has no unsaved changes. Inside the try so a
+      // tempstore failure hides the link rather than breaking the whole page.
+      $section_storage = $this->layoutTempstore->get($section_storage);
       $component = $section_storage->getSection((int) $delta)->getComponent($uuid);
     }
-    catch (\Exception) {
+    catch (\Exception $e) {
       // An unresolvable delta/uuid means there is nothing to detach here.
+      // Layout Builder hides a contextual link whose route access is denied
+      // without surfacing any error, so log the reason: otherwise a missing
+      // "Make non-reusable" action cannot be diagnosed from the outside.
+      $this->logger->debug('Cannot resolve component @uuid at delta @delta for the detach action, so it is not offered: @message', [
+        '@uuid' => $uuid,
+        '@delta' => $delta,
+        '@message' => $e->getMessage(),
+      ]);
       return AccessResult::forbidden()->setCacheMaxAge(0);
     }
     // The result depends on live, per-request layout state (which block is

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Form/DetachReusableBlockForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Form/DetachReusableBlockForm.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_layouts\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\layout_builder\Form\LayoutRebuildConfirmFormBase;
+use Drupal\layout_builder\LayoutTempstoreRepositoryInterface;
+use Drupal\layout_builder\SectionStorageInterface;
+use Drupal\ys_layouts\ReusableBlockDetacher;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Confirms detaching a reusable block into an independent inline block.
+ *
+ * @internal
+ *   Form classes are internal.
+ */
+class DetachReusableBlockForm extends LayoutRebuildConfirmFormBase {
+
+  /**
+   * The uuid of the block being detached.
+   *
+   * @var string
+   */
+  protected $uuid;
+
+  public function __construct(
+    LayoutTempstoreRepositoryInterface $layout_tempstore_repository,
+    protected ReusableBlockDetacher $detacher,
+  ) {
+    parent::__construct($layout_tempstore_repository);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('layout_builder.tempstore_repository'),
+      $container->get('ys_layouts.reusable_block_detacher'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'ys_layouts_detach_reusable_block';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    $label = $this->sectionStorage
+      ->getSection($this->delta)
+      ->getComponent($this->uuid)
+      ->getPlugin()
+      ->label();
+    return $this->t('Make the %label block non-reusable on this page?', ['%label' => $label]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return $this->t('This placement becomes an independent copy that you can edit here without affecting other pages. The original reusable block is left unchanged and stays available in the Reusable Blocks list. This cannot be undone.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this->t('Make non-reusable');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ?SectionStorageInterface $section_storage = NULL, $delta = NULL, $region = NULL, $uuid = NULL) {
+    // $region is part of the route path (matching core's layout_builder_block
+    // contextual-link group) but is not needed to detach; only the uuid is.
+    $this->uuid = $uuid;
+    return parent::buildForm($form, $form_state, $section_storage, $delta);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function handleSectionStorage(SectionStorageInterface $section_storage, FormStateInterface $form_state) {
+    $component = $section_storage->getSection($this->delta)->getComponent($this->uuid);
+    $this->detacher->detach($component);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Form/DetachReusableBlockForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Form/DetachReusableBlockForm.php
@@ -66,7 +66,7 @@ class DetachReusableBlockForm extends LayoutRebuildConfirmFormBase {
    * {@inheritdoc}
    */
   public function getDescription() {
-    return $this->t('This placement becomes an independent copy that you can edit here without affecting other pages. The original reusable block is left unchanged and stays available in the Reusable Blocks list. This cannot be undone.');
+    return $this->t('This placement becomes an independent copy you can edit here without affecting this block anywhere else it is used. If this block is placed on other pages, those placements are untouched and stay reusable - you can detach them separately if needed. This cannot be undone.');
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Render/DetachContextualOperations.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Render/DetachContextualOperations.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_layouts\Render;
+
+use Drupal\Core\Security\TrustedCallbackInterface;
+
+/**
+ * Registers the detach action in Layout Builder's contextual link metadata.
+ *
+ * Core stamps an "operations" list into the metadata of every
+ * layout_builder_block contextual link, and that metadata becomes part of the
+ * link's contextual id:
+ * @code
+ * // Add metadata about the current operations available in contextual links.
+ * // This will invalidate the client-side cache of links that were cached
+ * // before the 'move' link was added.
+ * 'metadata' => ['operations' => 'move:update:remove'],
+ * @endcode
+ * (\Drupal\layout_builder\Element\LayoutBuilder::buildAdministrativeSection()).
+ *
+ * That indirection matters because the contextual module caches each id's
+ * rendered links in the browser's sessionStorage and, on a cache hit, renders
+ * from it without contacting the server at all - invalidating only when the
+ * user's permissions hash changes (core/modules/contextual/js/contextual.js).
+ * So adding "Make non-reusable" to core's group without extending the
+ * operations list leaves the id byte-identical to the pre-feature id, and every
+ * browser that already opened that block's contextual menu keeps replaying the
+ * old three-link menu indefinitely. No amount of server-side cache clearing
+ * reaches it.
+ *
+ * Appending our operation changes the id exactly once, which is the same
+ * mechanism core used when it introduced its own "move" link.
+ */
+class DetachContextualOperations implements TrustedCallbackInterface {
+
+  /**
+   * The operation name appended to core's contextual link metadata.
+   */
+  protected const DETACH_OPERATION = 'detach';
+
+  /**
+   * The contextual link group core uses for placed blocks.
+   */
+  protected const CONTEXTUAL_GROUP = 'layout_builder_block';
+
+  /**
+   * Registers the detach operation on every placed block in the layout.
+   *
+   * Runs as a #pre_render on the layout_builder element (added in
+   * ys_layouts_element_info_alter()), so it sees the built sections before the
+   * theme layer turns #contextual_links into a contextual id.
+   *
+   * @param array $element
+   *   The layout_builder render element.
+   *
+   * @return array
+   *   The element with the detach operation registered.
+   */
+  public static function addDetachOperation(array $element): array {
+    static::registerRecursively($element);
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function trustedCallbacks() {
+    return ['addDetachOperation'];
+  }
+
+  /**
+   * Adds the operation to this element and every child that carries the group.
+   *
+   * The contextual links live on components nested under section and region
+   * keys, so the whole subtree is walked rather than a fixed depth assumed.
+   *
+   * @param array $element
+   *   The render array to process, by reference.
+   */
+  protected static function registerRecursively(array &$element): void {
+    $group = static::CONTEXTUAL_GROUP;
+    // Read through a copy: taking a reference to a nested key would create the
+    // whole path on elements that carry no contextual links at all.
+    $metadata = $element['#contextual_links'][$group]['metadata'] ?? NULL;
+    if (isset($metadata['operations'])) {
+      $operations = explode(':', $metadata['operations']);
+      if (!in_array(static::DETACH_OPERATION, $operations, TRUE)) {
+        $operations[] = static::DETACH_OPERATION;
+        $metadata['operations'] = implode(':', $operations);
+        $element['#contextual_links'][$group]['metadata'] = $metadata;
+      }
+    }
+
+    // Walked directly rather than through Element::children(), which throws on
+    // a non-array child and re-sorts its argument in place. Neither is wanted
+    // here: this walks the whole built tree, including subtrees the renderer
+    // itself never validates, so one malformed child would take down the entire
+    // Layout Builder UI instead of just omitting a link.
+    foreach ($element as $key => &$child) {
+      if (is_array($child) && (is_int($key) || $key === '' || $key[0] !== '#')) {
+        static::registerRecursively($child);
+      }
+    }
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/ReusableBlockDetacher.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/ReusableBlockDetacher.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Drupal\ys_layouts;
 
 use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\block_content\BlockContentInterface;
 use Drupal\layout_builder\SectionComponent;
 
 /**
@@ -23,12 +25,29 @@ class ReusableBlockDetacher {
    */
   protected const REUSABLE_PLUGIN_PREFIX = 'block_content:';
 
+  /**
+   * Plugin id prefix identifying a placed inline (non-shared) content block.
+   */
+  protected const INLINE_PLUGIN_PREFIX = 'inline_block:';
+
   public function __construct(
     protected EntityRepositoryInterface $entityRepository,
+    protected EntityTypeManagerInterface $entityTypeManager,
   ) {}
 
   /**
-   * Determines whether a component is a placed reusable content block.
+   * Determines whether a component places a detachable reusable block.
+   *
+   * A placement shows a shared reusable block in two shapes:
+   * - a library placement, plugin id block_content:<uuid>, which by definition
+   *   references a reusable block (the derivative only exists for reusable
+   *   blocks); and
+   * - an inline_block:<bundle> placement whose referenced block_content was
+   *   flagged reusable without the placement id being rewritten. That happens
+   *   when the "Reusable" checkbox is ticked (which saves reusable=TRUE on the
+   *   block immediately) but the layout is never saved, so the id conversion -
+   *   which lives only in tempstore until save - is discarded. Such a placement
+   *   still shows the shared reusable block, so it must be detachable too.
    *
    * @param \Drupal\layout_builder\SectionComponent $component
    *   The section component to inspect.
@@ -37,7 +56,17 @@ class ReusableBlockDetacher {
    *   TRUE if the component places a reusable block that can be detached.
    */
   public function isReusableBlockComponent(SectionComponent $component): bool {
-    return str_starts_with($component->getPluginId(), self::REUSABLE_PLUGIN_PREFIX);
+    $plugin_id = $component->getPluginId();
+
+    if (str_starts_with($plugin_id, self::REUSABLE_PLUGIN_PREFIX)) {
+      return TRUE;
+    }
+
+    if (str_starts_with($plugin_id, self::INLINE_PLUGIN_PREFIX)) {
+      return $this->loadReusableInlineBlock($component) instanceof BlockContentInterface;
+    }
+
+    return FALSE;
   }
 
   /**
@@ -57,14 +86,24 @@ class ReusableBlockDetacher {
    *   referenced block_content entity cannot be loaded.
    */
   public function detach(SectionComponent $component): void {
-    if (!$this->isReusableBlockComponent($component)) {
-      throw new \InvalidArgumentException('Only a placed reusable content block can be detached.');
+    $plugin_id = $component->getPluginId();
+
+    if (str_starts_with($plugin_id, self::REUSABLE_PLUGIN_PREFIX)) {
+      $uuid = substr($plugin_id, strlen(self::REUSABLE_PLUGIN_PREFIX));
+      $block = $this->entityRepository->loadEntityByUuid('block_content', $uuid);
+    }
+    elseif (str_starts_with($plugin_id, self::INLINE_PLUGIN_PREFIX)) {
+      // An inline placement of a block that was flagged reusable (see
+      // ::isReusableBlockComponent). Detaching it gives this page its own
+      // independent, non-reusable copy and stops it tracking the shared block.
+      $block = $this->loadReusableInlineBlock($component);
+    }
+    else {
+      $block = NULL;
     }
 
-    $uuid = substr($component->getPluginId(), strlen(self::REUSABLE_PLUGIN_PREFIX));
-    $block = $this->entityRepository->loadEntityByUuid('block_content', $uuid);
-    if ($block === NULL) {
-      throw new \InvalidArgumentException(sprintf('The reusable block "%s" could not be loaded.', $uuid));
+    if (!$block instanceof BlockContentInterface) {
+      throw new \InvalidArgumentException('Only a placed reusable content block can be detached.');
     }
 
     // An independent, non-reusable copy. Composed children (paragraphs) are
@@ -79,11 +118,37 @@ class ReusableBlockDetacher {
     // mapping, and any other keys it carries) and change only what turns the
     // shared reference into an owned inline copy.
     $configuration = $component->get('configuration');
-    $configuration['id'] = 'inline_block:' . $block->bundle();
+    $configuration['id'] = self::INLINE_PLUGIN_PREFIX . $block->bundle();
     $configuration['provider'] = 'layout_builder';
     $configuration['block_revision_id'] = NULL;
     $configuration['block_serialized'] = serialize($copy);
     $component->setConfiguration($configuration);
+  }
+
+  /**
+   * Loads the reusable block behind an inline_block placement, or NULL.
+   *
+   * An inline_block placement references its block by revision id. This returns
+   * that block only when it is flagged reusable - the state that makes an
+   * inline placement detachable - and NULL otherwise (an ordinary inline
+   * block, or an unsaved placement with only a serialized copy, has nothing
+   * shared to detach from).
+   *
+   * @param \Drupal\layout_builder\SectionComponent $component
+   *   The inline_block placement to inspect.
+   *
+   * @return \Drupal\block_content\BlockContentInterface|null
+   *   The referenced reusable block, or NULL.
+   */
+  protected function loadReusableInlineBlock(SectionComponent $component): ?BlockContentInterface {
+    $configuration = $component->get('configuration');
+    if (empty($configuration['block_revision_id'])) {
+      return NULL;
+    }
+    $block = $this->entityTypeManager
+      ->getStorage('block_content')
+      ->loadRevision($configuration['block_revision_id']);
+    return ($block instanceof BlockContentInterface && $block->isReusable()) ? $block : NULL;
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/ReusableBlockDetacher.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/ReusableBlockDetacher.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_layouts;
+
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\layout_builder\SectionComponent;
+
+/**
+ * Detaches a placed reusable block, converting it into an inline block.
+ *
+ * Instance-level detach: the placed component stops referencing the shared
+ * reusable block_content entity and instead carries its own independent,
+ * non-reusable copy. The original reusable block is left untouched and keeps
+ * working on every other page where it is placed.
+ */
+class ReusableBlockDetacher {
+
+  /**
+   * Plugin id prefix identifying a placed reusable content block.
+   */
+  protected const REUSABLE_PLUGIN_PREFIX = 'block_content:';
+
+  public function __construct(
+    protected EntityRepositoryInterface $entityRepository,
+  ) {}
+
+  /**
+   * Determines whether a component is a placed reusable content block.
+   *
+   * @param \Drupal\layout_builder\SectionComponent $component
+   *   The section component to inspect.
+   *
+   * @return bool
+   *   TRUE if the component places a reusable block that can be detached.
+   */
+  public function isReusableBlockComponent(SectionComponent $component): bool {
+    return str_starts_with($component->getPluginId(), self::REUSABLE_PLUGIN_PREFIX);
+  }
+
+  /**
+   * Converts a placed reusable block component into an inline block, in place.
+   *
+   * The component keeps its position (uuid, region, weight) and its visible
+   * label; only the underlying block reference changes from the shared reusable
+   * block to an independent, non-reusable copy serialized into the component.
+   * Layout Builder persists that copy as a new block_content entity when the
+   * layout is saved.
+   *
+   * @param \Drupal\layout_builder\SectionComponent $component
+   *   The placed reusable block component to detach.
+   *
+   * @throws \InvalidArgumentException
+   *   If the component is not a placed reusable content block, or its
+   *   referenced block_content entity cannot be loaded.
+   */
+  public function detach(SectionComponent $component): void {
+    if (!$this->isReusableBlockComponent($component)) {
+      throw new \InvalidArgumentException('Only a placed reusable content block can be detached.');
+    }
+
+    $uuid = substr($component->getPluginId(), strlen(self::REUSABLE_PLUGIN_PREFIX));
+    $block = $this->entityRepository->loadEntityByUuid('block_content', $uuid);
+    if ($block === NULL) {
+      throw new \InvalidArgumentException(sprintf('The reusable block "%s" could not be loaded.', $uuid));
+    }
+
+    // An independent, non-reusable copy. Composed children (paragraphs) are
+    // deep-cloned so the inline copy shares no owned entities with the
+    // original; plain references (media, nodes) are shared library assets and
+    // are intentionally left pointing at the same targets.
+    $copy = $block->createDuplicate();
+    $copy->set('reusable', FALSE);
+    $this->duplicateComposedChildren($copy);
+
+    // Keep the placement's existing configuration (label, view mode, context
+    // mapping, and any other keys it carries) and change only what turns the
+    // shared reference into an owned inline copy.
+    $configuration = $component->get('configuration');
+    $configuration['id'] = 'inline_block:' . $block->bundle();
+    $configuration['provider'] = 'layout_builder';
+    $configuration['block_revision_id'] = NULL;
+    $configuration['block_serialized'] = serialize($copy);
+    $component->setConfiguration($configuration);
+  }
+
+  /**
+   * Recursively replaces composed (paragraph) children with fresh duplicates.
+   *
+   * A shallow createDuplicate() copies entity_reference_revisions field values
+   * as-is, leaving the copy pointing at the SAME paragraph revisions as the
+   * original. Replacing each referenced paragraph with its own duplicate - and
+   * recursing so nested paragraphs are duplicated too - makes the detached copy
+   * fully independent. The duplicates are unsaved (no id) so they become new
+   * entities when the inline block is saved.
+   *
+   * Deliberately not reusing quick_node_clone's cloneParagraphs(): that method
+   * honors node-clone "exclude field" config (which would silently drop block
+   * fields), only clones one level deep, and is bound to a contrib form-builder
+   * service. This full-recursion, type-based clone keeps the copy faithful.
+   *
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+   *   The entity whose composed children should be duplicated.
+   */
+  protected function duplicateComposedChildren(FieldableEntityInterface $entity): void {
+    foreach ($entity->getFieldDefinitions() as $field_name => $definition) {
+      if ($definition->getType() !== 'entity_reference_revisions') {
+        continue;
+      }
+      $field = $entity->get($field_name);
+      if ($field->isEmpty()) {
+        continue;
+      }
+      foreach ($field as $item) {
+        if ($item->entity instanceof FieldableEntityInterface) {
+          $child_copy = $item->entity->createDuplicate();
+          $this->duplicateComposedChildren($child_copy);
+          $item->entity = $child_copy;
+        }
+      }
+    }
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/DetachReusableBlockAccessCheckTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/DetachReusableBlockAccessCheckTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Drupal\Tests\ys_layouts\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\layout_builder\Section;
+use Drupal\layout_builder\SectionComponent;
+use Drupal\layout_builder\SectionStorageInterface;
+use Drupal\ys_layouts\Access\DetachReusableBlockAccessCheck;
+use Drupal\ys_layouts\ReusableBlockDetacher;
+
+/**
+ * Tests the access check that gates the "Make non-reusable" contextual link.
+ *
+ * Covers issue #1449: the "Make non-reusable" affordance must appear on a
+ * placed reusable block and must NOT appear on an inline (non-reusable) block.
+ * Layout Builder decides whether to render a contextual link by checking that
+ * link's route access (see \Drupal\Core\Menu\ContextualLinkManager), so this
+ * access check is precisely what makes the affordance present or absent in the
+ * UI. ReusableBlockDetacherTest exercises the detach service in isolation but
+ * not this gate; this test closes that gap.
+ *
+ * @group ys_layouts
+ * @coversDefaultClass \Drupal\ys_layouts\Access\DetachReusableBlockAccessCheck
+ */
+class DetachReusableBlockAccessCheckTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    // The Section/SectionComponent value objects this test builds autoload via
+    // the PHPUnit bootstrap without enabling layout_builder, and the access
+    // check only reads the core entity.repository service, so no layout_builder
+    // (or block_content) module needs to be enabled here.
+    'system',
+    'user',
+  ];
+
+  /**
+   * The access check under test.
+   *
+   * @var \Drupal\ys_layouts\Access\DetachReusableBlockAccessCheck
+   */
+  protected DetachReusableBlockAccessCheck $accessCheck;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // The detacher discriminates reusable vs. inline purely from the component
+    // plugin id, but its constructor requires the entity repository.
+    // Instantiate directly so the test avoids enabling ys_layouts and its
+    // dependency chain (ys_localist -> migrate, etc.), matching
+    // ReusableBlockDetacherTest.
+    $detacher = new ReusableBlockDetacher($this->container->get('entity.repository'));
+    $this->accessCheck = new DetachReusableBlockAccessCheck($detacher);
+  }
+
+  /**
+   * Builds a section storage whose only section holds the given components.
+   *
+   * @param \Drupal\layout_builder\SectionComponent ...$components
+   *   The components placed in the section (delta 0).
+   *
+   * @return \Drupal\layout_builder\SectionStorageInterface
+   *   A section storage double returning that section for delta 0.
+   */
+  protected function sectionStorageWith(SectionComponent ...$components): SectionStorageInterface {
+    $section = new Section('layout_onecol', [], $components);
+    $section_storage = $this->prophesize(SectionStorageInterface::class);
+    $section_storage->getSection(0)->willReturn($section);
+    return $section_storage->reveal();
+  }
+
+  /**
+   * A placement's component for the given plugin id.
+   *
+   * @param string $uuid
+   *   The component uuid.
+   * @param string $plugin_id
+   *   The block plugin id (e.g. block_content:... or inline_block:...).
+   *
+   * @return \Drupal\layout_builder\SectionComponent
+   *   The section component.
+   */
+  protected function component(string $uuid, string $plugin_id): SectionComponent {
+    return new SectionComponent($uuid, 'content', ['id' => $plugin_id]);
+  }
+
+  /**
+   * The detach link is allowed on a placed reusable (block_content) block.
+   *
+   * @covers ::access
+   */
+  public function testAllowedForReusablePlacement(): void {
+    $uuid = '11111111-1111-1111-1111-111111111111';
+    $storage = $this->sectionStorageWith(
+      $this->component($uuid, 'block_content:99999999-9999-9999-9999-999999999999'),
+    );
+
+    $result = $this->accessCheck->access($storage, 0, $uuid);
+
+    $this->assertTrue($result->isAllowed(), 'The detach link is allowed for a placed reusable block, so it renders.');
+    // The decision reflects live per-request layout state and must not be
+    // cached, or an allowed result could leak onto other placements.
+    $this->assertSame(0, $result->getCacheMaxAge(), 'The access result is not cacheable.');
+  }
+
+  /**
+   * The detach link is not allowed on an inline (non-reusable) block.
+   *
+   * @covers ::access
+   */
+  public function testNotAllowedForInlinePlacement(): void {
+    $uuid = '22222222-2222-2222-2222-222222222222';
+    $storage = $this->sectionStorageWith(
+      $this->component($uuid, 'inline_block:accordion'),
+    );
+
+    $result = $this->accessCheck->access($storage, 0, $uuid);
+
+    $this->assertFalse($result->isAllowed(), 'The detach link is hidden on an inline block, which has nothing to detach.');
+  }
+
+  /**
+   * A component that cannot be resolved is forbidden (nothing to detach).
+   *
+   * @covers ::access
+   */
+  public function testForbiddenForUnknownComponent(): void {
+    // With nothing placed, any uuid is unresolvable: Section::getComponent()
+    // throws, which the access check must swallow into a forbidden result
+    // rather than surface as an error.
+    $storage = $this->sectionStorageWith();
+
+    $result = $this->accessCheck->access($storage, 0, 'deadbeef-0000-0000-0000-000000000000');
+
+    $this->assertFalse($result->isAllowed());
+    $this->assertTrue($result->isForbidden(), 'An unresolvable component is explicitly forbidden.');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/DetachReusableBlockAccessCheckTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/DetachReusableBlockAccessCheckTest.php
@@ -55,7 +55,10 @@ class DetachReusableBlockAccessCheckTest extends KernelTestBase {
     // Instantiate directly so the test avoids enabling ys_layouts and its
     // dependency chain (ys_localist -> migrate, etc.), matching
     // ReusableBlockDetacherTest.
-    $detacher = new ReusableBlockDetacher($this->container->get('entity.repository'));
+    $detacher = new ReusableBlockDetacher(
+      $this->container->get('entity.repository'),
+      $this->container->get('entity_type.manager'),
+    );
     $this->accessCheck = new DetachReusableBlockAccessCheck($detacher);
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/DetachReusableBlockAccessCheckTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/DetachReusableBlockAccessCheckTest.php
@@ -3,11 +3,14 @@
 namespace Drupal\Tests\ys_layouts\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\layout_builder\LayoutTempstoreRepositoryInterface;
 use Drupal\layout_builder\Section;
 use Drupal\layout_builder\SectionComponent;
 use Drupal\layout_builder\SectionStorageInterface;
 use Drupal\ys_layouts\Access\DetachReusableBlockAccessCheck;
 use Drupal\ys_layouts\ReusableBlockDetacher;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
 
 /**
  * Tests the access check that gates the "Make non-reusable" contextual link.
@@ -45,6 +48,20 @@ class DetachReusableBlockAccessCheckTest extends KernelTestBase {
   protected DetachReusableBlockAccessCheck $accessCheck;
 
   /**
+   * The logger the access check reports unresolvable components to.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $logger;
+
+  /**
+   * The layout tempstore holding the layout currently being edited.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $tempstore;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -59,7 +76,16 @@ class DetachReusableBlockAccessCheckTest extends KernelTestBase {
       $this->container->get('entity.repository'),
       $this->container->get('entity_type.manager'),
     );
-    $this->accessCheck = new DetachReusableBlockAccessCheck($detacher);
+    $this->logger = $this->prophesize(LoggerInterface::class);
+    // By default a layout has no unsaved changes, so the tempstore hands back
+    // the storage it was given.
+    $this->tempstore = $this->prophesize(LayoutTempstoreRepositoryInterface::class);
+    $this->tempstore->get(Argument::any())->willReturnArgument(0);
+    $this->accessCheck = new DetachReusableBlockAccessCheck(
+      $detacher,
+      $this->logger->reveal(),
+      $this->tempstore->reveal()
+    );
   }
 
   /**
@@ -143,6 +169,57 @@ class DetachReusableBlockAccessCheckTest extends KernelTestBase {
 
     $this->assertFalse($result->isAllowed());
     $this->assertTrue($result->isForbidden(), 'An unresolvable component is explicitly forbidden.');
+  }
+
+  /**
+   * An unresolvable component is logged rather than swallowed silently.
+   *
+   * Layout Builder hides a contextual link whose route access is denied without
+   * surfacing any error, so a swallowed exception here makes a missing
+   * "Make non-reusable" action impossible to diagnose from the outside. The log
+   * entry is the only trace, so it is part of the behavior under test.
+   *
+   * @covers ::access
+   */
+  public function testUnresolvableComponentIsLogged(): void {
+    $storage = $this->sectionStorageWith();
+
+    $this->accessCheck->access($storage, 0, 'deadbeef-0000-0000-0000-000000000000');
+
+    $this->logger->debug(Argument::type('string'), Argument::type('array'))
+      ->shouldHaveBeenCalled();
+  }
+
+  /**
+   * The check judges the layout being edited, not the last saved one.
+   *
+   * Layout Builder swaps in the tempstore copy from a route enhancer, which
+   * runs only while routing a real request - not from
+   * AccessManager::checkNamedRoute(), which is how the contextual link system
+   * evaluates this route. Judging the saved layout would keep offering
+   * "Make non-reusable" on a placement already detached in this editing
+   * session, and acting on it would then fail.
+   *
+   * @covers ::access
+   */
+  public function testJudgesTheLayoutBeingEdited(): void {
+    $uuid = '33333333-3333-3333-3333-333333333333';
+    // The saved layout still holds the reusable placement.
+    $saved = $this->sectionStorageWith(
+      $this->component($uuid, 'block_content:99999999-9999-9999-9999-999999999999'),
+    );
+    // The unsaved editing session has already detached it to an inline block.
+    $edited = $this->sectionStorageWith(
+      $this->component($uuid, 'inline_block:accordion'),
+    );
+    $this->tempstore->get($saved)->willReturn($edited);
+
+    $result = $this->accessCheck->access($saved, 0, $uuid);
+
+    $this->assertFalse(
+      $result->isAllowed(),
+      'A placement already detached in this session is no longer offered.'
+    );
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/ReusableBlockDetacherTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/ReusableBlockDetacherTest.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Drupal\Tests\ys_layouts\Kernel;
+
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\block_content\Entity\BlockContentType;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\layout_builder\SectionComponent;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\paragraphs\Entity\ParagraphsType;
+use Drupal\ys_layouts\ReusableBlockDetacher;
+
+/**
+ * Tests detaching a placed reusable block into an independent inline block.
+ *
+ * Covers issue #1449: an editor can convert a reusable (shared) block placement
+ * back into a normal, non-reusable block tied to just that page (instance-level
+ * detach), without affecting the original reusable block or its other
+ * placements.
+ *
+ * @group ys_layouts
+ * @coversDefaultClass \Drupal\ys_layouts\ReusableBlockDetacher
+ */
+class ReusableBlockDetacherTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'file',
+    'text',
+    'entity_reference_revisions',
+    'paragraphs',
+    'block_content',
+    'layout_builder',
+    'layout_discovery',
+  ];
+
+  /**
+   * The detacher under test.
+   *
+   * @var \Drupal\ys_layouts\ReusableBlockDetacher
+   */
+  protected ReusableBlockDetacher $detacher;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('paragraph');
+    $this->installEntitySchema('block_content');
+
+    // A paragraph type used as a composed child of the block.
+    ParagraphsType::create([
+      'id' => 'gallery_item',
+      'label' => 'Gallery Item',
+    ])->save();
+
+    // A block_content type that composes paragraphs.
+    BlockContentType::create([
+      'id' => 'gallery',
+      'label' => 'Gallery',
+    ])->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'field_gallery_items',
+      'entity_type' => 'block_content',
+      'type' => 'entity_reference_revisions',
+      'cardinality' => -1,
+      'settings' => ['target_type' => 'paragraph'],
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => 'field_gallery_items',
+      'entity_type' => 'block_content',
+      'bundle' => 'gallery',
+      'label' => 'Gallery Items',
+      'settings' => [
+        'handler' => 'default:paragraph',
+        'handler_settings' => [
+          'target_bundles' => ['gallery_item' => 'gallery_item'],
+        ],
+      ],
+    ])->save();
+
+    // The detacher only needs the entity repository; instantiate it directly so
+    // the test does not have to enable ys_layouts and its dependency chain
+    // (ys_localist -> migrate, etc.). The class autoloads via the PHPUnit
+    // bootstrap namespace registration.
+    $this->detacher = new ReusableBlockDetacher($this->container->get('entity.repository'));
+  }
+
+  /**
+   * Creates a saved reusable block with a paragraph and its placed component.
+   *
+   * @return array
+   *   A [BlockContent, Paragraph, SectionComponent] tuple.
+   */
+  protected function createReusablePlacement(): array {
+    $paragraph = Paragraph::create(['type' => 'gallery_item']);
+    $paragraph->save();
+
+    $block = BlockContent::create([
+      'type' => 'gallery',
+      'info' => 'Shared Gallery',
+      'reusable' => TRUE,
+      'field_gallery_items' => [
+        [
+          'target_id' => $paragraph->id(),
+          'target_revision_id' => $paragraph->getRevisionId(),
+        ],
+      ],
+    ]);
+    $block->save();
+
+    // A placed reusable block references the block by UUID via the
+    // block_content:<uuid> derivative plugin.
+    $component = new SectionComponent(
+      $this->container->get('uuid')->generate(),
+      'content',
+      [
+        'id' => 'block_content:' . $block->uuid(),
+        'label' => 'Shared Gallery',
+        'label_display' => 'visible',
+        'view_mode' => 'full',
+        'provider' => 'block_content',
+        'context_mapping' => [],
+      ]
+    );
+
+    return [$block, $paragraph, $component];
+  }
+
+  /**
+   * Returns the independent copy serialized into a detached component.
+   *
+   * @param \Drupal\layout_builder\SectionComponent $component
+   *   A component that has been through detach().
+   *
+   * @return \Drupal\block_content\Entity\BlockContent
+   *   The deserialized, non-reusable copy.
+   */
+  protected function getSerializedCopy(SectionComponent $component): BlockContent {
+    // The serialized data originates from this test's own controlled code, so
+    // unserializing it is safe.
+    // @codingStandardsIgnoreStart
+    return unserialize($component->get('configuration')['block_serialized']);
+    // @codingStandardsIgnoreEnd
+  }
+
+  /**
+   * A placed reusable block is converted to an inline block in place.
+   *
+   * @covers ::detach
+   */
+  public function testDetachSwapsToInlineBlock(): void {
+    [, , $component] = $this->createReusablePlacement();
+
+    $this->detacher->detach($component);
+
+    $config = $component->get('configuration');
+    $this->assertSame('inline_block:gallery', $config['id'], 'The component now uses the inline_block plugin for the block bundle.');
+    $this->assertNull($config['block_revision_id'], 'block_revision_id is null so Layout Builder saves the serialized copy as a new block.');
+    $this->assertNotEmpty($config['block_serialized'], 'The independent copy is serialized into the component.');
+    // The visible label configuration is preserved.
+    $this->assertSame('Shared Gallery', $config['label']);
+    $this->assertSame('visible', $config['label_display']);
+  }
+
+  /**
+   * The detached copy is non-reusable; the original stays reusable and intact.
+   *
+   * @covers ::detach
+   */
+  public function testDetachLeavesOriginalReusableUntouched(): void {
+    [$block, , $component] = $this->createReusablePlacement();
+    $original_uuid = $block->uuid();
+
+    $this->detacher->detach($component);
+
+    $copy = $this->getSerializedCopy($component);
+    $this->assertFalse((bool) $copy->get('reusable')->value, 'The detached copy is non-reusable.');
+
+    // The original reusable block is unchanged and still loadable.
+    $reloaded = $this->container->get('entity.repository')->loadEntityByUuid('block_content', $original_uuid);
+    $this->assertNotNull($reloaded, 'The original reusable block still exists.');
+    $this->assertTrue((bool) $reloaded->get('reusable')->value, 'The original block is still reusable.');
+  }
+
+  /**
+   * Composed paragraphs are deep-cloned so the copy owns independent children.
+   *
+   * @covers ::detach
+   */
+  public function testDetachDeepClonesParagraphs(): void {
+    [, $paragraph, $component] = $this->createReusablePlacement();
+    $original_paragraph_id = $paragraph->id();
+    $this->assertNotNull($original_paragraph_id);
+
+    $this->detacher->detach($component);
+
+    $copy = $this->getSerializedCopy($component);
+    $items = $copy->get('field_gallery_items');
+    $this->assertFalse($items->isEmpty(), 'The copy still has its gallery items.');
+
+    $copied_paragraph = $items->first()->entity;
+    $this->assertNotNull($copied_paragraph, 'The copy references a paragraph entity.');
+    $this->assertNull(
+      $copied_paragraph->id(),
+      'The copied paragraph must be a new unsaved entity (id === NULL); a non-null id means the original paragraph was shared, not cloned.'
+    );
+
+    // Persistence proof: saving the detached copy (as Layout Builder does on
+    // layout save) writes a NEW paragraph row, independent of the original
+    // reusable block's paragraph, rather than re-pointing at the shared one.
+    $copy->save();
+    $persisted_paragraph_id = $copy->get('field_gallery_items')->first()->entity->id();
+    $this->assertNotNull($persisted_paragraph_id, 'The saved copy persisted its own paragraph.');
+    $this->assertNotEquals(
+      $original_paragraph_id,
+      $persisted_paragraph_id,
+      'The saved copy owns a different paragraph entity than the original reusable block.'
+    );
+  }
+
+  /**
+   * Detaching a non-reusable (inline) component is rejected.
+   *
+   * @covers ::detach
+   * @covers ::isReusableBlockComponent
+   */
+  public function testDetachRejectsInlineComponent(): void {
+    $component = new SectionComponent(
+      $this->container->get('uuid')->generate(),
+      'content',
+      ['id' => 'inline_block:gallery', 'provider' => 'layout_builder']
+    );
+
+    $this->assertFalse($this->detacher->isReusableBlockComponent($component));
+    $this->expectException(\InvalidArgumentException::class);
+    $this->detacher->detach($component);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/ReusableBlockDetacherTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/ReusableBlockDetacherTest.php
@@ -91,11 +91,14 @@ class ReusableBlockDetacherTest extends KernelTestBase {
       ],
     ])->save();
 
-    // The detacher only needs the entity repository; instantiate it directly so
-    // the test does not have to enable ys_layouts and its dependency chain
-    // (ys_localist -> migrate, etc.). The class autoloads via the PHPUnit
-    // bootstrap namespace registration.
-    $this->detacher = new ReusableBlockDetacher($this->container->get('entity.repository'));
+    // The detacher only needs the entity repository and entity type manager;
+    // instantiate it directly so the test does not have to enable ys_layouts
+    // and its dependency chain (ys_localist -> migrate, etc.). The class
+    // autoloads via the PHPUnit bootstrap namespace registration.
+    $this->detacher = new ReusableBlockDetacher(
+      $this->container->get('entity.repository'),
+      $this->container->get('entity_type.manager'),
+    );
   }
 
   /**
@@ -245,6 +248,106 @@ class ReusableBlockDetacherTest extends KernelTestBase {
     );
 
     $this->assertFalse($this->detacher->isReusableBlockComponent($component));
+    $this->expectException(\InvalidArgumentException::class);
+    $this->detacher->detach($component);
+  }
+
+  /**
+   * Creates a saved block and an inline_block placement referencing it.
+   *
+   * Mirrors the state left when a block is flagged reusable - which saves
+   * reusable=TRUE on the entity immediately - but the layout is never saved, so
+   * the placement id is never rewritten from inline_block:<bundle> to
+   * block_content:<uuid>.
+   *
+   * @param bool $reusable
+   *   Whether the referenced block is flagged reusable.
+   *
+   * @return \Drupal\layout_builder\SectionComponent
+   *   The inline_block placement referencing the created block.
+   */
+  protected function createInlinePlacement(bool $reusable): SectionComponent {
+    $paragraph = Paragraph::create(['type' => 'gallery_item']);
+    $paragraph->save();
+
+    $block = BlockContent::create([
+      'type' => 'gallery',
+      'info' => 'Inline Gallery',
+      'reusable' => $reusable,
+      'field_gallery_items' => [
+        [
+          'target_id' => $paragraph->id(),
+          'target_revision_id' => $paragraph->getRevisionId(),
+        ],
+      ],
+    ]);
+    $block->save();
+
+    // An inline placement references its block by revision id.
+    $component = new SectionComponent(
+      $this->container->get('uuid')->generate(),
+      'content',
+      [
+        'id' => 'inline_block:gallery',
+        'label' => 'Inline Gallery',
+        'label_display' => 'visible',
+        'view_mode' => 'full',
+        'provider' => 'layout_builder',
+        'block_revision_id' => $block->getRevisionId(),
+        'block_serialized' => NULL,
+      ]
+    );
+
+    return $component;
+  }
+
+  /**
+   * An inline placement of a reusable block is detachable.
+   *
+   * A block can be flagged reusable while still placed as inline_block:<bundle>
+   * (reusable checkbox ticked, layout never saved). Such a placement shows the
+   * shared reusable block, so "Make non-reusable" must be offered and detaching
+   * must give the page its own independent, non-reusable copy.
+   *
+   * @covers ::isReusableBlockComponent
+   * @covers ::detach
+   */
+  public function testDetachInlinePlacementOfReusableBlock(): void {
+    $component = $this->createInlinePlacement(TRUE);
+
+    $this->assertTrue(
+      $this->detacher->isReusableBlockComponent($component),
+      'An inline placement whose referenced block is reusable is detachable.'
+    );
+
+    $this->detacher->detach($component);
+
+    $config = $component->get('configuration');
+    $this->assertSame('inline_block:gallery', $config['id']);
+    $this->assertNull($config['block_revision_id'], 'The shared revision reference is dropped so the copy is saved fresh.');
+    $this->assertNotEmpty($config['block_serialized'], 'An independent copy is serialized into the component.');
+
+    $copy = $this->getSerializedCopy($component);
+    $this->assertFalse((bool) $copy->get('reusable')->value, 'The detached copy is non-reusable.');
+    $this->assertNull(
+      $copy->get('field_gallery_items')->first()->entity->id(),
+      'The copied paragraph is a new unsaved entity, independent of the original.'
+    );
+  }
+
+  /**
+   * An inline placement of a non-reusable block is not detachable.
+   *
+   * @covers ::isReusableBlockComponent
+   * @covers ::detach
+   */
+  public function testInlinePlacementOfNonReusableBlockIsNotDetachable(): void {
+    $component = $this->createInlinePlacement(FALSE);
+
+    $this->assertFalse(
+      $this->detacher->isReusableBlockComponent($component),
+      'An ordinary inline block has nothing shared to detach from.'
+    );
     $this->expectException(\InvalidArgumentException::class);
     $this->detacher->detach($component);
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/DetachContextualOperationsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/DetachContextualOperationsTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Drupal\Tests\ys_layouts\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_layouts\Render\DetachContextualOperations;
+
+/**
+ * Tests that the detach action is registered in contextual link metadata.
+ *
+ * Covers issue #1449. Core bakes an "operations" list into every
+ * layout_builder_block contextual link id (see
+ * \Drupal\layout_builder\Element\LayoutBuilder), and the contextual module
+ * caches each id's rendered links in the browser's sessionStorage, re-fetching
+ * only when the id changes (see core/modules/contextual/js/contextual.js).
+ * Adding the "Make non-reusable" link without extending that list leaves the id
+ * unchanged, so any browser that already cached the menu keeps showing the old
+ * three links and never asks the server for the new one. These tests pin the
+ * cache-busting behavior core relies on for its own "move" link.
+ *
+ * @coversDefaultClass \Drupal\ys_layouts\Render\DetachContextualOperations
+ *
+ * @group yalesites
+ * @group ys_layouts
+ */
+class DetachContextualOperationsTest extends UnitTestCase {
+
+  /**
+   * A layout builder element holding one block with core's metadata.
+   *
+   * Mirrors the shape built by
+   * \Drupal\layout_builder\Element\LayoutBuilder::buildAdministrativeSection():
+   * the contextual links sit on a component nested under section and region
+   * keys, not at the top level.
+   *
+   * @param string $operations
+   *   The operations metadata value to seed.
+   *
+   * @return array
+   *   The render array.
+   */
+  protected function elementWithOperations(string $operations): array {
+    return [
+      '#section_storage' => NULL,
+      'layout_builder' => [
+        0 => [
+          'layout-builder__section' => [
+            'content' => [
+              'ffffffff-ffff-ffff-ffff-ffffffffffff' => [
+                '#contextual_links' => [
+                  'layout_builder_block' => [
+                    'route_parameters' => ['delta' => 0],
+                    'metadata' => ['operations' => $operations],
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Reads the operations metadata back out of a processed element.
+   *
+   * @param array $element
+   *   The processed render array.
+   *
+   * @return string
+   *   The operations metadata value.
+   */
+  protected function readOperations(array $element): string {
+    return $element['layout_builder'][0]['layout-builder__section']['content']['ffffffff-ffff-ffff-ffff-ffffffffffff']['#contextual_links']['layout_builder_block']['metadata']['operations'];
+  }
+
+  /**
+   * The detach operation is appended to core's operations metadata.
+   *
+   * This is what changes the contextual link id, which is what forces every
+   * browser holding a cached three-link menu to re-fetch and pick up
+   * "Make non-reusable".
+   *
+   * @covers ::addDetachOperation
+   */
+  public function testAppendsDetachOperation(): void {
+    $element = DetachContextualOperations::addDetachOperation(
+      $this->elementWithOperations('move:update:remove')
+    );
+
+    $this->assertSame(
+      'move:update:remove:detach',
+      $this->readOperations($element),
+      'The detach operation is appended, so the contextual link id changes and stale client-side caches are bypassed.'
+    );
+  }
+
+  /**
+   * Applying the callback twice does not duplicate the operation.
+   *
+   * The id must be stable after the first change, or every render would produce
+   * a new id and contextual links would never cache at all.
+   *
+   * @covers ::addDetachOperation
+   */
+  public function testIsIdempotent(): void {
+    $once = DetachContextualOperations::addDetachOperation(
+      $this->elementWithOperations('move:update:remove')
+    );
+    $twice = DetachContextualOperations::addDetachOperation($once);
+
+    $this->assertSame(
+      'move:update:remove:detach',
+      $this->readOperations($twice),
+      'The operation is added at most once so the contextual link id stays stable.'
+    );
+  }
+
+  /**
+   * Elements without layout builder contextual metadata are left alone.
+   *
+   * @covers ::addDetachOperation
+   */
+  public function testLeavesUnrelatedElementsUntouched(): void {
+    $element = [
+      'content' => [
+        'block' => [
+          '#contextual_links' => [
+            'block' => ['route_parameters' => ['block' => 'somewhere']],
+          ],
+        ],
+      ],
+    ];
+
+    $this->assertSame(
+      $element,
+      DetachContextualOperations::addDetachOperation($element),
+      'A contextual group that is not layout_builder_block is not modified.'
+    );
+  }
+
+  /**
+   * The callback is registered as trusted for use as a #pre_render.
+   *
+   * A #pre_render callback that is not trusted throws
+   * UntrustedCallbackException at render time, which would break every Layout
+   * Builder page rather than just the detach link.
+   *
+   * @covers ::trustedCallbacks
+   */
+  public function testCallbackIsTrusted(): void {
+    $this->assertContains(
+      'addDetachOperation',
+      DetachContextualOperations::trustedCallbacks(),
+      'The pre_render callback is declared trusted.'
+    );
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.info.yml
@@ -5,5 +5,7 @@ package: Core
 core_version_requirement: '^9 || ^10'
 version: VERSION
 dependencies:
+  - drupal:block_content
+  - drupal:layout_builder
   - calendar_link
   - ys_localist

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.libraries.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.libraries.yml
@@ -1,3 +1,9 @@
+detach_reusable_block:
+  version: VERSION
+  css:
+    theme:
+      css/detach-reusable-block.css: {}
+
 ys_layout_banner:
   version: VERSION
   css:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.links.contextual.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.links.contextual.yml
@@ -1,0 +1,10 @@
+ys_layouts_block_detach:
+  title: 'Make non-reusable'
+  route_name: 'ys_layouts.detach_reusable_block'
+  group: 'layout_builder_block'
+  weight: 5
+  options:
+    attributes:
+      class: ['use-ajax']
+      data-dialog-type: dialog
+      data-dialog-renderer: off_canvas

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
@@ -236,6 +236,55 @@ function ys_layouts_form_alter(&$form, $form_state, $form_id) {
 }
 
 /**
+ * Implements hook_form_FORM_ID_alter() for 'ys_layouts_detach_reusable_block'.
+ *
+ * Gin_lb only themes a hardcoded set of Layout Builder form IDs (see
+ * \Drupal\gin_lb\Service\ContextValidator::$formIds); our custom "Make
+ * non-reusable" confirm form is not in it, so its off-canvas dialog otherwise
+ * falls back to the front-end (atomic) theme - rendering the primary button as
+ * dark text on a blue background (a WCAG AA contrast failure) with cramped
+ * spacing. Opt the form into gin_lb's theming so it matches core's Remove/Move
+ * confirm dialogs, mirroring what gin_lb's own FormAlter does for a recognized
+ * form.
+ */
+function ys_layouts_form_ys_layouts_detach_reusable_block_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if (!\Drupal::moduleHandler()->moduleExists('gin_lb')) {
+    return;
+  }
+  /** @var \Drupal\gin_lb\Service\ContextValidatorInterface $context_validator */
+  $context_validator = \Drupal::service('gin_lb.context_validator');
+  // gin_lb only restyles when a non-Gin default theme is active (its whole
+  // purpose is to bring Gin's look to the front-end-themed off-canvas).
+  if (!$context_validator->isValidTheme()) {
+    return;
+  }
+  $form['#gin_lb_form'] = TRUE;
+  $form['#attributes']['class'][] = 'glb-form';
+  // Propagate the flag to child elements after build so their theme hooks pick
+  // up gin_lb's suggestions (e.g. the primary submit button gets glb-button).
+  $form['#after_build'][] = [
+    'Drupal\gin_lb\HookHandler\FormAlter',
+    'afterBuildAttachGinLbForm',
+  ];
+  // Give the confirm form the same off-canvas "canvas-form" layout gin_lb
+  // applies to core's Remove/Move confirm dialogs (see FormAlter::alter,
+  // layout_builder_remove_block branch): the canvas-form class spaces the body
+  // below the header, and the description/actions containers align with it -
+  // otherwise the description sits cramped against the header.
+  $form['#attributes']['class'][] = 'canvas-form';
+  if (isset($form['description'])) {
+    $form['description']['#type'] = 'container';
+    $form['description']['#attributes']['class'][] = 'canvas-form__settings';
+  }
+  if (isset($form['actions'])) {
+    $form['actions']['#attributes']['class'][] = 'canvas-form__actions';
+  }
+  // gin_lb's confirm-dialog top spacing is keyed to core's own remove form IDs,
+  // so extend the same padding to this form's off-canvas dialog.
+  $form['#attached']['library'][] = 'ys_layouts/detach_reusable_block';
+}
+
+/**
  * To aids in styling per section, set layout_section if using layout builder.
  *
  * For now this is only used with the link grid component:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\Context\Context;
 use Drupal\Core\Plugin\Context\EntityContextDefinition;
+use Drupal\ys_layouts\Render\DetachContextualOperations;
 
 /**
  * Add template files.
@@ -282,6 +283,27 @@ function ys_layouts_form_ys_layouts_detach_reusable_block_alter(&$form, FormStat
   // gin_lb's confirm-dialog top spacing is keyed to core's own remove form IDs,
   // so extend the same padding to this form's off-canvas dialog.
   $form['#attached']['library'][] = 'ys_layouts/detach_reusable_block';
+}
+
+/**
+ * Implements hook_element_info_alter().
+ *
+ * Registers the "Make non-reusable" action in Layout Builder's contextual link
+ * metadata. Without this, adding the action never changes the contextual link
+ * id, so browsers keep replaying the previously cached menu out of
+ * sessionStorage and never ask the server for the new link.
+ *
+ * @see \Drupal\ys_layouts\Render\DetachContextualOperations
+ */
+function ys_layouts_element_info_alter(array &$info) {
+  if (isset($info['layout_builder'])) {
+    // Appended so it runs after Layout Builder's own pre_render has built the
+    // sections, and before the theme layer derives the contextual link id.
+    $info['layout_builder']['#pre_render'][] = [
+      DetachContextualOperations::class,
+      'addDetachOperation',
+    ];
+  }
 }
 
 /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.routing.yml
@@ -22,3 +22,15 @@ block_content.add_page:
     _admin_route: TRUE
   requirements:
     _entity_create_any_access: 'block_content'
+ys_layouts.detach_reusable_block:
+  path: '/layout_builder/detach/block/{section_storage_type}/{section_storage}/{delta}/{region}/{uuid}'
+  defaults:
+    _form: '\Drupal\ys_layouts\Form\DetachReusableBlockForm'
+  requirements:
+    _layout_builder_access: 'view'
+    _ys_layouts_detach_reusable_block: 'TRUE'
+  options:
+    _admin_route: TRUE
+    parameters:
+      section_storage:
+        layout_builder_tempstore: TRUE

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.services.yml
@@ -23,7 +23,7 @@ services:
   # (instance-level detach) for the Layout Builder "Make non-reusable" action.
   ys_layouts.reusable_block_detacher:
     class: Drupal\ys_layouts\ReusableBlockDetacher
-    arguments: ['@entity.repository']
+    arguments: ['@entity.repository', '@entity_type.manager']
   # Restricts the detach route (and its contextual link) to placements of
   # reusable content blocks.
   ys_layouts.detach_reusable_block_access:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.services.yml
@@ -19,6 +19,18 @@ services:
   ys_layouts.resource_author_builder:
     class: Drupal\ys_layouts\Service\ResourceAuthorBuilder
     arguments: ['@ys_layouts.author_collator']
+  # Converts a placed reusable block into an independent inline block
+  # (instance-level detach) for the Layout Builder "Make non-reusable" action.
+  ys_layouts.reusable_block_detacher:
+    class: Drupal\ys_layouts\ReusableBlockDetacher
+    arguments: ['@entity.repository']
+  # Restricts the detach route (and its contextual link) to placements of
+  # reusable content blocks.
+  ys_layouts.detach_reusable_block_access:
+    class: Drupal\ys_layouts\Access\DetachReusableBlockAccessCheck
+    arguments: ['@ys_layouts.reusable_block_detacher']
+    tags:
+      - { name: access_check, applies_to: _ys_layouts_detach_reusable_block }
   # Resolves cover-image alt text for Resource media.
   # Used by ResourceMetaBlock and atomic_preprocess_node() so the block
   # render and the card/list templates apply identical alt text.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.services.yml
@@ -28,7 +28,10 @@ services:
   # reusable content blocks.
   ys_layouts.detach_reusable_block_access:
     class: Drupal\ys_layouts\Access\DetachReusableBlockAccessCheck
-    arguments: ['@ys_layouts.reusable_block_detacher']
+    arguments:
+      - '@ys_layouts.reusable_block_detacher'
+      - '@logger.channel.ys_layouts'
+      - '@layout_builder.tempstore_repository'
     tags:
       - { name: access_check, applies_to: _ys_layouts_detach_reusable_block }
   # Resolves cover-image alt text for Resource media.


### PR DESCRIPTION
## [1449: Ability to decouple a reusable block (make it non-reusable again)](https://github.com/yalesites-org/YaleSites-Internal/issues/1449)

### Description of work
- Adds a **"Make non-reusable"** action to every reusable block placement in Layout Builder. It converts just that placement into an independent, standalone (inline) block. The original reusable block is left completely untouched and keeps working on every other page where it is placed (**instance-level detach**).
- Previously, marking a block reusable was permanent — there was no way to turn a shared block back into a normal one. This resolves editor feedback about being stuck with a shared block they made reusable by mistake or that only lives on one page.
- The detached copy is a faithful, independent duplicate: composed paragraph content (accordions, cards, tabs, galleries, etc.) is deep-cloned so editing the detached block never affects the original, while shared library assets (media, referenced nodes) intentionally stay shared.
- The action is keyboard-accessible and screen-reader labeled (it reuses core Layout Builder's contextual-link + off-canvas confirm-form mechanism, matching the existing Configure/Move/Remove actions), and shows a confirmation dialog explaining exactly what it will and will not affect.

**Behavior decisions (confirmed with product):** instance-level detach (not source-level conversion), and the original reusable block is always left intact (never auto-deleted).

### Functional testing steps:
- [ ] Create a reusable block (or use an existing one) and place it on a page via Layout Builder
- [ ] Open the block's contextual links (the pencil/•• menu on the block) — confirm a **"Make non-reusable"** option appears
- [ ] Confirm the option does **not** appear on a normal inline (non-reusable) block
- [ ] Click "Make non-reusable", read the confirmation dialog, and confirm — the layout rebuilds with no error
- [ ] Save the layout, then edit the now-detached block's content and confirm the change does **not** affect the original reusable block on other pages
- [ ] Confirm the original reusable block still exists in Manage Reusable Blocks and is unchanged
- [ ] For a block with paragraph content (e.g. an accordion or gallery), confirm the detached copy's items are independent of the original

### Rework — re-test after this build (2026-07-22)
The reviewer found **"Make non-reusable"** missing on the multidev. Root cause was a stale route/plugin cache on that environment, not a code bug: the new route, contextual-link plugin, and access check register only after a cache rebuild. Verified locally on a clean `drush cr` — the affordance renders on a reusable placement and is absent on an inline block. This push triggers a fresh multidev rebuild, so the checklist above should now be completable; if the option is ever missing right after a deploy, a `drush cr` on that environment restores it.

Also added automated coverage for the gate that decides the affordance's visibility:
- [ ] (automated) `ys_layouts/tests/src/Kernel/DetachReusableBlockAccessCheckTest.php` — asserts access is allowed for a reusable (`block_content:*`) placement, not allowed for an inline (`inline_block:*`) placement, and forbidden for an unresolvable component.

### Rework round 2 — re-test after this build (2026-07-22)
Addressed the confirm-dialog and reusable-Accordion feedback. Please re-test:
- [ ] On a page with a **reusable Accordion** (or any composed block) placed via Layout Builder, confirm the **"Make non-reusable"** option now appears (if it is missing right after deploy, do a `drush cr` on the environment — the contextual link registers after a cache rebuild).
- [ ] Open the "Make non-reusable" dialog and confirm the primary button is **white text on blue** (readable) and the description text is **spaced below the header**, not cramped against it.
- [ ] Read the updated dialog copy and confirm it makes clear that other placements of the block on other pages stay reusable and untouched.
- [ ] Detach the reusable Accordion, save, and confirm the original reusable block is unchanged in Manage Reusable Blocks and unaffected elsewhere.

### Rework round 3 — re-test after this build (2026-07-27)
Root-caused the missing affordance: it was not a server-side cache. Core bakes an
operations allowlist into each Layout Builder contextual link's id, and the contextual
module caches links per-id in the browser's `sessionStorage`, so adding a fourth link
without extending that allowlist left the id unchanged and browsers replayed the old
three-link menu. The id now changes, so clients re-fetch once.

- [ ] On a page with a **reusable block** placed via Layout Builder (Accordion, Text, or
      Action Banner — it is not type-specific), open the block's contextual menu and
      confirm **"Make non-reusable"** appears alongside Configure / Move / Remove block.
- [ ] Confirm an **inline (non-reusable)** block in the same section still shows only
      Configure / Move / Remove block.
- [ ] Confirm the same reusable block type behaves the same on a **second page** (this is
      the asymmetry that failed before).
- [ ] Open the dialog and confirm the primary button is **white text on blue** and the
      description is **spaced below the header** — this is the first build where the dialog
      is actually reachable to check.
- [ ] Read the dialog copy and confirm it says other placements on other pages stay
      reusable and untouched.
- [ ] Detach, save the layout, and confirm the original reusable block is unchanged in
      Manage Reusable Blocks and unaffected elsewhere.
- [ ] After detaching, confirm the action is no longer offered on that placement (reload,
      or open a new tab — see note below).
- [ ] **If the action is still missing:** open the page in a **brand-new browser tab** (the
      contextual link cache is per-tab). If still missing, copy the block's
      `data-contextual-id` attribute — it should end in
      `operations=move:update:remove:detach`. If it does not, the fix did not deploy.
- [ ] (automated) `ys_layouts/tests/src/Unit/DetachContextualOperationsTest.php` — pins the
      metadata registration that makes the link appear, and that it is idempotent.
- [ ] (automated) `ys_layouts/tests/src/Kernel/DetachReusableBlockAccessCheckTest.php` —
      now also asserts the gate judges the layout being edited (not the last saved one) and
      logs an unresolvable component instead of hiding it silently.


References yalesites-org/YaleSites-Internal#1449

---
Created with AI



