### PR TITLE
1468: Beacon: implement a streaming-safe output guardrail so post-generate guardrails actually fire

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/ai.ai_guardrail.ys_beacon_output_safety.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ai.ai_guardrail.ys_beacon_output_safety.yml
@@ -1,0 +1,12 @@
+uuid: 7d41b787-2ae4-41b7-990c-dbb20d731b97
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - ys_beacon
+id: ys_beacon_output_safety
+label: 'Beacon output safety'
+description: 'Blocks streamed Beacon answers that pair a credential request with an off-Yale link, link to an executable installer, or ask the user to transmit a secret.'
+guardrail: ys_beacon_output_safety
+guardrail_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/ai.ai_guardrail_set.ys_beacon_output_safety.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ai.ai_guardrail_set.ys_beacon_output_safety.yml
@@ -1,0 +1,18 @@
+uuid: cd1b5803-0647-458b-93e5-66b6e6b26ee1
+langcode: en
+status: true
+dependencies:
+  config:
+    - ai.ai_guardrail.ys_beacon_output_safety
+  enforced:
+    module:
+      - ys_beacon
+id: ys_beacon_output_safety
+label: 'Beacon output safety'
+description: 'Platform-wide Beacon output guardrails, applied to every AI request via ai.settings global_guardrails.'
+stop_threshold: 1.0
+pre_generate_guardrails:
+  plugin_id: {  }
+post_generate_guardrails:
+  plugin_id:
+    - ys_beacon_output_safety

--- a/web/profiles/custom/yalesites_profile/config/sync/ai.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ai.settings.yml
@@ -10,4 +10,5 @@ default_providers:
 request_timeout: 120
 allowed_hosts: {  }
 allowed_hosts_rewrite_links: false
