### PR TITLE
1470: AI Tester: run the same questions against legacy ai_engine and compare against Beacon

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -158,6 +158,7 @@ module:
   ys_ai: 0
   ys_ai_system_instructions: 0
   ys_ai_tester: 0
+  ys_ai_tester_legacy: 0
   ys_alert: 0
   ys_beacon: 0
   ys_beacon_portkey: 0

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/css/compare.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/css/compare.css
@@ -13,6 +13,16 @@
   font-weight: 600;
 }
 
+/* Shown only when the two runs were answered by different assistants, so a
+   high "differs" count is not misread as a regression. */
+.ys-compare-caveat {
+  margin-block-end: 1rem;
+  padding: 0.75rem 1rem;
+  border-inline-start: 4px solid var(--gin-color-warning, #e5a611);
+  background: var(--gin-color-warning-light, #fdf3da);
+  color: var(--gin-color-text, #1b1b1d);
+}
+
 .ys-compare-meta {
   display: flex;
   flex-wrap: wrap;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/AiTesterBatch.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/AiTesterBatch.php
@@ -13,7 +13,10 @@ namespace Drupal\ys_ai_tester;
 class AiTesterBatch {
 
   /**
-   * Processes a single question through the Beacon assistant.
+   * Processes a single question through one assistant.
+   *
+   * A failure here is contained to its own question: the error is logged and
+   * recorded against the row so the rest of the batch still runs.
    *
    * @param int $run_id
    *   The run ID to write the result into.
@@ -21,29 +24,46 @@ class AiTesterBatch {
    *   The question text.
    * @param int $delta
    *   Position of this question within the run (0-based).
+   * @param string $backend_id
+   *   The id of the assistant answering this run.
    * @param array $context
    *   Batch context array (passed by reference by Drupal).
    */
-  public static function processQuestion(int $run_id, string $question, int $delta, array &$context): void {
+  public static function processQuestion(int $run_id, string $question, int $delta, string $backend_id, array &$context): void {
     $answer = '';
     // Citations are derived per question from this one answer, so there is no
     // cross-question leak: nothing carries over between batch operations.
     $citations = [];
+    $error = '';
 
     try {
-      $result = \Drupal::service('ys_beacon.beacon_answer')->answer($question);
+      $backend = \Drupal::service('ys_ai_tester.answer_backend_registry')
+        ->getAvailable($backend_id);
+      if ($backend === NULL) {
+        throw new \RuntimeException(sprintf('The "%s" assistant is not available on this site.', $backend_id));
+      }
+      $result = $backend->answer($question);
       $answer = $result['answer'];
-      // The formatter owns marker parsing, de-duplication, and the cited flag
-      // for the tester; the chat widget derives the same fields client-side.
+      // Normalizing here rather than in each backend is what makes the stored
+      // shape uniform: the formatter owns marker parsing, de-duplication, and
+      // the cited flag, so every assistant's rows carry a comparable cited
+      // count no matter who answered. The chat widget derives the same fields
+      // client-side.
       $citations = \Drupal::service('ys_beacon.citation_formatter')
         ->format($answer, $result['citations']);
     }
     catch (\Throwable $e) {
+      $error = $e->getMessage();
       \Drupal::logger('ys_ai_tester')->error(
-        'AI tester error on run @run question @delta: @msg',
-        ['@run' => $run_id, '@delta' => $delta, '@msg' => $e->getMessage()]
+        'AI tester error on run @run question @delta (@backend): @msg',
+        [
+          '@run' => $run_id,
+          '@delta' => $delta,
+          '@backend' => $backend_id,
+          '@msg' => $error,
+        ]
       );
-      $context['results']['errors'][] = "Question {$delta}: " . $e->getMessage();
+      $context['results']['errors'][] = "Question {$delta}: " . $error;
     }
 
     try {
@@ -54,6 +74,7 @@ class AiTesterBatch {
           'question' => $question,
           'answer' => $answer,
           'citations' => json_encode($citations),
+          'error' => $error,
         ])
         ->execute();
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/AnswerBackendInterface.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/AnswerBackendInterface.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_ai_tester;
+
+/**
+ * Answers a tester question with one assistant implementation.
+ *
+ * This is the seam that lets the tester run the same question list against more
+ * than one assistant. Implementations register themselves with the
+ * `ys_ai_tester.answer_backend` service tag, so a backend appears and
+ * disappears with the module that provides it, and no tester-core class needs
+ * to know a specific backend exists.
+ *
+ * An implementation returns the assistant's answer and its raw retrieved
+ * sources. Normalizing those into the tester's stored citation shape is the
+ * batch's job, not a backend's — so a backend cannot accidentally store a shape
+ * `RunComparator` would silently miscount.
+ */
+interface AnswerBackendInterface {
+
+  /**
+   * The backend a run is attributed to when none was recorded.
+   *
+   * Runs created before the tester supported more than one assistant were all
+   * answered by Beacon, so this is also the value the run table backfills to.
+   */
+  const DEFAULT_ID = 'beacon';
+
+  /**
+   * Returns the stable machine id stored on a run.
+   *
+   * @return string
+   *   The backend id, e.g. 'beacon'.
+   */
+  public function id(): string;
+
+  /**
+   * Returns the human-readable assistant name.
+   *
+   * @return string|\Stringable
+   *   The label, shown in the run history and the comparison view.
+   */
+  public function label(): string|\Stringable;
+
+  /**
+   * Returns whether this backend can answer a question right now.
+   *
+   * An unavailable backend is not offered for new runs, but stays resolvable so
+   * runs it already produced remain viewable and correctly labelled.
+   *
+   * @return bool
+   *   TRUE when the backend is configured and usable.
+   */
+  public function isAvailable(): bool;
+
+  /**
+   * Answers one question.
+   *
+   * @param string $question
+   *   The question text.
+   *
+   * @return array
+   *   An array with two keys: 'answer' (string) and 'citations' (the sources
+   *   the assistant retrieved, in the Azure "on your data" shape that
+   *   \Drupal\ys_beacon\Service\CitationFormatter consumes — the batch formats
+   *   them before storing).
+   *
+   * @throws \Throwable
+   *   When the assistant cannot be reached or fails to answer. The batch
+   *   records the failure against the question and continues.
+   */
+  public function answer(string $question): array;
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/AnswerBackendRegistry.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/AnswerBackendRegistry.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_ai_tester;
+
+/**
+ * Collects the assistants the tester can run a question list against.
+ *
+ * Backends arrive through the `ys_ai_tester.answer_backend` service tag, in tag
+ * priority order. Resolving for labelling and resolving for running are
+ * deliberately kept apart: labelFor() answers for any registered backend so a
+ * stored run keeps its assistant's name, while getAvailable() — the only way to
+ * reach a backend that will be asked a question — resolves nothing that cannot
+ * answer right now.
+ */
+class AnswerBackendRegistry {
+
+  /**
+   * The registered backends, keyed by backend id.
+   *
+   * @var \Drupal\ys_ai_tester\AnswerBackendInterface[]
+   */
+  protected array $backends = [];
+
+  /**
+   * Constructs the registry.
+   *
+   * @param iterable $backends
+   *   The tagged answer backends.
+   */
+  public function __construct(iterable $backends) {
+    foreach ($backends as $backend) {
+      $this->backends[$backend->id()] = $backend;
+    }
+  }
+
+  /**
+   * Returns a registered backend regardless of its availability.
+   *
+   * Not public: callers that intend to ask a question must go through
+   * getAvailable() so they cannot skip the availability check.
+   *
+   * @param string $id
+   *   The backend id.
+   *
+   * @return \Drupal\ys_ai_tester\AnswerBackendInterface|null
+   *   The backend, or NULL when nothing is registered under that id.
+   */
+  protected function get(string $id): ?AnswerBackendInterface {
+    return $this->backends[$id] ?? NULL;
+  }
+
+  /**
+   * Returns a backend only when it can answer a question now.
+   *
+   * @param string $id
+   *   The backend id.
+   *
+   * @return \Drupal\ys_ai_tester\AnswerBackendInterface|null
+   *   The backend, or NULL when it is unregistered or unavailable.
+   */
+  public function getAvailable(string $id): ?AnswerBackendInterface {
+    $backend = $this->get($id);
+    return ($backend !== NULL && $backend->isAvailable()) ? $backend : NULL;
+  }
+
+  /**
+   * Returns the available backends as form options.
+   *
+   * @return array
+   *   Labels keyed by backend id, in tag priority order.
+   */
+  public function availableOptions(): array {
+    $options = [];
+    foreach ($this->backends as $id => $backend) {
+      if ($backend->isAvailable()) {
+        $options[$id] = $backend->label();
+      }
+    }
+    return $options;
+  }
+
+  /**
+   * Returns the ids of the backends that can answer a question now.
+   *
+   * @return string[]
+   *   The available backend ids, in tag priority order.
+   */
+  public function availableIds(): array {
+    return array_keys($this->availableOptions());
+  }
+
+  /**
+   * Returns the display label for a stored backend id.
+   *
+   * Falls back to the raw id so a run whose backend module has since been
+   * uninstalled still reads as something rather than an empty cell.
+   *
+   * @param string $id
+   *   The backend id recorded on a run.
+   *
+   * @return string|\Stringable
+   *   The backend label, or the id itself when it is no longer registered.
+   */
+  public function labelFor(string $id): string|\Stringable {
+    return $this->get($id)?->label() ?? $id;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/Backend/BeaconAnswerBackend.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/Backend/BeaconAnswerBackend.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_ai_tester\Backend;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\ys_ai_tester\AnswerBackendInterface;
+use Drupal\ys_beacon\Service\BeaconAnswerService;
+
+/**
+ * Answers tester questions with the Beacon assistant.
+ *
+ * This is the tester's default and only built-in backend: it holds the path the
+ * batch used directly before backends existed.
+ */
+class BeaconAnswerBackend implements AnswerBackendInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * Constructs the Beacon answer backend.
+   *
+   * @param \Drupal\ys_beacon\Service\BeaconAnswerService $beaconAnswer
+   *   The Beacon answer service.
+   */
+  public function __construct(
+    protected BeaconAnswerService $beaconAnswer,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function id(): string {
+    return self::DEFAULT_ID;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function label(): string|\Stringable {
+    return $this->t('Beacon');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isAvailable(): bool {
+    // Beacon is the assistant the tester exists to test, so it is always
+    // offered. A misconfigured chat provider surfaces per question as a
+    // recorded error rather than by hiding the tester's whole reason to exist.
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function answer(string $question): array {
+    // BeaconAnswerService already returns the ['answer', 'citations'] contract
+    // this interface declares, so there is nothing to adapt.
+    return $this->beaconAnswer->answer($question);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/Controller/AiTesterController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/Controller/AiTesterController.php
@@ -12,6 +12,7 @@ use Drupal\Core\Database\Connection;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Url;
+use Drupal\ys_ai_tester\AnswerBackendRegistry;
 use Drupal\ys_ai_tester\RunComparator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -32,11 +33,14 @@ class AiTesterController extends ControllerBase {
    *   The date formatter.
    * @param \Drupal\ys_ai_tester\RunComparator $runComparator
    *   The run comparator.
+   * @param \Drupal\ys_ai_tester\AnswerBackendRegistry $backendRegistry
+   *   The answer backend registry, used to label a run's assistant.
    */
   public function __construct(
     protected Connection $database,
     protected DateFormatterInterface $dateFormatter,
     protected RunComparator $runComparator,
+    protected AnswerBackendRegistry $backendRegistry,
   ) {}
 
   /**
@@ -47,6 +51,7 @@ class AiTesterController extends ControllerBase {
       $container->get('database'),
       $container->get('date.formatter'),
       $container->get('ys_ai_tester.run_comparator'),
+      $container->get('ys_ai_tester.answer_backend_registry'),
     );
   }
 
@@ -54,7 +59,7 @@ class AiTesterController extends ControllerBase {
    * Renders the detail page for a single tester run.
    */
   public function run(int $run_id): array {
-    $run = $this->loadRunOr404($run_id, 'id, created, source_filename, status');
+    $run = $this->loadRunOr404($run_id, 'id, created, source_filename, status, backend');
 
     $results = $this->database->query(
       'SELECT * FROM {ys_ai_tester_result} WHERE run_id = :run_id ORDER BY delta ASC',
@@ -63,9 +68,17 @@ class AiTesterController extends ControllerBase {
 
     $rows = [];
     foreach ($results as $result) {
+      $error = (string) ($result->error ?? '');
       $rows[] = [
         ['data' => $result->question, 'class' => ['views-field', 'views-field-question']],
-        ['data' => $result->answer, 'class' => ['views-field', 'views-field-answer']],
+        [
+          // A recorded error is shown in place of the blank answer it would
+          // otherwise leave behind, so a failure is not read as a real answer.
+          'data' => $error !== ''
+            ? ['#markup' => $this->t('<em>Error: @msg</em>', ['@msg' => $error])]
+            : $result->answer,
+          'class' => ['views-field', 'views-field-answer'],
+        ],
         [
           'data' => $this->buildCitationsCell($this->decodeCitations($result->citations)),
           'class' => ['views-field', 'views-field-citations', 'priority-low'],
@@ -79,11 +92,12 @@ class AiTesterController extends ControllerBase {
       '#type' => 'container',
       'meta' => [
         '#markup' => $this->t(
-          '<p><strong>Run #@id</strong> — @date — File: @file — Status: @status</p>',
+          '<p><strong>Run #@id</strong> — @date — File: @file — Assistant: @backend — Status: @status</p>',
           [
             '@id' => $run->id,
             '@date' => $this->dateFormatter->format($run->created, 'medium'),
             '@file' => $run->source_filename,
+            '@backend' => $this->backendRegistry->labelFor((string) $run->backend),
             '@status' => $run->status,
           ]
         ),
@@ -226,6 +240,9 @@ class AiTesterController extends ControllerBase {
       $output[] = [
         'question' => $result->question,
         'answer' => $result->answer,
+        // Exported so a failed question is not read as an assistant that
+        // answered nothing — the export is the artefact people quote.
+        'error' => (string) ($result->error ?? ''),
         'citations' => $this->decodeCitations($result->citations),
       ];
     }
@@ -269,6 +286,7 @@ class AiTesterController extends ControllerBase {
       $rows[] = [
         'question' => (string) $result->question,
         'answer' => (string) $result->answer,
+        'error' => (string) ($result->error ?? ''),
         'sources' => $this->joinSourceUrls($sources),
       ];
     }
@@ -291,7 +309,7 @@ class AiTesterController extends ControllerBase {
    */
   protected function loadResultRows(int $run_id): array {
     return $this->database->query(
-      'SELECT question, answer, citations FROM {ys_ai_tester_result}
+      'SELECT question, answer, citations, error FROM {ys_ai_tester_result}
        WHERE run_id = :run_id ORDER BY delta ASC',
       [':run_id' => $run_id]
     )->fetchAll();
@@ -305,18 +323,20 @@ class AiTesterController extends ControllerBase {
    * injection. Multiline answers are quoted by fputcsv and stay in one cell.
    *
    * @param array $rows
-   *   Result rows, each with 'question', 'answer', and 'sources' strings.
+   *   Result rows, each with 'question', 'answer', 'error', and 'sources'
+   *   strings.
    *
    * @return string
    *   The CSV file body, including the leading BOM.
    */
   protected function buildResultsCsv(array $rows): string {
     $handle = fopen('php://temp', 'r+');
-    fputcsv($handle, ['Question', 'Answer', 'Sources']);
+    fputcsv($handle, ['Question', 'Answer', 'Error', 'Sources']);
     foreach ($rows as $row) {
       fputcsv($handle, array_map([$this, 'csvCell'], [
         $row['question'],
         $row['answer'],
+        $row['error'] ?? '',
         $row['sources'],
       ]));
     }
@@ -354,6 +374,7 @@ class AiTesterController extends ControllerBase {
           '@b' => $summary['only_b'],
         ]
       ), 'p'),
+      'caveat' => $this->crossAssistantCaveat($data),
       'meta' => [
         '#type' => 'container',
         '#attributes' => ['class' => ['ys-compare-meta']],
@@ -437,15 +458,45 @@ class AiTesterController extends ControllerBase {
    */
   protected function runMetaBlock(string|MarkupInterface $label, array $meta): array {
     return $this->wrap('ys-compare-meta__run', $this->t(
-      '<strong>@label — Run #@id</strong><br>@date<br>File: @file<br>Status: @status',
+      '<strong>@label — Run #@id</strong><br>@date<br>File: @file<br>Assistant: @backend<br>Status: @status',
       [
         '@label' => $label,
         '@id' => $meta['id'],
         '@date' => $this->dateFormatter->format($meta['created'], 'medium'),
         '@file' => $meta['source_filename'],
+        '@backend' => $this->backendRegistry->labelFor($meta['backend']),
         '@status' => $meta['status'],
       ]
     ));
+  }
+
+  /**
+   * Builds the caveat shown when the two runs used different assistants.
+   *
+   * Two assistants differ in content set, index, system prompt, retrieval and
+   * model, so a high "differs" count is the expected outcome of the comparison
+   * rather than evidence that one of them regressed. Saying so on the page
+   * stops the number being quoted as a defect count.
+   *
+   * @param array $data
+   *   The comparison structure from the run comparator.
+   *
+   * @return array
+   *   A #markup render element, or an empty array when both runs used the same
+   *   assistant and no caveat is warranted.
+   */
+  protected function crossAssistantCaveat(array $data): array {
+    if ($data['run_a']['backend'] === $data['run_b']['backend']) {
+      return [];
+    }
+
+    return $this->wrap('ys-compare-caveat', $this->t(
+      'These runs were answered by different assistants (@a vs @b). They use a different content set, index, system prompt, retrieval strategy and model, so answers are expected to differ — a high "differs" count here is not a regression in either assistant.',
+      [
+        '@a' => $this->backendRegistry->labelFor($data['run_a']['backend']),
+        '@b' => $this->backendRegistry->labelFor($data['run_b']['backend']),
+      ]
+    ), 'p');
   }
 
   /**
@@ -502,7 +553,15 @@ class AiTesterController extends ControllerBase {
       'answer' => $this->wrap('ys-diff ys-diff--' . $direction, $answer_html),
     ];
 
-    if ($side['empty']) {
+    if ($side['error'] !== '') {
+      // A failure and a genuinely empty answer look identical in the answer
+      // column, so the recorded error is what the meta line reports.
+      $cell['meta'] = $this->wrap(
+        'ys-compare-side-meta ys-compare-side-meta--empty',
+        $this->t('Error: @msg', ['@msg' => $side['error']])
+      );
+    }
+    elseif ($side['empty']) {
       $cell['meta'] = $this->wrap(
         'ys-compare-side-meta ys-compare-side-meta--empty',
         $this->t('Empty answer')
@@ -582,6 +641,7 @@ class AiTesterController extends ControllerBase {
     $handle = fopen('php://temp', 'r+');
     fputcsv($handle, [
       'question', 'status', 'answer_a', 'answer_b',
+      'error_a', 'error_b',
       'cited_a', 'cited_b', 'len_a', 'len_b',
       'shared_sources', 'only_a_sources', 'only_b_sources',
     ]);
@@ -595,6 +655,8 @@ class AiTesterController extends ControllerBase {
         $pair['status'],
         $a['answer'] ?? '',
         $b['answer'] ?? '',
+        (string) ($a['error'] ?? ''),
+        (string) ($b['error'] ?? ''),
         (string) ($a['cited'] ?? ''),
         (string) ($b['cited'] ?? ''),
         (string) ($a['len'] ?? ''),

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/Form/AiTesterForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/Form/AiTesterForm.php
@@ -11,15 +11,22 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\ys_ai_tester\AiTesterBatch;
+use Drupal\ys_ai_tester\AnswerBackendInterface;
+use Drupal\ys_ai_tester\AnswerBackendRegistry;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Form for batch testing the Beacon assistant with a list of questions.
+ * Form for batch testing an AI assistant with a list of questions.
  *
  * Questions are supplied one per line, either as an uploaded plain-text file or
  * typed directly into a textarea (one input or the other, never both).
+ *
+ * When more than one assistant is available the run can target either one, or
+ * both at once — which records two runs over an identical question list and
+ * opens the existing side-by-side comparison.
  */
 class AiTesterForm extends FormBase {
 
@@ -27,6 +34,13 @@ class AiTesterForm extends FormBase {
    * Maximum allowed size, in bytes, for an uploaded questions file.
    */
   const MAX_UPLOAD_BYTES = 262144;
+
+  /**
+   * Selector value meaning "run this list against every assistant".
+   *
+   * Prefixed so it cannot collide with a backend id.
+   */
+  const RUN_ALL = '__all';
 
   /**
    * Constructs the AI Tester form.
@@ -39,12 +53,15 @@ class AiTesterForm extends FormBase {
    *   The date formatter.
    * @param \Drupal\Component\Datetime\TimeInterface $time
    *   The time service.
+   * @param \Drupal\ys_ai_tester\AnswerBackendRegistry $backendRegistry
+   *   The answer backend registry.
    */
   public function __construct(
     protected Connection $database,
     protected AccountProxyInterface $currentUser,
     protected DateFormatterInterface $dateFormatter,
     protected TimeInterface $time,
+    protected AnswerBackendRegistry $backendRegistry,
   ) {}
 
   /**
@@ -56,7 +73,60 @@ class AiTesterForm extends FormBase {
       $container->get('current_user'),
       $container->get('date.formatter'),
       $container->get('datetime.time'),
+      $container->get('ys_ai_tester.answer_backend_registry'),
     );
+  }
+
+  /**
+   * Builds the assistant selector options for the available backends.
+   *
+   * @param array $available_labels
+   *   Labels keyed by backend id, as returned by the registry.
+   *
+   * @return array
+   *   The radio options, or an empty array when there is nothing to choose
+   *   between and no selector should be rendered at all.
+   */
+  public static function backendChoices(array $available_labels): array {
+    // One assistant is not a choice: the form must look exactly as it did
+    // before more than one backend existed — no selector, no warning.
+    if (count($available_labels) < 2) {
+      return [];
+    }
+
+    $choices = $available_labels;
+    // The comparison view takes exactly two runs, so running "both" is only a
+    // coherent option when exactly two assistants are available.
+    if (count($available_labels) === 2) {
+      $choices[self::RUN_ALL] = new TranslatableMarkup('Both — run the same questions against each assistant and compare');
+    }
+
+    return $choices;
+  }
+
+  /**
+   * Resolves which assistants a submission runs against.
+   *
+   * @param string $choice
+   *   The submitted selector value, which may be empty (no selector rendered)
+   *   or stale (a backend that has since become unavailable).
+   * @param string[] $available_ids
+   *   The backend ids that can answer right now.
+   *
+   * @return string[]
+   *   One backend id per run to create, in creation order.
+   */
+  public static function resolveRunBackends(string $choice, array $available_ids): array {
+    if ($choice === self::RUN_ALL && $available_ids !== []) {
+      return $available_ids;
+    }
+
+    // Anything unrecognised — an empty value, or a backend that went away
+    // between rendering and submitting — falls back to the default assistant
+    // rather than running something the user did not ask for.
+    return in_array($choice, $available_ids, TRUE)
+      ? [$choice]
+      : [AnswerBackendInterface::DEFAULT_ID];
   }
 
   /**
@@ -113,9 +183,28 @@ class AiTesterForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state): array {
+    $choices = self::backendChoices($this->backendRegistry->availableOptions());
+
+    // Naming Beacon in the intro would contradict the selector, so the
+    // assistant is a placeholder — one sentence to translate, and the guidance
+    // below it cannot drift between the two wordings.
     $form['intro'] = [
-      '#markup' => '<p>' . $this->t('Run a list of questions through the Beacon assistant, one question per line. Either upload a plain-text file or type the questions below — use one or the other, not both.') . '</p>',
+      '#markup' => '<p>' . $this->t('Run a list of questions through @assistant, one question per line. Either upload a plain-text file or type the questions below — use one or the other, not both.', [
+        '@assistant' => $choices
+          ? $this->t('an AI assistant')
+          : $this->t('the Beacon assistant'),
+      ]) . '</p>',
     ];
+
+    if ($choices) {
+      $form['backend'] = [
+        '#type' => 'radios',
+        '#title' => $this->t('Assistant'),
+        '#options' => $choices,
+        '#default_value' => AnswerBackendInterface::DEFAULT_ID,
+        '#description' => $this->t('Which assistant answers this run. Running both records two runs over the same question list and opens the comparison view.'),
+      ];
+    }
 
     $form['questions_file'] = [
       '#type' => 'file',
@@ -178,8 +267,11 @@ class AiTesterForm extends FormBase {
    */
   protected function buildHistoryTable(): array {
     $query = $this->database->select('ys_ai_tester_run', 'r')
-      ->fields('r', ['id', 'created', 'uid', 'source_filename', 'question_count', 'status'])
+      ->fields('r', ['id', 'created', 'uid', 'source_filename', 'question_count', 'status', 'backend'])
       ->orderBy('r.created', 'DESC')
+      // Both runs of a "run both" submission share a request timestamp, so id
+      // breaks the tie and keeps the pair's order stable across renders.
+      ->orderBy('r.id', 'DESC')
       ->range(0, 50);
     $query->leftJoin('users_field_data', 'u', 'r.uid = u.uid');
     $query->addField('u', 'name');
@@ -208,6 +300,9 @@ class AiTesterForm extends FormBase {
         'date' => $this->dateFormatter->format($row->created, 'short'),
         'user' => $row->name ?? $this->t('Unknown'),
         'file' => $row->source_filename,
+        // Runs recorded before the tester supported more than one assistant
+        // read back as Beacon via the column default.
+        'backend' => $this->backendRegistry->labelFor((string) $row->backend),
         'questions' => $row->question_count,
         'status' => $row->status,
         'actions' => ['data' => $actions],
@@ -224,6 +319,7 @@ class AiTesterForm extends FormBase {
         'date' => $this->t('Date'),
         'user' => $this->t('User'),
         'file' => $this->t('File'),
+        'backend' => $this->t('Assistant'),
         'questions' => $this->t('Questions'),
         'status' => $this->t('Status'),
         'actions' => $this->t('Actions'),
@@ -302,8 +398,69 @@ class AiTesterForm extends FormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $questions = $form_state->get('questions');
+    $backends = self::resolveRunBackends(
+      (string) $form_state->getValue('backend'),
+      $this->backendRegistry->availableIds(),
+    );
 
-    $run_id = $this->database->insert('ys_ai_tester_run')
+    // Each assistant gets its own run over the identical question list, so the
+    // two are directly comparable and either can be re-run on its own.
+    $run_ids = [];
+    foreach ($backends as $backend_id) {
+      $run_id = $this->insertRun($form_state, count($questions), $backend_id);
+      $run_ids[] = $run_id;
+
+      $operations = [];
+      foreach ($questions as $delta => $question) {
+        $operations[] = [
+          [AiTesterBatch::class, 'processQuestion'],
+          [$run_id, $question, $delta, $backend_id],
+        ];
+      }
+
+      // One batch SET per run, not one set for both. Each set carries its own
+      // results array, so finished() records the status of the run it actually
+      // belongs to, and one assistant's failure cannot mark the other
+      // assistant's run failed. A single shared set would leave the first run
+      // stuck at 'processing' forever, because every operation overwrites the
+      // same results['run_id'].
+      batch_set([
+        'title' => $this->t('Running AI tests (@assistant)', [
+          '@assistant' => $this->backendRegistry->labelFor($backend_id),
+        ]),
+        'operations' => $operations,
+        'finished' => [AiTesterBatch::class, 'finished'],
+        'progress_message' => $this->t('Processed @current of @total questions.'),
+      ]);
+    }
+
+    // Two runs over one list exist to be read side by side, so the batch lands
+    // on the comparison rather than back on this form. The form's redirect is
+    // what the batch honours once every operation has completed.
+    if (count($run_ids) === 2) {
+      sort($run_ids);
+      $form_state->setRedirect('ys_ai_tester.compare', [
+        'run_a' => $run_ids[0],
+        'run_b' => $run_ids[1],
+      ]);
+    }
+  }
+
+  /**
+   * Inserts one run row and returns its id.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state carrying the validated question source.
+   * @param int $question_count
+   *   How many questions the run covers.
+   * @param string $backend_id
+   *   The assistant answering this run.
+   *
+   * @return int
+   *   The new run id.
+   */
+  protected function insertRun(FormStateInterface $form_state, int $question_count, string $backend_id): int {
+    return (int) $this->database->insert('ys_ai_tester_run')
       ->fields([
         'uid' => $this->currentUser->id(),
         'created' => $this->time->getRequestTime(),
@@ -311,24 +468,10 @@ class AiTesterForm extends FormBase {
         'source_content' => $form_state->get('source_content'),
         'source_run_id' => 0,
         'status' => 'processing',
-        'question_count' => count($questions),
+        'question_count' => $question_count,
+        'backend' => $backend_id,
       ])
       ->execute();
-
-    $operations = [];
-    foreach ($questions as $delta => $question) {
-      $operations[] = [
-        [AiTesterBatch::class, 'processQuestion'],
-        [(int) $run_id, $question, $delta],
-      ];
-    }
-
-    batch_set([
-      'title' => $this->t('Running AI tests'),
-      'operations' => $operations,
-      'finished' => [AiTesterBatch::class, 'finished'],
-      'progress_message' => $this->t('Processed @current of @total questions.'),
-    ]);
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/Form/AiTesterRerunForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/Form/AiTesterRerunForm.php
@@ -11,6 +11,8 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\ys_ai_tester\AiTesterBatch;
+use Drupal\ys_ai_tester\AnswerBackendInterface;
+use Drupal\ys_ai_tester\AnswerBackendRegistry;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -46,11 +48,14 @@ class AiTesterRerunForm extends ConfirmFormBase {
    *   The current user.
    * @param \Drupal\Component\Datetime\TimeInterface $time
    *   The time service.
+   * @param \Drupal\ys_ai_tester\AnswerBackendRegistry $backendRegistry
+   *   The answer backend registry.
    */
   public function __construct(
     protected Connection $database,
     protected AccountProxyInterface $currentUser,
     protected TimeInterface $time,
+    protected AnswerBackendRegistry $backendRegistry,
   ) {}
 
   /**
@@ -61,6 +66,7 @@ class AiTesterRerunForm extends ConfirmFormBase {
       $container->get('database'),
       $container->get('current_user'),
       $container->get('datetime.time'),
+      $container->get('ys_ai_tester.answer_backend_registry'),
     );
   }
 
@@ -78,12 +84,19 @@ class AiTesterRerunForm extends ConfirmFormBase {
    *   The status of the run being re-run.
    * @param int $in_flight_count
    *   How many reruns of that run are already processing.
+   * @param bool $backend_available
+   *   Whether the assistant that answered the run can still answer.
    *
    * @return string|null
-   *   'source_processing' or 'already_running' when the rerun must be refused,
-   *   or NULL when it may proceed.
+   *   'backend_unavailable', 'source_processing' or 'already_running' when the
+   *   rerun must be refused, or NULL when it may proceed.
    */
-  public static function isBlocked(?string $source_status, int $in_flight_count): ?string {
+  public static function isBlocked(?string $source_status, int $in_flight_count, bool $backend_available): ?string {
+    // Checked first because it is the most fundamental refusal: there is no
+    // assistant left to answer, so the run's own state cannot make it runnable.
+    if (!$backend_available) {
+      return 'backend_unavailable';
+    }
     if ($source_status === 'processing') {
       return 'source_processing';
     }
@@ -107,9 +120,33 @@ class AiTesterRerunForm extends ConfirmFormBase {
    * {@inheritdoc}
    */
   public function getDescription(): \Stringable|string {
-    return $this->t('This runs the same questions through Beacon again and records them as a new run. Run #@id is kept so you can compare the old and new answers. This may take a while.', [
+    return $this->t('This runs the same questions through @backend again and records them as a new run. Run #@id is kept so you can compare the old and new answers. This may take a while.', [
+      '@backend' => $this->backendRegistry->labelFor($this->backendId()),
       '@id' => $this->runId,
     ]);
+  }
+
+  /**
+   * Returns the id of the assistant that answered the run being re-run.
+   *
+   * A rerun always targets the same assistant as its source run, so the two are
+   * comparable.
+   *
+   * @return string
+   *   The stored backend id.
+   */
+  protected function backendId(): string {
+    return (string) ($this->run->backend ?? AnswerBackendInterface::DEFAULT_ID);
+  }
+
+  /**
+   * Returns whether the run's assistant can still answer questions.
+   *
+   * @return bool
+   *   TRUE when the assistant is registered and available.
+   */
+  protected function backendIsAvailable(): bool {
+    return $this->backendRegistry->getAvailable($this->backendId()) !== NULL;
   }
 
   /**
@@ -131,10 +168,14 @@ class AiTesterRerunForm extends ConfirmFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state, ?int $run_id = NULL): array {
     $this->runId = (int) $run_id;
-    $this->run = $this->loadRun($this->runId);
+    $this->loadRun($this->runId);
     $form_state->set('rerun_run_id', $this->runId);
 
-    $blocked = self::isBlocked($this->run->status, $this->countInFlight($this->runId));
+    $blocked = self::isBlocked(
+      $this->run->status,
+      $this->countInFlight($this->runId),
+      $this->backendIsAvailable(),
+    );
     if ($blocked !== NULL) {
       $this->messenger()->addWarning($this->blockedMessage($blocked));
       return [
@@ -156,12 +197,19 @@ class AiTesterRerunForm extends ConfirmFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $run_id = (int) $form_state->get('rerun_run_id');
     $this->runId = $run_id;
+    // Reloaded rather than reused from buildForm() because this is a fresh
+    // request: the status read here is what the guard below acts on.
     $run = $this->loadRun($run_id);
+    $backend_id = $this->backendId();
 
     // Re-check the guard at the point of mutation. This is what actually
     // stops a double-fire: a reload or a second tab reaching submit finds the
     // first rerun already processing and is refused.
-    $blocked = self::isBlocked($run->status, $this->countInFlight($run_id));
+    $blocked = self::isBlocked(
+      $run->status,
+      $this->countInFlight($run_id),
+      $this->backendIsAvailable(),
+    );
     if ($blocked !== NULL) {
       $this->messenger()->addWarning($this->blockedMessage($blocked));
       $form_state->setRedirect('ys_ai_tester.tester');
@@ -184,6 +232,9 @@ class AiTesterRerunForm extends ConfirmFormBase {
         'source_run_id' => $run_id,
         'status' => 'processing',
         'question_count' => count($questions),
+        // A rerun targets the same assistant as its source, so the old and new
+        // answers are a like-for-like comparison.
+        'backend' => $backend_id,
       ])
       ->execute();
 
@@ -191,7 +242,7 @@ class AiTesterRerunForm extends ConfirmFormBase {
     foreach ($questions as $delta => $question) {
       $operations[] = [
         [AiTesterBatch::class, 'processQuestion'],
-        [(int) $new_run_id, $question, $delta],
+        [(int) $new_run_id, $question, $delta, $backend_id],
       ];
     }
 
@@ -223,16 +274,21 @@ class AiTesterRerunForm extends ConfirmFormBase {
 
   /**
    * Loads a run row for re-running, or throws a 404.
+   *
+   * Also caches it on the form, so backendId() and the blocked messages read
+   * the same row the caller is working with rather than querying again.
    */
   protected function loadRun(int $run_id): object {
     $run = $this->database->query(
-      'SELECT id, source_filename, source_content, source_run_id, status, question_count FROM {ys_ai_tester_run} WHERE id = :id',
+      'SELECT id, source_filename, source_content, source_run_id, status, question_count, backend FROM {ys_ai_tester_run} WHERE id = :id',
       [':id' => $run_id]
     )->fetchObject();
 
     if (!$run) {
       throw new NotFoundHttpException();
     }
+
+    $this->run = $run;
     return $run;
   }
 
@@ -243,6 +299,10 @@ class AiTesterRerunForm extends ConfirmFormBase {
     return match ($reason) {
       'source_processing' => $this->t('Run #@id is still processing. Wait until it finishes before re-running it.', ['@id' => $this->runId]),
       'already_running' => $this->t('A rerun of run #@id is already in progress. Wait for it to finish.', ['@id' => $this->runId]),
+      'backend_unavailable' => $this->t('Run #@id was answered by @backend, which is no longer available on this site. The run can still be viewed and compared, but it cannot be re-run.', [
+        '@id' => $this->runId,
+        '@backend' => $this->backendRegistry->labelFor($this->backendId()),
+      ]),
       default => $this->t('This run cannot be re-run right now.'),
     };
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/RunComparator.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/RunComparator.php
@@ -163,6 +163,9 @@ class RunComparator {
       'cited' => $cited,
       'retrieved' => count($citations),
       'empty' => trim($answer) === '',
+      // Distinguishes "the assistant failed on this question" from "the
+      // assistant genuinely answered with nothing".
+      'error' => (string) ($result['error'] ?? ''),
     ];
   }
 
@@ -219,6 +222,9 @@ class RunComparator {
       'created' => (int) $meta['created'],
       'source_filename' => (string) $meta['source_filename'],
       'status' => (string) $meta['status'],
+      // Which assistant answered this side. Runs recorded before the tester
+      // supported more than one read back as Beacon.
+      'backend' => (string) ($meta['backend'] ?? AnswerBackendInterface::DEFAULT_ID),
     ];
   }
 
@@ -227,7 +233,7 @@ class RunComparator {
    */
   protected function loadRun(int $run_id): array {
     $row = $this->database->query(
-      'SELECT id, created, source_filename, status FROM {ys_ai_tester_run} WHERE id = :id',
+      'SELECT id, created, source_filename, status, backend FROM {ys_ai_tester_run} WHERE id = :id',
       [':id' => $run_id]
     )->fetchAssoc();
 
@@ -242,7 +248,7 @@ class RunComparator {
    */
   protected function loadResults(int $run_id): array {
     $rows = $this->database->query(
-      'SELECT question, answer, citations FROM {ys_ai_tester_result} WHERE run_id = :run_id ORDER BY delta ASC',
+      'SELECT question, answer, citations, error FROM {ys_ai_tester_result} WHERE run_id = :run_id ORDER BY delta ASC',
       [':run_id' => $run_id]
     )->fetchAll();
 
@@ -252,6 +258,7 @@ class RunComparator {
         'question' => $row->question,
         'answer' => $row->answer,
         'citations' => json_decode($row->citations ?? '', TRUE) ?: [],
+        'error' => (string) ($row->error ?? ''),
       ];
     }
     return $results;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterBackendChoiceTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterBackendChoiceTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ys_ai_tester\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai_tester\AnswerBackendInterface;
+use Drupal\ys_ai_tester\Form\AiTesterForm;
+
+/**
+ * Tests which assistant a submitted run targets.
+ *
+ * @coversDefaultClass \Drupal\ys_ai_tester\Form\AiTesterForm
+ * @group ys_beacon
+ */
+class AiTesterBackendChoiceTest extends UnitTestCase {
+
+  /**
+   * @covers ::backendChoices
+   * @dataProvider provideBackendChoices
+   */
+  public function testBackendChoices(array $available, array $expected_keys, string $message): void {
+    $this->assertSame($expected_keys, array_keys(AiTesterForm::backendChoices($available)), $message);
+  }
+
+  /**
+   * Data provider for testBackendChoices().
+   */
+  public static function provideBackendChoices(): array {
+    return [
+      'no backends at all offers nothing' => [
+        [],
+        [],
+        'An empty registry renders no selector.',
+      ],
+      'one backend offers no selector' => [
+        ['beacon' => 'Beacon'],
+        [],
+        'Beacon-only must look exactly as it does today: no selector, no warning.',
+      ],
+      'two backends offer each plus a compare-both option' => [
+        ['beacon' => 'Beacon', 'legacy' => 'Legacy'],
+        ['beacon', 'legacy', AiTesterForm::RUN_ALL],
+        'Both assistants plus the run-both option are offered.',
+      ],
+      'three backends drop the compare-both option' => [
+        ['beacon' => 'Beacon', 'legacy' => 'Legacy', 'other' => 'Other'],
+        ['beacon', 'legacy', 'other'],
+        'The comparison view takes exactly two runs, so run-both is not offered for three.',
+      ],
+    ];
+  }
+
+  /**
+   * @covers ::resolveRunBackends
+   * @dataProvider provideRunBackends
+   */
+  public function testResolveRunBackends(string $choice, array $available, array $expected, string $message): void {
+    $this->assertSame($expected, AiTesterForm::resolveRunBackends($choice, $available), $message);
+  }
+
+  /**
+   * Data provider for testResolveRunBackends().
+   */
+  public static function provideRunBackends(): array {
+    return [
+      'explicit beacon' => [
+        'beacon',
+        ['beacon', 'legacy'],
+        ['beacon'],
+        'A chosen backend runs on its own.',
+      ],
+      'explicit legacy' => [
+        'legacy',
+        ['beacon', 'legacy'],
+        ['legacy'],
+        'The legacy assistant can be targeted on its own.',
+      ],
+      'run all runs every available backend in order' => [
+        AiTesterForm::RUN_ALL,
+        ['beacon', 'legacy'],
+        ['beacon', 'legacy'],
+        'Beacon is created first so it becomes Run A.',
+      ],
+      'empty choice falls back to the default backend' => [
+        '',
+        ['beacon'],
+        ['beacon'],
+        'With no selector rendered, the submission targets Beacon.',
+      ],
+      'a choice that is no longer available falls back to the default' => [
+        'legacy',
+        ['beacon'],
+        ['beacon'],
+        'A stale form submitted after legacy went away must not run legacy.',
+      ],
+      'run all with a single backend runs just that one' => [
+        AiTesterForm::RUN_ALL,
+        ['beacon'],
+        ['beacon'],
+        'Run-all degrades to the only available backend.',
+      ],
+      'unknown choice falls back to the default backend' => [
+        'wat',
+        ['beacon', 'legacy'],
+        ['beacon'],
+        'An unrecognised value never selects an arbitrary backend.',
+      ],
+    ];
+  }
+
+  /**
+   * The fallback is the interface's declared default, not a copied literal.
+   */
+  public function testFallbackIsTheDeclaredDefaultBackend(): void {
+    $this->assertSame(
+      [AnswerBackendInterface::DEFAULT_ID],
+      AiTesterForm::resolveRunBackends('', [AnswerBackendInterface::DEFAULT_ID])
+    );
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterCompareRenderTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterCompareRenderTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\ys_ai_tester\Unit;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai_tester\AnswerBackendRegistry;
 use Drupal\ys_ai_tester\Controller\AiTesterController;
 use Drupal\ys_ai_tester\RunComparator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -34,14 +35,28 @@ class AiTesterCompareRenderTest extends UnitTestCase {
   /**
    * A side entry as produced by RunComparator::side().
    */
-  protected function side(string $answer, int $cited, int $retrieved, bool $empty): array {
+  protected function side(string $answer, int $cited, int $retrieved, bool $empty, string $error = ''): array {
     return [
+      'error' => $error,
       'answer' => $answer,
       'citations' => [],
       'len' => mb_strlen($answer),
       'cited' => $cited,
       'retrieved' => $retrieved,
       'empty' => $empty,
+    ];
+  }
+
+  /**
+   * A run meta entry as produced by RunComparator::metaArray().
+   */
+  protected function runMeta(int $id, string $file, string $backend = 'beacon'): array {
+    return [
+      'id' => $id,
+      'created' => $id * 1000,
+      'source_filename' => $file,
+      'status' => 'complete',
+      'backend' => $backend,
     ];
   }
 
@@ -55,10 +70,16 @@ class AiTesterCompareRenderTest extends UnitTestCase {
     $date_formatter = $this->createMock(DateFormatterInterface::class);
     $date_formatter->method('format')->willReturn('2026-06-20');
 
+    $registry = $this->createMock(AnswerBackendRegistry::class);
+    $registry->method('labelFor')->willReturnCallback(
+      static fn (string $id): string => ucfirst($id)
+    );
+
     return new AiTesterController(
       $this->createMock(Connection::class),
       $date_formatter,
       $comparator,
+      $registry,
     );
   }
 
@@ -71,8 +92,8 @@ class AiTesterCompareRenderTest extends UnitTestCase {
    */
   public function testCompareRendersEveryPairState(): void {
     $data = [
-      'run_a' => ['id' => 2, 'created' => 1000, 'source_filename' => 'a.yml', 'status' => 'complete'],
-      'run_b' => ['id' => 3, 'created' => 2000, 'source_filename' => 'b.yml', 'status' => 'complete'],
+      'run_a' => $this->runMeta(2, 'a.yml'),
+      'run_b' => $this->runMeta(3, 'b.yml'),
       'pairs' => [
         [
           'question' => 'What is Yale?',
@@ -142,8 +163,8 @@ class AiTesterCompareRenderTest extends UnitTestCase {
    */
   public function testCompareUniqueSourcesAreNewWindowLinks(): void {
     $data = [
-      'run_a' => ['id' => 2, 'created' => 1000, 'source_filename' => 'a.yml', 'status' => 'complete'],
-      'run_b' => ['id' => 3, 'created' => 2000, 'source_filename' => 'b.yml', 'status' => 'complete'],
+      'run_a' => $this->runMeta(2, 'a.yml'),
+      'run_b' => $this->runMeta(3, 'b.yml'),
       'pairs' => [
         [
           'question' => 'What is Yale?',
@@ -220,6 +241,92 @@ class AiTesterCompareRenderTest extends UnitTestCase {
     $fallback = $cell['#items'][1]['link'];
     $this->assertArrayNotHasKey('#type', $fallback);
     $this->assertArrayHasKey('#markup', $fallback);
+  }
+
+  /**
+   * Builds a minimal one-pair comparison over the two given backends.
+   *
+   * @param string $backend_a
+   *   Run A's backend id.
+   * @param string $backend_b
+   *   Run B's backend id.
+   * @param array $side_b
+   *   Run B's side entry.
+   *
+   * @return array
+   *   A comparison structure ready to hand to the stubbed comparator.
+   */
+  protected function comparisonOf(string $backend_a, string $backend_b, array $side_b): array {
+    return [
+      'run_a' => $this->runMeta(2, 'a.txt', $backend_a),
+      'run_b' => $this->runMeta(3, 'a.txt', $backend_b),
+      'pairs' => [
+        [
+          'question' => 'What are the office hours?',
+          'status' => 'differs',
+          'a' => $this->side('Beacon answer.', 1, 1, FALSE),
+          'b' => $side_b,
+          'len_delta' => 0,
+          'citation_overlap' => ['both' => [], 'only_a' => [], 'only_b' => []],
+        ],
+      ],
+      'summary' => [
+        'total_compared' => 1,
+        'differ' => 1,
+        'identical' => 0,
+        'only_a' => 0,
+        'only_b' => 0,
+      ],
+    ];
+  }
+
+  /**
+   * Comparing two assistants warns that answers are expected to differ.
+   *
+   * @covers ::compare
+   * @covers ::crossAssistantCaveat
+   */
+  public function testCrossAssistantComparisonShowsCaveat(): void {
+    $data = $this->comparisonOf('beacon', 'legacy', $this->side('Legacy answer.', 1, 1, FALSE));
+
+    $build = $this->controllerReturning($data)->compare(2, 3);
+
+    $this->assertArrayHasKey('#markup', $build['caveat']);
+    $caveat = (string) $build['caveat']['#markup'];
+    $this->assertStringContainsString('different assistants', $caveat);
+    $this->assertStringContainsString('not a regression', $caveat);
+    $this->assertStringContainsString('Beacon', $caveat);
+    $this->assertStringContainsString('Legacy', $caveat);
+  }
+
+  /**
+   * Comparing two runs of one assistant shows no caveat at all.
+   *
+   * @covers ::compare
+   * @covers ::crossAssistantCaveat
+   */
+  public function testSameAssistantComparisonHasNoCaveat(): void {
+    $data = $this->comparisonOf('beacon', 'beacon', $this->side('Second answer.', 1, 1, FALSE));
+
+    $build = $this->controllerReturning($data)->compare(2, 3);
+
+    $this->assertSame([], $build['caveat']);
+  }
+
+  /**
+   * A recorded error is reported instead of reading as an empty answer.
+   *
+   * @covers ::sideCell
+   */
+  public function testErroredSideReportsTheError(): void {
+    $errored = $this->side('', 0, 0, TRUE, 'cURL error 28: Operation timed out');
+    $data = $this->comparisonOf('beacon', 'legacy', $errored);
+
+    $build = $this->controllerReturning($data)->compare(2, 3);
+    $meta = (string) $build['results']['#rows'][0][3]['data']['meta']['#markup'];
+
+    $this->assertStringContainsString('Operation timed out', $meta);
+    $this->assertStringNotContainsString('Empty answer', $meta);
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterCsvCellTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterCsvCellTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\ys_ai_tester\Unit;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai_tester\AnswerBackendRegistry;
 use Drupal\ys_ai_tester\Controller\AiTesterController;
 use Drupal\ys_ai_tester\RunComparator;
 
@@ -27,6 +28,7 @@ class AiTesterCsvCellTest extends UnitTestCase {
       $this->createMock(Connection::class),
       $this->createMock(DateFormatterInterface::class),
       $this->createMock(RunComparator::class),
+      $this->createMock(AnswerBackendRegistry::class),
     );
     $method = new \ReflectionMethod($controller, 'csvCell');
     $method->setAccessible(TRUE);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterRerunGuardTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterRerunGuardTest.php
@@ -20,21 +20,37 @@ class AiTesterRerunGuardTest extends UnitTestCase {
    * @covers ::isBlocked
    * @dataProvider provideGuardCases
    */
-  public function testIsBlocked(?string $source_status, int $in_flight, ?string $expected): void {
-    $this->assertSame($expected, AiTesterRerunForm::isBlocked($source_status, $in_flight));
+  public function testIsBlocked(
+    ?string $source_status,
+    int $in_flight,
+    bool $backend_available,
+    ?string $expected,
+  ): void {
+    $this->assertSame(
+      $expected,
+      AiTesterRerunForm::isBlocked($source_status, $in_flight, $backend_available)
+    );
   }
 
   /**
-   * Source status + in-flight rerun count and the resolved block reason.
+   * Source status, in-flight rerun count, backend availability, block reason.
+   *
+   * A run whose assistant is gone is refused rather than attempted: a stored
+   * legacy run stays viewable and comparable after the legacy option becomes
+   * unavailable, but re-running it is refused gracefully rather than erroring
+   * part-way through a batch.
    */
   public static function provideGuardCases(): array {
     return [
-      'complete run, none in flight, allowed' => ['complete', 0, NULL],
-      'failed run may be re-run' => ['failed', 0, NULL],
-      'source still processing is blocked' => ['processing', 0, 'source_processing'],
-      'existing in-flight rerun is blocked' => ['complete', 1, 'already_running'],
-      'multiple in-flight reruns blocked' => ['complete', 3, 'already_running'],
-      'processing source takes precedence over in-flight' => ['processing', 2, 'source_processing'],
+      'complete run, none in flight, allowed' => ['complete', 0, TRUE, NULL],
+      'failed run may be re-run' => ['failed', 0, TRUE, NULL],
+      'source still processing is blocked' => ['processing', 0, TRUE, 'source_processing'],
+      'existing in-flight rerun is blocked' => ['complete', 1, TRUE, 'already_running'],
+      'multiple in-flight reruns blocked' => ['complete', 3, TRUE, 'already_running'],
+      'processing source takes precedence over in-flight' => ['processing', 2, TRUE, 'source_processing'],
+      'unavailable backend blocks a clean rerun' => ['complete', 0, FALSE, 'backend_unavailable'],
+      'unavailable backend outranks a processing source' => ['processing', 0, FALSE, 'backend_unavailable'],
+      'unavailable backend outranks an in-flight rerun' => ['complete', 2, FALSE, 'backend_unavailable'],
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterResultsCsvTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterResultsCsvTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\ys_ai_tester\Unit;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai_tester\AnswerBackendRegistry;
 use Drupal\ys_ai_tester\Controller\AiTesterController;
 use Drupal\ys_ai_tester\RunComparator;
 
@@ -27,6 +28,7 @@ class AiTesterResultsCsvTest extends UnitTestCase {
       $this->createMock(Connection::class),
       $this->createMock(DateFormatterInterface::class),
       $this->createMock(RunComparator::class),
+      $this->createMock(AnswerBackendRegistry::class),
     );
     $method = new \ReflectionMethod($controller, 'buildResultsCsv');
     $method->setAccessible(TRUE);
@@ -44,9 +46,30 @@ class AiTesterResultsCsvTest extends UnitTestCase {
   /**
    * @covers ::buildResultsCsv
    */
-  public function testHasQuestionAnswerSourcesHeader(): void {
+  public function testHasQuestionAnswerErrorSourcesHeader(): void {
     $csv = $this->buildResultsCsv([]);
-    $this->assertStringContainsString('Question,Answer,Sources', $csv);
+    $this->assertStringContainsString('Question,Answer,Error,Sources', $csv);
+  }
+
+  /**
+   * A failed question exports its error, not just a blank answer.
+   *
+   * The download is the artefact people quote as comparison evidence, so an
+   * empty Answer cell must be distinguishable from an assistant that failed.
+   *
+   * @covers ::buildResultsCsv
+   */
+  public function testExportsTheRecordedError(): void {
+    $csv = $this->buildResultsCsv([
+      [
+        'question' => 'Q',
+        'answer' => '',
+        'error' => 'cURL error 28: Operation timed out',
+        'sources' => '',
+      ],
+    ]);
+
+    $this->assertStringContainsString('cURL error 28: Operation timed out', $csv);
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AnswerBackendRegistryTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AnswerBackendRegistryTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ys_ai_tester\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai_tester\AnswerBackendInterface;
+use Drupal\ys_ai_tester\AnswerBackendRegistry;
+
+/**
+ * Tests the answer backend registry that collects tagged backends.
+ *
+ * @coversDefaultClass \Drupal\ys_ai_tester\AnswerBackendRegistry
+ * @group ys_beacon
+ */
+class AnswerBackendRegistryTest extends UnitTestCase {
+
+  /**
+   * Builds a stub backend.
+   *
+   * @param string $id
+   *   The backend id.
+   * @param string $label
+   *   The human-readable label.
+   * @param bool $available
+   *   Whether the backend reports itself as available.
+   *
+   * @return \Drupal\ys_ai_tester\AnswerBackendInterface
+   *   The stub backend.
+   */
+  private function backend(string $id, string $label, bool $available): AnswerBackendInterface {
+    $backend = $this->createMock(AnswerBackendInterface::class);
+    $backend->method('id')->willReturn($id);
+    $backend->method('label')->willReturn($label);
+    $backend->method('isAvailable')->willReturn($available);
+    return $backend;
+  }
+
+  /**
+   * Builds a registry over the given backends.
+   *
+   * @param \Drupal\ys_ai_tester\AnswerBackendInterface ...$backends
+   *   The backends to register.
+   *
+   * @return \Drupal\ys_ai_tester\AnswerBackendRegistry
+   *   The registry.
+   */
+  private function registry(AnswerBackendInterface ...$backends): AnswerBackendRegistry {
+    return new AnswerBackendRegistry($backends);
+  }
+
+  /**
+   * @covers ::getAvailable
+   */
+  public function testGetAvailableReturnsBackendById(): void {
+    $beacon = $this->backend('beacon', 'Beacon', TRUE);
+    $registry = $this->registry($beacon);
+
+    $this->assertSame($beacon, $registry->getAvailable('beacon'));
+  }
+
+  /**
+   * @covers ::getAvailable
+   */
+  public function testGetAvailableReturnsNullForUnknownId(): void {
+    $registry = $this->registry($this->backend('beacon', 'Beacon', TRUE));
+
+    $this->assertNull($registry->getAvailable('nope'));
+  }
+
+  /**
+   * Tests that an unavailable backend is nameable but not runnable.
+   *
+   * Historical runs stay viewable and correctly labelled after the backend
+   * they used is switched off, but nothing can be run against it.
+   *
+   * @covers ::getAvailable
+   * @covers ::labelFor
+   */
+  public function testUnavailableBackendIsNameableButNotRunnable(): void {
+    $registry = $this->registry(
+      $this->backend('beacon', 'Beacon', TRUE),
+      $this->backend('legacy', 'Legacy ai_engine', FALSE),
+    );
+
+    $this->assertSame(
+      'Legacy ai_engine',
+      (string) $registry->labelFor('legacy'),
+      'An unavailable backend still names itself, so its stored runs stay readable.'
+    );
+    $this->assertNull($registry->getAvailable('legacy'), 'An unavailable backend cannot be run.');
+  }
+
+  /**
+   * @covers ::availableOptions
+   */
+  public function testAvailableOptionsExcludesUnavailableBackends(): void {
+    $registry = $this->registry(
+      $this->backend('beacon', 'Beacon', TRUE),
+      $this->backend('legacy', 'Legacy ai_engine', FALSE),
+    );
+
+    $this->assertSame(['beacon' => 'Beacon'], $registry->availableOptions());
+  }
+
+  /**
+   * @covers ::availableOptions
+   */
+  public function testAvailableOptionsKeepsRegistrationOrder(): void {
+    $registry = $this->registry(
+      $this->backend('beacon', 'Beacon', TRUE),
+      $this->backend('legacy', 'Legacy ai_engine', TRUE),
+    );
+
+    $this->assertSame(
+      ['beacon' => 'Beacon', 'legacy' => 'Legacy ai_engine'],
+      $registry->availableOptions()
+    );
+  }
+
+  /**
+   * @covers ::availableIds
+   */
+  public function testAvailableIdsListsOnlyRunnableBackends(): void {
+    $registry = $this->registry(
+      $this->backend('beacon', 'Beacon', TRUE),
+      $this->backend('legacy', 'Legacy ai_engine', FALSE),
+    );
+
+    $this->assertSame(['beacon'], $registry->availableIds());
+  }
+
+  /**
+   * @covers ::labelFor
+   */
+  public function testLabelForUsesTheBackendLabel(): void {
+    $registry = $this->registry($this->backend('beacon', 'Beacon', TRUE));
+
+    $this->assertSame('Beacon', (string) $registry->labelFor('beacon'));
+  }
+
+  /**
+   * Tests that an unknown backend id falls back to showing the raw id.
+   *
+   * A run stored against a backend whose module has since been uninstalled has
+   * no service to ask for a label, so the stored id is shown rather than an
+   * empty cell — the run stays readable.
+   *
+   * @covers ::labelFor
+   */
+  public function testLabelForFallsBackToTheStoredId(): void {
+    $registry = $this->registry($this->backend('beacon', 'Beacon', TRUE));
+
+    $this->assertSame('legacy', (string) $registry->labelFor('legacy'));
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/RunComparatorTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/RunComparatorTest.php
@@ -273,4 +273,38 @@ class RunComparatorTest extends UnitTestCase {
     $this->assertSame('run7.yml', $out['run_a']['source_filename']);
   }
 
+  /**
+   * The comparison exposes which assistant answered each side.
+   *
+   * @covers ::compareResults
+   */
+  public function testRunMetaExposesTheBackend(): void {
+    $out = $this->comparator->compareResults(
+      ['backend' => 'beacon'] + $this->meta(7),
+      ['backend' => 'legacy'] + $this->meta(9),
+      [$this->result('Q1', 'x')],
+      [$this->result('Q1', 'y')],
+    );
+
+    $this->assertSame('beacon', $out['run_a']['backend']);
+    $this->assertSame('legacy', $out['run_b']['backend']);
+  }
+
+  /**
+   * A run stored before backends existed reads back as Beacon.
+   *
+   * @covers ::compareResults
+   */
+  public function testRunMetaBackendDefaultsToBeacon(): void {
+    $out = $this->comparator->compareResults(
+      $this->meta(1),
+      $this->meta(2),
+      [$this->result('Q1', 'x')],
+      [$this->result('Q1', 'x')],
+    );
+
+    $this->assertSame('beacon', $out['run_a']['backend']);
+    $this->assertSame('beacon', $out['run_b']['backend']);
+  }
+
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/ys_ai_tester.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/ys_ai_tester.info.yml
@@ -1,6 +1,6 @@
 name: YS AI Tester
 type: module
-description: 'Batch test the Beacon AI assistant against a YAML list of questions and review the answers and source citations.'
+description: 'Batch test an AI assistant against a plain-text list of questions and review the answers and source citations.'
 core_version_requirement: ^10 || ^11
 package: YaleSites
 dependencies:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/ys_ai_tester.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/ys_ai_tester.install
@@ -26,6 +26,13 @@ function ys_ai_tester_schema(): array {
       ],
       'status' => ['type' => 'varchar', 'length' => 32, 'not null' => TRUE, 'default' => 'processing'],
       'question_count' => ['type' => 'int', 'unsigned' => TRUE, 'not null' => TRUE, 'default' => 0],
+      'backend' => [
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+        'default' => 'beacon',
+        'description' => 'Id of the assistant that answered this run.',
+      ],
     ],
     'primary key' => ['id'],
     'indexes' => [
@@ -44,6 +51,12 @@ function ys_ai_tester_schema(): array {
       'question' => ['type' => 'text', 'size' => 'medium', 'not null' => TRUE],
       'answer' => ['type' => 'text', 'size' => 'big', 'not null' => TRUE],
       'citations' => ['type' => 'text', 'size' => 'medium', 'not null' => TRUE],
+      'error' => [
+        'type' => 'text',
+        'size' => 'medium',
+        'not null' => FALSE,
+        'description' => 'Error recorded against this question, or empty when it was answered.',
+      ],
     ],
     'primary key' => ['id'],
     'indexes' => ['run_id' => ['run_id']],
@@ -95,6 +108,38 @@ function ys_ai_tester_update_10001(): void {
   if (!$schema->indexExists('ys_ai_tester_run', 'source_run_id')) {
     $schema->addIndex('ys_ai_tester_run', 'source_run_id', ['source_run_id'], [
       'fields' => ['source_run_id' => $source_run_id_spec],
+    ]);
+  }
+}
+
+/**
+ * Record which assistant answered a run, and per-question errors.
+ */
+function ys_ai_tester_update_10002(): void {
+  $schema = \Drupal::database()->schema();
+
+  // Every run that exists today was answered by Beacon, so the column default
+  // backfills existing rows correctly and no data migration is needed.
+  if (!$schema->fieldExists('ys_ai_tester_run', 'backend')) {
+    $schema->addField('ys_ai_tester_run', 'backend', [
+      'type' => 'varchar',
+      'length' => 32,
+      'not null' => TRUE,
+      'default' => 'beacon',
+      'description' => 'Id of the assistant that answered this run.',
+    ]);
+  }
+
+  // Before this column a failed question stored an empty answer, which was
+  // indistinguishable from an assistant that genuinely answered with nothing.
+  // A text column cannot carry a default in MySQL, so it is nullable and read
+  // back with a '' fallback.
+  if (!$schema->fieldExists('ys_ai_tester_result', 'error')) {
+    $schema->addField('ys_ai_tester_result', 'error', [
+      'type' => 'text',
+      'size' => 'medium',
+      'not null' => FALSE,
+      'description' => 'Error recorded against this question, or empty when it was answered.',
     ]);
   }
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/ys_ai_tester.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/ys_ai_tester.services.yml
@@ -3,3 +3,20 @@ services:
     class: Drupal\ys_ai_tester\RunComparator
     arguments:
       - '@database'
+
+  # Collects every tagged assistant. A backend disappears with the module that
+  # provides it, so uninstalling a backend submodule removes the option without
+  # the tester core ever referencing that submodule.
+  ys_ai_tester.answer_backend_registry:
+    class: Drupal\ys_ai_tester\AnswerBackendRegistry
+    arguments:
+      - !tagged_iterator ys_ai_tester.answer_backend
+
+  # Beacon carries the highest priority so it sorts first and becomes Run A when
+  # a submission is run against every assistant at once.
+  ys_ai_tester.backend.beacon:
+    class: Drupal\ys_ai_tester\Backend\BeaconAnswerBackend
+    arguments:
+      - '@ys_beacon.beacon_answer'
+    tags:
+      - { name: ys_ai_tester.answer_backend, priority: 100 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/README.md
@@ -77,23 +77,49 @@ cutover cleanup. The check is made at runtime instead.
 Removal is designed to be a clean, one-way door. Beacon-only testing keeps
 working at every step.
 
-1. **Uninstall the module.**
+Uninstalling removes the feature outright: the backend is registered through the
+`ys_ai_tester.answer_backend` service tag, so the option disappears with the
+service, and the tester core never references this module.
 
-   ```
-   drush pm:uninstall ys_ai_tester_legacy
-   ```
+Runs already recorded against the legacy assistant stay viewable and comparable —
+the run history and comparison view fall back to showing the stored backend id
+when no service can be asked for a label. Only the creation of new legacy runs
+stops, and re-running a stored legacy run is refused with an explanatory message
+rather than erroring mid-batch.
 
-   This alone removes the feature: the backend was registered through the
-   `ys_ai_tester.answer_backend` service tag, so the option disappears with the
-   service. The tester core never references this module.
+**Do the removal across two releases, and do not delete the code and the
+`core.extension.yml` line in the same one.** The platform removes modules through
+`drush deploy`, not by running `drush pm:uninstall` on each site by hand.
+`config:import` has to *uninstall* this module, which needs its code present to
+resolve `getPath()` — with the directory already gone it throws
+`UnknownExtensionException`, and installing any other module in that same import
+rebuilds the module list from active `core.extension` and trips the same error.
+This is not hypothetical: it is what happened to `ys_servicenow` (YaleSites-Internal
+issue #1372, PRs #1360 then #1364). The tell at `updatedb` bootstrap is the
+requirements warning "marked as installed in the core.extension configuration, but
+it is missing".
 
-   Runs already recorded against the legacy assistant stay viewable and
-   comparable — the run history and comparison view fall back to showing the
-   stored backend id when no service can be asked for a label. Only the creation
-   of new legacy runs stops, and re-running a stored legacy run is refused with an
-   explanatory message rather than erroring mid-batch.
+1. **Release N — drop the config, keep the code.** Delete the
+   `ys_ai_tester_legacy: 0` line from
+   `web/profiles/custom/yalesites_profile/config/sync/core.extension.yml` and
+   leave this directory in place. On deploy, `config:import` uninstalls the module
+   cleanly — the code is present and there is no `hook_uninstall` or installed
+   config to clean up. Afterwards, confirm the module is gone from each site's
+   **active** `core.extension`; a green deploy on its own is not proof, because an
+   import with no module-install step will not trip the crash while the stale
+   entry survives.
 
-2. **Delete the module directory** and this README.
+2. **Release N+1 — delete the code.** Delete this module directory and this
+   README. No other file changes; `ys_ai_tester` and `ys_beacon` should stay
+   green.
+
+   If waiting a release is unacceptable, the single-release alternative is the
+   `ys_servicenow` pattern: add a `hook_update_N` to `ys_ai_tester` that strips
+   the module from active `core.extension` and cleans its `system.schema`
+   key_value entry, then delete the directory in the same commit. `updatedb` runs
+   before `config:import` in `drush deploy`, so it clears in time. Note a
+   `hook_update_N` runs once — a site whose schema has already advanced past it
+   needs the removal re-issued under a fresh, higher number.
 
 3. **Optionally drop the `backend` column** from `ys_ai_tester_run` with one
    update hook in `ys_ai_tester`, once nobody needs to tell historical legacy runs

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/README.md
@@ -1,0 +1,121 @@
+# YS AI Tester legacy assistant
+
+**This module is temporary.** It exists to support and defend the migration from
+the legacy `ai_engine` chat to Beacon, by letting the AI Tester run one question
+list against both assistants and read the answers side by side. It is expected to
+be removed in a later release — see [Removing this module](#removing-this-module).
+
+## What it adds
+
+The AI Tester's assistant is normally Beacon. This module registers a second
+answer backend, so the tester form offers a choice: run the question list against
+Beacon, against the legacy assistant, or against both at once. Running both
+records two runs over an identical list and lands on the tester's existing
+comparison view, with each side labelled by the assistant that answered it.
+
+Because `RunComparator` pairs results by question text rather than row order, a
+Beacon run and a legacy run over the same list already align — the comparator
+needed no changes.
+
+## How it talks to the legacy assistant
+
+`ai_engine` has no server-side answer path: answering lives entirely in the
+external Azure app that the React chat widget calls. `LegacyConversationClient`
+is the smallest possible PHP mirror of that call — it POSTs a one-message
+transcript to `{azure_base_url}/conversation` and hands the newline-delimited JSON
+reply to `LegacyStreamParser`, which concatenates the assistant deltas and reads
+the citation list out of the `role: "tool"` message. Nothing inside `ai_engine`
+is modified.
+
+Both timeouts are explicit (`REQUEST_TIMEOUT`, `CONNECT_TIMEOUT` on
+`LegacyConversationClient`) so a single hung legacy request cannot stall a whole
+batch. A failed or timed-out question is logged, recorded against that row, and
+the rest of the batch continues.
+
+The parser accumulates text until it parses rather than assuming one complete
+JSON object per line. Note what that does and does not defend against: the client
+buffers the whole response body, so a mid-object network chunk boundary — the case
+the browser widget genuinely faces over a streamed `fetch` — cannot reach this
+parser. It tolerates a producer that spreads an envelope over several lines, and
+keeps the parser correct if the client is ever switched to a real stream.
+
+Legacy citations need no bespoke normalization: they already carry the same keys
+as Beacon's (both descend from the Azure "on your data" citation shape), and
+legacy answers reference sources with the same `[docN]` markers, so the tester
+batch's shared `ys_beacon.citation_formatter` derives an equivalent `cited` flag.
+Citation overlap and cited-source counts are therefore meaningful on both sides.
+
+Formatting happens in `AiTesterBatch`, not in this module: a backend returns the
+assistant's answer and its raw retrieved sources, and the tester core owns the
+stored citation shape. That is why this module has no dependency on the citation
+formatter, and why a backend cannot accidentally store a shape `RunComparator`
+would silently miscount. If a future assistant cited sources with markers other
+than `[docN]`, that assumption would need revisiting — it holds for these two.
+
+## When the option appears
+
+The legacy option is offered only when **both** are true:
+
+1. `ai_engine_chat` is installed, and
+2. `ai_engine_chat.settings:azure_base_url` is non-empty.
+
+Otherwise the tester presents no selector and no compare-both option — it behaves
+exactly as a Beacon-only tester, with no warning and no disabled control.
+
+Availability is deliberately **not** keyed on `ai_engine_chat.settings:enable`,
+`LegacyAiEngine::isActive()` or `LegacyAiEngine::chatActive()`. Cutover sets those
+to FALSE while leaving `azure_base_url` in place, and `'ai_engine*'` is
+config-ignored so `drush deploy` does not revert it. A cut-over site that still
+has a base URL is the primary case for this comparison, not an edge case.
+
+This module does **not** declare a dependency on `ai_engine_chat`, on purpose: a
+hard dependency would make Drupal refuse to uninstall `ai_engine_chat` during
+cutover cleanup. The check is made at runtime instead.
+
+## Removing this module
+
+Removal is designed to be a clean, one-way door. Beacon-only testing keeps
+working at every step.
+
+1. **Uninstall the module.**
+
+   ```
+   drush pm:uninstall ys_ai_tester_legacy
+   ```
+
+   This alone removes the feature: the backend was registered through the
+   `ys_ai_tester.answer_backend` service tag, so the option disappears with the
+   service. The tester core never references this module.
+
+   Runs already recorded against the legacy assistant stay viewable and
+   comparable — the run history and comparison view fall back to showing the
+   stored backend id when no service can be asked for a label. Only the creation
+   of new legacy runs stops, and re-running a stored legacy run is refused with an
+   explanatory message rather than erroring mid-batch.
+
+2. **Delete the module directory** and this README.
+
+3. **Optionally drop the `backend` column** from `ys_ai_tester_run` with one
+   update hook in `ys_ai_tester`, once nobody needs to tell historical legacy runs
+   apart:
+
+   ```php
+   \Drupal::database()->schema()->dropField('ys_ai_tester_run', 'backend');
+   ```
+
+   Leave the column in place if the comparison evidence is still being cited —
+   without it, legacy runs become indistinguishable from Beacon runs.
+
+4. **Optionally collapse the backend seam** in `ys_ai_tester`: with only Beacon
+   left, `AnswerBackendInterface`, `AnswerBackendRegistry` and
+   `Backend\BeaconAnswerBackend` can fold back into `AiTesterBatch`, and
+   `AiTesterForm::backendChoices()`/`resolveRunBackends()` can go, along with
+   `AiTesterController::crossAssistantCaveat()` and the `.ys-compare-caveat`
+   rule in `css/compare.css` (which can no longer fire once every run is
+   Beacon). This is optional cleanup — the seam is harmless with a single
+   backend. Keep the `error` column: any assistant can fail, so it is not
+   legacy-specific.
+
+The feature also retires itself: once `ai_engine_chat` is uninstalled
+platform-wide, the legacy option stops appearing even if this module is still
+installed.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/src/LegacyAnswerBackend.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/src/LegacyAnswerBackend.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_ai_tester_legacy;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\ys_ai_tester\AnswerBackendInterface;
+
+/**
+ * Exposes the legacy ai_engine assistant as an AI Tester answer backend.
+ *
+ * Registered through the `ys_ai_tester.answer_backend` tag, so uninstalling
+ * this module removes the option and leaves the Beacon-only tester intact.
+ */
+class LegacyAnswerBackend implements AnswerBackendInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The backend id recorded on a legacy run.
+   */
+  const ID = 'legacy';
+
+  /**
+   * Constructs the legacy answer backend.
+   *
+   * @param \Drupal\ys_ai_tester_legacy\LegacyConversationClient $client
+   *   The legacy conversation client.
+   */
+  public function __construct(
+    protected LegacyConversationClient $client,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function id(): string {
+    return self::ID;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function label(): string|\Stringable {
+    return $this->t('Legacy ai_engine (Azure)');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isAvailable(): bool {
+    return $this->client->isConfigured();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function answer(string $question): array {
+    // The legacy citations need no bespoke adapting: they already carry the
+    // same keys as Beacon's (both come from the Azure "on your data" shape),
+    // and legacy answers reference sources with the same [docN] markers — so
+    // the batch's shared formatter derives an equivalent cited flag from them.
+    // That is what keeps citation overlap and cited-source counts meaningful
+    // on both sides of a comparison.
+    return $this->client->ask($question);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/src/LegacyConversationClient.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/src/LegacyConversationClient.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_ai_tester_legacy;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+
+/**
+ * Calls the legacy ai_engine Azure conversation endpoint from PHP.
+ *
+ * The legacy assistant has no server-side answer path in Drupal: answering
+ * lives entirely in the external Azure app the React widget talks to. This is
+ * the smallest adapter that mirrors what the widget does — POST a one-message
+ * transcript to {azure_base_url}/conversation and read the streamed reply. It
+ * requires no changes inside ai_engine.
+ */
+class LegacyConversationClient {
+
+  /**
+   * The module whose settings hold the endpoint.
+   */
+  const MODULE = 'ai_engine_chat';
+
+  /**
+   * The config object holding the endpoint.
+   */
+  const CONFIG_NAME = 'ai_engine_chat.settings';
+
+  /**
+   * Seconds to wait for the whole request.
+   *
+   * Generous because the legacy app has to run a retrieval and a completion,
+   * but bounded: without it one hung request could stall an entire batch.
+   */
+  const REQUEST_TIMEOUT = 60;
+
+  /**
+   * Seconds to wait for the connection itself.
+   */
+  const CONNECT_TIMEOUT = 10;
+
+  /**
+   * Constructs the legacy conversation client.
+   *
+   * @param \GuzzleHttp\ClientInterface $httpClient
+   *   The HTTP client.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
+   *   The module handler.
+   * @param \Drupal\Component\Uuid\UuidInterface $uuid
+   *   The UUID generator, for the message id the widget also sends.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service, for the message timestamp.
+   */
+  public function __construct(
+    protected ClientInterface $httpClient,
+    protected ConfigFactoryInterface $configFactory,
+    protected ModuleHandlerInterface $moduleHandler,
+    protected UuidInterface $uuid,
+    protected TimeInterface $time,
+  ) {}
+
+  /**
+   * Returns whether the legacy endpoint is configured on this site.
+   *
+   * Deliberately keyed on the module being installed and the base URL being
+   * set — never on ai_engine_chat.settings:enable or the LegacyAiEngine
+   * active/chat-active helpers. Cutover switches those off while leaving the
+   * base URL in place, and a cut-over site is the primary case for comparing
+   * the two assistants, not an edge case.
+   *
+   * @return bool
+   *   TRUE when a legacy run can be attempted.
+   */
+  public function isConfigured(): bool {
+    if (!$this->moduleHandler->moduleExists(self::MODULE)) {
+      return FALSE;
+    }
+    return $this->baseUrl() !== '';
+  }
+
+  /**
+   * Asks the legacy assistant one question.
+   *
+   * @param string $question
+   *   The question text.
+   *
+   * @return array
+   *   An array with 'answer' (string) and 'citations' (the legacy citation
+   *   list).
+   *
+   * @throws \RuntimeException
+   *   When the endpoint is not configured, the request fails or times out, or
+   *   the stream carries an error.
+   */
+  public function ask(string $question): array {
+    if (!$this->isConfigured()) {
+      throw new \RuntimeException('The legacy ai_engine chat endpoint is not configured.');
+    }
+
+    try {
+      $response = $this->httpClient->request('POST', $this->baseUrl() . '/conversation', [
+        'headers' => ['Content-Type' => 'application/json'],
+        // The same single-turn transcript shape the widget posts. The tester
+        // asks each question independently, so no history is carried over.
+        'json' => [
+          'messages' => [
+            [
+              'id' => $this->uuid->generate(),
+              'role' => 'user',
+              'content' => $question,
+              'date' => gmdate('Y-m-d\TH:i:s\Z', $this->time->getRequestTime()),
+            ],
+          ],
+        ],
+        'timeout' => self::REQUEST_TIMEOUT,
+        'connect_timeout' => self::CONNECT_TIMEOUT,
+      ]);
+    }
+    catch (GuzzleException $e) {
+      // Surfaced as a readable message because it is recorded against the
+      // question and shown in the tester UI.
+      throw new \RuntimeException('The legacy ai_engine request failed: ' . $e->getMessage(), 0, $e);
+    }
+
+    return LegacyStreamParser::parse((string) $response->getBody());
+  }
+
+  /**
+   * Returns the configured base URL without a trailing slash.
+   *
+   * @return string
+   *   The base URL, or an empty string when it is unset or blank.
+   */
+  protected function baseUrl(): string {
+    $configured = (string) $this->configFactory->get(self::CONFIG_NAME)->get('azure_base_url');
+    return rtrim(trim($configured), '/');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/src/LegacyStreamParser.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/src/LegacyStreamParser.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_ai_tester_legacy;
+
+/**
+ * Parses the legacy Azure app's newline-delimited JSON answer stream.
+ *
+ * The wire format is the one the shipped React widget already consumes: one
+ * JSON envelope per line, each carrying choices[0].messages[]. Assistant
+ * messages hold answer deltas that concatenate in arrival order; a single
+ * role "tool" message holds the citation list as a JSON *string*.
+ *
+ * Static because it is a pure function over a wire format with no
+ * collaborators, which also makes it directly testable without a container.
+ */
+final class LegacyStreamParser {
+
+  /**
+   * Parses a response body into an answer and its citations.
+   *
+   * @param string $body
+   *   The newline-delimited JSON response body.
+   *
+   * @return array
+   *   An array with 'answer' (string) and 'citations' (the legacy citation
+   *   list, untouched — its keys already match what the tester's citation
+   *   formatter consumes).
+   *
+   * @throws \RuntimeException
+   *   When the stream carries an error instead of an answer.
+   */
+  public static function parse(string $body): array {
+    $answer = '';
+    $citations = [];
+    // Text is accumulated until it parses rather than assuming one complete
+    // object per line. The caller buffers the whole body, so a mid-object TCP
+    // chunk boundary cannot reach here — what this tolerates is a producer that
+    // spreads an envelope over several lines (e.g. pretty-printed JSON), and it
+    // keeps the parser correct if the caller is ever switched to a real stream.
+    $pending = '';
+    $parsed = 0;
+
+    foreach (preg_split('/\r\n|\r|\n/', $body) as $line) {
+      if ($line === '' || $line === '{}') {
+        continue;
+      }
+
+      $candidate = $pending . $line;
+      $envelope = json_decode($candidate, TRUE);
+
+      // A line that opens a new object means the text accumulated so far can
+      // never complete, so it is abandoned rather than prefixed onto this one.
+      // Without this, a single unparsable line mid-body (a keep-alive, an SSE
+      // "data:" prefix) would poison every envelope after it and silently
+      // truncate the answer.
+      if (!is_array($envelope) && $pending !== '' && str_starts_with(ltrim($line), '{')) {
+        $candidate = $line;
+        $envelope = json_decode($candidate, TRUE);
+      }
+
+      if (!is_array($envelope)) {
+        // Incomplete — keep accumulating. Trailing text that never completes is
+        // simply dropped when the loop ends.
+        $pending = $candidate;
+        continue;
+      }
+      $pending = '';
+      $parsed++;
+
+      if (isset($envelope['error'])) {
+        throw new \RuntimeException(self::errorMessage($envelope['error']));
+      }
+
+      foreach ($envelope['choices'][0]['messages'] ?? [] as $message) {
+        $role = $message['role'] ?? '';
+        if ($role === 'assistant') {
+          $answer .= (string) ($message['content'] ?? '');
+        }
+        elseif ($role === 'tool') {
+          // Matches the widget: the last tool message seen wins, and unparsable
+          // tool content yields no citations rather than failing the answer.
+          $citations = self::decodeCitations((string) ($message['content'] ?? ''));
+        }
+      }
+    }
+
+    // A body that carried content but yielded no envelope is a failure, not an
+    // empty answer — an Azure sign-in page or a proxy interstitial returned
+    // with a 200 would otherwise be stored as "the assistant answered
+    // nothing", exactly the ambiguity the run's error column exists to remove.
+    if ($parsed === 0 && trim($body) !== '') {
+      throw new \RuntimeException('The legacy assistant returned an unreadable response.');
+    }
+
+    return ['answer' => $answer, 'citations' => $citations];
+  }
+
+  /**
+   * Renders an envelope's error payload as a readable message.
+   *
+   * The upstream may report either a bare string or a structured object (the
+   * Azure OpenAI shape, `{code, message}`); casting the latter to string would
+   * record the literal "Array" and lose the diagnosis.
+   *
+   * @param mixed $error
+   *   The envelope's error value.
+   *
+   * @return string
+   *   The message to record against the question.
+   */
+  private static function errorMessage(mixed $error): string {
+    if (is_scalar($error)) {
+      return (string) $error;
+    }
+    if (is_array($error) && isset($error['message']) && is_scalar($error['message'])) {
+      return (string) $error['message'];
+    }
+    return (string) json_encode($error);
+  }
+
+  /**
+   * Decodes a tool message's JSON-string content into its citation list.
+   *
+   * @param string $content
+   *   The tool message content.
+   *
+   * @return array
+   *   The citation list, or an empty array when it cannot be read.
+   */
+  private static function decodeCitations(string $content): array {
+    $decoded = json_decode($content, TRUE);
+    if (!is_array($decoded) || !is_array($decoded['citations'] ?? NULL)) {
+      return [];
+    }
+    return $decoded['citations'];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/tests/src/Unit/LegacyAnswerBackendTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/tests/src/Unit/LegacyAnswerBackendTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ys_ai_tester_legacy\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai_tester\AnswerBackendInterface;
+use Drupal\ys_ai_tester_legacy\LegacyAnswerBackend;
+use Drupal\ys_ai_tester_legacy\LegacyConversationClient;
+use Drupal\ys_beacon\Service\CitationFormatter;
+
+/**
+ * Tests the legacy assistant exposed as an AI Tester answer backend.
+ *
+ * @coversDefaultClass \Drupal\ys_ai_tester_legacy\LegacyAnswerBackend
+ * @group ys_beacon
+ */
+class LegacyAnswerBackendTest extends UnitTestCase {
+
+  /**
+   * Builds one legacy citation in the Azure "on your data" shape.
+   *
+   * @param string $title
+   *   The source title.
+   * @param string $url
+   *   The source URL.
+   *
+   * @return array
+   *   The citation, with every key the legacy widget contract defines.
+   */
+  private static function citation(string $title, string $url): array {
+    return [
+      'content' => 'Body text for ' . $title,
+      'id' => NULL,
+      'title' => $title,
+      'filepath' => NULL,
+      'url' => $url,
+      'metadata' => NULL,
+      'chunk_id' => '0',
+      'reindex_id' => NULL,
+    ];
+  }
+
+  /**
+   * Builds the backend over a stubbed client.
+   *
+   * @param bool $configured
+   *   Whether the client reports the endpoint as configured.
+   * @param array $answer
+   *   The answer the client returns, or empty to stub nothing.
+   *
+   * @return \Drupal\ys_ai_tester_legacy\LegacyAnswerBackend
+   *   The backend.
+   */
+  private function backend(bool $configured, array $answer = []): LegacyAnswerBackend {
+    $client = $this->createMock(LegacyConversationClient::class);
+    $client->method('isConfigured')->willReturn($configured);
+    if ($answer !== []) {
+      $client->method('ask')->willReturn($answer);
+    }
+
+    $backend = new LegacyAnswerBackend($client);
+    $backend->setStringTranslation($this->getStringTranslationStub());
+    return $backend;
+  }
+
+  /**
+   * @covers ::id
+   */
+  public function testIdIsStableAndNotTheDefaultBackend(): void {
+    $backend = $this->backend(TRUE);
+
+    $this->assertSame('legacy', $backend->id());
+    $this->assertNotSame(AnswerBackendInterface::DEFAULT_ID, $backend->id());
+  }
+
+  /**
+   * @covers ::isAvailable
+   */
+  public function testAvailabilityFollowsTheClientConfiguration(): void {
+    $this->assertTrue($this->backend(TRUE)->isAvailable());
+    $this->assertFalse($this->backend(FALSE)->isAvailable());
+  }
+
+  /**
+   * The backend passes the assistant's answer and raw sources straight through.
+   *
+   * @covers ::answer
+   */
+  public function testAnswerReturnsTheClientResultUnchanged(): void {
+    $result = [
+      'answer' => 'Office hours are in the handbook. [doc1]',
+      'citations' => [self::citation('Handbook', 'https://example.com/handbook')],
+    ];
+
+    $this->assertSame($result, $this->backend(TRUE, $result)->answer('Hours?'));
+  }
+
+  /**
+   * @covers ::answer
+   */
+  public function testAnswerWithNoCitationsStillReturnsTheAnswer(): void {
+    $result = ['answer' => 'Plain answer.', 'citations' => []];
+
+    $this->assertSame($result, $this->backend(TRUE, $result)->answer('Anything?'));
+  }
+
+  /**
+   * Tests that legacy citations normalize with the tester's shared formatter.
+   *
+   * This is the load-bearing assumption behind the legacy backend: because a
+   * legacy citation already carries the same keys as a Beacon one, and legacy
+   * answers cite sources with the same [docN] markers, the batch's existing
+   * CitationFormatter derives a correct cited flag from them with no
+   * legacy-specific normalization. RunComparator counts that flag, so if this
+   * were wrong every legacy row would report zero cited sources — reading as
+   * "legacy never cites anything". The real formatter is used, not a mock,
+   * because a mock would prove nothing here.
+   */
+  public function testLegacyCitationsNormalizeWithTheSharedFormatter(): void {
+    $answer = 'Office hours are in the handbook. [doc1]';
+    $citations = [
+      self::citation('Handbook', 'https://example.com/handbook'),
+      self::citation('Other page', 'https://example.com/other'),
+    ];
+
+    $formatted = (new CitationFormatter())->format($answer, $citations);
+
+    $this->assertCount(2, $formatted);
+    $this->assertTrue((bool) $formatted[0]['cited'], 'The [doc1] source is flagged cited.');
+    $this->assertFalse((bool) $formatted[1]['cited'], 'The unreferenced source is retrieved, not cited.');
+    $this->assertSame('Handbook', $formatted[0]['title']);
+    $this->assertSame('https://example.com/handbook', $formatted[0]['url']);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/tests/src/Unit/LegacyConversationClientTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/tests/src/Unit/LegacyConversationClientTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ys_ai_tester_legacy\Unit;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai_tester_legacy\LegacyConversationClient;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Psr7\Utils;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Tests the HTTP adapter for the legacy Azure conversation endpoint.
+ *
+ * @coversDefaultClass \Drupal\ys_ai_tester_legacy\LegacyConversationClient
+ * @group ys_beacon
+ */
+class LegacyConversationClientTest extends UnitTestCase {
+
+  /**
+   * Builds the client under test.
+   *
+   * @param bool $module_exists
+   *   Whether ai_engine_chat reports as installed.
+   * @param string|null $azure_base_url
+   *   The configured base URL.
+   * @param \GuzzleHttp\ClientInterface|null $http_client
+   *   The HTTP client, or NULL for one that must never be called.
+   * @param bool $strict_config
+   *   When TRUE, assert azure_base_url is the only config key ever read.
+   *
+   * @return \Drupal\ys_ai_tester_legacy\LegacyConversationClient
+   *   The client.
+   */
+  private function client(
+    bool $module_exists,
+    ?string $azure_base_url,
+    ?ClientInterface $http_client = NULL,
+    bool $strict_config = FALSE,
+  ): LegacyConversationClient {
+    $config = $this->createMock(ImmutableConfig::class);
+    $get = $config->method('get')->willReturn($azure_base_url);
+    if ($strict_config) {
+      // Proves availability never depends on ai_engine_chat's "enable" flag,
+      // which cutover sets to FALSE while leaving azure_base_url in place.
+      $get->with('azure_base_url');
+    }
+
+    $config_factory = $this->createMock(ConfigFactoryInterface::class);
+    $config_factory->method('get')
+      ->with('ai_engine_chat.settings')
+      ->willReturn($config);
+
+    $module_handler = $this->createMock(ModuleHandlerInterface::class);
+    $module_handler->method('moduleExists')
+      ->with('ai_engine_chat')
+      ->willReturn($module_exists);
+
+    $uuid = $this->createMock(UuidInterface::class);
+    $uuid->method('generate')->willReturn('fixed-uuid');
+
+    $time = $this->createMock(TimeInterface::class);
+    $time->method('getRequestTime')->willReturn(1700000000);
+
+    return new LegacyConversationClient(
+      $http_client ?? $this->neverCalledHttpClient(),
+      $config_factory,
+      $module_handler,
+      $uuid,
+      $time,
+    );
+  }
+
+  /**
+   * Builds an HTTP client that fails the test if it is used.
+   */
+  private function neverCalledHttpClient(): ClientInterface {
+    $http_client = $this->createMock(ClientInterface::class);
+    $http_client->expects($this->never())->method('request');
+    return $http_client;
+  }
+
+  /**
+   * Builds a response whose body is the given NDJSON.
+   */
+  private function response(string $body): ResponseInterface {
+    $response = $this->createMock(ResponseInterface::class);
+    $response->method('getBody')->willReturn(Utils::streamFor($body));
+    return $response;
+  }
+
+  /**
+   * @covers ::isConfigured
+   */
+  public function testNotConfiguredWhenModuleIsUninstalled(): void {
+    $this->assertFalse($this->client(FALSE, 'https://example.com')->isConfigured());
+  }
+
+  /**
+   * @covers ::isConfigured
+   */
+  public function testNotConfiguredWhenBaseUrlIsEmpty(): void {
+    $this->assertFalse($this->client(TRUE, '')->isConfigured());
+  }
+
+  /**
+   * @covers ::isConfigured
+   */
+  public function testNotConfiguredWhenBaseUrlIsMissing(): void {
+    $this->assertFalse($this->client(TRUE, NULL)->isConfigured());
+  }
+
+  /**
+   * @covers ::isConfigured
+   */
+  public function testNotConfiguredWhenBaseUrlIsOnlyWhitespace(): void {
+    $this->assertFalse($this->client(TRUE, "  \n ")->isConfigured());
+  }
+
+  /**
+   * Tests the primary cutover case: chat switched off, base URL still set.
+   *
+   * A cut-over site has ai_engine_chat.settings:enable = FALSE. The legacy
+   * option must stay available anyway, so availability reads only the base URL.
+   *
+   * @covers ::isConfigured
+   */
+  public function testConfiguredOnCutOverSiteWithOnlyTheBaseUrl(): void {
+    $client = $this->client(TRUE, 'https://askyale.example.com', NULL, TRUE);
+
+    $this->assertTrue($client->isConfigured());
+  }
+
+  /**
+   * @covers ::ask
+   */
+  public function testAskRefusesWhenNotConfigured(): void {
+    $client = $this->client(TRUE, '');
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('legacy ai_engine chat endpoint is not configured');
+
+    $client->ask('Any question?');
+  }
+
+  /**
+   * Tests the request contract the Azure app expects, plus the timeouts.
+   *
+   * @covers ::ask
+   */
+  public function testAskPostsTheWidgetRequestShapeWithExplicitTimeouts(): void {
+    $captured = [];
+    $http_client = $this->createMock(ClientInterface::class);
+    $http_client->expects($this->once())
+      ->method('request')
+      ->willReturnCallback(function (string $method, string $uri, array $options) use (&$captured): ResponseInterface {
+        $captured = ['method' => $method, 'uri' => $uri, 'options' => $options];
+        return $this->response(json_encode([
+          'choices' => [['messages' => [['role' => 'assistant', 'content' => 'Answer.']]]],
+        ]));
+      });
+
+    // A trailing slash on the configured base URL must not double up.
+    $client = $this->client(TRUE, 'https://askyale.example.com/', $http_client);
+    $result = $client->ask('What are the office hours?');
+
+    $this->assertSame('POST', $captured['method']);
+    $this->assertSame('https://askyale.example.com/conversation', $captured['uri']);
+    $this->assertSame(
+      [
+        [
+          'id' => 'fixed-uuid',
+          'role' => 'user',
+          'content' => 'What are the office hours?',
+          'date' => '2023-11-14T22:13:20Z',
+        ],
+      ],
+      $captured['options']['json']['messages']
+    );
+    $this->assertSame(
+      LegacyConversationClient::REQUEST_TIMEOUT,
+      $captured['options']['timeout'],
+      'One hung request must not be able to stall the whole batch.'
+    );
+    $this->assertSame(
+      LegacyConversationClient::CONNECT_TIMEOUT,
+      $captured['options']['connect_timeout']
+    );
+    $this->assertSame('Answer.', $result['answer']);
+  }
+
+  /**
+   * @covers ::ask
+   */
+  public function testAskReturnsParsedAnswerAndCitations(): void {
+    $body = json_encode([
+      'choices' => [
+        [
+          'messages' => [
+            [
+              'role' => 'tool',
+              'content' => json_encode([
+                'citations' => [['title' => 'Handbook', 'url' => 'https://example.com/h']],
+                'intent' => 'hours',
+              ]),
+            ],
+            ['role' => 'assistant', 'content' => 'See the handbook. [doc1]'],
+          ],
+        ],
+      ],
+    ]);
+
+    $http_client = $this->createMock(ClientInterface::class);
+    $http_client->method('request')->willReturn($this->response($body));
+
+    $result = $this->client(TRUE, 'https://askyale.example.com', $http_client)->ask('Hours?');
+
+    $this->assertSame('See the handbook. [doc1]', $result['answer']);
+    $this->assertSame('Handbook', $result['citations'][0]['title']);
+  }
+
+  /**
+   * A transport failure surfaces as a readable error, not a raw Guzzle trace.
+   *
+   * @covers ::ask
+   */
+  public function testAskWrapsTransportFailures(): void {
+    $http_client = $this->createMock(ClientInterface::class);
+    $http_client->method('request')
+      ->willThrowException(new TransferException('cURL error 28: Operation timed out'));
+
+    $client = $this->client(TRUE, 'https://askyale.example.com', $http_client);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('The legacy ai_engine request failed: cURL error 28');
+
+    $client->ask('Hours?');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/tests/src/Unit/LegacyStreamParserTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/tests/src/Unit/LegacyStreamParserTest.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ys_ai_tester_legacy\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai_tester_legacy\LegacyStreamParser;
+
+/**
+ * Tests parsing the legacy Azure app's newline-delimited JSON answer stream.
+ *
+ * The fixtures mirror the contract the shipped React widget already relies on:
+ * an envelope per line with choices[0].messages[], assistant messages carrying
+ * answer deltas and a single role "tool" message whose content is a JSON string
+ * holding the citation list (see ai_engine_chat/react/src/api/models.ts).
+ *
+ * @coversDefaultClass \Drupal\ys_ai_tester_legacy\LegacyStreamParser
+ * @group ys_beacon
+ */
+class LegacyStreamParserTest extends UnitTestCase {
+
+  /**
+   * Builds one NDJSON envelope line.
+   *
+   * @param array $messages
+   *   The messages the envelope carries.
+   *
+   * @return string
+   *   The encoded envelope, without a trailing newline.
+   */
+  private static function envelope(array $messages): string {
+    return json_encode([
+      'id' => 'resp-1',
+      'model' => 'gpt-4',
+      'created' => 1700000000,
+      'object' => 'chat.completion.chunk',
+      'choices' => [['messages' => $messages]],
+    ]);
+  }
+
+  /**
+   * Builds an assistant delta message.
+   */
+  private static function assistant(string $content): array {
+    return ['role' => 'assistant', 'content' => $content];
+  }
+
+  /**
+   * Builds a tool message whose content is the encoded citation payload.
+   */
+  private static function tool(array $citations, string $intent = 'office hours'): array {
+    return [
+      'role' => 'tool',
+      'content' => json_encode(['citations' => $citations, 'intent' => $intent]),
+    ];
+  }
+
+  /**
+   * Builds one legacy citation in the Azure "on your data" shape.
+   */
+  private static function citation(string $title, ?string $url): array {
+    return [
+      'content' => 'Body text for ' . $title,
+      'id' => NULL,
+      'title' => $title,
+      'filepath' => NULL,
+      'url' => $url,
+      'metadata' => NULL,
+      'chunk_id' => '0',
+      'reindex_id' => NULL,
+    ];
+  }
+
+  /**
+   * @covers ::parse
+   */
+  public function testConcatenatesAssistantDeltasInOrder(): void {
+    $body = implode("\n", [
+      self::envelope([self::assistant('Office hours are ')]),
+      self::envelope([self::assistant('in the handbook. ')]),
+      self::envelope([self::assistant('[doc1]')]),
+    ]);
+
+    $result = LegacyStreamParser::parse($body);
+
+    $this->assertSame('Office hours are in the handbook. [doc1]', $result['answer']);
+  }
+
+  /**
+   * Citations must survive with every key the tester's formatter consumes.
+   *
+   * @covers ::parse
+   */
+  public function testExtractsCitationsFromTheToolMessage(): void {
+    $citation = self::citation('Handbook', 'https://example.com/handbook');
+    $body = implode("\n", [
+      self::envelope([self::tool([$citation])]),
+      self::envelope([self::assistant('See the handbook. [doc1]')]),
+    ]);
+
+    $result = LegacyStreamParser::parse($body);
+
+    $this->assertCount(1, $result['citations']);
+    $this->assertSame($citation, $result['citations'][0]);
+    $this->assertSame(
+      ['content', 'id', 'title', 'filepath', 'url', 'metadata', 'chunk_id', 'reindex_id'],
+      array_keys($result['citations'][0]),
+      'The 8-key legacy citation shape is preserved for CitationFormatter.'
+    );
+  }
+
+  /**
+   * Tests that an envelope spread over several lines is reassembled.
+   *
+   * The caller buffers the whole response, so this is not defending against a
+   * mid-object network chunk boundary — it covers a producer that does not emit
+   * exactly one complete object per line, and keeps the parser correct if the
+   * caller is ever switched to a real stream.
+   *
+   * @covers ::parse
+   */
+  public function testReassemblesAnEnvelopeSpreadOverLines(): void {
+    $envelope = self::envelope([self::assistant('Split answer.')]);
+    $cut = (int) (strlen($envelope) / 2);
+    $body = substr($envelope, 0, $cut) . "\n" . substr($envelope, $cut);
+
+    $result = LegacyStreamParser::parse($body);
+
+    $this->assertSame('Split answer.', $result['answer']);
+  }
+
+  /**
+   * @covers ::parse
+   */
+  public function testIgnoresBlankAndEmptyObjectLines(): void {
+    $body = implode("\n", [
+      '',
+      '{}',
+      self::envelope([self::assistant('Answer.')]),
+      '{}',
+      '',
+    ]);
+
+    $result = LegacyStreamParser::parse($body);
+
+    $this->assertSame('Answer.', $result['answer']);
+    $this->assertSame([], $result['citations']);
+  }
+
+  /**
+   * @covers ::parse
+   */
+  public function testThrowsOnAnErrorEnvelope(): void {
+    $body = json_encode(['error' => 'Upstream model timed out.']);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Upstream model timed out.');
+
+    LegacyStreamParser::parse($body);
+  }
+
+  /**
+   * An unparsable line mid-body must not swallow everything after it.
+   *
+   * Regression: accumulating past a line that can never complete poisoned the
+   * buffer, so a keep-alive or an SSE "data:" prefix silently truncated the
+   * answer and dropped the citations — with no error recorded.
+   *
+   * @covers ::parse
+   */
+  public function testUnparseableLineMidBodyDoesNotDiscardLaterEnvelopes(): void {
+    $body = implode("\n", [
+      self::envelope([self::assistant('Office hours ')]),
+      'data: keep-alive',
+      self::envelope([self::assistant('are 9-5. [doc1]')]),
+      self::envelope([self::tool([self::citation('Handbook', 'https://example.com/h')])]),
+    ]);
+
+    $result = LegacyStreamParser::parse($body);
+
+    $this->assertSame('Office hours are 9-5. [doc1]', $result['answer']);
+    $this->assertCount(1, $result['citations'], 'The citation after the bad line survives.');
+  }
+
+  /**
+   * A 200 whose body is not the expected stream errors, not answers blank.
+   *
+   * An Azure sign-in page or proxy interstitial returned with a 200 must be
+   * recorded as a failure; storing it as an empty answer would recreate exactly
+   * the ambiguity the per-question error column exists to remove.
+   *
+   * @covers ::parse
+   */
+  public function testUnreadableBodyIsAnError(): void {
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('unreadable response');
+
+    LegacyStreamParser::parse('<!DOCTYPE html><html><body>Sign in</body></html>');
+  }
+
+  /**
+   * A structured error payload keeps its message instead of becoming "Array".
+   *
+   * @covers ::parse
+   */
+  public function testStructuredErrorPayloadKeepsItsMessage(): void {
+    $body = json_encode([
+      'error' => ['code' => '429', 'message' => 'Rate limit exceeded'],
+    ]);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Rate limit exceeded');
+
+    LegacyStreamParser::parse($body);
+  }
+
+  /**
+   * @covers ::parse
+   */
+  public function testMalformedToolContentYieldsNoCitations(): void {
+    $body = implode("\n", [
+      self::envelope([['role' => 'tool', 'content' => 'not json at all']]),
+      self::envelope([self::assistant('Answer.')]),
+    ]);
+
+    $result = LegacyStreamParser::parse($body);
+
+    $this->assertSame('Answer.', $result['answer']);
+    $this->assertSame([], $result['citations']);
+  }
+
+  /**
+   * @covers ::parse
+   */
+  public function testToolMessageWithoutCitationsKeyYieldsNoCitations(): void {
+    $body = self::envelope([
+      ['role' => 'tool', 'content' => json_encode(['intent' => 'x'])],
+    ]);
+
+    $this->assertSame([], LegacyStreamParser::parse($body)['citations']);
+  }
+
+  /**
+   * @covers ::parse
+   */
+  public function testAnswerWithNoToolMessageHasNoCitations(): void {
+    $body = self::envelope([self::assistant('No sources for this one.')]);
+
+    $result = LegacyStreamParser::parse($body);
+
+    $this->assertSame('No sources for this one.', $result['answer']);
+    $this->assertSame([], $result['citations']);
+  }
+
+  /**
+   * The reference widget keeps the last tool message it sees; so does this.
+   *
+   * @covers ::parse
+   */
+  public function testTheLastToolMessageWins(): void {
+    $body = implode("\n", [
+      self::envelope([self::tool([self::citation('First', 'https://example.com/1')])]),
+      self::envelope([self::tool([self::citation('Second', 'https://example.com/2')])]),
+      self::envelope([self::assistant('Answer.')]),
+    ]);
+
+    $result = LegacyStreamParser::parse($body);
+
+    $this->assertCount(1, $result['citations']);
+    $this->assertSame('Second', $result['citations'][0]['title']);
+  }
+
+  /**
+   * @covers ::parse
+   */
+  public function testEmptyBodyYieldsAnEmptyAnswer(): void {
+    $this->assertSame(
+      ['answer' => '', 'citations' => []],
+      LegacyStreamParser::parse('')
+    );
+  }
+
+  /**
+   * Trailing text that never parses is dropped rather than raising.
+   *
+   * @covers ::parse
+   */
+  public function testUnparseableTrailingTextIsIgnored(): void {
+    $body = self::envelope([self::assistant('Answer.')]) . "\n" . '{"partial":';
+
+    $result = LegacyStreamParser::parse($body);
+
+    $this->assertSame('Answer.', $result['answer']);
+  }
+
+  /**
+   * A tool message and assistant deltas in one envelope are both read.
+   *
+   * @covers ::parse
+   */
+  public function testHandlesToolAndAssistantInTheSameEnvelope(): void {
+    $body = self::envelope([
+      self::tool([self::citation('Handbook', 'https://example.com/handbook')]),
+      self::assistant('Answer. [doc1]'),
+    ]);
+
+    $result = LegacyStreamParser::parse($body);
+
+    $this->assertSame('Answer. [doc1]', $result['answer']);
+    $this->assertCount(1, $result['citations']);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/ys_ai_tester_legacy.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/ys_ai_tester_legacy.info.yml
@@ -1,0 +1,7 @@
+name: YS AI Tester legacy assistant
+type: module
+description: 'Temporary: lets the AI Tester also run its question list against the legacy ai_engine Azure assistant, so Beacon answers can be compared side by side to defend the cutover. Uninstall to remove the option.'
+core_version_requirement: ^10 || ^11
+package: YaleSites
+dependencies:
+  - ys_ai_tester

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/ys_ai_tester_legacy.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/ys_ai_tester_legacy.services.yml
@@ -1,0 +1,18 @@
+services:
+  ys_ai_tester_legacy.conversation_client:
+    class: Drupal\ys_ai_tester_legacy\LegacyConversationClient
+    arguments:
+      - '@http_client'
+      - '@config.factory'
+      - '@module_handler'
+      - '@uuid'
+      - '@datetime.time'
+
+  # Lower priority than the Beacon backend so Beacon sorts first and becomes
+  # Run A when a submission runs against both assistants.
+  ys_ai_tester_legacy.backend:
+    class: Drupal\ys_ai_tester_legacy\LegacyAnswerBackend
+    arguments:
+      - '@ys_ai_tester_legacy.conversation_client'
+    tags:
+      - { name: ys_ai_tester.answer_backend, priority: 0 }


### PR DESCRIPTION
## [1470: AI Tester: run the same questions against legacy ai_engine and compare against Beacon](https://github.com/yalesites-org/YaleSites-Internal/issues/1470)

### Description of work

The AI Tester can now run its question list against Beacon, against the legacy `ai_engine` Azure assistant, or against **both from one submission** — which records two runs over an identical list and lands on the existing comparison view, each side labelled by the assistant that answered. This exists to support and defend the cutover decision, and is built to be deleted later.

- **A minimal `AnswerBackendInterface`** in `ys_ai_tester`, with the existing Beacon path as its default implementation. Backends register through the `ys_ai_tester.answer_backend` service tag, so no tester-core class names a specific backend.
- **All legacy code in a new `ys_ai_tester_legacy` submodule.** Uninstalling it removes the feature and leaves the Beacon-only tester fully working. Removal steps are documented in `ys_ai_tester_legacy/README.md`.
- **`backend` column on `ys_ai_tester_run`**, defaulting to `beacon`, so runs recorded before this change read back correctly. Shown in the run history and on both sides of the comparison. Added by `ys_ai_tester_update_10002`.
- **The comparison view warns when the two runs used different assistants** — different content set, index, system prompt, retrieval and model — so a high "differs" count is not misread as a Beacon regression.
- `RunComparator` needed **no changes**: it already pairs results by question text rather than row order, so a Beacon run and a legacy run over the same list already align.

**Availability is conditional, and deliberately not keyed on the flags cutover clears.** The legacy option appears only when `ai_engine_chat` is installed *and* `ai_engine_chat.settings:azure_base_url` is non-empty — never on `LegacyAiEngine::isActive()` or `::chatActive()`, both of which return FALSE once a site is cut over. A cut-over site that still has a base URL is the primary use case here, not an edge case. When the endpoint is not configured, the tester shows no selector and no compare-both option — no warning, no disabled control. The submodule does **not** declare a dependency on `ai_engine_chat`, because a hard dependency would make Drupal refuse to uninstall `ai_engine_chat` during cutover cleanup.

**Legacy citations needed no bespoke normalization.** They already carry the same keys as Beacon's (both descend from the Azure "on your data" citation shape), and legacy answers cite sources with the same `[docN]` markers, so the shared citation formatter derives an equivalent `cited` flag — which is what keeps citation overlap and cited-source counts meaningful on both sides. Formatting now happens once in `AiTesterBatch` rather than in each backend, so a backend cannot forget it and silently report zero cited sources.

**Also adds an `error` column on `ys_ai_tester_result`, which fixes a pre-existing flaw.** Before this, a failed question stored an *empty answer* that was indistinguishable from an assistant that genuinely answered nothing, and the only record was a batch-scoped message that vanished with the request. The error is now recorded per question, rendered in the run and comparison views, and included in the JSON and CSV exports — the artefacts people quote as evidence. A failed or timed-out legacy request lets the rest of the batch finish.

Two things reviewers may want to look at specifically:

- **Each run gets its own batch set**, rather than both sharing one. A single shared set overwrites `results['run_id']` on every operation, so `finished()` would record only the last run's status and leave the first stuck at `processing` forever — hiding its Rerun link and labelling Run A "processing" on the very page this feature produces. Separate sets also stop one assistant's failure from marking the other assistant's run failed.
- **`ys_ai_tester_legacy` is added to `core.extension.yml`.** Without that line `config:import` would never install it, and would uninstall it if it were enabled by hand. Note for whoever removes this feature later: that line has to go too, or `config:import` will put it back.

The legacy HTTP adapter mirrors what the React widget already does — POST a one-message transcript to `{azure_base_url}/conversation` and read the newline-delimited JSON reply, taking citations from the `role: "tool"` message. It requires no changes inside `ai_engine`. Both timeouts are explicit so one hung request cannot stall a batch. A `200` carrying an unreadable body (an Azure sign-in page, a proxy interstitial) is recorded as an error rather than as an empty answer, and an unparsable line mid-stream no longer discards the envelopes after it.

**Reachability, the risk the issue asked to settle first:** probed server-side from the appliance against the real configured `azure_base_url`. DNS resolves, `GET /` returns 200, and `HEAD /conversation` returns **405** — the route exists, is reachable, and rejects only the method, so it is not gated by Easy Auth or an IP allowlist on that egress path.

**What is NOT yet verified, and is the one thing to confirm on the multidev:** a real `POST /conversation`. No live POST was made from this branch, so legacy answers have not been observed end to end. The parser is covered by unit tests built from the widget's own TypeScript contract, and the HTTP client is unit-tested against a mocked Guzzle client, but the live round trip is unproven. See the first testing step.

Tests: `ys_ai_tester` 51 → 80 passing (+29); new `ys_ai_tester_legacy` suite 29 passing; `ys_beacon` unchanged at 274 passing. `composer code-sniff` clean.

### Functional testing steps:

- [ ] **Confirm the legacy endpoint is reachable and answers (the unverified step).** On the multidev, check `drush cget ai_engine_chat.settings azure_base_url` is set. Go to **Configuration → YaleSites Beacon settings → AI Tester**, choose **Legacy ai_engine (Azure)**, enter one question, and run it. Confirm a real answer and source citations come back — not an empty answer and not a recorded error.
- [ ] With `azure_base_url` set, the AI Tester shows an **Assistant** selector with three options: Beacon, Legacy ai_engine (Azure), and "Both — run the same questions against each assistant and compare". Beacon is preselected.
- [ ] Choose **Both**, enter 2–3 questions, and run. Confirm you land on the comparison view, that it shows **two** runs, and that Run A and Run B each say which assistant answered.
- [ ] On that comparison, confirm the yellow caveat explains the runs used different assistants and that a high "differs" count is not a regression. Confirm the "N of M sources cited" figures are populated on **both** sides (not `0 of 0` on the legacy side).
- [ ] Go back to the tester. The **Run History** table has an **Assistant** column, and any run created before this release reads as **Beacon**.
- [ ] Download **JSON** and **CSV** from a run detail page and from a comparison. Confirm the run CSV has an `Error` column and the comparison CSV has `error_a` / `error_b`.
- [ ] Click **Rerun** on a legacy run and confirm it re-runs against the legacy assistant (not Beacon) and completes. Confirm the new run's status reaches `complete` or `failed` — **not** stuck at `processing`.
- [ ] Run **Both** again and confirm **both** runs finish with a real status in the Run History. Neither should remain `processing`.
- [ ] **Unconfigured behaviour:** clear the base URL (`drush cset ai_engine_chat.settings azure_base_url ''`, then `drush cr`) and reload the tester. Confirm there is **no** Assistant selector and **no** compare-both option, and no warning or disabled control — it looks exactly like the Beacon-only tester. Existing legacy runs must still be viewable and comparable, and clicking **Rerun** on one must show a clear "no longer available … cannot be re-run" message rather than erroring. Restore the base URL afterwards.

References yalesites-org/YaleSites-Internal#1470

---
Created with AI
