### PR TITLE
579: YS Core cleanup — complete Phase 0 characterization tests

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/README.md
@@ -20,4 +20,64 @@ lando ssh -c "env SIMPLETEST_DB=mysql://pantheon:pantheon@database/pantheon \
   /app/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests --testdox"
 ```
 
-Unit-only tests (no database) can also be run with the shorthand `lando phpunit web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests`.
+The Unit tests need no database and run in under a second, so for a quick check
+point the shorthand at the `Unit` directory specifically:
+
+```bash
+lando phpunit web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit
+```
+
+Passing the whole `tests` directory to that shorthand also discovers `Kernel/`,
+which errors without `SIMPLETEST_DB` — use the full command above for those.
+
+Note that **CI does not run PHPUnit at all**: `.ci/test/static/run` calls
+`composer unit-test`, which is currently a stub. These tests only run when
+someone runs them locally.
+
+## Known test coverage gaps
+
+Recorded here so they are visible to anyone working in this module, particularly
+during the staged cleanup tracked in yalesites-org/YaleSites-Internal#579.
+
+- **No config schema for this module's settings objects.** `config/schema/ys_core.schema.yml`
+  covers only `ys_core.dashboard_settings`. `ys_core.site`, `ys_core.header_settings`,
+  `ys_core.footer_settings`, and `ys_core.social_links` have none, so a kernel test
+  that installs this module's config fails with `SchemaIncompleteException` under
+  PHPUnit's default strict schema checking. That blocks kernel-level characterization
+  of every service that reads these objects, so the tests here work around it by
+  exercising only code paths that need no config save. Adding the schema is not
+  test-only work: `environment_indicator.show` ships as boolean `true` in
+  `config/install` but `SiteSettingsForm` saves integer `1`, and `custom_favicon` /
+  `site_name_image` are declared as `''` but hold arrays of file IDs, so no schema
+  type validates both the install defaults and real saved values without also
+  correcting those.
+- **`getFavicons()` custom-favicon branch is only partly pinned.** The test for it
+  stubs a single image style for all four sizes, so it cannot show that each size
+  resolves to its own distinct URL. Verifying that needs a real image style and a
+  saved `custom_favicon` value, so it is blocked on the missing schema above. The
+  fallback branch is covered against the real filesystem and the shipped image
+  style config in `YaleSitesMediaManagerTest`.
+- **`CoreTwigExtension::getAssetPath()`'s `_yale-packages` fallback is uncovered.**
+  A normal checkout has an asset manifest under the theme's `node_modules`, so the
+  first path always wins; the fallback only runs where the theme's npm assets are
+  absent but `_yale-packages` is populated.
+- **`CoreTwigExtension::getUrlType()` can never return `'mailto'`.** It checks
+  `isInternal()` first, and that treats any URL with an empty `parse_url()` host as
+  internal, which every `mailto:` URL is. The private `isMailTo()` method is dead
+  code. Both the current behavior and the intended behavior are recorded as a
+  characterization/skipped test pair in `CoreTwigExtensionTest`; fixing the ordering
+  is a behavior change and is out of scope for a behavior-preserving refactor.
+
+## Known configuration inconsistencies
+
+- **`bluesky` is missing from the shipped social links defaults.** `SocialLinksManager::SITES`
+  offers it, but `config/install/ys_core.social_links.yml` does not list it, so a
+  freshly installed site has no `bluesky` key until an editor saves the Footer
+  Settings form.
+- **`config/facts_figures_icons.yml` is unused.** `FactsAndFiguresIconManager` reads
+  the component library manifest at
+  `themes/contrib/atomic/node_modules/@yalesites-org/component-library-twig/components/02-molecules/facts-and-figures/facts-and-figures-icons.yml`.
+  Nothing reads the in-module file, and its structure is not compatible with what the
+  service expects.
+- **`seo.google_analytics_id`** is present in both `config/install` and the profile's
+  `config/sync` but is read and written by nothing; Google Tag Manager replaced it.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/FactsIconAllowedValuesBridgeTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/FactsIconAllowedValuesBridgeTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Characterizes the Facts and Figures icon allowed-values bridge.
+ *
+ * Phase 0 of the ys_core cleanup (yalesites-org/YaleSites-Internal#579)
+ * requires pinning the current behavior of everything scheduled to move in a
+ * later phase. The procedural bridge ys_core_facts_icon_allowed_values() had
+ * no coverage at all: it calls \Drupal::service(), so a unit test cannot
+ * exercise it, and no test in the tree loaded ys_core.module.
+ *
+ * The bridge matters more than its size suggests. Field storage config names
+ * it as an 'allowed_values_function' string, so the wiring is a
+ * stringly-typed contract that no static analysis or refactoring tool can
+ * follow. If a later phase moves the icon manager to a new module and renames
+ * the function without updating every synced field storage YAML, the icon
+ * field silently loses all of its options and nothing else in the suite
+ * fails.
+ *
+ * @group ys_core
+ * @group yalesites
+ *
+ * @see ys_core_facts_icon_allowed_values()
+ * @see \Drupal\ys_core\FactsAndFiguresIconManager
+ */
+class FactsIconAllowedValuesBridgeTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   *
+   * Because ys_core declares cas + role_delegation + the two form-element
+   * modules as dependencies, and cas in turn needs externalauth, enabling
+   * ys_core in a kernel test pulls the whole chain in. Omitting externalauth
+   * fails at container compile with a non-obvious "non-existent service
+   * externalauth.externalauth".
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'file',
+    'image',
+    'media',
+    'multivalue_form_element',
+    'media_library_form_element',
+    'role_delegation',
+    'externalauth',
+    'cas',
+    'ys_core',
+  ];
+
+  /**
+   * The icon manager service.
+   *
+   * @var \Drupal\ys_core\FactsAndFiguresIconManager
+   */
+  protected $iconManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->iconManager = $this->container->get('ys_core.facts_and_figures_icon_manager');
+    // Start from a cold cache so the YAML-parsing path is the one under test,
+    // not a warm entry left by another test in the same kernel.
+    $this->iconManager->clearCache();
+  }
+
+  /**
+   * Calls the procedural bridge the way Drupal's field system calls it.
+   *
+   * @return array
+   *   The allowed values returned by the bridge.
+   */
+  protected function callBridge(): array {
+    $definition = $this->createMock(FieldStorageDefinitionInterface::class);
+    return ys_core_facts_icon_allowed_values($definition);
+  }
+
+  /**
+   * The bridge is reachable and delegates to the icon manager service.
+   */
+  public function testBridgeDelegatesToIconManager(): void {
+    $this->assertTrue(
+      function_exists('ys_core_facts_icon_allowed_values'),
+      'Enabling ys_core loads ys_core.module, which defines the bridge.'
+    );
+
+    $options = $this->callBridge();
+    // Without this, two empty arrays would satisfy the comparison below and the
+    // test would survive the service returning nothing.
+    $this->assertNotEmpty($options, 'The bridge returns actual options.');
+
+    $this->assertSame(
+      $this->iconManager->getFlatIconOptions(),
+      $options,
+      'The bridge returns the icon manager service output unchanged.'
+    );
+  }
+
+  /**
+   * The bridge returns the "none" option plus icons from the CLT manifest.
+   *
+   * The component library YAML is the documented single source of truth, so
+   * this asserts against the manifest rather than a hardcoded icon list:
+   * adding or removing an icon in the component library must not fail this
+   * test, but losing the manifest wiring entirely must.
+   *
+   * Comparing the service against the file it reads looks circular, but the
+   * point is to catch a *silent fallback*. When the manifest cannot be found or
+   * parsed, getIconConfig() logs and returns getFallbackConfig() -- three
+   * hardcoded icons instead of the manifest's full set -- and every caller
+   * carries on as if nothing happened. The exact-count assertion below is what
+   * distinguishes "read the real manifest" from "quietly degraded".
+   */
+  public function testBridgeReturnsNoneOptionAndManifestIcons(): void {
+    $manifest = $this->readIconManifest();
+    $options = $this->callBridge();
+
+    $this->assertArrayHasKey(
+      $manifest['config']['default_value'],
+      $options,
+      'The default ("none") value is offered as an option.'
+    );
+    $this->assertSame(
+      $manifest['config']['none_label'],
+      $options[$manifest['config']['default_value']],
+      'The none option uses the label from the manifest.'
+    );
+
+    // Every icon in the manifest is offered, with the manifest's label.
+    $this->assertNotEmpty($manifest['icons'], 'Guard: the manifest defines icons.');
+    foreach ($manifest['icons'] as $key => $label) {
+      $this->assertArrayHasKey($key, $options, "Manifest icon '$key' is offered.");
+      $this->assertSame($label, $options[$key], "Icon '$key' keeps its manifest label.");
+    }
+
+    // The none option is the only entry that is not a manifest icon.
+    $this->assertCount(count($manifest['icons']) + 1, $options);
+  }
+
+  /**
+   * Every ys_core allowed-values function named in synced config exists.
+   *
+   * This is the guard for constraint 5 of the cleanup issue. The
+   * 'allowed_values_function' setting is stored as a plain string in field
+   * storage config, so a rename that misses a YAML file breaks the field with
+   * no other symptom. Any relocation phase that renames or moves the bridge
+   * must update every synced field storage in the same change, and this test
+   * is what enforces that.
+   */
+  public function testSyncedAllowedValuesFunctionsExist(): void {
+    $sync_dir = \Drupal::root() . '/' . \Drupal::service('extension.list.profile')
+      ->getPath('yalesites_profile') . '/config/sync';
+    $this->assertDirectoryExists($sync_dir);
+
+    $checked = [];
+    foreach (glob($sync_dir . '/field.storage.*.yml') as $file) {
+      $storage = Yaml::parseFile($file);
+      $function = $storage['settings']['allowed_values_function'] ?? '';
+      // Only our own callbacks; contrib and core ones are not our contract.
+      if ($function === '' || !str_starts_with($function, 'ys_core_')) {
+        continue;
+      }
+      $checked[$function][] = basename($file);
+      $this->assertTrue(
+        function_exists($function),
+        sprintf(
+          "Synced config %s names allowed_values_function '%s', which does not exist. "
+          . 'Moving or renaming that function requires updating the field storage config in the same change.',
+          basename($file),
+          $function
+        )
+      );
+    }
+
+    // Anti-vacuity guard: if the glob or the key path ever stops matching, this
+    // test must fail loudly rather than silently checking nothing.
+    $this->assertNotEmpty(
+      $checked,
+      'Expected at least one synced field storage to name a ys_core_* allowed_values_function.'
+    );
+    $this->assertArrayHasKey(
+      'ys_core_facts_icon_allowed_values',
+      $checked,
+      'The Facts and Figures icon bridge is still wired up in synced field storage config.'
+    );
+  }
+
+  /**
+   * A cache miss parses the manifest and caches it with the manifest's tags.
+   *
+   * The existing unit test stubs a permanent cache hit, so the cache-write path
+   * in FactsAndFiguresIconManager::getIconConfig() was never executed. Real TTL
+   * and tag behavior cannot be expressed with a mocked backend.
+   */
+  public function testIconConfigIsCachedWithManifestTagsAndMaxAge(): void {
+    $manifest = $this->readIconManifest();
+    $cache = $this->container->get('cache.default');
+
+    // setUp() cleared the cache; confirm the starting state before asserting a
+    // write, so an always-warm cache cannot make this pass vacuously.
+    $this->assertFalse($cache->get('ys_core_facts_figures_icons'), 'Cache starts cold.');
+
+    $before = time();
+    $this->iconManager->getFlatIconOptions();
+
+    $cached = $cache->get('ys_core_facts_figures_icons');
+    $this->assertNotFalse($cached, 'Reading options on a cold cache writes the cache entry.');
+    $this->assertSame($manifest['icons'], $cached->data['icons'], 'The parsed manifest is what gets cached.');
+
+    // Tags and TTL come from the manifest's own cache section.
+    $this->assertNotEmpty(
+      $manifest['cache']['tags'],
+      'Guard: the manifest declares cache tags, so the loop asserts something.'
+    );
+    foreach ($manifest['cache']['tags'] as $tag) {
+      $this->assertContains($tag, $cached->tags, "Cache entry carries the '$tag' tag.");
+    }
+    $this->assertGreaterThanOrEqual($before + $manifest['cache']['max_age'], $cached->expire);
+
+    // clearCache() removes it again.
+    $this->iconManager->clearCache();
+    $this->assertFalse($cache->get('ys_core_facts_figures_icons'), 'clearCache() deletes the entry.');
+  }
+
+  /**
+   * Reads the component library icon manifest the service reads.
+   *
+   * @return array
+   *   The parsed manifest.
+   */
+  protected function readIconManifest(): array {
+    $path = \Drupal::root() . '/themes/contrib/atomic/'
+      . 'node_modules/@yalesites-org/component-library-twig/components/02-molecules/'
+      . 'facts-and-figures/facts-and-figures-icons.yml';
+
+    if (!file_exists($path)) {
+      $this->markTestSkipped(
+        'The component library icon manifest is not installed at ' . $path
+        . ' (run the theme npm install). The service falls back to a hardcoded'
+        . ' list in that case, which is a different code path.'
+      );
+    }
+
+    return Yaml::parseFile($path);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/CoreTwigExtensionTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/CoreTwigExtensionTest.php
@@ -175,7 +175,135 @@ class CoreTwigExtensionTest extends UnitTestCase {
    * @covers ::getUrlType
    */
   public function testGetUrlTypeShouldClassifyMailtoLinksAsMailto(): void {
-    $this->markTestSkipped('GAP: getUrlType() never returns "mailto" because isInternal() already matches any host-less URL -- see ~/Documents/Claude/not_dave/module-tests-20260710/ys_core.md');
+    $this->markTestSkipped(
+      'GAP: getUrlType() can never return "mailto". It tests isInternal() before '
+      . 'isMailTo(), and isInternal() treats any URL whose parse_url() host is '
+      . 'empty as internal -- which every mailto: URL is. Fixing it means moving '
+      . 'the isMailTo() check above isInternal(); that is a behavior change, so it '
+      . 'is out of scope for the behavior-preserving ys_core cleanup '
+      . '(yalesites-org/YaleSites-Internal#579). Delete this test and its '
+      . 'characterization pair once the ordering is fixed.'
+    );
+  }
+
+  /**
+   * The Twig extension registers exactly the five documented function names.
+   *
+   * These names are a public contract: atomic's templates call them
+   * directly, so renaming or dropping one breaks rendering with no PHP
+   * error. Constraint 2 of the ys_core cleanup issue
+   * (yalesites-org/YaleSites-Internal#579) states the names must not change,
+   * and nothing pinned them until now -- a class move or namespace change
+   * during the refactor could have silently altered this list.
+   *
+   * @covers ::getFunctions
+   */
+  public function testGetFunctionsRegistersTheDocumentedTwigFunctionNames(): void {
+    $names = array_map(
+      static fn($function) => $function->getName(),
+      $this->extension->getFunctions()
+    );
+
+    $this->assertSame(
+      [
+        'getCoreSetting',
+        'getHeaderSetting',
+        'getUrlType',
+        'getQueryParam',
+        'getAssetPath',
+      ],
+      $names
+    );
+  }
+
+  /**
+   * An absent manifest falls back to the unversioned asset name.
+   *
+   * A bogus directory makes both file_exists() checks miss, so this reaches the
+   * early return. It cannot tell the two misses apart, though: deleting the
+   * _yale-packages fallback would not fail this test. That branch is in fact
+   * uncovered -- a normal checkout has a manifest under node_modules, so the
+   * first path always wins and the fallback only runs where the theme's npm
+   * assets are absent but _yale-packages is populated.
+   *
+   * @covers ::getAssetPath
+   */
+  public function testGetAssetPathFallsBackToInputWhenManifestMissing(): void {
+    $this->assertSame(
+      'icons.svg',
+      $this->extension->getAssetPath('icons.svg', 'themes/contrib/does-not-exist')
+    );
+  }
+
+  /**
+   * A known asset resolves to the versioned filename from the manifest.
+   *
+   * Asserted against the manifest's actual contents rather than a literal hash:
+   * the hash changes on every component-library build, so hardcoding one would
+   * make this test fail on an unrelated rebuild.
+   *
+   * @covers ::getAssetPath
+   */
+  public function testGetAssetPathReturnsVersionedNameFromManifest(): void {
+    $manifest = $this->readAssetManifest();
+    $asset = array_key_first($manifest);
+
+    // Without this guard the assertion below would pass even if getAssetPath()
+    // never read the manifest and just returned its input, whenever the
+    // manifest happens to map an asset to its own unversioned name.
+    $this->assertNotSame(
+      $asset,
+      $manifest[$asset],
+      'Guard: the manifest actually versions this asset.'
+    );
+
+    $this->assertSame($manifest[$asset], $this->extension->getAssetPath($asset));
+  }
+
+  /**
+   * An asset missing from a present manifest falls back to the input name.
+   *
+   * @covers ::getAssetPath
+   */
+  public function testGetAssetPathFallsBackToInputWhenAssetNotInManifest(): void {
+    $manifest = $this->readAssetManifest();
+    $this->assertArrayNotHasKey('not-a-real-asset.svg', $manifest, 'Guard: the key is genuinely absent.');
+
+    $this->assertSame('not-a-real-asset.svg', $this->extension->getAssetPath('not-a-real-asset.svg'));
+  }
+
+  /**
+   * Reads the component library asset manifest getAssetPath() resolves against.
+   *
+   * GetAssetPath() reads the real filesystem relative to DRUPAL_ROOT and offers
+   * no seam to inject a fixture, so the manifest-present branches are exercised
+   * against the installed manifest and skipped when the theme's npm assets have
+   * not been built.
+   *
+   * @return array
+   *   The decoded manifest, asset name => versioned asset name.
+   */
+  protected function readAssetManifest(): array {
+    $base = DRUPAL_ROOT . '/themes/contrib/atomic/';
+    $candidates = [
+      $base . 'node_modules/@yalesites-org/component-library-twig/dist/manifest.json',
+      $base . '_yale-packages/component-library-twig/dist/manifest.json',
+    ];
+
+    foreach ($candidates as $path) {
+      if (file_exists($path)) {
+        $manifest = json_decode(file_get_contents($path), TRUE);
+        if (is_array($manifest) && $manifest !== []) {
+          return $manifest;
+        }
+      }
+    }
+
+    $this->markTestSkipped(
+      'No component library asset manifest is installed (build the theme assets). '
+      . 'getAssetPath() falls back to the unversioned name in that case, which '
+      . 'testGetAssetPathFallsBackToInputWhenManifestMissing() already covers.'
+    );
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/YaleSitesMediaManagerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/YaleSitesMediaManagerTest.php
@@ -151,6 +151,108 @@ class YaleSitesMediaManagerTest extends UnitTestCase {
   }
 
   /**
+   * The fallback set is four favicons with their page-head attributes.
+   *
+   * Pins the markup contract ys_core_page_attachments() renders into the head,
+   * so a relocation that drops or renames a tag is visible. Added for Phase 0
+   * of yalesites-org/YaleSites-Internal#579.
+   *
+   * @covers ::getFavicons
+   */
+  public function testGetFaviconsFallbackSetStructure(): void {
+    $this->yaleSettings->method('get')->with('custom_favicon')->willReturn(NULL);
+
+    $favicons = $this->manager->getFavicons();
+
+    $this->assertSame(
+      ['apple-touch-icon', 'icon-32', 'icon-16', 'icon-ico'],
+      array_keys($favicons)
+    );
+
+    $expected_rels = [
+      'apple-touch-icon' => 'apple-touch-icon',
+      'icon-32' => 'icon',
+      'icon-16' => 'icon',
+      'icon-ico' => 'shortcut icon',
+    ];
+    foreach ($expected_rels as $key => $rel) {
+      $this->assertSame('link', $favicons[$key]['#tag'], "$key renders a link.");
+      $this->assertSame($rel, $favicons[$key]['#attributes']['rel'], "$key rel.");
+    }
+
+    $this->assertSame('32x32', $favicons['icon-32']['#attributes']['sizes']);
+    $this->assertSame('16x16', $favicons['icon-16']['#attributes']['sizes']);
+  }
+
+  /**
+   * Every fallback favicon href points at a file that exists on disk.
+   *
+   * The other fallback tests assert these hrefs as hardcoded strings, so they
+   * stay green even if the files move or are deleted -- which is what Phase 1
+   * of yalesites-org/YaleSites-Internal#579 does when it relocates this class
+   * and the images/favicons/ directory into a new module.
+   *
+   * @covers ::getFavicons
+   */
+  public function testGetFaviconsFallbackFilesExistOnDisk(): void {
+    $this->yaleSettings->method('get')->with('custom_favicon')->willReturn(NULL);
+
+    $favicons = $this->manager->getFavicons();
+    $this->assertCount(4, $favicons, 'Guard: all four hrefs get checked.');
+
+    foreach ($favicons as $key => $favicon) {
+      $href = $favicon['#attributes']['href'];
+      $this->assertStringStartsWith('/', $href, "$key href is root-relative.");
+
+      $path = DRUPAL_ROOT . $href;
+      $this->assertFileExists($path, sprintf(
+        "The '%s' fallback favicon href (%s) must resolve to a real file. If "
+        . 'the ys_core module or its images/favicons/ directory moved, update '
+        . 'the hardcoded hrefs in getFavicons().',
+        $key,
+        $href
+      ));
+      $this->assertGreaterThan(0, filesize($path), "$key file is not empty.");
+    }
+  }
+
+  /**
+   * Every image style getFavicons() names ships in the profile's config.
+   *
+   * A missing style is a silent cliff rather than an error: getFavicons()
+   * unset()s that favicon, so once a site sets a custom favicon the tag just
+   * disappears from the page head. The styles ship in the profile's
+   * config/sync, so this checks the shipped YAML rather than active config.
+   *
+   * @covers ::getFavicons
+   */
+  public function testGetFaviconsNamedImageStylesShipInConfig(): void {
+    $this->yaleSettings->method('get')->with('custom_favicon')->willReturn(NULL);
+
+    $styles = [];
+    foreach ($this->manager->getFavicons() as $key => $favicon) {
+      $this->assertArrayHasKey('#image_style', $favicon, "$key names a style.");
+      $styles[$key] = $favicon['#image_style'];
+    }
+    $this->assertCount(4, $styles, 'Guard: four style names to check.');
+
+    // The profile path is already hardcoded in the favicon hrefs themselves,
+    // so resolving it the same way here introduces no new coupling.
+    $sync = DRUPAL_ROOT . '/profiles/custom/yalesites_profile/config/sync';
+    $this->assertDirectoryExists($sync);
+
+    foreach ($styles as $key => $style) {
+      $this->assertFileExists($sync . '/image.style.' . $style . '.yml', sprintf(
+        "getFavicons() maps '%s' to image style '%s', which ships in no "
+        . 'config/sync file. Without it the favicon is silently dropped from '
+        . 'the page head whenever a site has a custom favicon set.',
+        $key,
+        $style
+      ));
+    }
+  }
+
+  /**
    * @covers ::getFavicons
    */
   public function testGetFaviconsKeepsFallbackWhenCustomFileNotFound(): void {


### PR DESCRIPTION
## [579: YS Core cleanup — complete Phase 0 characterization tests](https://github.com/yalesites-org/YaleSites-Internal/issues/579)

### Description of work

Completes Phase 0 of the ys_core cleanup — the characterization tests that must merge before any relocation phase. Test-only plus a README section; **no production code is changed.**

Phase 0 turned out to be much further along than the ticket suggested. yalesites-org/yalesites-project#1338 and yalesites-org/yalesites-project#1339 covered part of it, and yalesites-org/yalesites-project#1354 (filed under issue #1388, so it never referenced 579) added 87 unit tests across six services, the Twig extension, and three event subscribers. This PR closes the four gaps that were genuinely still open — each one a place where a later phase could break something with no test failure:

- **`ys_core_facts_icon_allowed_values()` had zero coverage.** It calls `\Drupal::service()`, so a unit test cannot reach it, and no test in the tree loaded `ys_core.module`. New `FactsIconAllowedValuesBridgeTest` (Kernel) covers the bridge, the `_none` + manifest icon options, and the previously-unexercised cache-miss path (real YAML parse, `cache.set()` with the manifest's own tags and TTL, then `clearCache()`).
- **Nothing guarded constraint 5.** `allowed_values_function` is stored as a plain string in field storage config, so a rename that misses a YAML file breaks the icon field silently. The new test walks every `field.storage.*.yml` in `config/sync` and fails, naming the offending file, for any `ys_core_*` function that does not exist. It is generic, so it will also cover the second field storage that yalesites-org/yalesites-project#1407 adds for In-Line Message once that merges.
- **`getFavicons()`'s fallback hrefs were only pinned as strings.** The existing tests assert them against mocked storage, so they stay green even if `images/favicons/` is moved or emptied — exactly what Phase 1 does. Three new tests in `YaleSitesMediaManagerTest` assert each href resolves to a real non-empty file on disk, that every image style `getFavicons()` names actually ships in `config/sync`, and the page-head attribute contract (keys, `rel`, `sizes`). The image-style one is a silent cliff: a missing style makes `getFavicons()` `unset()` the favicon, so the tag just disappears from the page head.
- **`CoreTwigExtension::getFunctions()` and `getAssetPath()` had zero coverage.** `getFunctions()` now pins the five Twig function names in order, which is the contract constraint 2 says must not change and which atomic's templates call directly. `getAssetPath()` covers all three branches, asserting against the manifest's actual contents rather than a content hash that changes on every build.

Both new guards were **mutation-tested** rather than just observed green — renaming the bridge function, and pointing one favicon href at a missing file, each produce a failure naming the exact cause. A characterization test that cannot fail is worse than no test.

The README gains "Known test coverage gaps" and "Known configuration inconsistencies" sections so the findings below live in the repo rather than only in a ticket comment.

**Two things for the reviewer to note, both explained in detail on the issue:**

1. **Phase 0's Kernel tests are not achievable as the ticket specifies, and this PR works around it rather than fixing it.** `installConfig(['ys_core'])` throws `SchemaIncompleteException: No schema for ys_core.footer_settings` — only `ys_core.dashboard_settings` has schema. The tests here therefore exercise only paths needing no config save. Adding the schema is **not** test-only work (`environment_indicator.show` ships as boolean `true` but the form saves integer `1`; `custom_favicon`/`site_name_image` are declared `''` but hold arrays of file IDs), so it is recommended as its own small PR instead of being smuggled into a characterization change.
2. **Phase 5 needs reshaping.** The icon service is becoming shared infrastructure rather than Facts-and-Figures-specific, so extracting a `ys_facts_figures` module that owns it would leave In-Line Message depending on an F&F-named module. Also, the ticket names `config/facts_figures_icons.yml` as the icon source in both Phase 0 and Phase 5 — nothing reads that file; the real source is the component library manifest, and the in-module file should be deleted as dead data.
3. **None of these tests run in CI.** `.ci/test/static/run` calls `composer unit-test`, which is a stub (`echo 'No unit test step defined.'`), so the `Test` job only lints and sniffs. Every test on this ticket runs only when someone runs it locally. That means Phase 0's safety net is real but unenforced, and the acceptance criterion "each PR keeps the full test suite green" is currently convention rather than a gate. Wiring it up is not a one-liner (the Kernel tests need a database CI does not provision, and bare `phpunit` discovery fatals on a broken contrib `honeypot` test), so it is written up as its own follow-up on the issue rather than bolted on here.

### Functional testing steps:

- [ ] Run the ys_core suite and confirm it is green: `lando ssh -c "env SIMPLETEST_DB=mysql://pantheon:pantheon@database/pantheon php /app/vendor/bin/phpunit -c /app/phpunit.xml /app/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests --testdox"`
- [ ] Confirm `lando composer code-sniff` exits 0 (run it from the repo root — it fails on warnings, not just errors)
- [ ] Confirm no production code is touched: `git diff develop...HEAD --stat` should show only `tests/src/Kernel/FactsIconAllowedValuesBridgeTest.php`, `tests/src/Unit/CoreTwigExtensionTest.php`, `tests/src/Unit/YaleSitesMediaManagerTest.php`, and `README.md`
- [ ] Spot-check that the guards are real, not vacuous — temporarily rename `ys_core_facts_icon_allowed_values` in `ys_core.module` and confirm `testSyncedAllowedValuesFunctionsExist` fails naming `field.storage.paragraph.field_icon.yml`, then revert
- [ ] Sanity-check the Facts & Figures icon picker still works in the UI (add a Facts and Figures paragraph, open the icon select) — this PR should not change it, since no production code changed

References yalesites-org/YaleSites-Internal#579

---
Created with AI
