### PR TITLE
190: Add block cloning to Layout Builder - Alternative

### DIFF
--- a/docs/block-cloning.md
+++ b/docs/block-cloning.md
@@ -1,0 +1,71 @@
+# Cloning Blocks in Layout Builder
+
+## Overview
+
+Some pages repeat the same block over and over — a checkerboard of Content
+Spotlights, a row of Facts, a stack of Callouts. Instead of adding a new block
+and re-entering every setting each time, you can **clone** an existing block and
+then edit the copy.
+
+Cloning is available in **Edit Layout and Content** (Layout Builder) on any
+content type that uses it.
+
+## How to clone a block
+
+1. Open the page and choose **Edit Layout and Content**.
+2. Hover over (or keyboard-focus) the block you want to copy and open its
+   pencil/contextual menu.
+3. Choose **Clone block**.
+4. The copy appears immediately below the original, in the same region, with all
+   of its content and settings already filled in.
+5. Edit the copy as usual (**Configure**), then press **Save layout** to publish
+   your changes.
+
+The clone is not saved until you save the layout. **Discard changes** removes the
+copy again, exactly like any other unsaved edit.
+
+## What gets copied
+
+- Every field of the block — text, links, media references, and repeatable
+  items such as gallery images, cards, tabs, accordion items or facts.
+- Block settings such as the heading, style/variation options and padding.
+- The block's position: the copy is always placed directly after the original.
+
+The copy is a **separate block**. Editing the clone never changes the original,
+and editing the original never changes the clone.
+
+## Limitations
+
+- **Reusable blocks cannot be cloned.** A reusable block is already shared
+  across pages by design, so a copy would silently disconnect from the
+  original.
+- **Blocks with no content of their own cannot be cloned** — views listings,
+  page metadata, profile contact details and other built-in blocks. For all of
+  these, **Clone block** simply does not appear in the menu.
+- **Locked regions.** If a section or region has been locked so blocks cannot
+  be added to it, cloning is unavailable there too.
+- Cloning copies a block **within the same page**. To reuse a block on another
+  page, either use a reusable block from the block library or clone the whole
+  page.
+
+## Accessibility
+
+**Clone block** is a normal contextual-menu link, so it is reachable with the
+keyboard in the same way as **Configure**, **Move** and **Remove block**. After
+cloning, screen readers hear "Block cloned. The copy was added below the
+original."
+
+## Notes for the YaleSites team
+
+The editor-facing Help Center lives outside this repository. This document is
+the source material for that separate, external article — publishing it there is
+a follow-up task for the documentation team.
+
+Cloning is implemented in `ys_layouts` (`BlockCloner`, `CloneBlockController`,
+`CloneContextualLinks`, `CloneBlockAccessCheck`). One half of the feature is in
+the theme: `atomic/templates/paragraphs/_gallery-item.twig` renders the Gallery
+modal from the paragraph object (twig_tweak's `view` filter) instead of by
+paragraph ID, because a cloned paragraph has no ID until the layout is saved and
+rendering by ID produced an empty lightbox in the Layout Builder preview. That
+change ships on an `atomic` branch with the same name as the
+`yalesites-project` branch so the multidev build picks it up.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Access/CloneBlockAccessCheck.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Access/CloneBlockAccessCheck.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Drupal\ys_layouts\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\layout_builder\LayoutTempstoreRepositoryInterface;
+use Drupal\layout_builder\SectionStorageInterface;
+use Drupal\ys_layouts\Service\BlockCloner;
+
+/**
+ * Allows the clone route only for inline blocks.
+ *
+ * This is the server-side half of the reusable-block exclusion; the contextual
+ * link itself is removed in ys_layouts_contextual_links_view_alter() so the
+ * option never appears on a block that cannot be cloned.
+ *
+ * The storage passed in has to be re-read from the layout tempstore: route
+ * enhancers do not run inside AccessManager::checkNamedRoute(), which is how
+ * the contextual link manager evaluates access, so without this the check
+ * would look at the last saved layout and could not see a block the editor
+ * added moments ago.
+ *
+ * @see \Drupal\Core\Access\AccessManager::checkNamedRoute()
+ * @see \Drupal\layout_builder\Routing\LayoutTempstoreRouteEnhancer
+ */
+class CloneBlockAccessCheck implements AccessInterface {
+
+  /**
+   * The layout tempstore repository.
+   *
+   * @var \Drupal\layout_builder\LayoutTempstoreRepositoryInterface
+   */
+  protected $layoutTempstoreRepository;
+
+  /**
+   * The block cloner service.
+   *
+   * @var \Drupal\ys_layouts\Service\BlockCloner
+   */
+  protected $blockCloner;
+
+  /**
+   * Constructs a new CloneBlockAccessCheck object.
+   *
+   * @param \Drupal\layout_builder\LayoutTempstoreRepositoryInterface $layout_tempstore_repository
+   *   The layout tempstore repository.
+   * @param \Drupal\ys_layouts\Service\BlockCloner $block_cloner
+   *   The block cloner service.
+   */
+  public function __construct(
+    LayoutTempstoreRepositoryInterface $layout_tempstore_repository,
+    BlockCloner $block_cloner,
+  ) {
+    $this->layoutTempstoreRepository = $layout_tempstore_repository;
+    $this->blockCloner = $block_cloner;
+  }
+
+  /**
+   * Checks that the requested component is a clonable inline block.
+   *
+   * @param \Drupal\layout_builder\SectionStorageInterface $section_storage
+   *   The section storage.
+   * @param mixed $delta
+   *   The delta of the section holding the block.
+   * @param mixed $uuid
+   *   The UUID of the component being cloned.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(
+    SectionStorageInterface $section_storage,
+    $delta = NULL,
+    $uuid = NULL,
+  ): AccessResultInterface {
+    // Unsaved layouts only exist in the tempstore.
+    $section_storage = $this->layoutTempstoreRepository->get($section_storage);
+
+    try {
+      $component = $section_storage->getSection((int) $delta)
+        ->getComponent((string) $uuid);
+    }
+    catch (\OutOfBoundsException | \InvalidArgumentException $e) {
+      // The component is not in this layout (any more).
+      return AccessResult::forbidden()->setCacheMaxAge(0);
+    }
+
+    $clonable = $this->blockCloner->isClonable($component);
+
+    // Not cacheable: the answer depends on the current user's unsaved layout.
+    return AccessResult::allowedIf($clonable)->setCacheMaxAge(0);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/CloneContextualLinks.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/CloneContextualLinks.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Drupal\ys_layouts;
+
+use Drupal\Core\Render\Element;
+use Drupal\Core\Security\TrustedCallbackInterface;
+use Drupal\layout_builder\SectionStorageInterface;
+
+/**
+ * Decides which Layout Builder blocks offer the "Clone block" contextual link.
+ *
+ * Contextual link plugins are registered per group, not per block, so the
+ * Clone link is offered to every block in the layout_builder_block group and
+ * then removed again for the blocks that cannot be cloned. The decision is
+ * taken once per block while the Layout Builder element is pre-rendered (where
+ * the unsaved section storage is already loaded) and recorded in the block's
+ * contextual-links metadata; ys_layouts_contextual_links_view_alter() then
+ * drops the link for any block that was not marked.
+ *
+ * Stamping the metadata does double duty: the metadata is part of the
+ * client-side contextual id, so adding a key busts the browser's cached
+ * contextual menus and editors actually see the new link.
+ *
+ * @see layout_builder_lock_contextual_links_view_alter()
+ * @see \Drupal\layout_builder\Element\LayoutBuilder::buildAdministrativeSection()
+ * @see _contextual_links_to_id()
+ */
+class CloneContextualLinks implements TrustedCallbackInterface {
+
+  /**
+   * The contextual-links metadata key marking a block as clonable.
+   */
+  const METADATA_KEY = 'ys_layouts_clone';
+
+  /**
+   * The id of this module's contextual link plugin.
+   *
+   * Implementations of hook_contextual_links_view_alter() receive $items keyed
+   * by plugin id.
+   *
+   * @see ys_layouts.links.contextual.yml
+   */
+  const PLUGIN_ID = 'ys_layouts_clone_block';
+
+  /**
+   * The key the Clone link has in $element['#links'].
+   *
+   * ContextualLinks::preRenderLinks() runs the plugin id through
+   * Html::getClass().
+   */
+  const LINK_KEY = 'ys-layouts-clone-block';
+
+  /**
+   * Pre-render callback that marks clonable blocks in the layout.
+   *
+   * Runs after layout_builder_lock's own pre-render (module hook order puts
+   * "layout_builder_lock" before "ys_layouts"), so a region whose "Add block"
+   * link has been removed by a lock is already recognisable here and is not
+   * offered Clone either — otherwise cloning would be a way to add a block to
+   * a locked region.
+   *
+   * @param array $element
+   *   The Layout Builder render element.
+   *
+   * @return array
+   *   The modified Layout Builder render element.
+   */
+  public static function preRender(array $element): array {
+    $section_storage = $element['#section_storage'] ?? NULL;
+    if (!$section_storage instanceof SectionStorageInterface
+      || empty($element['layout_builder'])) {
+      return $element;
+    }
+
+    $cloner = \Drupal::service('ys_layouts.block_cloner');
+
+    foreach (Element::children($element['layout_builder']) as $index) {
+      foreach (Element::children($element['layout_builder'][$index]) as $name) {
+        $section = &$element['layout_builder'][$index][$name];
+        // Only the layout render array holds regions full of blocks; its
+        // siblings are the configure/remove section links.
+        if (!isset($section['#layout'])) {
+          continue;
+        }
+
+        foreach (Element::children($section) as $region) {
+          // A region that no longer accepts new blocks must not accept clones.
+          $region_is_open = isset($section[$region]['layout_builder_add_block']);
+
+          foreach (Element::children($section[$region]) as $key) {
+            $block = &$section[$region][$key];
+            if (!isset($block['#contextual_links']['layout_builder_block'])) {
+              continue;
+            }
+
+            $links = &$block['#contextual_links']['layout_builder_block'];
+            $component = static::getComponent($section_storage, $links);
+            if ($region_is_open
+              && $component
+              && $cloner->isClonable($component)) {
+              $links['metadata'][static::METADATA_KEY] = '1';
+            }
+            unset($links);
+          }
+        }
+        unset($section);
+      }
+    }
+
+    return $element;
+  }
+
+  /**
+   * Determines whether the Clone link should be kept for a block.
+   *
+   * @param array $item
+   *   The ys_layouts_clone_block contextual-link item, as found in the $items
+   *   passed to hook_contextual_links_view_alter(). Items are keyed by plugin
+   *   id and each one carries the metadata of its group.
+   *
+   * @return bool
+   *   TRUE if the block was marked clonable during pre-render.
+   */
+  public static function shouldKeepLink(array $item): bool {
+    return !empty($item['metadata'][static::METADATA_KEY]);
+  }
+
+  /**
+   * Loads the component a contextual-links item points at.
+   *
+   * @param \Drupal\layout_builder\SectionStorageInterface $section_storage
+   *   The section storage being rendered.
+   * @param array $links
+   *   The layout_builder_block contextual-links definition, whose route
+   *   parameters identify the section delta and the component UUID.
+   *
+   * @return \Drupal\layout_builder\SectionComponent|null
+   *   The component, or NULL if it cannot be found.
+   */
+  protected static function getComponent(
+    SectionStorageInterface $section_storage,
+    array $links,
+  ) {
+    $parameters = $links['route_parameters'] ?? [];
+    if (!isset($parameters['delta'], $parameters['uuid'])) {
+      return NULL;
+    }
+
+    try {
+      return $section_storage->getSection((int) $parameters['delta'])
+        ->getComponent((string) $parameters['uuid']);
+    }
+    catch (\OutOfBoundsException | \InvalidArgumentException $e) {
+      return NULL;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function trustedCallbacks() {
+    return ['preRender'];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Controller/CloneBlockController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Controller/CloneBlockController.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Drupal\ys_layouts\Controller;
+
+use Drupal\Core\Ajax\AnnounceCommand;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\layout_builder\Controller\LayoutRebuildTrait;
+use Drupal\layout_builder\LayoutTempstoreRepositoryInterface;
+use Drupal\layout_builder\SectionStorageInterface;
+use Drupal\ys_layouts\Service\BlockCloner;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Clones a single Layout Builder block in place.
+ *
+ * Modelled on core's MoveBlockController: the component is copied into the
+ * layout tempstore and the Layout Builder element is re-rendered over AJAX, so
+ * cloning is a single click with no dialog and no page reload. Nothing is
+ * written to the database here — the editor still has to press "Save layout"
+ * (or "Discard changes"), which is what creates the cloned block content and
+ * its usage record.
+ *
+ * @see \Drupal\layout_builder\Controller\MoveBlockController
+ * @see \Drupal\layout_builder\InlineBlockEntityOperations::handlePreSave()
+ */
+class CloneBlockController implements ContainerInjectionInterface {
+
+  use LayoutRebuildTrait;
+  use StringTranslationTrait;
+
+  /**
+   * The layout tempstore repository.
+   *
+   * @var \Drupal\layout_builder\LayoutTempstoreRepositoryInterface
+   */
+  protected $layoutTempstoreRepository;
+
+  /**
+   * The block cloner service.
+   *
+   * @var \Drupal\ys_layouts\Service\BlockCloner
+   */
+  protected $blockCloner;
+
+  /**
+   * Constructs a new CloneBlockController object.
+   *
+   * @param \Drupal\layout_builder\LayoutTempstoreRepositoryInterface $layout_tempstore_repository
+   *   The layout tempstore repository.
+   * @param \Drupal\ys_layouts\Service\BlockCloner $block_cloner
+   *   The block cloner service.
+   */
+  public function __construct(
+    LayoutTempstoreRepositoryInterface $layout_tempstore_repository,
+    BlockCloner $block_cloner,
+  ) {
+    $this->layoutTempstoreRepository = $layout_tempstore_repository;
+    $this->blockCloner = $block_cloner;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('layout_builder.tempstore_repository'),
+      $container->get('ys_layouts.block_cloner')
+    );
+  }
+
+  /**
+   * Clones the given block directly after itself.
+   *
+   * @param \Drupal\layout_builder\SectionStorageInterface $section_storage
+   *   The section storage.
+   * @param int $delta
+   *   The delta of the section holding the block.
+   * @param string $region
+   *   The region of the block. Unused: the region is read from the component
+   *   itself so the copy always lands beside the original, but the parameter
+   *   is part of the contextual link route and must be accepted.
+   * @param string $uuid
+   *   The UUID of the component being cloned.
+   *
+   * @return \Drupal\Core\Ajax\AjaxResponse
+   *   An AJAX response that re-renders the Layout Builder element.
+   */
+  public function build(
+    SectionStorageInterface $section_storage,
+    int $delta,
+    string $region,
+    string $uuid,
+  ) {
+    try {
+      $section = $section_storage->getSection($delta);
+      $component = $section->getComponent($uuid);
+    }
+    catch (\OutOfBoundsException | \InvalidArgumentException $e) {
+      throw new NotFoundHttpException($e->getMessage());
+    }
+
+    // Defense in depth: the contextual link is hidden and the route is guarded
+    // by an access check, but never trust either to be the only gate.
+    if (!$this->blockCloner->isClonable($component)) {
+      throw new AccessDeniedHttpException(
+        'Only inline blocks can be cloned.'
+      );
+    }
+
+    try {
+      $clone = $this->blockCloner->cloneComponent($component);
+    }
+    catch (\InvalidArgumentException $e) {
+      throw new BadRequestHttpException($e->getMessage());
+    }
+
+    // The clone carries the original's region, which insertAfterComponent()
+    // requires in order to find the preceding component. Weights of the
+    // following components are rebalanced by insertComponent().
+    $section->insertAfterComponent($uuid, $clone);
+
+    $this->layoutTempstoreRepository->set($section_storage);
+
+    // Replacing the whole layout gives assistive technology no clue that
+    // anything happened, so announce the new block the way core announces
+    // drag-and-drop moves.
+    $response = $this->rebuildLayout($section_storage);
+    $response->addCommand(new AnnounceCommand(
+      $this->t('Block cloned. The copy was added below the original.')
+    ));
+
+    return $response;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Service/BlockCloner.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Service/BlockCloner.php
@@ -1,0 +1,383 @@
+<?php
+
+namespace Drupal\ys_layouts\Service;
+
+use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\entity_reference_revisions\EntityNeedsSaveInterface;
+use Drupal\layout_builder\Plugin\Block\InlineBlock;
+use Drupal\layout_builder\SectionComponent;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Duplicates a single Layout Builder component and its inline block content.
+ *
+ * Layout Builder stores an unsaved inline block inside the component
+ * configuration as `block_serialized`. Cloning a component therefore means
+ * building a brand new, still unsaved block_content object and serializing it
+ * into a fresh component. The block_content entity itself (and any paragraph
+ * it references) is only written to the database when the editor presses
+ * "Save layout", which is what InlineBlockEntityOperations::handlePreSave()
+ * does for every component whose configuration carries `block_serialized`.
+ *
+ * Three details make this harder than calling createDuplicate():
+ *
+ * 1. createDuplicate() does not duplicate referenced paragraphs, so the copy
+ *    would keep pointing at the original's paragraph revisions and editing one
+ *    block would silently change the other. Every
+ *    `entity_reference_revisions` item is therefore duplicated recursively.
+ * 2. A duplicated paragraph inherits parent_type/parent_id, so it claims the
+ *    ORIGINAL inline block as its parent — the wrong owner, and one whose
+ *    access it also inherits, because
+ *    ParagraphAccessControlHandler::checkAccess() ANDs in the parent entity's
+ *    access. The pointers are therefore cleared here and rebuilt by
+ *    EntityReferenceRevisionsItem::postSave() when the layout is saved.
+ *    (This is ownership hygiene, not the fix for the "media missing from the
+ *    Gallery preview" bug: that one is in atomic's
+ *    templates/paragraphs/_gallery-item.twig, which rendered the modal by
+ *    paragraph ID and so rendered nothing for an unsaved copy.)
+ * 3. The duplicate has to survive the layout tempstore, which re-serializes
+ *    the component configuration on every AJAX step.
+ *    ContentEntityBase::__sleep() reduces each field to getValue(), and the
+ *    in-memory `entity` property is only re-attached by
+ *    EntityReferenceItem::getValue() while hasNewEntity() holds (target_id
+ *    NULL plus an unsaved entity) or by
+ *    EntityReferenceRevisionsItem::getValue() when the paragraph needsSave().
+ *    Both target properties are therefore nulled and setNeedsSave(TRUE) is
+ *    applied — the same flag the paragraphs widgets set for newly added
+ *    items, and the one that makes ERR save the paragraph with its host.
+ *
+ * Plain `entity_reference` fields (media, taxonomy, …) are intentionally left
+ * alone: they point at independently saved entities that serialize losslessly,
+ * and duplicating the referenced media would be wrong.
+ */
+class BlockCloner {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The UUID generator.
+   *
+   * @var \Drupal\Component\Uuid\UuidInterface
+   */
+  protected $uuid;
+
+  /**
+   * The logger service.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * Constructs a new BlockCloner object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   * @param \Drupal\Component\Uuid\UuidInterface $uuid
+   *   The UUID generator, used for the cloned component UUID.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger service.
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    UuidInterface $uuid,
+    LoggerInterface $logger,
+  ) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->uuid = $uuid;
+    $this->logger = $logger;
+  }
+
+  /**
+   * Determines whether a component may be cloned.
+   *
+   * Only inline blocks are clonable. Reusable content blocks are shared by
+   * design, so copying one would create a redundant, disconnected duplicate.
+   * Everything else (views blocks, plugin blocks, system blocks) has no
+   * per-instance content to copy.
+   *
+   * @param \Drupal\layout_builder\SectionComponent $component
+   *   The component to inspect.
+   *
+   * @return bool
+   *   TRUE if the component wraps an inline block, FALSE otherwise.
+   */
+  public function isClonable(SectionComponent $component): bool {
+    // A component with no plugin id, or with a missing or broken plugin, is
+    // never clonable.
+    try {
+      // Cheap check first: the inline block deriver ids are prefixed with
+      // "inline_block:", while reusable blocks use "block_content:<uuid>".
+      $plugin_id = (string) $component->getPluginId();
+      if (!str_starts_with($plugin_id, 'inline_block:')) {
+        return FALSE;
+      }
+
+      // Authoritative check.
+      return $component->getPlugin() instanceof InlineBlock;
+    }
+    catch (\Exception $e) {
+      return FALSE;
+    }
+  }
+
+  /**
+   * Clones a component, including a deep copy of its inline block content.
+   *
+   * The returned component keeps every piece of the original's configuration
+   * (label, view mode, styling, context mapping) plus its region and any
+   * additional/third-party settings. Only the component UUID and the block
+   * content identifiers differ.
+   *
+   * @param \Drupal\layout_builder\SectionComponent $component
+   *   The component being cloned.
+   *
+   * @return \Drupal\layout_builder\SectionComponent
+   *   The new, not yet inserted component.
+   *
+   * @throws \InvalidArgumentException
+   *   Thrown when the component is not an inline block, or when its block
+   *   content cannot be loaded. Cloning without the block content would leave
+   *   both components sharing a single block_content revision.
+   */
+  public function cloneComponent(SectionComponent $component): SectionComponent {
+    if (!$this->isClonable($component)) {
+      throw new \InvalidArgumentException(
+        sprintf(
+          'Component "%s" is not an inline block and cannot be cloned.',
+          $component->getUuid()
+        )
+      );
+    }
+
+    $component_array = $component->toArray();
+    $configuration = $component_array['configuration'];
+
+    $block = $this->loadBlockContent($configuration);
+    if (!$block) {
+      throw new \InvalidArgumentException(
+        sprintf(
+          'The inline block content for component "%s" could not be loaded.',
+          $component->getUuid()
+        )
+      );
+    }
+
+    $duplicate = $this->duplicateBlockContent($block);
+
+    // The clone owns a brand new block_content: drop every pointer to the
+    // original's entity and revision so Layout Builder creates (and tracks
+    // usage for) a separate entity when the layout is saved. Serializing
+    // happens last, once the deep copy is complete.
+    $configuration['block_id'] = NULL;
+    $configuration['block_revision_id'] = NULL;
+    $configuration['block_serialized'] = serialize($duplicate);
+
+    return new SectionComponent(
+      $this->uuid->generate(),
+      $component->getRegion(),
+      $configuration,
+      $component_array['additional']
+    );
+  }
+
+  /**
+   * Creates a deep, unsaved duplicate of an inline block content entity.
+   *
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $block
+   *   The block content entity to duplicate.
+   *
+   * @return \Drupal\Core\Entity\FieldableEntityInterface
+   *   The duplicate, with every referenced paragraph replaced by its own
+   *   unsaved duplicate.
+   */
+  public function duplicateBlockContent(
+    FieldableEntityInterface $block,
+  ): FieldableEntityInterface {
+    /** @var \Drupal\Core\Entity\FieldableEntityInterface $duplicate */
+    $duplicate = $block->createDuplicate();
+    $this->duplicateReferences($duplicate);
+    $this->warnIfLossy($duplicate);
+
+    return $duplicate;
+  }
+
+  /**
+   * Loads the block content referenced by a component configuration.
+   *
+   * Mirrors InlineBlock::getEntity(): an unsaved edit lives in
+   * `block_serialized` and takes precedence over the saved revision.
+   *
+   * @param array $configuration
+   *   The component configuration.
+   *
+   * @return \Drupal\Core\Entity\FieldableEntityInterface|null
+   *   The block content entity, or NULL if it cannot be found.
+   */
+  protected function loadBlockContent(
+    array $configuration,
+  ): ?FieldableEntityInterface {
+    if (!empty($configuration['block_serialized'])) {
+      // The payload is Layout Builder's own tempstore data for a layout the
+      // current user is already permitted to edit, exactly as core's
+      // InlineBlock::getEntity() reads it.
+      // phpcs:ignore DrupalPractice.FunctionCalls.InsecureUnserialize
+      $block = unserialize($configuration['block_serialized']);
+      return $block instanceof FieldableEntityInterface ? $block : NULL;
+    }
+
+    if (!empty($configuration['block_revision_id'])) {
+      $block = $this->entityTypeManager->getStorage('block_content')
+        ->loadRevision($configuration['block_revision_id']);
+      return $block instanceof FieldableEntityInterface ? $block : NULL;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Recursively replaces revisioned references with unsaved duplicates.
+   *
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+   *   The entity whose reference fields are rewritten in place.
+   */
+  protected function duplicateReferences(
+    FieldableEntityInterface $entity,
+  ): void {
+    foreach ($entity->getFieldDefinitions() as $field_name => $definition) {
+      $type = $definition->getFieldStorageDefinition()->getType();
+
+      // Paragraph (and any other revisioned composite) references. Every
+      // YaleSites block bundle stores its repeatable content this way.
+      if ($type === 'entity_reference_revisions') {
+        $this->duplicateFieldItems($entity, $field_name);
+      }
+    }
+  }
+
+  /**
+   * Duplicates every referenced entity of a single field.
+   *
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+   *   The entity holding the field.
+   * @param string $field_name
+   *   The name of the field to process.
+   */
+  protected function duplicateFieldItems(
+    FieldableEntityInterface $entity,
+    string $field_name,
+  ): void {
+    $field = $entity->get($field_name);
+    if ($field->isEmpty()) {
+      return;
+    }
+
+    foreach ($field as $item) {
+      $referenced = $item->entity;
+      if (!$referenced instanceof FieldableEntityInterface) {
+        continue;
+      }
+
+      $duplicate = $referenced->createDuplicate();
+      $this->resetParentPointers($duplicate, $field_name);
+
+      // Recurse before flagging so grandchildren are duplicated too.
+      $this->duplicateReferences($duplicate);
+
+      // Keeps the unsaved duplicate attached to the field across the layout
+      // tempstore's serialize/unserialize cycles, and tells ERR to save it
+      // together with its host. See the class docblock.
+      if ($duplicate instanceof EntityNeedsSaveInterface) {
+        $duplicate->setNeedsSave(TRUE);
+      }
+
+      $item->entity = $duplicate;
+
+      // Defensive: assigning `entity` already nulls the target properties,
+      // but a stale target_revision_id would make
+      // EntityReferenceRevisionsFieldItemList::referencedEntities() resolve
+      // the ORIGINAL paragraph and quietly render the wrong content.
+      $item->target_id = NULL;
+      $item->target_revision_id = NULL;
+    }
+  }
+
+  /**
+   * Clears a duplicate's pointer back to the entity it was copied from.
+   *
+   * Duplicating an entity copies parent_type/parent_id, so a duplicated
+   * paragraph would claim the ORIGINAL block content as its parent. Besides
+   * being the wrong owner, that also makes the copy's view access ride on the
+   * original block, because ParagraphAccessControlHandler::checkAccess() ANDs
+   * in the parent entity's access. Clearing the pointers keeps the copy
+   * self-contained until EntityReferenceRevisionsItem::postSave() rewrites all
+   * three properties when the layout is saved.
+   *
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $duplicate
+   *   The duplicated entity.
+   * @param string $field_name
+   *   The name of the field the duplicate is referenced from.
+   */
+  protected function resetParentPointers(
+    FieldableEntityInterface $duplicate,
+    string $field_name,
+  ): void {
+    if ($duplicate->hasField('parent_type')) {
+      $duplicate->set('parent_type', NULL);
+    }
+    if ($duplicate->hasField('parent_id')) {
+      $duplicate->set('parent_id', NULL);
+    }
+    if ($duplicate->hasField('parent_field_name')) {
+      $duplicate->set('parent_field_name', $field_name);
+    }
+  }
+
+  /**
+   * Logs a warning if a duplicate loses references when serialized.
+   *
+   * Cheap guard against a future field type re-introducing the silent data
+   * loss described in the class docblock: the layout tempstore serializes the
+   * component configuration on every AJAX step, so anything that does not
+   * survive a round trip never reaches the preview.
+   *
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $duplicate
+   *   The duplicate about to be serialized into the component configuration.
+   */
+  protected function warnIfLossy(FieldableEntityInterface $duplicate): void {
+    // The value comes from the object built moments ago in this request.
+    // phpcs:ignore DrupalPractice.FunctionCalls.InsecureUnserialize
+    $round_tripped = unserialize(serialize($duplicate));
+    if (!$round_tripped instanceof FieldableEntityInterface) {
+      $this->logger->warning(
+        'A cloned block of type %bundle did not survive serialization.',
+        ['%bundle' => $duplicate->bundle()]
+      );
+      return;
+    }
+
+    foreach ($duplicate->getFieldDefinitions() as $field_name => $definition) {
+      $type = $definition->getFieldStorageDefinition()->getType();
+      if ($type !== 'entity_reference_revisions') {
+        continue;
+      }
+      if ($duplicate->get($field_name)->isEmpty()) {
+        continue;
+      }
+      if ($round_tripped->get($field_name)->isEmpty()) {
+        $this->logger->warning(
+          'Cloned block field %field lost its references when serialized.',
+          ['%field' => $field_name]
+        );
+      }
+    }
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/BlockClonerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/BlockClonerTest.php
@@ -1,0 +1,560 @@
+<?php
+
+namespace Drupal\Tests\ys_layouts\Kernel;
+
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\block_content\Entity\BlockContentType;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\file\Entity\File;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\layout_builder\Section;
+use Drupal\layout_builder\SectionComponent;
+use Drupal\media\MediaInterface;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\paragraphs\Entity\ParagraphsType;
+use Drupal\Tests\media\Traits\MediaTypeCreationTrait;
+use Drupal\user\Entity\User;
+use Drupal\ys_layouts\Service\BlockCloner;
+
+/**
+ * Tests cloning a Layout Builder component and its inline block content.
+ *
+ * Covers the things that break when a block is cloned naively: the cloned
+ * block sharing paragraph entities with the original, the duplicated paragraph
+ * (and therefore its media reference) not surviving the layout tempstore's
+ * serialize cycles, the copy still claiming the original block as its parent,
+ * and reusable blocks being offered a Clone operation they must not have.
+ *
+ * @coversDefaultClass \Drupal\ys_layouts\Service\BlockCloner
+ *
+ * @group ys_layouts
+ * @group yalesites
+ */
+class BlockClonerTest extends KernelTestBase {
+
+  use MediaTypeCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'file',
+    'image',
+    'text',
+    'media',
+    'block',
+    'block_content',
+    'contextual',
+    'entity_reference_revisions',
+    'paragraphs',
+    'layout_discovery',
+    'layout_builder',
+  ];
+
+  /**
+   * The cloner under test.
+   *
+   * @var \Drupal\ys_layouts\Service\BlockCloner
+   */
+  protected BlockCloner $cloner;
+
+  /**
+   * The media entity referenced by the gallery item paragraph.
+   *
+   * @var \Drupal\media\MediaInterface
+   */
+  protected MediaInterface $media;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('media');
+    $this->installEntitySchema('paragraph');
+    $this->installEntitySchema('block_content');
+    $this->installSchema('file', 'file_usage');
+    $this->installConfig(['system', 'field', 'file', 'media']);
+
+    $this->createMediaType('image', ['id' => 'image']);
+
+    ParagraphsType::create([
+      'id' => 'gallery_item',
+      'label' => 'Gallery Item',
+    ])->save();
+
+    BlockContentType::create([
+      'id' => 'gallery',
+      'label' => 'Gallery',
+    ])->save();
+
+    // The gallery block holds repeatable gallery items.
+    $this->createField(
+      'block_content',
+      'gallery',
+      'field_gallery_items',
+      'entity_reference_revisions',
+      'paragraph'
+    );
+    // Each gallery item points at an image media entity.
+    $this->createField(
+      'paragraph',
+      'gallery_item',
+      'field_media',
+      'entity_reference',
+      'media'
+    );
+
+    $file = File::create([
+      'uri' => 'public://kroon-hall.jpg',
+      'filename' => 'kroon-hall.jpg',
+    ]);
+    $file->save();
+
+    $media = $this->container->get('entity_type.manager')
+      ->getStorage('media')
+      ->create([
+        'bundle' => 'image',
+        'name' => 'kroon-hall.jpg',
+        'field_media_image' => [
+          'target_id' => $file->id(),
+          'alt' => 'Kroon Hall in autumn',
+        ],
+      ]);
+    $media->save();
+    $this->media = $media;
+
+    $this->cloner = new BlockCloner(
+      $this->container->get('entity_type.manager'),
+      $this->container->get('uuid'),
+      $this->container->get('logger.factory')->get('ys_layouts')
+    );
+  }
+
+  /**
+   * Creates a reference field on a bundle.
+   *
+   * @param string $entity_type
+   *   The entity type to attach the field to.
+   * @param string $bundle
+   *   The bundle to attach the field to.
+   * @param string $field_name
+   *   The field name.
+   * @param string $type
+   *   The field type.
+   * @param string $target_type
+   *   The referenced entity type.
+   */
+  protected function createField(
+    string $entity_type,
+    string $bundle,
+    string $field_name,
+    string $type,
+    string $target_type,
+  ): void {
+    $storage = FieldStorageConfig::create([
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'type' => $type,
+      'cardinality' => -1,
+      'settings' => ['target_type' => $target_type],
+    ]);
+    $storage->save();
+
+    FieldConfig::create([
+      'field_storage' => $storage,
+      'bundle' => $bundle,
+      'label' => $field_name,
+    ])->save();
+  }
+
+  /**
+   * Creates a saved gallery block referencing a saved gallery item paragraph.
+   *
+   * @return \Drupal\block_content\Entity\BlockContent
+   *   The saved block content entity.
+   */
+  protected function createGalleryBlock(): BlockContent {
+    $paragraph = Paragraph::create([
+      'type' => 'gallery_item',
+      'field_media' => ['target_id' => $this->media->id()],
+    ]);
+    $paragraph->save();
+
+    $block = BlockContent::create([
+      'type' => 'gallery',
+      'info' => 'Campus gallery',
+      // Inline Layout Builder blocks are never reusable.
+      'reusable' => FALSE,
+      'field_gallery_items' => [
+        [
+          'target_id' => $paragraph->id(),
+          'target_revision_id' => $paragraph->getRevisionId(),
+        ],
+      ],
+    ]);
+    $block->save();
+
+    return $block;
+  }
+
+  /**
+   * Builds an inline block component for a saved block content entity.
+   *
+   * @param \Drupal\block_content\Entity\BlockContent $block
+   *   The block content the component renders.
+   * @param string $region
+   *   The region the component lives in.
+   *
+   * @return \Drupal\layout_builder\SectionComponent
+   *   The component.
+   */
+  protected function createInlineComponent(
+    BlockContent $block,
+    string $region = 'content',
+  ): SectionComponent {
+    return new SectionComponent(
+      $this->container->get('uuid')->generate(),
+      $region,
+      [
+        'id' => 'inline_block:gallery',
+        'block_revision_id' => $block->getRevisionId(),
+        'block_serialized' => NULL,
+        'label' => 'Campus gallery',
+        'label_display' => 'visible',
+        'view_mode' => 'full',
+        'provider' => 'layout_builder',
+        'context_mapping' => [],
+      ],
+      ['third_party_settings' => ['ys_layouts' => ['padding' => 'none']]]
+    );
+  }
+
+  /**
+   * Unserializes the block content held by a component configuration.
+   *
+   * @param \Drupal\layout_builder\SectionComponent $component
+   *   The component to read.
+   * @param int $passes
+   *   How many additional serialize/unserialize round trips to apply. The
+   *   layout tempstore re-serializes the configuration on every AJAX step.
+   *
+   * @return \Drupal\block_content\Entity\BlockContent
+   *   The block content object.
+   */
+  protected function readSerializedBlock(
+    SectionComponent $component,
+    int $passes = 0,
+  ): BlockContent {
+    $configuration = $component->get('configuration');
+    $this->assertNotEmpty($configuration['block_serialized']);
+
+    // Test-owned payload built by the code under test.
+    // phpcs:ignore DrupalPractice.FunctionCalls.InsecureUnserialize
+    $block = unserialize($configuration['block_serialized']);
+    for ($i = 0; $i < $passes; $i++) {
+      // phpcs:ignore DrupalPractice.FunctionCalls.InsecureUnserialize
+      $block = unserialize(serialize($block));
+    }
+
+    $this->assertInstanceOf(BlockContent::class, $block);
+    return $block;
+  }
+
+  /**
+   * The clone keeps every piece of the original's configuration.
+   *
+   * @covers ::cloneComponent
+   */
+  public function testCloneKeepsComponentConfiguration(): void {
+    $component = $this->createInlineComponent($this->createGalleryBlock());
+    $clone = $this->cloner->cloneComponent($component);
+
+    $original = $component->get('configuration');
+    $cloned = $clone->get('configuration');
+
+    // Everything except the identity of the block content is preserved.
+    foreach (['id', 'label', 'label_display', 'view_mode', 'provider'] as $key) {
+      $this->assertSame($original[$key], $cloned[$key], $key);
+    }
+    $this->assertSame(
+      $original['context_mapping'],
+      $cloned['context_mapping']
+    );
+
+    // Region, third party settings and a fresh UUID.
+    $this->assertSame($component->getRegion(), $clone->getRegion());
+    $this->assertSame(
+      $component->toArray()['additional'],
+      $clone->toArray()['additional']
+    );
+    $this->assertNotSame($component->getUuid(), $clone->getUuid());
+    $this->assertNotEmpty($clone->getUuid());
+
+    // The clone must not point at the original's block content, or Layout
+    // Builder would reuse (and later garbage collect) a shared revision.
+    $this->assertNull($cloned['block_revision_id']);
+    $this->assertNull($cloned['block_id']);
+    $this->assertNotEmpty($cloned['block_serialized']);
+  }
+
+  /**
+   * The clone is inserted directly after the original component.
+   *
+   * @covers ::cloneComponent
+   */
+  public function testCloneLandsDirectlyAfterTheOriginal(): void {
+    $first = $this->createInlineComponent($this->createGalleryBlock());
+    $second = $this->createInlineComponent($this->createGalleryBlock());
+    $third = $this->createInlineComponent($this->createGalleryBlock());
+    $first->setWeight(0);
+    $second->setWeight(1);
+    $third->setWeight(2);
+
+    $section = new Section(
+      'layout_onecol',
+      [],
+      [$first, $second, $third]
+    );
+
+    $clone = $this->cloner->cloneComponent($first);
+    $section->insertAfterComponent($first->getUuid(), $clone);
+
+    $order = array_keys($section->getComponentsByRegion('content'));
+    $this->assertSame(
+      [
+        $first->getUuid(),
+        $clone->getUuid(),
+        $second->getUuid(),
+        $third->getUuid(),
+      ],
+      $order
+    );
+  }
+
+  /**
+   * The cloned paragraph is a new object and survives the tempstore.
+   *
+   * This is the media-in-preview regression: without setNeedsSave(TRUE) the
+   * duplicated paragraph is dropped by serialize(), the cloned block renders an
+   * empty gallery in the Layout Builder preview, and the media never appears.
+   *
+   * @covers ::cloneComponent
+   * @covers ::duplicateBlockContent
+   */
+  public function testClonedParagraphSurvivesSerializationWithMedia(): void {
+    $block = $this->createGalleryBlock();
+    $original_paragraph = $block->get('field_gallery_items')->first()->entity;
+
+    $clone = $this->cloner->cloneComponent(
+      $this->createInlineComponent($block)
+    );
+
+    // Two round trips: the tempstore re-serializes on every AJAX step.
+    foreach ([0, 1] as $passes) {
+      $cloned_block = $this->readSerializedBlock($clone, $passes);
+      $items = $cloned_block->get('field_gallery_items');
+      $this->assertFalse(
+        $items->isEmpty(),
+        'The cloned gallery kept its items after serialization.'
+      );
+
+      // The in-memory duplicate must win: a leftover target revision would
+      // silently resolve back to the original paragraph.
+      $this->assertNull($items->first()->target_id);
+      $this->assertNull($items->first()->target_revision_id);
+
+      $paragraph = $items->first()->entity;
+      $this->assertInstanceOf(Paragraph::class, $paragraph);
+      $this->assertNull($paragraph->id());
+      $this->assertTrue($paragraph->needsSave());
+      $this->assertNotSame($original_paragraph->uuid(), $paragraph->uuid());
+
+      // The media reference is what the preview renders.
+      $this->assertSame(
+        $this->media->id(),
+        $paragraph->get('field_media')->first()->target_id
+      );
+
+      // The stale pointer at the original block is cleared so the preview is
+      // not blanked by a parent access check.
+      $this->assertTrue($paragraph->get('parent_type')->isEmpty());
+      $this->assertTrue($paragraph->get('parent_id')->isEmpty());
+      $this->assertSame(
+        'field_gallery_items',
+        $paragraph->get('parent_field_name')->value
+      );
+    }
+
+    // The original is untouched.
+    $reloaded = $this->container->get('entity_type.manager')
+      ->getStorage('block_content')
+      ->loadUnchanged($block->id());
+    $this->assertSame(
+      $original_paragraph->id(),
+      $reloaded->get('field_gallery_items')->first()->target_id
+    );
+  }
+
+  /**
+   * The copied paragraph does not claim the original block as its parent.
+   *
+   * A plain createDuplicate() inherits parent_type/parent_id, so the copy
+   * claims the ORIGINAL inline block as its owner, and
+   * ParagraphAccessControlHandler::checkAccess() then ANDs in that block's
+   * access instead of the copy's own host. The pointers are cleared until the
+   * layout is saved, at which point ERR rewrites them (see
+   * testSavingTheCloneCreatesItsOwnParagraph()).
+   *
+   * Note this is ownership hygiene, not the "media missing from the Gallery
+   * preview" bug: in production the original block has an inline_block_usage
+   * row, so its access resolves to the host the editor is already viewing and
+   * even a naive copy would be viewable. That preview bug lives in atomic's
+   * templates/paragraphs/_gallery-item.twig, which rendered the modal by
+   * paragraph ID and therefore rendered nothing for an unsaved copy.
+   *
+   * @covers ::duplicateBlockContent
+   */
+  public function testClonedParagraphDropsTheOriginalsParentPointer(): void {
+    $this->installConfig(['paragraphs']);
+    $account = User::create(['name' => 'editor', 'status' => 1]);
+    $account->save();
+
+    $block = $this->createGalleryBlock();
+    $original = $block->get('field_gallery_items')->first()->entity;
+
+    // What a naive clone produces: the original block as its parent.
+    $naive = $original->createDuplicate();
+    $this->assertSame('block_content', $naive->get('parent_type')->value);
+    $this->assertSame(
+      (string) $block->id(),
+      (string) $naive->get('parent_id')->value
+    );
+
+    // What this service produces: no parent until the layout is saved, so the
+    // copy's access no longer depends on the block it was copied from.
+    $cloned_block = $this->cloner->duplicateBlockContent($block);
+    $cloned = $cloned_block->get('field_gallery_items')->first()->entity;
+    $this->assertNull($cloned->get('parent_type')->value);
+    $this->assertNull($cloned->get('parent_id')->value);
+    $this->assertSame(
+      'field_gallery_items',
+      $cloned->get('parent_field_name')->value
+    );
+    $this->assertNull($cloned->getParentEntity());
+    $this->assertTrue($cloned->access('view', $account));
+  }
+
+  /**
+   * Saving the clone creates its own paragraph, leaving the original alone.
+   *
+   * @covers ::duplicateBlockContent
+   */
+  public function testSavingTheCloneCreatesItsOwnParagraph(): void {
+    $block = $this->createGalleryBlock();
+    $original_paragraph = $block->get('field_gallery_items')->first()->entity;
+
+    $clone = $this->cloner->cloneComponent(
+      $this->createInlineComponent($block)
+    );
+    $cloned_block = $this->readSerializedBlock($clone);
+    $cloned_block->save();
+
+    $paragraph = $cloned_block->get('field_gallery_items')->first()->entity;
+    $this->assertNotNull($paragraph->id());
+    $this->assertNotSame($original_paragraph->id(), $paragraph->id());
+    $this->assertSame(
+      'block_content',
+      $paragraph->get('parent_type')->value
+    );
+    $this->assertSame(
+      (string) $cloned_block->id(),
+      (string) $paragraph->get('parent_id')->value
+    );
+    $this->assertSame(
+      $this->media->id(),
+      $paragraph->get('field_media')->first()->target_id
+    );
+
+    // The original block still owns its own paragraph.
+    $reloaded = $this->container->get('entity_type.manager')
+      ->getStorage('block_content')
+      ->loadUnchanged($block->id());
+    $this->assertSame(
+      $original_paragraph->id(),
+      $reloaded->get('field_gallery_items')->first()->target_id
+    );
+  }
+
+  /**
+   * Reusable content blocks are refused.
+   *
+   * @covers ::isClonable
+   * @covers ::cloneComponent
+   */
+  public function testReusableBlockIsNotClonable(): void {
+    $component = new SectionComponent(
+      $this->container->get('uuid')->generate(),
+      'content',
+      [
+        'id' => 'block_content:0e0f0a1a-0000-4000-8000-000000000000',
+        'label' => 'Shared call to action',
+        'provider' => 'block_content',
+      ]
+    );
+
+    $this->assertFalse($this->cloner->isClonable($component));
+    $this->expectException(\InvalidArgumentException::class);
+    $this->cloner->cloneComponent($component);
+  }
+
+  /**
+   * Plugin blocks that are not inline blocks are refused.
+   *
+   * @covers ::isClonable
+   */
+  public function testNonInlineBlocksAreNotClonable(): void {
+    foreach (['views_block:events-block_1', 'page_meta_block', ''] as $id) {
+      $component = new SectionComponent(
+        $this->container->get('uuid')->generate(),
+        'content',
+        ['id' => $id]
+      );
+      $this->assertFalse(
+        $this->cloner->isClonable($component),
+        sprintf('Plugin "%s" is not clonable.', $id)
+      );
+    }
+  }
+
+  /**
+   * An inline block whose content cannot be loaded is refused.
+   *
+   * Cloning it anyway would leave both components sharing one revision.
+   *
+   * @covers ::cloneComponent
+   */
+  public function testMissingBlockContentIsRefused(): void {
+    $component = new SectionComponent(
+      $this->container->get('uuid')->generate(),
+      'content',
+      [
+        'id' => 'inline_block:gallery',
+        'block_revision_id' => NULL,
+        'block_serialized' => NULL,
+      ]
+    );
+
+    $this->assertTrue($this->cloner->isClonable($component));
+    $this->expectException(\InvalidArgumentException::class);
+    $this->cloner->cloneComponent($component);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/CloneBlockAccessCheckTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/CloneBlockAccessCheckTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Drupal\Tests\ys_layouts\Unit;
+
+use Drupal\layout_builder\LayoutTempstoreRepositoryInterface;
+use Drupal\layout_builder\Section;
+use Drupal\layout_builder\SectionComponent;
+use Drupal\layout_builder\SectionStorageInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_layouts\Access\CloneBlockAccessCheck;
+use Drupal\ys_layouts\Service\BlockCloner;
+
+/**
+ * Tests the route guard that restricts cloning to inline blocks.
+ *
+ * @coversDefaultClass \Drupal\ys_layouts\Access\CloneBlockAccessCheck
+ *
+ * @group yalesites
+ * @group ys_layouts
+ */
+class CloneBlockAccessCheckTest extends UnitTestCase {
+
+  /**
+   * The mocked block cloner service.
+   *
+   * @var \Drupal\ys_layouts\Service\BlockCloner|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $cloner;
+
+  /**
+   * The mocked layout tempstore repository.
+   *
+   * @var \Drupal\layout_builder\LayoutTempstoreRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $repository;
+
+  /**
+   * The access check under test.
+   *
+   * @var \Drupal\ys_layouts\Access\CloneBlockAccessCheck
+   */
+  protected CloneBlockAccessCheck $accessCheck;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->cloner = $this->createMock(BlockCloner::class);
+    $this->repository = $this->createMock(
+      LayoutTempstoreRepositoryInterface::class
+    );
+    $this->accessCheck = new CloneBlockAccessCheck(
+      $this->repository,
+      $this->cloner
+    );
+  }
+
+  /**
+   * Builds a section storage holding a single component.
+   *
+   * @param \Drupal\layout_builder\SectionComponent|null $component
+   *   The component to place in delta 0, or NULL for an empty layout.
+   *
+   * @return \Drupal\layout_builder\SectionStorageInterface
+   *   The mocked section storage.
+   */
+  protected function storage(?SectionComponent $component = NULL) {
+    $storage = $this->createMock(SectionStorageInterface::class);
+    if ($component) {
+      $section = new Section('layout_onecol', [], [$component]);
+      $storage->method('getSection')->willReturn($section);
+    }
+    else {
+      $storage->method('getSection')
+        ->willThrowException(new \OutOfBoundsException('No section.'));
+    }
+    return $storage;
+  }
+
+  /**
+   * Access is granted for a clonable inline block in the tempstore layout.
+   *
+   * @covers ::access
+   */
+  public function testClonableBlockIsAllowed(): void {
+    $component = new SectionComponent('block-uuid', 'content', [
+      'id' => 'inline_block:text',
+    ]);
+    // The saved layout is deliberately empty: only the tempstore copy knows
+    // about the block, exactly as when an editor has unsaved changes.
+    $saved = $this->storage();
+    $this->repository->method('get')->willReturn($this->storage($component));
+    $this->cloner->method('isClonable')->willReturn(TRUE);
+
+    $result = $this->accessCheck->access($saved, 0, 'block-uuid');
+
+    $this->assertTrue($result->isAllowed());
+    $this->assertSame(0, $result->getCacheMaxAge());
+  }
+
+  /**
+   * Access is denied for a block the cloner refuses, such as a reusable one.
+   *
+   * @covers ::access
+   */
+  public function testNonClonableBlockIsForbidden(): void {
+    $component = new SectionComponent('block-uuid', 'content', [
+      'id' => 'block_content:some-uuid',
+    ]);
+    $storage = $this->storage($component);
+    $this->repository->method('get')->willReturn($storage);
+    $this->cloner->method('isClonable')->willReturn(FALSE);
+
+    $this->assertFalse(
+      $this->accessCheck->access($storage, 0, 'block-uuid')->isAllowed()
+    );
+  }
+
+  /**
+   * Access is denied when the component is not in the layout.
+   *
+   * @covers ::access
+   */
+  public function testUnknownComponentIsForbidden(): void {
+    $component = new SectionComponent('block-uuid', 'content', [
+      'id' => 'inline_block:text',
+    ]);
+    $storage = $this->storage($component);
+    $this->repository->method('get')->willReturn($storage);
+    $this->cloner->expects($this->never())->method('isClonable');
+
+    $this->assertFalse(
+      $this->accessCheck->access($storage, 0, 'other-uuid')->isAllowed()
+    );
+  }
+
+  /**
+   * Access is denied when the section itself does not exist.
+   *
+   * @covers ::access
+   */
+  public function testUnknownSectionIsForbidden(): void {
+    $storage = $this->storage();
+    $this->repository->method('get')->willReturn($storage);
+    $this->cloner->expects($this->never())->method('isClonable');
+
+    $this->assertFalse(
+      $this->accessCheck->access($storage, 9, 'block-uuid')->isAllowed()
+    );
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/CloneBlockControllerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/CloneBlockControllerTest.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace Drupal\Tests\ys_layouts\Unit;
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\layout_builder\LayoutTempstoreRepositoryInterface;
+use Drupal\layout_builder\Section;
+use Drupal\layout_builder\SectionComponent;
+use Drupal\layout_builder\SectionStorageInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_layouts\Controller\CloneBlockController;
+use Drupal\ys_layouts\Service\BlockCloner;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Tests the controller behind the "Clone block" contextual link.
+ *
+ * Covers the guarantees the editor actually sees: the copy lands directly
+ * after the original, the layout tempstore is written so the copy survives to
+ * the next AJAX step, the change is announced to assistive technology, and
+ * anything that must not be cloned is refused rather than half-cloned.
+ *
+ * @coversDefaultClass \Drupal\ys_layouts\Controller\CloneBlockController
+ *
+ * @group yalesites
+ * @group ys_layouts
+ */
+class CloneBlockControllerTest extends UnitTestCase {
+
+  /**
+   * The mocked layout tempstore repository.
+   *
+   * @var \Drupal\layout_builder\LayoutTempstoreRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $tempstore;
+
+  /**
+   * The mocked block cloner service.
+   *
+   * @var \Drupal\ys_layouts\Service\BlockCloner|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $cloner;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->tempstore = $this->createMock(
+      LayoutTempstoreRepositoryInterface::class
+    );
+    $this->cloner = $this->createMock(BlockCloner::class);
+  }
+
+  /**
+   * Builds the controller under test.
+   *
+   * Core's LayoutRebuildTrait::rebuildLayout() renders the whole Layout Builder
+   * element through the renderer, which needs a bootstrapped site. It is core's
+   * own tested code, so it is stubbed out here while the section storage it was
+   * handed is recorded for assertion.
+   *
+   * @return \Drupal\ys_layouts\Controller\CloneBlockController
+   *   The controller.
+   */
+  protected function buildController(): CloneBlockController {
+    $controller = new class($this->tempstore, $this->cloner) extends CloneBlockController {
+
+      /**
+       * The section storage the layout was rebuilt from.
+       *
+       * @var \Drupal\layout_builder\SectionStorageInterface
+       */
+      public $rebuiltFrom;
+
+      /**
+       * {@inheritdoc}
+       */
+      protected function rebuildLayout(
+        SectionStorageInterface $section_storage,
+      ) {
+        $this->rebuiltFrom = $section_storage;
+        return new AjaxResponse();
+      }
+
+    };
+    $controller->setStringTranslation($this->getStringTranslationStub());
+
+    return $controller;
+  }
+
+  /**
+   * Builds a section storage holding one section with three inline blocks.
+   *
+   * @param \Drupal\layout_builder\Section|null $section
+   *   Receives the section, so tests can inspect the component order.
+   *
+   * @return \Drupal\layout_builder\SectionStorageInterface|\PHPUnit\Framework\MockObject\MockObject
+   *   The section storage.
+   */
+  protected function buildSectionStorage(?Section &$section = NULL) {
+    $components = [];
+    foreach (['first', 'second', 'third'] as $weight => $uuid) {
+      $component = new SectionComponent(
+        $uuid,
+        'content',
+        ['id' => 'inline_block:content_spotlight']
+      );
+      $component->setWeight($weight);
+      $components[] = $component;
+    }
+    $section = new Section('layout_onecol', [], $components);
+
+    $storage = $this->createMock(SectionStorageInterface::class);
+    $storage->method('getSection')->willReturn($section);
+
+    return $storage;
+  }
+
+  /**
+   * The copy is inserted directly after the original and persisted.
+   *
+   * @covers ::build
+   */
+  public function testCloneLandsDirectlyAfterTheOriginal(): void {
+    $storage = $this->buildSectionStorage($section);
+    $clone = new SectionComponent(
+      'clone',
+      'content',
+      ['id' => 'inline_block:content_spotlight']
+    );
+
+    $this->cloner->method('isClonable')->willReturn(TRUE);
+    $this->cloner->expects($this->once())
+      ->method('cloneComponent')
+      ->willReturn($clone);
+    // Without this the copy is gone by the next AJAX request.
+    $this->tempstore->expects($this->once())
+      ->method('set')
+      ->with($storage);
+
+    $controller = $this->buildController();
+    $response = $controller->build($storage, 0, 'content', 'first');
+
+    $this->assertSame(
+      ['first', 'clone', 'second', 'third'],
+      array_keys($section->getComponentsByRegion('content'))
+    );
+    $this->assertSame($storage, $controller->rebuiltFrom);
+    $this->assertInstanceOf(AjaxResponse::class, $response);
+  }
+
+  /**
+   * A middle block is cloned into its own region, not appended to the end.
+   *
+   * @covers ::build
+   */
+  public function testCloneOfMiddleBlockKeepsRegionOrder(): void {
+    $storage = $this->buildSectionStorage($section);
+    $clone = new SectionComponent(
+      'clone',
+      'content',
+      ['id' => 'inline_block:content_spotlight']
+    );
+
+    $this->cloner->method('isClonable')->willReturn(TRUE);
+    $this->cloner->method('cloneComponent')->willReturn($clone);
+
+    $this->buildController()->build($storage, 0, 'content', 'second');
+
+    $this->assertSame(
+      ['first', 'second', 'clone', 'third'],
+      array_keys($section->getComponentsByRegion('content'))
+    );
+  }
+
+  /**
+   * Cloning is announced, because the whole layout is silently replaced.
+   *
+   * @covers ::build
+   */
+  public function testCloningIsAnnounced(): void {
+    $storage = $this->buildSectionStorage($section);
+    $this->cloner->method('isClonable')->willReturn(TRUE);
+    $this->cloner->method('cloneComponent')->willReturn(
+      new SectionComponent('clone', 'content', ['id' => 'inline_block:text'])
+    );
+
+    $response = $this->buildController()
+      ->build($storage, 0, 'content', 'first');
+
+    $announcements = array_filter(
+      $response->getCommands(),
+      fn (array $command) => $command['command'] === 'announce'
+    );
+    $this->assertCount(1, $announcements);
+    $this->assertStringContainsString(
+      'Block cloned',
+      (string) reset($announcements)['text']
+    );
+  }
+
+  /**
+   * A component that must not be cloned is refused, even by URL.
+   *
+   * @covers ::build
+   */
+  public function testNonClonableComponentIsDenied(): void {
+    $storage = $this->buildSectionStorage($section);
+    $this->cloner->method('isClonable')->willReturn(FALSE);
+    $this->cloner->expects($this->never())->method('cloneComponent');
+    $this->tempstore->expects($this->never())->method('set');
+
+    $this->expectException(AccessDeniedHttpException::class);
+    $this->buildController()->build($storage, 0, 'content', 'first');
+  }
+
+  /**
+   * An unknown component UUID is a 404, not a broken layout.
+   *
+   * @covers ::build
+   */
+  public function testUnknownComponentIsNotFound(): void {
+    $storage = $this->buildSectionStorage($section);
+    $this->tempstore->expects($this->never())->method('set');
+
+    $this->expectException(NotFoundHttpException::class);
+    $this->buildController()->build($storage, 0, 'content', 'nope');
+  }
+
+  /**
+   * A missing section delta is a 404.
+   *
+   * @covers ::build
+   */
+  public function testMissingSectionIsNotFound(): void {
+    $storage = $this->createMock(SectionStorageInterface::class);
+    $storage->method('getSection')
+      ->willThrowException(new \OutOfBoundsException('No section.'));
+    $this->tempstore->expects($this->never())->method('set');
+
+    $this->expectException(NotFoundHttpException::class);
+    $this->buildController()->build($storage, 7, 'content', 'first');
+  }
+
+  /**
+   * A block whose content cannot be copied is a bad request, not a 500.
+   *
+   * @covers ::build
+   */
+  public function testUncopyableBlockIsBadRequest(): void {
+    $storage = $this->buildSectionStorage($section);
+    $this->cloner->method('isClonable')->willReturn(TRUE);
+    $this->cloner->method('cloneComponent')
+      ->willThrowException(new \InvalidArgumentException('No content.'));
+    $this->tempstore->expects($this->never())->method('set');
+
+    $this->expectException(BadRequestHttpException::class);
+    $this->buildController()->build($storage, 0, 'content', 'first');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/CloneContextualLinksTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/CloneContextualLinksTest.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace Drupal\Tests\ys_layouts\Unit;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\layout_builder\Section;
+use Drupal\layout_builder\SectionComponent;
+use Drupal\layout_builder\SectionStorageInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_layouts\CloneContextualLinks;
+use Drupal\ys_layouts\Service\BlockCloner;
+
+/**
+ * Tests which Layout Builder blocks are offered the Clone contextual link.
+ *
+ * @coversDefaultClass \Drupal\ys_layouts\CloneContextualLinks
+ *
+ * @group yalesites
+ * @group ys_layouts
+ */
+class CloneContextualLinksTest extends UnitTestCase {
+
+  /**
+   * The mocked block cloner service.
+   *
+   * @var \Drupal\ys_layouts\Service\BlockCloner|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $cloner;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->cloner = $this->createMock(BlockCloner::class);
+    $container = new ContainerBuilder();
+    $container->set('ys_layouts.block_cloner', $this->cloner);
+    \Drupal::setContainer($container);
+
+    // The hook under test lives in the procedural module file. It only calls
+    // static methods, so loading the file is enough.
+    require_once __DIR__ . '/../../../ys_layouts.module';
+  }
+
+  /**
+   * Builds a Layout Builder element with one region and two blocks.
+   *
+   * @param bool $region_is_open
+   *   Whether the region still offers its "Add block" link. A lock removes it.
+   *
+   * @return array
+   *   The fake Layout Builder render element.
+   */
+  protected function buildElement(bool $region_is_open = TRUE): array {
+    $inline = new SectionComponent('inline-uuid', 'content', [
+      'id' => 'inline_block:text',
+    ]);
+    $reusable = new SectionComponent('reusable-uuid', 'content', [
+      'id' => 'block_content:some-uuid',
+    ]);
+    $section = new Section('layout_onecol', [], [$inline, $reusable]);
+
+    $storage = $this->createMock(SectionStorageInterface::class);
+    $storage->method('getSection')->willReturn($section);
+
+    $region = [
+      'inline-uuid' => [
+        '#contextual_links' => [
+          'layout_builder_block' => [
+            'route_parameters' => ['delta' => 0, 'uuid' => 'inline-uuid'],
+            'metadata' => ['operations' => 'move:update:remove'],
+          ],
+        ],
+      ],
+      'reusable-uuid' => [
+        '#contextual_links' => [
+          'layout_builder_block' => [
+            'route_parameters' => ['delta' => 0, 'uuid' => 'reusable-uuid'],
+            'metadata' => ['operations' => 'move:update:remove'],
+          ],
+        ],
+      ],
+    ];
+    if ($region_is_open) {
+      $region = ['layout_builder_add_block' => ['link' => []]] + $region;
+    }
+
+    return [
+      '#section_storage' => $storage,
+      'layout_builder' => [
+        0 => ['link' => ['#url' => 'add-section']],
+        1 => [
+          'configure' => ['#url' => 'configure-section'],
+          'layout-builder__section' => [
+            '#layout' => 'layout_onecol',
+            'content' => $region,
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Reads the clone metadata stamped on a block.
+   *
+   * @param array $element
+   *   The processed element.
+   * @param string $uuid
+   *   The component UUID to read.
+   *
+   * @return array
+   *   The block's contextual-links metadata.
+   */
+  protected function metadata(array $element, string $uuid): array {
+    return $element['layout_builder'][1]['layout-builder__section']['content'][$uuid]['#contextual_links']['layout_builder_block']['metadata'];
+  }
+
+  /**
+   * Only clonable blocks are marked during pre-render.
+   *
+   * @covers ::preRender
+   */
+  public function testOnlyClonableBlocksAreMarked(): void {
+    $this->cloner->method('isClonable')
+      ->willReturnCallback(function (SectionComponent $component) {
+        return $component->getUuid() === 'inline-uuid';
+      });
+
+    $element = CloneContextualLinks::preRender($this->buildElement());
+
+    $inline = $this->metadata($element, 'inline-uuid');
+    $reusable = $this->metadata($element, 'reusable-uuid');
+
+    $this->assertSame('1', $inline[CloneContextualLinks::METADATA_KEY]);
+    $this->assertArrayNotHasKey(
+      CloneContextualLinks::METADATA_KEY,
+      $reusable
+    );
+
+    // Core's own metadata is left intact so the other links keep working.
+    $this->assertSame('move:update:remove', $inline['operations']);
+  }
+
+  /**
+   * A region that no longer accepts new blocks is not offered cloning.
+   *
+   * Layout Builder Lock removes the "Add block" link from locked regions;
+   * cloning must not become a way around that.
+   *
+   * @covers ::preRender
+   */
+  public function testLockedRegionIsNotMarked(): void {
+    $this->cloner->method('isClonable')->willReturn(TRUE);
+
+    $element = CloneContextualLinks::preRender(
+      $this->buildElement(FALSE)
+    );
+
+    $this->assertArrayNotHasKey(
+      CloneContextualLinks::METADATA_KEY,
+      $this->metadata($element, 'inline-uuid')
+    );
+  }
+
+  /**
+   * An element without section storage is returned untouched.
+   *
+   * @covers ::preRender
+   */
+  public function testElementWithoutSectionStorageIsUntouched(): void {
+    $this->cloner->expects($this->never())->method('isClonable');
+    $element = ['layout_builder' => []];
+
+    $this->assertSame($element, CloneContextualLinks::preRender($element));
+  }
+
+  /**
+   * Builds the $items array core hands to the alter hook.
+   *
+   * \Drupal\Core\Menu\ContextualLinkManager::getContextualLinksArrayByGroup()
+   * keys the items by contextual-link PLUGIN id — not by group name — and
+   * copies the group's metadata into every one of them.
+   *
+   * @param array $metadata
+   *   The contextual-links metadata of the block being rendered.
+   *
+   * @return array
+   *   The items for the layout_builder_block group.
+   */
+  protected function buildItems(array $metadata): array {
+    $items = [];
+    $plugins = [
+      'layout_builder_block_update',
+      'layout_builder_block_move',
+      'layout_builder_block_remove',
+      CloneContextualLinks::PLUGIN_ID,
+    ];
+    foreach ($plugins as $plugin_id) {
+      $items[$plugin_id] = [
+        'route_name' => 'route.' . $plugin_id,
+        'route_parameters' => ['delta' => 0, 'uuid' => 'inline-uuid'],
+        'title' => $plugin_id,
+        'weight' => 0,
+        'localized_options' => [],
+        'metadata' => $metadata,
+      ];
+    }
+    return $items;
+  }
+
+  /**
+   * The hook keeps the Clone link for a block marked during pre-render.
+   *
+   * Guards the wiring between the two halves of the feature: the pre-render
+   * stamps the metadata and the hook has to find it under the plugin id.
+   */
+  public function testHookKeepsTheLinkForClonableBlock(): void {
+    $this->cloner->method('isClonable')->willReturn(TRUE);
+    $element = CloneContextualLinks::preRender($this->buildElement());
+    $items = $this->buildItems($this->metadata($element, 'inline-uuid'));
+
+    $links = [
+      'layout-builder-block-update' => ['title' => 'Configure'],
+      CloneContextualLinks::LINK_KEY => ['title' => 'Clone block'],
+    ];
+    $links_element = ['#links' => $links];
+    ys_layouts_contextual_links_view_alter($links_element, $items);
+
+    $this->assertSame($links, $links_element['#links']);
+  }
+
+  /**
+   * The hook removes the Clone link from a block that was not marked.
+   */
+  public function testHookRemovesTheLinkForNonClonableBlock(): void {
+    $this->cloner->method('isClonable')->willReturn(FALSE);
+    $element = CloneContextualLinks::preRender($this->buildElement());
+    $items = $this->buildItems($this->metadata($element, 'reusable-uuid'));
+
+    $links_element = [
+      '#links' => [
+        'layout-builder-block-update' => ['title' => 'Configure'],
+        CloneContextualLinks::LINK_KEY => ['title' => 'Clone block'],
+      ],
+    ];
+    ys_layouts_contextual_links_view_alter($links_element, $items);
+
+    $this->assertSame(
+      ['layout-builder-block-update'],
+      array_keys($links_element['#links'])
+    );
+  }
+
+  /**
+   * The Clone link is kept only for blocks marked during pre-render.
+   *
+   * @covers ::shouldKeepLink
+   */
+  public function testShouldKeepLink(): void {
+    $this->assertTrue(CloneContextualLinks::shouldKeepLink([
+      'metadata' => [CloneContextualLinks::METADATA_KEY => '1'],
+    ]));
+    $this->assertFalse(CloneContextualLinks::shouldKeepLink([
+      'metadata' => ['operations' => 'move:update:remove'],
+    ]));
+    $this->assertFalse(CloneContextualLinks::shouldKeepLink([]));
+  }
+
+  /**
+   * The pre-render callback is declared as a trusted callback.
+   *
+   * @covers ::trustedCallbacks
+   */
+  public function testPreRenderIsTrusted(): void {
+    $this->assertContains(
+      'preRender',
+      CloneContextualLinks::trustedCallbacks()
+    );
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.info.yml
@@ -5,5 +5,10 @@ package: Core
 core_version_requirement: '^9 || ^10'
 version: VERSION
 dependencies:
+  # The Clone block link injects layout_builder.tempstore_repository and adds a
+  # link to the contextual group layout_builder_block, so both are hard
+  # requirements of the service container rather than optional integrations.
+  - drupal:contextual
+  - drupal:layout_builder
   - calendar_link
   - ys_localist

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.links.contextual.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.links.contextual.yml
@@ -1,0 +1,8 @@
+ys_layouts_clone_block:
+  title: 'Clone block'
+  route_name: 'ys_layouts.clone_block'
+  group: 'layout_builder_block'
+  weight: 1
+  options:
+    attributes:
+      class: ['use-ajax']

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\Context\Context;
 use Drupal\Core\Plugin\Context\EntityContextDefinition;
+use Drupal\ys_layouts\CloneContextualLinks;
 
 /**
  * Add template files.
@@ -378,5 +379,38 @@ function ys_layouts_preprocess_layout__page_meta(&$variables) {
         }
       }
     }
+  }
+}
+
+/**
+ * Marks the Layout Builder blocks that may offer the Clone link.
+ *
+ * Implements hook_element_info_alter().
+ */
+function ys_layouts_element_info_alter(array &$info) {
+  if (!empty($info['layout_builder'])) {
+    $info['layout_builder']['#pre_render'][] = [
+      CloneContextualLinks::class,
+      'preRender',
+    ];
+  }
+}
+
+/**
+ * Removes the Clone link from blocks that cannot be cloned.
+ *
+ * Implements hook_contextual_links_view_alter().
+ */
+function ys_layouts_contextual_links_view_alter(&$element, $items) {
+  if (!isset($element['#links'][CloneContextualLinks::LINK_KEY])) {
+    return;
+  }
+
+  // $items is keyed by contextual-link PLUGIN id, not by group name; every
+  // item in a group carries that group's metadata.
+  // @see \Drupal\Core\Menu\ContextualLinkManager::getContextualLinksArrayByGroup()
+  $item = $items[CloneContextualLinks::PLUGIN_ID] ?? [];
+  if (!CloneContextualLinks::shouldKeepLink($item)) {
+    unset($element['#links'][CloneContextualLinks::LINK_KEY]);
   }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.routing.yml
@@ -13,6 +13,29 @@ ys_layouts.resource_download:
   requirements:
     _custom_access: '\Drupal\ys_layouts\Controller\ResourceDownloadController::access'
     file_id: '\d+'
+# Clones a single Layout Builder block into the layout tempstore. The path and
+# parameter names mirror core's layout_builder.remove_block route because the
+# contextual link group "layout_builder_block" passes exactly these parameters.
+ys_layouts.clone_block:
+  path: '/layout_builder/clone/block/{section_storage_type}/{section_storage}/{delta}/{region}/{uuid}'
+  defaults:
+    _controller: '\Drupal\ys_layouts\Controller\CloneBlockController::build'
+  requirements:
+    # Matches core's layout_builder.add_block / update_block, which gate on the
+    # layout alone. Anyone who passes this can already add an inline block of
+    # any type to the layout, so cloning one grants no extra authority. Do not
+    # add a block_content permission here: "create and edit custom blocks" was
+    # removed from core in 10.1 and only still works because stale grants
+    # linger in the role config, so it would break on a role cleanup.
+    _layout_builder_access: 'view'
+    _ys_layouts_clonable_block: 'TRUE'
+    # The link is a GET that changes the tempstore, so it carries a token.
+    _csrf_token: 'TRUE'
+  options:
+    _admin_route: TRUE
+    parameters:
+      section_storage:
+        layout_builder_tempstore: TRUE
 block_content.add_page:
   path: '/block/add'
   defaults:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.services.yml
@@ -19,6 +19,18 @@ services:
   ys_layouts.resource_author_builder:
     class: Drupal\ys_layouts\Service\ResourceAuthorBuilder
     arguments: ['@ys_layouts.author_collator']
+  # Deep-duplicates a Layout Builder component and its inline block content.
+  # Used by the "Clone block" contextual link and by the access check that
+  # decides which blocks may offer it.
+  ys_layouts.block_cloner:
+    class: Drupal\ys_layouts\Service\BlockCloner
+    arguments: ['@entity_type.manager', '@uuid', '@logger.channel.ys_layouts']
+  # Restricts the clone route to inline (non-reusable) blocks.
+  ys_layouts.clone_block_access_check:
+    class: Drupal\ys_layouts\Access\CloneBlockAccessCheck
+    arguments: ['@layout_builder.tempstore_repository', '@ys_layouts.block_cloner']
+    tags:
+      - { name: access_check, applies_to: _ys_layouts_clonable_block }
   # Resolves cover-image alt text for Resource media.
   # Used by ResourceMetaBlock and atomic_preprocess_node() so the block
   # render and the card/list templates apply identical alt text.


### PR DESCRIPTION
## [190: Add Block Cloning Functionality](https://github.com/yalesites-org/YaleSites-Internal/issues/190)

### Description of work
- Adds a **Clone block** option to the block hover (contextual) menu in Layout Builder. One
  click duplicates the block in place, directly after the original, with all configuration
  intact. Nothing is written to the database until the editor hits **Save layout**, matching
  how Layout Builder already handles inline blocks.
- **Reusable blocks are excluded**, per the scope note on the ticket. Enforced twice: the
  Clone link is not rendered on them, and the route itself refuses them, so a hand-crafted
  URL cannot clone one either.
- Implemented natively in `ys_layouts` with **no new composer dependencies**. This departs
  from the approach described on the ticket (entity_clone plus a custom module based on
  layout_builder_block_clone) — neither module is installed here, and the deep-clone logic
  this needs already exists in the repo's patched `quick_node_clone`, so a contrib
  dependency bought nothing.
- **Resolves the media-in-preview bug that paused this ticket.** Two independent causes:
  1. `createDuplicate()` copies `parent_type`/`parent_id`, so a cloned paragraph claimed the
     *original* block as its parent. `ParagraphAccessControlHandler` ANDs in that parent's
     access, a hostless non-reusable block is forbidden, and the formatter then silently
     dropped the paragraph — an empty gallery in the preview, fine on the canonical route.
     Fixed by resetting parent pointers, which entity_reference_revisions rebuilds on save.
  2. The gallery lightbox was separately broken in `atomic` (companion PR below) — it
     rendered the modal by paragraph ID, which an unsaved paragraph does not have. That bug
     also affected brand-new gallery items, not just clones.
  `target_id`/`target_revision_id` are also nulled, otherwise `referencedEntities()` resolves
  the *original* paragraph — the old "clone shows the wrong images" bug.
- The route gates on `_layout_builder_access` alone, matching core's `add_block` and
  `update_block`. Deliberately **no** block_content permission: `create and edit custom
  blocks` was removed from core in 10.1 and only still resolves because stale grants linger
  in `user.role.*.yml`, so gating on it would silently break the feature on a role cleanup.
- Adds 14 tests (kernel + unit) and `docs/block-cloning.md`.
- Companion PR: yalesites-org/atomic#496 — **review and merge together**; the gallery
  lightbox is only correct with both.

### What was verified on a running site
Beyond the test suite, this was exercised end-to-end against a local Drupal instance:
- Clone appears in the real hover menu alongside Configure / Move / Remove block.
- On a real editor-created `custom_cards` block, the original and the clone render
  **byte-identical** previews (25071 bytes, same 3 images).
- Ordering: weights land `text, gallery, CLONE, text` — trailing blocks shift, not append.
- After save, the clone owns **separate** paragraphs with correctly rebuilt parents and the
  same media targets, so editing one copy cannot affect the other.
- Permission matrix — clone access tracks core's `update_block` exactly:
  contributor / editor / site_admin / platform_admin allowed on inline blocks; plain
  authenticated denied; reusable blocks denied for **every** role.

### Functional testing steps:
- [ ] On a page with several blocks, open a block's hover menu in Layout Builder and confirm a **Clone block** option appears
- [ ] Click it — a copy appears immediately below the original, with the same content and settings, and the preview refreshes without a page reload
- [ ] Save the layout, reload, and confirm both blocks are present and correct
- [ ] Edit the copy (change text, swap an image) and confirm the **original is unchanged** — and vice versa
- [ ] Clone a **Gallery** block and confirm the images appear in the Layout Builder preview (not just after saving), and that the lightbox opens with the right image
- [ ] Clone blocks of several other types (Text, Custom Cards, Content Spotlight, Accordion, Tabs)
- [ ] On a **reusable** block placed from the block library, confirm there is **no** Clone option
- [ ] Repeat as a Contributor and an Editor, not just an admin
- [ ] Keyboard/screen-reader check: the Clone item is reachable by keyboard in the hover menu, and cloning announces "Block cloned. The copy was added below the original."

### Known gaps
- Cloning does not re-validate `layout_builder_restrictions` per-region allow-lists, so an
  existing block of a now-restricted type can still be cloned in place. Not in the ticket's
  acceptance criteria — flagging for a follow-up issue. `layout_builder_lock` regions are
  respected.
- The editor Help Center is external to this repo, so AC "document the feature in the help
  center" is only half-done here (`docs/block-cloning.md`); the Help Center entry is a
  follow-up for the docs team.

References yalesites-org/YaleSites-Internal#190

---
Created with AI