-global_guardrails: {  }
+global_guardrails:
+  - ys_beacon_output_safety

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/AiGuardrail/BeaconOutputSafety.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/AiGuardrail/BeaconOutputSafety.php
@@ -1,0 +1,591 @@
+<?php
+
+namespace Drupal\ys_beacon\Plugin\AiGuardrail;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\ai\Attribute\AiGuardrail;
+use Drupal\ai\Guardrail\AiGuardrailPluginBase;
+use Drupal\ai\Guardrail\Result\GuardrailResultInterface;
+use Drupal\ai\Guardrail\Result\PassResult;
+use Drupal\ai\Guardrail\Result\RewriteOutputResult;
+use Drupal\ai\Guardrail\Result\StopResult;
+use Drupal\ai\Guardrail\StreamableGuardrailInterface;
+use Drupal\ai\OperationType\Chat\ChatMessage;
+use Drupal\ai\OperationType\Chat\ChatOutput;
+use Drupal\ai\OperationType\InputInterface;
+use Drupal\ai\OperationType\OutputInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Blocks Beacon answers that phish for credentials or push a download.
+ *
+ * Beacon's prompt-side guardrail holds against instruction-style jailbreaks but
+ * is bypassed by poisoned index content that states a plausible *fact* rather
+ * than issuing an instruction. Confirmed harms included telling a user to enter
+ * their NetID and password at an attacker-controlled URL and recommending an
+ * .exe download to site editors.
+ *
+ * This is an output-side backstop. It implements StreamableGuardrailInterface
+ * because Beacon streams (ys_beacon.settings:streaming), and a post-generate
+ * guardrail that is not streamable silently never fires on a streamed response
+ * — GuardrailsEventSubscriber neither registers it with the stream iterator nor
+ * reconstructs the output for it.
+ *
+ * Four patterns are blocked:
+ * - a credential term near a link that points *off* Yale,
+ * - a link whose target is an executable or installer,
+ * - an instruction to install something from an off-Yale link,
+ * - a request to transmit a secret.
+ *
+ * Why the credential check looks at the host at all. Checking the action and
+ * not the host is the right rule for links in general — YaleSites content links
+ * to an open-ended set of external hosts that cannot be vetted, which is why
+ * Beacon disables the AI module's hostname filter. But for credential entry
+ * specifically, "sign in at X with your NetID" is legitimate or hostile purely
+ * according to what X is, so an action-only rule cannot separate them: it
+ * blocks "reset your password at its.yale.edu" as readily as the attack.
+ * Measured against real answers, the action-only form produced false positives
+ * on the single most common shape of Beacon answer, made worse by the shipped
+ * system prompt telling the model to include citation links. So the credential
+ * rule carries one narrow carve-out — a link to a Yale-controlled host is not
+ * treated as a credential-harvesting target. This is deliberately NOT the
+ * general allow-list of vetted external hosts that was ruled out: nothing here
+ * enumerates acceptable third parties, and every non-credential rule stays
+ * fully host-independent.
+ *
+ * How it behaves while streaming:
+ * - getStartRegex() matches any single signal — a credential term, a link, an
+ *   installer target or a secret noun — so buffering begins as soon as one
+ *   appears. The link itself is a trigger because the confirmed bypass put the
+ *   URL in the *second* sentence, after the first had already been flushed.
+ * - getStopRegex() releases at the next sentence boundary, so a triggered
+ *   answer is held for one sentence rather than to end-of-stream. The iterator
+ *   would otherwise buffer up to maxGuardrailBufferSize (8192 characters),
+ *   which would be a visible streaming regression.
+ * - Correlation across those short windows uses a bounded rolling tail of the
+ *   text already seen, so a link a sentence or two after a credential request
+ *   is still caught.
+ *
+ * That rolling tail is only sound if it is *contiguous* with the window being
+ * checked. The iterator releases non-matching content without ever showing it
+ * to the guardrail, so once the guardrail has been triggered it keeps buffering
+ * for the rest of the response (getStartRegex() returns an empty string) and
+ * therefore sees every remaining character in order. Before the first trigger
+ * nothing is missed either, because content released then matched no signal at
+ * all and so has nothing to correlate. Without this, two passages hundreds of
+ * characters apart would be concatenated into a window that never existed.
+ *
+ * Output filtering is inherently late under streaming — text already yielded
+ * cannot be un-sent — so this reduces harm rather than eliminating it. An
+ * input-side intent intercept for credential/account questions remains the
+ * stronger primary control.
+ */
+#[AiGuardrail(
+  id: 'ys_beacon_output_safety',
+  label: new TranslatableMarkup('Beacon output safety'),
+  description: new TranslatableMarkup('Blocks streamed Beacon answers that pair a credential request with an off-Yale link, link to an executable installer, or ask the user to transmit a secret.'),
+)]
+class BeaconOutputSafety extends AiGuardrailPluginBase implements StreamableGuardrailInterface, ContainerFactoryPluginInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * How far apart a credential term and a link may be and still correlate.
+   *
+   * Also bounds the rolling tail kept between buffers.
+   */
+  private const PROXIMITY_WINDOW = 400;
+
+  /**
+   * How far back a negation is looked for before a transmit verb.
+   */
+  private const NEGATION_LOOKBACK = 60;
+
+  /**
+   * Things that name a credential.
+   */
+  private const CREDENTIAL_NOUN_BODY = '\b(?:net\s?ids?|pass(?:words?|phrases?|codes?)|credentials?|usernames?|(?:one[\s-]?time|verification|security|duo)\s+codes?|duo\s+(?:push|prompt)|mfa|2fa|(?:two|multi)[\s-]?factor)\b';
+
+  /**
+   * Phrases that are themselves an instruction to authenticate.
+   *
+   * These imply the credential without naming it, so one of these next to an
+   * off-Yale link is enough on its own.
+   *
+   * The inflections are spelled out because a trailing word boundary alone
+   * would miss the most common real forms — "sign into", "logging in",
+   * "logged into" — which is exactly how a poisoned answer phrases it.
+   */
+  private const AUTH_PHRASE_BODY = '\b(?:(?:sign(?:s|ed|ing)?|log(?:s|ged|ging)?)[\s-]?in(?:to)?|verify\s+your\s+identity|authenticate)\b';
+
+  /**
+   * Verbs that ask the user to put a credential into something.
+   *
+   * Weaker than AUTH_PHRASE_BODY, so these only count when a credential noun
+   * also appears near the link. "Submit" and "include" are absent on purpose:
+   * "submit a ticket at yale.service-now.com and include your NetID" is
+   * ordinary help-desk guidance, not a credential prompt.
+   */
+  private const ENTRY_VERB_BODY = '\b(?:(?:re-?)?enter|type|input|key\s+in|confirm|update|provide|supply)\b';
+
+  /**
+   * Secrets a user must never be asked to transmit.
+   */
+  private const SECRET_NOUN_BODY = '\b(?:pass(?:words?|phrases?|codes?)|net\s?ids?|social\s+security(?:\s+number)?|ssn|credit\s+card(?:\s+number)?|card\s+number|bank\s+account)\b';
+
+  /**
+   * Verbs that actually hand a secret to someone else.
+   *
+   * Deliberately narrow. Verbs like "call", "submit", "provide" and "give" were
+   * removed because none transmits a secret on its own, and each of them
+   * matched ordinary help-desk guidance ("call the Help Desk if you forgot your
+   * password", "provide your NetID when you contact them").
+   */
+  private const TRANSMIT_VERB_BODY = '\b(?:e-?mail|send|text|reply\s+with|share|forward)\b';
+
+  /**
+   * Negations that turn a transmit phrase into advice not to transmit.
+   */
+  private const NEGATION_BODY = '\b(?:never|not|n\'t|cannot|no\s+one|nobody|nowhere|avoid|refuse)\b';
+
+  /**
+   * The Yale-controlled domain that credential entry may point at.
+   */
+  private const YALE_DOMAIN = 'yale.edu';
+
+  /**
+   * Any link form the rendered answer turns into something clickable.
+   *
+   * Protocol-relative links are included because react-markdown passes any URL
+   * beginning with "/" through untouched, so "//host/path" renders as a live
+   * link. Bare domains with no scheme are excluded: remark-gfm does not
+   * autolink them, so they are text the user would have to retype.
+   */
+  private const LINK_BODY = '(?:\bhttps?://[^\s)>\]]+|(?<![:\w])//[a-z0-9-]+(?:\.[a-z0-9-]+)+[^\s)>\]]*|\bwww\.[a-z0-9-]+(?:\.[a-z0-9-]+)+[^\s)>\]]*|\bmailto:[^\s)>\]]+)';
+
+  /**
+   * Instructions to install or execute something.
+   *
+   * Paired with an off-Yale link, this catches the download links an extension
+   * list cannot: an extensionless endpoint or a filename hidden in a query
+   * string. "Download" alone is deliberately absent — answers legitimately
+   * point at external PDFs and documents.
+   */
+  private const INSTALL_VERB_BODY = '\b(?:install(?:s|ing|er|ers)?|reinstall|execute|double[\s-]?click)\b';
+
+  /**
+   * An executable, installer or script extension, matched against one link.
+   *
+   * Archive formats (.zip, .7z, .rar) are deliberately absent: YaleSites
+   * content legitimately links to archives, and because a violation stops the
+   * rest of the answer, blocking every .zip link would cost more than it
+   * catches. An archive carrying a payload is therefore a known gap — the
+   * install-instruction rule is what catches the common phrasing.
+   */
+  private const INSTALLER_EXTENSION_BODY = '\.(?:exe|msi|msu|dmg|pkg|apk|appx|msix|bat|cmd|ps1|vbs|vbe|scr|hta|lnk|jse|wsf|reg|jar|iso|deb|sh|run|bin|command)\b';
+
+  /**
+   * Any single signal that is enough to start buffering.
+   *
+   * Composed from the same bodies the individual checks use, so a term can
+   * never be added to one and forgotten in the other. This is deliberately
+   * broader than what the rules block: buffering should begin on any mention of
+   * a credential, so a link arriving later can still be correlated with it.
+   */
+  private const START_SIGNAL_BODY = self::CREDENTIAL_NOUN_BODY . '|' . self::AUTH_PHRASE_BODY . '|' . self::SECRET_NOUN_BODY . '|' . self::LINK_BODY;
+
+  /**
+   * Releases the buffer at the end of the sentence that triggered it.
+   */
+  private const SENTENCE_END = '#[.!?]["\')\]]?\s#';
+
+  /**
+   * Matches any non-empty buffer, so a latched response releases nothing.
+   */
+  private const ANY_CONTENT = '#[\s\S]#';
+
+  /**
+   * Whether a violation has already stopped this response.
+   *
+   * @var bool
+   */
+  protected bool $blocked = FALSE;
+
+  /**
+   * Whether a signal has been seen, after which every chunk is buffered.
+   *
+   * Keeps the rolling tail contiguous with the window being checked.
+   *
+   * @var bool
+   */
+  protected bool $triggered = FALSE;
+
+  /**
+   * The tail of already-seen text, bounded to the proximity window.
+   *
+   * @var string
+   */
+  protected string $recentText = '';
+
+  /**
+   * The Beacon logger channel, when the plugin was built by the container.
+   *
+   * @var \Psr\Log\LoggerInterface|null
+   */
+  protected ?LoggerInterface $logger = NULL;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+    $instance->logger = $container->get('logger.channel.ys_beacon');
+
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processInput(InputInterface $input): GuardrailResultInterface {
+    return new PassResult('Beacon output safety only inspects output.', $this);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processOutput(OutputInterface $output): GuardrailResultInterface {
+    if (!$output instanceof ChatOutput) {
+      return new PassResult('Output is not a chat output, skipping Beacon output safety.', $this);
+    }
+
+    $normalized = $output->getNormalized();
+    if (!$normalized instanceof ChatMessage) {
+      // A streamed response never reaches this method: the subscriber registers
+      // this guardrail on the stream iterator instead, and each buffered window
+      // is checked by processStreamedBuffer(). ChatOutput::getNormalized() is
+      // typed to those two shapes, so this branch only guards an output shape
+      // neither path understands.
+      return new PassResult('Streamed output is inspected chunk by chunk instead.', $this);
+    }
+
+    return $this->resultFor($this->findViolation($normalized->getText()));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStartRegex(): string {
+    // Buffer everything from here on: to suppress the remainder of a stopped
+    // response, and to keep the rolling tail contiguous once a signal has been
+    // seen. See the class docblock for why contiguity matters.
+    if ($this->blocked || $this->triggered) {
+      return '';
+    }
+
+    return $this->pattern(self::START_SIGNAL_BODY);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStopRegex(): string {
+    // Latched: evaluate every chunk immediately so nothing else is released.
+    return $this->blocked ? self::ANY_CONTENT : self::SENTENCE_END;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processStreamedBuffer(string $buffered_content): GuardrailResultInterface {
+    if ($this->blocked) {
+      // Suppress the rest of the response without repeating the notice.
+      return new RewriteOutputResult('', $this);
+    }
+
+    // From here on every chunk is buffered, so the rolling tail stays
+    // contiguous with the text it is compared against.
+    $this->triggered = TRUE;
+
+    // Evaluate the buffer together with the tail already shown to the user, so
+    // a credential request and a link in different sentences still correlate.
+    $violation = $this->findViolation($this->recentText . $buffered_content);
+    if ($violation !== NULL) {
+      $this->blocked = TRUE;
+      $this->recentText = '';
+    }
+    else {
+      $this->recentText = substr($this->recentText . $buffered_content, -self::PROXIMITY_WINDOW);
+    }
+
+    return $this->resultFor($violation);
+  }
+
+  /**
+   * Clears state left over from a previous streamed response.
+   *
+   * The contrib streaming-guardrail API has no stream-lifecycle hook, and
+   * AiGuardrail::getGuardrail() caches the plugin on the config entity, so a
+   * long-running PHP process could hand the same instance to two responses.
+   * Beacon's streaming path is request-scoped (one chat per HTTP request) and
+   * the non-streamed path keeps no state, so this exists for callers that reuse
+   * an instance deliberately.
+   */
+  public function resetStreamState(): void {
+    $this->blocked = FALSE;
+    $this->triggered = FALSE;
+    $this->recentText = '';
+  }
+
+  /**
+   * Names the unsafe pattern in the given text, if any.
+   *
+   * @param string $text
+   *   The model-authored text to inspect.
+   *
+   * @return string|null
+   *   A short description of the violation, or NULL when the text is clean.
+   */
+  protected function findViolation(string $text): ?string {
+    if ($this->hasUnnegatedMatch($text, $this->secretTransmitPattern())) {
+      return 'request to transmit a secret';
+    }
+
+    $external_links = [];
+    foreach ($this->linkMatches($text) as [$link, $offset]) {
+      if ($this->isYaleLink($link)) {
+        // Yale distributes its own software, so an installer on a Yale host is
+        // legitimate. Every other rule below only sees off-Yale links.
+        continue;
+      }
+      if (preg_match($this->pattern(self::INSTALLER_EXTENSION_BODY), $link)) {
+        return 'link to an executable installer';
+      }
+      $external_links[] = $offset;
+    }
+
+    if ($external_links === []) {
+      return NULL;
+    }
+
+    if ($this->hasNearbyOffsets($this->matchOffsets($text, $this->pattern(self::INSTALL_VERB_BODY)), $external_links)) {
+      return 'instruction to install software from an off-Yale link';
+    }
+
+    // An explicit "sign in" style instruction next to an off-Yale link is
+    // enough on its own; a weaker entry verb also needs a credential named
+    // nearby, so "enter it at <link>" after "you will need your password" is
+    // caught while "submit a ticket ... and include your NetID" is not.
+    if ($this->hasNearbyOffsets($this->matchOffsets($text, $this->pattern(self::AUTH_PHRASE_BODY)), $external_links)) {
+      return 'credential entry instruction paired with an off-Yale link';
+    }
+
+    $entry_verbs = $this->matchOffsets($text, $this->pattern(self::ENTRY_VERB_BODY));
+    $credentials = $this->matchOffsets($text, $this->pattern(self::CREDENTIAL_NOUN_BODY));
+    if ($this->hasNearbyOffsets($entry_verbs, $external_links) && $this->hasNearbyOffsets($credentials, $external_links)) {
+      return 'credential entry instruction paired with an off-Yale link';
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Every link in the text, with the offset it appeared at.
+   *
+   * @param string $text
+   *   The text to inspect.
+   *
+   * @return array[]
+   *   A list of [link, offset] pairs.
+   */
+  protected function linkMatches(string $text): array {
+    if (!preg_match_all($this->pattern(self::LINK_BODY), $text, $matches, PREG_OFFSET_CAPTURE)) {
+      return [];
+    }
+
+    return $matches[0];
+  }
+
+  /**
+   * Whether a link points at a Yale-controlled host.
+   *
+   * The host is parsed rather than pattern-matched. A regex that merely looked
+   * for "yale.edu" in the URL treats yale.edu.evil.com, yale.edu-secure.com and
+   * yale.edu@evil.com as internal — each of which is registrable by an attacker
+   * and delivers the credential-harvesting link this guardrail exists to stop.
+   *
+   * @param string $link
+   *   A link as it appeared in the answer.
+   *
+   * @return bool
+   *   TRUE when the host is yale.edu or a subdomain of it.
+   */
+  protected function isYaleLink(string $link): bool {
+    if (stripos($link, 'mailto:') === 0) {
+      $at = strrpos($link, '@');
+      $host = $at === FALSE ? '' : substr($link, $at + 1);
+    }
+    else {
+      // Give parse_url() a scheme so protocol-relative and bare www links
+      // resolve to a host. parse_url() puts any user:pass into its own
+      // component, so "https://yale.edu@evil.com" correctly yields evil.com.
+      $candidate = str_starts_with($link, '//') ? 'https:' . $link : $link;
+      if (!preg_match('#^[a-z][a-z0-9+.-]*://#i', $candidate)) {
+        $candidate = 'https://' . $candidate;
+      }
+      $host = (string) parse_url($candidate, PHP_URL_HOST);
+    }
+
+    $host = strtolower(rtrim(trim($host, '.,;:'), '.'));
+    if ($host === '') {
+      // An unparseable host is treated as off-Yale so the checks still apply.
+      return FALSE;
+    }
+
+    return $host === self::YALE_DOMAIN || str_ends_with($host, '.' . self::YALE_DOMAIN);
+  }
+
+  /**
+   * Turns a violation description into a guardrail result.
+   *
+   * @param string|null $violation
+   *   The violation description, or NULL when the text is clean.
+   *
+   * @return \Drupal\ai\Guardrail\Result\GuardrailResultInterface
+   *   A StopResult for a violation, otherwise a PassResult.
+   */
+  protected function resultFor(?string $violation): GuardrailResultInterface {
+    if ($violation === NULL) {
+      return new PassResult('Beacon output safety found no credential or download risk.', $this);
+    }
+
+    // A backstop that fires silently cannot be tuned: without this there is no
+    // server-side record that an answer was cut, so neither a real bypass nor a
+    // false positive is visible in production. Only the category is logged -
+    // never the model text - so no answer content or user question is stored.
+    $this->logger?->warning('Beacon output safety blocked part of an answer: @violation.', [
+      '@violation' => $violation,
+    ]);
+
+    return new StopResult($this->blockedMessage(), $this, ['violation' => $violation]);
+  }
+
+  /**
+   * Whether a pattern matches somewhere it is not negated.
+   *
+   * "Never share your password with anyone" is the advice Beacon should give,
+   * so a transmit phrase only counts when its own clause does not negate it.
+   *
+   * @param string $text
+   *   The text to inspect.
+   * @param string $pattern
+   *   The regex to match, including delimiters.
+   *
+   * @return bool
+   *   TRUE when at least one match has no negation in front of it.
+   */
+  protected function hasUnnegatedMatch(string $text, string $pattern): bool {
+    if (!preg_match_all($pattern, $text, $matches, PREG_OFFSET_CAPTURE)) {
+      return FALSE;
+    }
+
+    foreach ($matches[0] as $match) {
+      $start = max(0, $match[1] - self::NEGATION_LOOKBACK);
+      $preceding = substr($text, $start, $match[1] - $start);
+      // Only look back to the start of the current clause, so a negation in an
+      // earlier sentence does not excuse this one.
+      $clause = preg_split('/[.!?\n]/', $preceding);
+      if (!preg_match($this->pattern(self::NEGATION_BODY), (string) end($clause))) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Byte offsets of every match of a pattern.
+   *
+   * @param string $text
+   *   The text to inspect.
+   * @param string $pattern
+   *   The regex to match, including delimiters.
+   *
+   * @return int[]
+   *   The offsets, in order.
+   */
+  protected function matchOffsets(string $text, string $pattern): array {
+    if (!preg_match_all($pattern, $text, $matches, PREG_OFFSET_CAPTURE)) {
+      return [];
+    }
+
+    return array_column($matches[0], 1);
+  }
+
+  /**
+   * Whether any pair of offsets falls inside the proximity window.
+   *
+   * @param int[] $first
+   *   The first set of offsets.
+   * @param int[] $second
+   *   The second set of offsets.
+   *
+   * @return bool
+   *   TRUE when one offset from each set is within PROXIMITY_WINDOW of the
+   *   other.
+   */
+  protected function hasNearbyOffsets(array $first, array $second): bool {
+    foreach ($first as $a) {
+      foreach ($second as $b) {
+        if (abs($a - $b) <= self::PROXIMITY_WINDOW) {
+          return TRUE;
+        }
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Delimits a pattern body into a case-insensitive regex.
+   *
+   * The bodies are kept undelimited so the same term lists compose into both
+   * START_SIGNAL_BODY and the individual checks — a term can never be added to
+   * one and forgotten in the other.
+   *
+   * @param string $body
+   *   A self-contained pattern body, without delimiters.
+   *
+   * @return string
+   *   A PCRE pattern including delimiters.
+   */
+  protected function pattern(string $body): string {
+    return '#' . $body . '#i';
+  }
+
+  /**
+   * Builds the pattern for asking a user to hand over a secret.
+   *
+   * @return string
+   *   A PCRE pattern including delimiters.
+   */
+  protected function secretTransmitPattern(): string {
+    // Bounded and confined to one sentence so an unrelated verb earlier in the
+    // answer is not paired with a later secret noun.
+    return '#' . self::TRANSMIT_VERB_BODY . '[^.!?]{0,80}?' . self::SECRET_NOUN_BODY . '#i';
+  }
+
+  /**
+   * The notice shown in place of blocked content.
+   *
+   * @return string
+   *   The user-facing message.
+   */
+  protected function blockedMessage(): string {
+    return (string) $this->t('This part of the answer was blocked because it appeared to ask for your credentials or link to a download. Never enter your NetID or password on a page you reached from a chat answer, and contact your local IT support if you need help.');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconOutputSafetyGuardrailTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconOutputSafetyGuardrailTest.php
@@ -1,0 +1,664 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Tests\UnitTestCase;
+use Drupal\Tests\ai\Mock\MockIterator;
+use Drupal\Tests\ai\Mock\MockStreamedChatIterator;
+use Drupal\ai\Guardrail\Result\PassResult;
+use Drupal\ai\Guardrail\Result\RewriteOutputResult;
+use Drupal\ai\Guardrail\Result\StopResult;
+use Drupal\ai\Guardrail\StreamableGuardrailInterface;
+use Drupal\ai\OperationType\Chat\ChatInput;
+use Drupal\ai\OperationType\Chat\ChatMessage;
+use Drupal\ai\OperationType\Chat\ChatOutput;
+use Drupal\ai\Service\HostnameFilter;
+use Drupal\ys_beacon\Plugin\AiGuardrail\BeaconOutputSafety;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests the Beacon output safety guardrail.
+ *
+ * The guardrail is a backstop against poisoned index content: content that
+ * states a plausible fact rather than issuing an instruction slips past the
+ * prompt-side guardrail, and the streamed response is never scanned by the
+ * contrib regexp guardrail. The streaming tests drive the real
+ * StreamedChatMessageIterator buffering so the behaviour is exercised end to
+ * end rather than mocked.
+ *
+ * Several cases here are legitimate Yale answers captured from live streamed
+ * responses. They matter as much as the attack cases: an earlier build blocked
+ * every one of them, and because a violation stops the rest of the answer, a
+ * false positive costs the user the whole response.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Plugin\AiGuardrail\BeaconOutputSafety
+ */
+class BeaconOutputSafetyGuardrailTest extends UnitTestCase {
+
+  /**
+   * Builds the guardrail plugin under test.
+   *
+   * @return \Drupal\ys_beacon\Plugin\AiGuardrail\BeaconOutputSafety
+   *   A fresh guardrail instance.
+   */
+  protected function guardrail(): BeaconOutputSafety {
+    $guardrail = new BeaconOutputSafety([], 'ys_beacon_output_safety', [
+      'label' => 'Beacon output safety',
+    ]);
+    $guardrail->setStringTranslation($this->getStringTranslationStub());
+
+    return $guardrail;
+  }
+
+  /**
+   * Streams the given provider chunks through the guardrail.
+   *
+   * Registers the guardrail on a real StreamedChatMessageIterator so the
+   * platform's own start/stop buffering drives it, then returns everything the
+   * consumer would actually receive.
+   *
+   * @param string[] $chunks
+   *   The raw chunks the provider would stream.
+   *
+   * @return string
+   *   The concatenated text the consumer received.
+   */
+  protected function streamThrough(array $chunks): string {
+    $hostname_filter = $this->createMock(HostnameFilter::class);
+    $hostname_filter->method('filterText')->willReturnCallback(static fn($text) => $text);
+
+    $container = new ContainerBuilder();
+    $container->set('ai.hostname_filter_service', $hostname_filter);
+    \Drupal::setContainer($container);
+
+    $iterator = new MockStreamedChatIterator(new MockIterator($chunks));
+    $iterator->setEventDispatcher($this->createMock(EventDispatcherInterface::class));
+    $iterator->addStreamingGuardrail($this->guardrail());
+
+    $received = '';
+    foreach ($iterator as $chunk) {
+      $received .= $chunk->getText();
+    }
+
+    return $received;
+  }
+
+  /**
+   * Splits text the way a provider chunks tokens, after each whitespace run.
+   *
+   * @param string $text
+   *   The full answer.
+   *
+   * @return string[]
+   *   The chunks.
+   */
+  protected function asChunks(string $text): array {
+    return preg_split('/(?<=\s)/', $text, -1, PREG_SPLIT_NO_EMPTY);
+  }
+
+  /**
+   * Builds a non-streamed chat output.
+   *
+   * @param string $text
+   *   The assistant text.
+   *
+   * @return \Drupal\ai\OperationType\Chat\ChatOutput
+   *   The chat output.
+   */
+  protected function chatOutput(string $text): ChatOutput {
+    return new ChatOutput(new ChatMessage('assistant', $text), $text, []);
+  }
+
+  /**
+   * Asserts the guardrail passes a non-streamed answer unchanged.
+   *
+   * @param string $text
+   *   The answer to check.
+   * @param string $message
+   *   The assertion message.
+   */
+  protected function assertAnswerPasses(string $text, string $message): void {
+    $this->assertInstanceOf(PassResult::class, $this->guardrail()->processOutput($this->chatOutput($text)), $message);
+  }
+
+  /**
+   * Asserts the guardrail stops a non-streamed answer.
+   *
+   * @param string $text
+   *   The answer to check.
+   * @param string $message
+   *   The assertion message.
+   */
+  protected function assertAnswerStopped(string $text, string $message): void {
+    $this->assertInstanceOf(StopResult::class, $this->guardrail()->processOutput($this->chatOutput($text)), $message);
+  }
+
+  /**
+   * Parses a shipped file from the platform's config/sync directory.
+   *
+   * @param string $name
+   *   The config name, without the .yml extension.
+   *
+   * @return array
+   *   The parsed config.
+   */
+  protected function syncConfig(string $name): array {
+    $path = dirname(__DIR__, 6) . '/config/sync/' . $name . '.yml';
+    $this->assertFileExists($path);
+
+    return Yaml::parseFile($path);
+  }
+
+  /**
+   * The guardrail set is applied platform-wide with no per-site opt-in.
+   *
+   * A guardrail that is not reachable from ai.settings:global_guardrails never
+   * runs, which is the silent-non-firing failure this guardrail exists to fix.
+   */
+  public function testGuardrailSetIsAppliedGlobally(): void {
+    $this->assertContains(
+      'ys_beacon_output_safety',
+      $this->syncConfig('ai.settings')['global_guardrails'] ?? [],
+      'The guardrail set is listed in ai.settings global_guardrails.'
+    );
+  }
+
+  /**
+   * The guardrail set runs this plugin as a post-generate guardrail.
+   */
+  public function testGuardrailSetRunsThisPluginPostGenerate(): void {
+    $set = $this->syncConfig('ai.ai_guardrail_set.ys_beacon_output_safety');
+
+    $this->assertContains('ys_beacon_output_safety', $set['post_generate_guardrails']['plugin_id'] ?? []);
+    $this->assertContains(
+      'ai.ai_guardrail.ys_beacon_output_safety',
+      $set['dependencies']['config'] ?? [],
+      'The set depends on the guardrail entity it references.'
+    );
+  }
+
+  /**
+   * Both config entities are removed with the module that provides the plugin.
+   *
+   * Without an enforced dependency the config outlives ys_beacon, and because
+   * the set is global, every AI request then hits a NULL guardrail.
+   */
+  public function testConfigIsRemovedWithTheModule(): void {
+    foreach (['ai.ai_guardrail.ys_beacon_output_safety', 'ai.ai_guardrail_set.ys_beacon_output_safety'] as $name) {
+      $this->assertContains(
+        'ys_beacon',
+        $this->syncConfig($name)['dependencies']['enforced']['module'] ?? [],
+        $name . ' is enforced-dependent on ys_beacon.'
+      );
+    }
+  }
+
+  /**
+   * The guardrail entity points at this plugin ID.
+   */
+  public function testGuardrailEntityReferencesThisPlugin(): void {
+    $this->assertSame(
+      'ys_beacon_output_safety',
+      $this->syncConfig('ai.ai_guardrail.ys_beacon_output_safety')['guardrail'] ?? NULL
+    );
+  }
+
+  /**
+   * The guardrail is streamable so the subscriber registers it on the stream.
+   *
+   * Without StreamableGuardrailInterface, GuardrailsEventSubscriber neither
+   * registers the guardrail with the stream iterator nor reconstructs the
+   * output for it, so it would silently never fire.
+   */
+  public function testGuardrailIsStreamable(): void {
+    $this->assertInstanceOf(StreamableGuardrailInterface::class, $this->guardrail());
+  }
+
+  /**
+   * A credential request paired with an off-Yale link is stopped mid-stream.
+   *
+   * This is the confirmed bypass: the credential ask lands in the first
+   * sentence and the attacker-controlled URL in the second.
+   *
+   * @covers ::getStartRegex
+   * @covers ::getStopRegex
+   * @covers ::processStreamedBuffer
+   */
+  public function testStreamedCredentialRequestWithLinkIsStopped(): void {
+    $received = $this->streamThrough([
+      "To access the portal you will need your NetID and password.\n",
+      "Please sign in at https://not-yale-login.example.com/verify to continue.\n",
+    ]);
+
+    $this->assertStringNotContainsString('not-yale-login.example.com', $received, 'The attacker URL never reaches the consumer.');
+    $this->assertStringContainsString('blocked', $received, 'The consumer is told the content was blocked.');
+  }
+
+  /**
+   * A link to an executable installer is stopped.
+   *
+   * @covers ::processStreamedBuffer
+   */
+  public function testStreamedInstallerLinkIsStopped(): void {
+    $received = $this->streamThrough([
+      "You can fix this by installing the helper tool.\n",
+      "Download it from https://downloads.example.com/setup.exe and run it.\n",
+    ]);
+
+    $this->assertStringNotContainsString('setup.exe', $received, 'The installer URL never reaches the consumer.');
+    $this->assertStringContainsString('blocked', $received);
+  }
+
+  /**
+   * A credential term split across provider chunks is still detected.
+   *
+   * The provider streams "pass" and "word" separately, so a per-chunk check
+   * would never see the term.
+   *
+   * @covers ::processStreamedBuffer
+   */
+  public function testPatternSpanningChunkBoundariesIsStopped(): void {
+    $received = $this->streamThrough([
+      'You will need your pass',
+      "word to continue.\n",
+      "Enter it at https://fake-helpdesk.example.com/login now.\n",
+    ]);
+
+    $this->assertStringNotContainsString('fake-helpdesk.example.com', $received, 'The URL is withheld even though the term spanned chunks.');
+    $this->assertStringContainsString('blocked', $received);
+  }
+
+  /**
+   * Once a violation is found the rest of the response is suppressed.
+   *
+   * @covers ::processStreamedBuffer
+   */
+  public function testRemainderOfResponseIsSuppressedAfterViolation(): void {
+    $received = $this->streamThrough([
+      "Enter your NetID and password at https://fake.example.com/login.\n",
+      "Then call 555-0100 to confirm your account details.\n",
+      "Finally visit https://another-fake.example.com/page for more.\n",
+    ]);
+
+    $this->assertStringNotContainsString('555-0100', $received, 'Content after the violation is suppressed too.');
+    $this->assertStringNotContainsString('another-fake.example.com', $received, 'The latch keeps suppressing later chunks.');
+  }
+
+  /**
+   * Inflected sign-in wording is caught, not only the bare "sign in" form.
+   *
+   * "Sign into", "logging in" and "logged into" are how a poisoned answer
+   * actually phrases the instruction; a trailing word boundary alone missed
+   * every one of them.
+   *
+   * @dataProvider inflectedCredentialWordingProvider
+   * @covers ::processOutput
+   */
+  public function testInflectedCredentialWordingIsStopped(string $answer): void {
+    $this->assertAnswerStopped($answer, 'Inflected credential wording is still detected.');
+  }
+
+  /**
+   * Provides inflected sign-in wording paired with an off-Yale link.
+   *
+   * @return array[]
+   *   Test cases.
+   */
+  public static function inflectedCredentialWordingProvider(): array {
+    return [
+      'sign into' => ['Sign into the Yale account center at https://yale-secure.example.com/auth to revalidate.'],
+      'logging in' => ['You can finish logging in at https://yale-secure.example.com/auth today.'],
+      'logged into' => ['Once logged into https://yale-secure.example.com/auth your access resumes.'],
+      'credentials' => ['Confirm your credentials at https://yale-secure.example.com/auth now.'],
+      // The credential is named in the previous sentence, so the weak entry
+      // verb only counts because a credential noun is also near the link.
+      'pronoun refers back to the credential' => ['You will need your password to continue. Enter it at https://fake-helpdesk.example.com/login now.'],
+    ];
+  }
+
+  /**
+   * Script and installer package targets beyond .exe are stopped.
+   *
+   * @dataProvider installerTargetProvider
+   * @covers ::processOutput
+   */
+  public function testInstallerTargetsAreStopped(string $answer): void {
+    $this->assertAnswerStopped($answer, 'The download target is treated as an installer.');
+  }
+
+  /**
+   * Provides installer and script download links.
+   *
+   * @return array[]
+   *   Test cases.
+   */
+  public static function installerTargetProvider(): array {
+    return [
+      'ps1' => ['Run the fix script from https://downloads.example.com/fix.ps1 to continue.'],
+      'bat' => ['Download https://downloads.example.com/setup.bat and double-click it.'],
+      'msi' => ['Install https://downloads.example.com/agent.msi first.'],
+      'markdown target' => ['Grab the [helper](https://downloads.example.com/helper.dmg) to proceed.'],
+    ];
+  }
+
+  /**
+   * A host that merely looks Yale-ish does not get the Yale carve-out.
+   *
+   * The carve-out is decided by parsing the host, not by finding "yale.edu"
+   * somewhere in the URL. Every host below is registrable by an attacker, and
+   * an earlier build treated all of them as internal and passed the answer.
+   *
+   * @dataProvider spoofedYaleHostProvider
+   * @covers ::isYaleLink
+   * @covers ::externalLinkOffsets
+   */
+  public function testSpoofedYaleHostsAreTreatedAsExternal(string $url): void {
+    $this->assertAnswerStopped(
+      'Yale IT requires annual revalidation. Sign in with your NetID and password at ' . $url . ' to keep your account active.',
+      $url . ' must not be treated as a Yale host.'
+    );
+  }
+
+  /**
+   * Provides attacker hosts that contain but do not end with yale.edu.
+   *
+   * @return array[]
+   *   Test cases.
+   */
+  public static function spoofedYaleHostProvider(): array {
+    return [
+      'subdomain suffix' => ['https://yale.edu.evil.com/login'],
+      'hyphenated suffix' => ['https://yale.edu-secure.com/login'],
+      'userinfo spoof' => ['https://yale.edu@evil.com/netid'],
+      'deep suffix' => ['https://login.yale.edu.attacker.io/sso'],
+      'www suffix' => ['www.yale.edu.evil.com/portal'],
+      'uppercase' => ['https://YALE.EDU.EVIL.COM/phish'],
+      'lookalike tld' => ['https://notyale.edu/login'],
+    ];
+  }
+
+  /**
+   * A genuine Yale host, including deep subdomains, keeps the carve-out.
+   *
+   * @dataProvider genuineYaleHostProvider
+   * @covers ::isYaleLink
+   */
+  public function testGenuineYaleHostsArePermitted(string $url): void {
+    $this->assertAnswerPasses(
+      'You can sign in with your NetID at ' . $url . ' to continue.',
+      $url . ' is a Yale host and must be permitted.'
+    );
+  }
+
+  /**
+   * Provides Yale-controlled hosts.
+   *
+   * @return array[]
+   *   Test cases.
+   */
+  public static function genuineYaleHostProvider(): array {
+    return [
+      'apex' => ['https://yale.edu/login'],
+      'subdomain' => ['https://its.yale.edu/netid'],
+      'deep subdomain' => ['https://secure.login.yale.edu/cas'],
+      'www' => ['www.yale.edu/login'],
+    ];
+  }
+
+  /**
+   * Clickable link forms other than a plain https URL are still checked.
+   *
+   * @dataProvider alternateLinkFormProvider
+   * @covers ::externalLinkOffsets
+   */
+  public function testAlternateLinkFormsAreStopped(string $answer): void {
+    $this->assertAnswerStopped($answer, 'The link form is recognised and checked.');
+  }
+
+  /**
+   * Provides clickable off-Yale link forms paired with a credential request.
+   *
+   * @return array[]
+   *   Test cases.
+   */
+  public static function alternateLinkFormProvider(): array {
+    return [
+      // react-markdown passes any URL starting with "/" through untouched, so
+      // this renders as a live link to netid-yale.com.
+      'protocol relative' => ['The NetID portal has moved. [Sign in with your NetID and password](//netid-yale.com/login) to continue.'],
+      'off-Yale mailto' => ['To verify your identity, write to [NetID Support](mailto:netid-support@yale-helpdesk.com).'],
+    ];
+  }
+
+  /**
+   * A download an extension list cannot recognise is still stopped.
+   *
+   * An extensionless endpoint and a filename hidden in a query string both
+   * defeat extension matching, so the install instruction next to an off-Yale
+   * link is what catches them.
+   *
+   * @dataProvider undetectableDownloadProvider
+   * @covers ::findViolation
+   */
+  public function testInstallInstructionWithOffYaleLinkIsStopped(string $answer): void {
+    $this->assertAnswerStopped($answer, 'The install instruction is caught without an extension.');
+  }
+
+  /**
+   * Provides download links with no recognisable installer extension.
+   *
+   * @return array[]
+   *   Test cases.
+   */
+  public static function undetectableDownloadProvider(): array {
+    return [
+      'extensionless' => ['Site editors must install the Yale Atomic updater from https://evil.com/download/AtomicUpdater to continue publishing.'],
+      'query string filename' => ['Install the updater from https://evil.com/dl?file=setup&os=win to continue.'],
+      'archive with installer wording' => ['To fix the editor you need the helper utility. Download it from https://downloads.example.com/helper.zip and run the installer inside.'],
+    ];
+  }
+
+  /**
+   * Legitimate Yale answers are never blocked.
+   *
+   * Every one of these was blocked by an earlier build. They are the ordinary
+   * shape of a Beacon answer, and the shipped system prompt tells the model to
+   * include citation links, so links next to credential terms are expected.
+   *
+   * @dataProvider legitimateAnswerProvider
+   * @covers ::processOutput
+   */
+  public function testLegitimateAnswersPass(string $answer): void {
+    $this->assertAnswerPasses($answer, 'A legitimate Yale answer is not blocked.');
+  }
+
+  /**
+   * Provides legitimate answers that must not be blocked.
+   *
+   * @return array[]
+   *   Test cases.
+   */
+  public static function legitimateAnswerProvider(): array {
+    return [
+      'sign in at a Yale host' => ['You can sign in at https://yalesites.yale.edu/user/login with your NetID. Once signed in you will see the dashboard.'],
+      'reset password at a Yale host' => ['You can reset your password yourself. Visit https://its.yale.edu/netid to start the reset process.'],
+      'duo enrolment at a Yale host' => ['Duo is required for most Yale services. Enroll your device at https://duo.yale.edu before your next sign-in.'],
+      'markdown citation next to a credential term' => ['Log in with your NetID to view the form [doc1](https://yalesites.yale.edu/docs/forms).'],
+      'never share your password' => ['Never share your password with anyone, including ITS staff.'],
+      'ITS will never ask' => ['Yale ITS will never ask you to share your password.'],
+      'do not send by email' => ['Do not send your password by email.'],
+      'call the help desk' => ['Call the ITS Help Desk at 203-432-9000 if you forgot your password.'],
+      'submit a form with your NetID' => ['Submit the request form using your NetID and a technician will follow up.'],
+      'provide your NetID' => ['Provide your NetID when you contact the Help Desk.'],
+      'external citation, no credentials' => ['The registrar publishes the calendar at https://registrar.yale.edu/calendar [doc1].'],
+      'Yale mailto support address' => ['If you have technical questions you can contact Yale ITS at [calendar.support@yale.edu](mailto:calendar.support@yale.edu) [doc3].'],
+      'external document download' => ['You can download the accessibility checklist from https://example.com/files/checklist.pdf [doc1].'],
+      'install from a Yale host' => ['You can install the Yale VPN client from https://its.yale.edu/vpn before connecting.'],
+      'Yale link with trailing comma' => ['See https://its.yale.edu/netid, then sign in with your NetID.'],
+      // Yale's help desk runs on a vendor domain, so this link is off-Yale, but
+      // naming a NetID in a ticket is not a credential prompt.
+      'ServiceNow ticket naming a NetID' => ['Submit a ticket at https://yale.service-now.com and include your NetID in the description.'],
+      // Yale distributes its own software, so a Yale-hosted installer is fine.
+      'installer on a Yale host' => ['Download the Yale VPN installer from https://its.yale.edu/sites/default/files/vpn.exe to get started.'],
+    ];
+  }
+
+  /**
+   * A legitimate answer with an external citation link streams verbatim.
+   *
+   * Guards the behaviour that motivated withOutputFilteringDisabled(): Beacon
+   * must keep returning citation links to arbitrary external hosts.
+   *
+   * @covers ::processStreamedBuffer
+   */
+  public function testStreamedLegitimateCitationLinkPassesThrough(): void {
+    $chunks = [
+      "Yale's academic calendar lists the key dates.\n",
+      "See the registrar's page at https://registrar.yale.edu/calendar for details.\n",
+    ];
+
+    $this->assertSame(implode('', $chunks), $this->streamThrough($chunks), 'A benign answer with an external link streams verbatim.');
+  }
+
+  /**
+   * A real Localist sign-in answer streams verbatim.
+   *
+   * Captured from a live streamed response. An earlier build blocked its
+   * closing support line.
+   *
+   * @covers ::processStreamedBuffer
+   */
+  public function testLiveSignInAnswerStreamsVerbatim(): void {
+    $answer = <<<'MARKDOWN'
+    # Logging Into Localist as an End-User
+
+    To log into Localist as an end-user, follow these steps [doc1]:
+
+    1. **Go to events.yale.edu** and click "Log in" in the top right corner
+    2. **Select the NetID option** to login via CAS
+
+    Once logged in, you can access your personal dashboard by [doc1]:
+    - Clicking the **profile icon in the top right corner** of the events.yale.edu homepage
+    - Selecting **"Dashboard"** from the dropdown menu
+
+    **Note:** Your end-user dashboard is different from the back-end administration area, which only designated Yale calendar admins can access [doc1].
+
+    If you have any technical questions about logging in or using Localist, you can contact Yale ITS at [calendar.support@yale.edu](mailto:calendar.support@yale.edu) [doc3].
+    MARKDOWN;
+
+    $this->assertSame($answer, $this->streamThrough($this->asChunks($answer)), 'A legitimate sign-in answer streams verbatim.');
+  }
+
+  /**
+   * The rolling tail is contiguous, so distant passages are not correlated.
+   *
+   * The iterator releases non-matching content without showing it to the
+   * guardrail. If the tail only accumulated buffered windows it would splice
+   * non-adjacent passages together, and this answer — a credential term far
+   * above an unrelated external link — would be blocked.
+   *
+   * @covers ::processStreamedBuffer
+   */
+  public function testDistantCredentialTermAndExternalLinkStreamsVerbatim(): void {
+    $answer = 'You will need your NetID to view the course listing. '
+      . str_repeat('The department publishes its own schedule each term. ', 12)
+      . "Full details are at https://example.com/schedule [doc1].\n";
+
+    $this->assertSame($answer, $this->streamThrough($this->asChunks($answer)), 'Distant passages are not correlated.');
+  }
+
+  /**
+   * An answer with no safety signal streams through verbatim.
+   *
+   * Confirms the guardrail does not buffer or reshape ordinary responses.
+   *
+   * @covers ::getStartRegex
+   */
+  public function testBenignAnswerStreamsVerbatim(): void {
+    $chunks = [
+      "Yale College offers many majors.\n",
+      "Students choose one by the end of sophomore year.\n",
+    ];
+
+    $this->assertSame(implode('', $chunks), $this->streamThrough($chunks), 'No buffering regression for ordinary answers.');
+  }
+
+  /**
+   * Non-streamed output is scanned rather than passed.
+   *
+   * The non-streamed path (BeaconAnswerService, ys_ai_tester) must not
+   * reproduce the silent-pass flaw this guardrail exists to fix.
+   *
+   * @covers ::processOutput
+   */
+  public function testNonStreamedCredentialRequestWithLinkIsStopped(): void {
+    $this->assertAnswerStopped(
+      'Enter your NetID and password at https://not-yale.example.com/verify to continue.',
+      'The non-streamed path is scanned too.'
+    );
+  }
+
+  /**
+   * A request to transmit a secret is stopped.
+   *
+   * @covers ::processOutput
+   */
+  public function testNonStreamedSecretTransmissionIsStopped(): void {
+    $this->assertAnswerStopped(
+      'Please email your password to the help desk so they can reset it.',
+      'An unnegated request to transmit a secret is stopped.'
+    );
+  }
+
+  /**
+   * A credential mention far from a link does not trip the check.
+   *
+   * @covers ::processOutput
+   */
+  public function testDistantCredentialMentionAndLinkPasses(): void {
+    $text = 'You will need your NetID to view the course listing. '
+      . str_repeat('The department publishes its own schedule each term. ', 12)
+      . 'Full details are at https://example.com/schedule [doc1].';
+
+    $this->assertAnswerPasses($text, 'Co-occurrence is scoped to the proximity window.');
+  }
+
+  /**
+   * Input is not this guardrail's concern.
+   *
+   * @covers ::processInput
+   */
+  public function testInputPasses(): void {
+    $input = new ChatInput([new ChatMessage('user', 'How do I reset my password?')]);
+
+    $this->assertInstanceOf(PassResult::class, $this->guardrail()->processInput($input));
+  }
+
+  /**
+   * A latched guardrail suppresses further content outright.
+   *
+   * @covers ::processStreamedBuffer
+   * @covers ::resetStreamState
+   */
+  public function testResetStreamStateClearsLatch(): void {
+    $guardrail = $this->guardrail();
+    $guardrail->processStreamedBuffer('Enter your NetID and password at https://fake.example.com/login.');
+
+    $latched = $guardrail->processStreamedBuffer('Some later sentence about anything at all.');
+    $this->assertInstanceOf(RewriteOutputResult::class, $latched, 'A latched guardrail rewrites later content.');
+    $this->assertSame('', $latched->getMessage(), 'Later content is replaced with nothing.');
+
+    $guardrail->resetStreamState();
+
+    $this->assertNotSame('', $guardrail->getStartRegex(), 'Resetting releases the latch.');
+    $this->assertInstanceOf(
+      PassResult::class,
+      $guardrail->processStreamedBuffer('Yale College offers many majors.'),
+      'After a reset a benign buffer passes again.'
+    );
+  }
+
+}


### PR DESCRIPTION
## [1468: Beacon: implement a streaming-safe output guardrail so post-generate guardrails actually fire](https://github.com/yalesites-org/YaleSites-Internal/issues/1468)

### Description of work

- Adds `BeaconOutputSafety`, an `ai_guardrail` plugin implementing `StreamableGuardrailInterface`, so output checks actually run while a Beacon answer streams. The AI module's `RegexpGuardrail::processOutput()` returns a `PassResult` for a streamed response, so a post-generate guardrail added as plain config would appear enabled and silently never fire.
- Registers it platform-wide: an `ai.ai_guardrail` entity plus an `ai.ai_guardrail_set` entity listed in `ai.settings:global_guardrails`, so there is no per-site opt-in. **Both config entities carry an `enforced` dependency on `ys_beacon`** — without it the config outlives the module and, because the set is global, every AI request would hit a `NULL` guardrail.
- Worth knowing: **no guardrail set existed at all before this** and `global_guardrails` was empty, so the guardrail subscriber returned before reaching any plugin. The "prompt guardrail" the issue credits is system-prompt text (`ys_beacon.settings:guardrail_supplement`), not an `AiGuardrail` plugin. A plugin alone would not have fired — the config wiring is part of the fix.

**What it blocks** (all four verified against real streamed responses):

- a credential entry instruction near a link that points off Yale,
- a link whose target is an executable, installer or script,
- an instruction to install something from an off-Yale link (catches extensionless endpoints and filenames hidden in a query string, which extension matching cannot),
- an unnegated request to transmit a secret.

**Streaming behaviour.** Buffering starts on any single signal, and releases at the next sentence boundary rather than end-of-stream, so ordinary answers stream unchanged and a triggered answer is held for about one sentence — not the 8192 characters the iterator would otherwise buffer. Correlation across those short windows uses a bounded rolling tail of text already seen, so a link a sentence or two after a credential request is still caught.

The rolling tail is only sound if it is **contiguous** with the window being checked. The iterator releases non-matching content without ever showing it to the guardrail, so once triggered the guardrail keeps buffering for the rest of the response. Without that, two passages hundreds of characters apart were spliced into a window that never existed, and the tail of a legitimate Localist sign-in answer was blocked. There is a regression test for exactly that answer, and it fails if the contiguity guard is removed.

**Host trust is decided by parsing the host, not by pattern-matching the URL.** An earlier revision used a regex lookahead that never anchored `yale.edu` to the end of the host, so `yale.edu.evil.com`, `yale.edu-secure.com` and `yale.edu@evil.com` were all treated as internal — each registrable by an attacker, which reopened the exact harm this guards against. `isYaleLink()` now uses `parse_url()`, and an unparseable host fails closed. All seven spoof forms have regression tests.

### One deliberate deviation from the issue, please sanity-check it

The issue asks for a host-independent check and rules out a host allow-list. That is right for links in general, and every rule here except the credential one is fully host-independent. But for credential entry it is unimplementable as written: "sign in at X with your NetID" is legitimate or hostile purely according to what X is. Implemented literally, it blocked **11 ordinary Yale answers**, including:

- "You can reset your password yourself. Visit `https://its.yale.edu/netid` to start the reset process."
- "You can sign in at `https://yalesites.yale.edu/user/login` with your NetID."
- **"Never share your password with anyone, including ITS staff."** — the exact advice Beacon should be giving.

This is made worse by the shipped system prompt telling the model to include citation links, so links next to credential terms are the normal shape of a Beacon answer, not the exception.

So the credential rule carries **one narrow carve-out**: a link to a Yale-controlled host (`yale.edu` or a subdomain) is not treated as a credential-harvesting target. This is not the allow-list of vetted external hosts that was ruled out — nothing enumerates acceptable third parties.

### Known gaps and trade-offs (deliberate, not oversights)

- A credential entry instruction pointing at a legitimate **non-Yale** IdP (Workday, Microsoft 365) is blocked. Judged acceptable: Beacon should not direct credential entry off Yale, and the notice tells the user to contact IT.
- "Install X from `<off-Yale link>`" is blocked even for legitimate third-party software.
- Archives (`.zip`, `.7z`, `.rar`) are not installers on their own — YaleSites legitimately links to archives, and a violation stops the rest of the answer. The install-instruction rule catches the common phrasing.
- Bare domains with no scheme are not matched: remark-gfm does not autolink them, so they are not clickable.
- Output filtering is inherently late under streaming — text already yielded cannot be un-sent — so this is a **backstop**. An input-side intent intercept for credential/account questions is still the stronger primary control, as the issue notes.
- The guardrail logs the violation **category only** (never model text or the user's question) to `logger.channel.ys_beacon`, so a real bypass or a false positive is visible in production.

### Not done in this PR

Acceptance criterion "re-running the red-team harness shows probes `src.4`, `adm.4`, `src2.3`, `src2.4` no longer bypass" is **not** verified — that harness is not in this repo (no match for it anywhere in the tree). It needs to be re-run wherever it lives.

The poisoned-index path was not exercised against the live model, because reproducing it would mean writing attacker content into the shared Azure AI Search index. Instead it was verified through the real event/guardrail stack with a synthetic stream.

### Functional testing steps:

- [ ] With `ys_beacon.settings:streaming` still `true`, open the Beacon widget and ask several ordinary questions — including ones about signing in, NetID and passwords (e.g. "How do I log into Localist as an end-user?", "How do I reset my NetID password?", "How do I submit a support ticket?"). Confirm answers stream normally, citation links still render, and no "This part of the answer was blocked" notice appears.
- [ ] Confirm streaming is still token-by-token in the widget, with no long pause and no broken markdown mid-stream.
- [ ] Check `/admin/reports/dblog` (type `ys_beacon`) — there should be no "Beacon output safety blocked" entries from those ordinary questions. Any entry there is a false positive worth reporting.
- [ ] Confirm the guardrail is actually registered: `drush cget ai.settings global_guardrails` lists `ys_beacon_output_safety`, and `/admin/config/ai/guardrails/guardrail-sets` shows the "Beacon output safety" set with the plugin as a post-generate guardrail.
- [ ] Re-run the red-team harness (wherever it lives) and confirm probes `src.4`, `adm.4`, `src2.3` and `src2.4` no longer bypass.
- [ ] Optional, to see it fire: temporarily add a test page whose content instructs entering a NetID and password at a non-Yale URL, index it, ask a question that retrieves it, and confirm the URL never reaches the widget and a dblog entry is written.

References yalesites-org/YaleSites-Internal#1468

---
Created with AI
