### PR TITLE
1482: Hide the legacy YaleSites AI menu, forms, and integration cards once Beacon is platform-authorized

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/modules/ys_ai_system_instructions/src/Plugin/ys_integrations/SystemInstructionsIntegrationPlugin.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/modules/ys_ai_system_instructions/src/Plugin/ys_integrations/SystemInstructionsIntegrationPlugin.php
@@ -10,6 +10,7 @@ use Drupal\ys_ai_system_instructions\Service\SystemInstructionsManagerService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\ys_ai\BeaconSupersession;
 
 /**
  * Provides a System Instructions integration plugin.
@@ -29,6 +30,13 @@ class SystemInstructionsIntegrationPlugin extends IntegrationPluginBase {
   protected $instructionsManager;
 
   /**
+   * The legacy AI supersession service.
+   *
+   * @var \Drupal\ys_ai\BeaconSupersession
+   */
+  protected BeaconSupersession $supersession;
+
+  /**
    * Constructs a new SystemInstructionsIntegrationPlugin object.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
@@ -39,10 +47,13 @@ class SystemInstructionsIntegrationPlugin extends IntegrationPluginBase {
    *   The current user.
    * @param \Drupal\ys_ai_system_instructions\Service\SystemInstructionsManagerService $instructions_manager
    *   The system instructions manager service.
+   * @param \Drupal\ys_ai\BeaconSupersession $supersession
+   *   The legacy AI supersession service.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, array $plugin_definition, AccountInterface $current_user, SystemInstructionsManagerService $instructions_manager) {
+  public function __construct(ConfigFactoryInterface $config_factory, array $plugin_definition, AccountInterface $current_user, SystemInstructionsManagerService $instructions_manager, BeaconSupersession $supersession) {
     parent::__construct($config_factory, $plugin_definition, $current_user);
     $this->instructionsManager = $instructions_manager;
+    $this->supersession = $supersession;
   }
 
   /**
@@ -54,6 +65,7 @@ class SystemInstructionsIntegrationPlugin extends IntegrationPluginBase {
       $plugin_definition,
       $container->get('current_user'),
       $container->get('ys_ai_system_instructions.manager'),
+      $container->get('ys_ai.beacon_supersession'),
     );
   }
 
@@ -61,6 +73,12 @@ class SystemInstructionsIntegrationPlugin extends IntegrationPluginBase {
    * {@inheritdoc}
    */
   public function isTurnedOn(): bool {
+    // Beacon ships its own system instructions editor, so the legacy one is
+    // hidden once Beacon supersedes it, however well configured it is.
+    if ($this->supersession->isSuperseded()) {
+      return FALSE;
+    }
+
     $config = $this->configFactory->get('ys_ai_system_instructions.settings');
 
     // Check if system instructions are enabled.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/modules/ys_ai_system_instructions/tests/src/Unit/SystemInstructionsIntegrationPluginTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/modules/ys_ai_system_instructions/tests/src/Unit/SystemInstructionsIntegrationPluginTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\Tests\ys_ai_system_instructions\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai\BeaconSupersession;
+use Drupal\ys_ai_system_instructions\Plugin\ys_integrations\SystemInstructionsIntegrationPlugin;
+use Drupal\ys_ai_system_instructions\Service\SystemInstructionsManagerService;
+
+/**
+ * Unit tests for the supersession gate on SystemInstructionsIntegrationPlugin.
+ *
+ * The legacy system instructions card is fully configured on a site that has
+ * moved to Beacon, so without a supersession gate it keeps offering a second
+ * instructions editor next to Beacon's own.
+ *
+ * @coversDefaultClass \Drupal\ys_ai_system_instructions\Plugin\ys_integrations\SystemInstructionsIntegrationPlugin
+ *
+ * @group ys_ai
+ * @group yalesites
+ */
+class SystemInstructionsIntegrationPluginTest extends UnitTestCase {
+
+  /**
+   * Builds the plugin over a fully configured site in a supersession state.
+   */
+  protected function createPlugin(bool $superseded): SystemInstructionsIntegrationPlugin {
+    $config = $this->getMockBuilder(ImmutableConfig::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $config->method('get')->willReturnMap([
+      ['system_instructions_enabled', TRUE],
+      ['system_instructions_api_endpoint', 'https://example.com/api'],
+      ['system_instructions_web_app_name', 'example-app'],
+      ['system_instructions_api_key', 'example-key'],
+    ]);
+
+    $config_factory = $this->createMock(ConfigFactoryInterface::class);
+    $config_factory->method('get')
+      ->with('ys_ai_system_instructions.settings')
+      ->willReturn($config);
+
+    $supersession = $this->createMock(BeaconSupersession::class);
+    $supersession->method('isSuperseded')->willReturn($superseded);
+
+    $manager = $this->createMock(SystemInstructionsManagerService::class);
+
+    return new SystemInstructionsIntegrationPlugin(
+      $config_factory,
+      ['label' => 'AI System Instructions', 'description' => 'Manage AI system instructions.'],
+      $this->createMock(AccountInterface::class),
+      $manager,
+      $supersession,
+    );
+  }
+
+  /**
+   * A fully configured integration still reports on as usual.
+   *
+   * @covers ::isTurnedOn
+   */
+  public function testIsTurnedOnWhenConfiguredAndNotSuperseded(): void {
+    $this->assertTrue($this->createPlugin(FALSE)->isTurnedOn());
+  }
+
+  /**
+   * The same configured integration reports off once superseded.
+   *
+   * @covers ::isTurnedOn
+   */
+  public function testIsTurnedOffWhenSuperseded(): void {
+    $this->assertFalse($this->createPlugin(TRUE)->isTurnedOn());
+  }
+
+  /**
+   * No card is rendered once superseded.
+   *
+   * @covers ::build
+   */
+  public function testBuildRendersNothingWhenSuperseded(): void {
+    $this->assertSame([], $this->createPlugin(TRUE)->build());
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/modules/ys_ai_system_instructions/ys_ai_system_instructions.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/modules/ys_ai_system_instructions/ys_ai_system_instructions.routing.yml
@@ -6,6 +6,7 @@ ys_ai_system_instructions.settings:
     _title: 'YS AI System Instructions Settings'
   requirements:
     _permission: 'configure ys ai system instructions'
+    _ys_ai_not_superseded: 'TRUE'
 
 # System Instructions Management
 ys_ai_system_instructions.form:
@@ -15,6 +16,7 @@ ys_ai_system_instructions.form:
     _title: 'YS AI System Instructions'
   requirements:
     _ys_ai_system_instructions_access: 'TRUE'
+    _ys_ai_not_superseded: 'TRUE'
 
 ys_ai_system_instructions.versions:
   path: '/admin/config/ys-ai/system-instructions/versions'
@@ -23,6 +25,7 @@ ys_ai_system_instructions.versions:
     _title: 'YS AI System Instructions Version History'
   requirements:
     _ys_ai_system_instructions_access: 'TRUE'
+    _ys_ai_not_superseded: 'TRUE'
 
 ys_ai_system_instructions.view:
   path: '/admin/config/ys-ai/system-instructions/versions/{version}'
@@ -31,6 +34,7 @@ ys_ai_system_instructions.view:
     _title: 'View YS AI System Instructions Version'
   requirements:
     _ys_ai_system_instructions_access: 'TRUE'
+    _ys_ai_not_superseded: 'TRUE'
     version: \d+
 
 ys_ai_system_instructions.revert:
@@ -40,4 +44,5 @@ ys_ai_system_instructions.revert:
     _title: 'Revert YS AI System Instructions'
   requirements:
     _ys_ai_system_instructions_access: 'TRUE'
+    _ys_ai_not_superseded: 'TRUE'
     version: \d+

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/src/Access/NotSupersededAccessCheck.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/src/Access/NotSupersededAccessCheck.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\ys_ai\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\ys_ai\BeaconSupersession;
+
+/**
+ * Denies the legacy YaleSites AI routes once Beacon supersedes them.
+ *
+ * Applied additively to every ys_ai-owned route, so a bookmarked URL cannot
+ * reach a form whose menu link has been hidden. Menu links follow route
+ * access in Drupal, so this is also what removes the legacy items from the
+ * Integrations menu and from Configuration > AI Engine. The permission and
+ * configuration checks already on those routes continue to apply.
+ */
+class NotSupersededAccessCheck implements AccessInterface {
+
+  /**
+   * Constructs a NotSupersededAccessCheck object.
+   *
+   * @param \Drupal\ys_ai\BeaconSupersession $supersession
+   *   The legacy AI supersession service.
+   */
+  public function __construct(
+    protected BeaconSupersession $supersession,
+  ) {
+  }
+
+  /**
+   * Checks access against the Beacon supersession state.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The currently logged in account.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(AccountInterface $account) {
+    // Forbidden rather than neutral, so nothing else on the route can grant
+    // what this denies; allowed rather than neutral, because Drupal requires
+    // every requirement on a route to return allowed.
+    $result = $this->supersession->isSuperseded()
+      ? AccessResult::forbidden('Beacon supersedes the legacy YaleSites AI configuration.')
+      : AccessResult::allowed();
+
+    return $result->addCacheTags($this->supersession->getCacheTags());
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/src/BeaconSupersession.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/src/BeaconSupersession.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\ys_ai;
+
+use Drupal\ys_beacon\BeaconAuthorization;
+
+/**
+ * Answers whether Beacon has superseded the legacy YaleSites AI surfaces.
+ *
+ * Sites are being moved from ai_engine onto ys_beacon. While both modules are
+ * installed a site would otherwise show two AI configuration trees and two
+ * system instructions editors, one of them retired. The legacy surfaces are
+ * therefore hidden as soon as Beacon is available to the site's admins, which
+ * is exactly when a platform admin has authorized Beacon for the site: until
+ * then Beacon hides all of its own surfaces, so precisely one tree is ever
+ * visible.
+ *
+ * Deliberately not gated on ai_engine_chat.settings:azure_base_url. The
+ * assisted cutover's "Turn off legacy AI Engine" step never clears that value,
+ * so a site whose legacy chatbot is fully switched off still looks configured.
+ *
+ * ys_beacon is an optional dependency: the authorization service is injected
+ * with an optional container reference, which resolves to NULL on a site where
+ * ys_beacon is not installed. ys_ai then behaves exactly as it always has.
+ *
+ * @see \Drupal\ys_beacon\BeaconAuthorization
+ */
+class BeaconSupersession {
+
+  /**
+   * Constructs a BeaconSupersession object.
+   *
+   * @param \Drupal\ys_beacon\BeaconAuthorization|null $beaconAuthorization
+   *   The Beacon authorization service, or NULL without ys_beacon.
+   */
+  public function __construct(
+    protected ?BeaconAuthorization $beaconAuthorization = NULL,
+  ) {
+  }
+
+  /**
+   * Whether Beacon supersedes the legacy YaleSites AI surfaces here.
+   *
+   * @return bool
+   *   TRUE when the legacy menu, forms and cards should be hidden.
+   */
+  public function isSuperseded(): bool {
+    return $this->beaconAuthorization?->isAuthorized() ?? FALSE;
+  }
+
+  /**
+   * The cache tags every answer from this service depends on.
+   *
+   * @return string[]
+   *   Cache tags to add to anything gated on supersession, so that flipping
+   *   authorization takes effect without a manual cache rebuild.
+   */
+  public function getCacheTags(): array {
+    // Spelled out rather than derived from BeaconAuthorization::CONFIG_NAME so
+    // that reading it never loads a ys_beacon class.
+    return ['config:ys_beacon.settings'];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/src/Plugin/ys_integrations/AiIntegrationPlugin.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/src/Plugin/ys_integrations/AiIntegrationPlugin.php
@@ -4,8 +4,12 @@ namespace Drupal\ys_ai\Plugin\ys_integrations;
 
 use Drupal\ys_integrations\IntegrationPluginBase;
 use Drupal\ys_integrations\Attribute\Integration;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
+use Drupal\ys_ai\BeaconSupersession;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
 * Provides an AI integration plugin.
@@ -18,9 +22,49 @@ use Drupal\Core\Url;
 class AiIntegrationPlugin extends IntegrationPluginBase {
 
   /**
+   * The legacy AI supersession service.
+   *
+   * @var \Drupal\ys_ai\BeaconSupersession
+   */
+  protected BeaconSupersession $supersession;
+
+  /**
+   * Constructs a new AiIntegrationPlugin object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param array $plugin_definition
+   *   The plugin definition.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\ys_ai\BeaconSupersession $supersession
+   *   The legacy AI supersession service.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, array $plugin_definition, AccountInterface $current_user, BeaconSupersession $supersession) {
+    parent::__construct($config_factory, $plugin_definition, $current_user);
+    $this->supersession = $supersession;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $container->get('config.factory'),
+      $plugin_definition,
+      $container->get('current_user'),
+      $container->get('ys_ai.beacon_supersession'),
+    );
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function isTurnedOn(): bool {
+    if ($this->supersession->isSuperseded()) {
+      return FALSE;
+    }
+
     $config = $this->configFactory->get('ai_engine_chat.settings');
     return $config->get('azure_base_url') != NULL;
   }
@@ -43,6 +87,14 @@ class AiIntegrationPlugin extends IntegrationPluginBase {
    * {@inheritdoc}
    */
   public function build(): array {
+    // Render no card at all once Beacon supersedes this integration, rather
+    // than the "not configured" card, which would still advertise a retired
+    // integration. Checked here as well as in isTurnedOn() because an
+    // unconfigured-but-not-superseded site keeps showing that card.
+    if ($this->supersession->isSuperseded()) {
+      return [];
+    }
+
     $form = [];
 
     $form['title'] = $this->pluginDefinition['label'];

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/tests/src/Unit/Access/NotSupersededAccessCheckTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/tests/src/Unit/Access/NotSupersededAccessCheckTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\Tests\ys_ai\Unit\Access;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai\Access\NotSupersededAccessCheck;
+use Drupal\ys_ai\BeaconSupersession;
+
+/**
+ * Unit tests for NotSupersededAccessCheck.
+ *
+ * Applied additively to every ys_ai-owned route, so a bookmarked URL cannot
+ * reach a form whose menu link has been hidden. The check answers only the
+ * supersession question; the permission and configuration checks already on
+ * those routes continue to apply alongside it.
+ *
+ * @coversDefaultClass \Drupal\ys_ai\Access\NotSupersededAccessCheck
+ *
+ * @group ys_ai
+ * @group yalesites
+ */
+class NotSupersededAccessCheckTest extends UnitTestCase {
+
+  /**
+   * Builds the access check over a supersession service in a given state.
+   */
+  protected function createAccessCheck(bool $superseded): NotSupersededAccessCheck {
+    $supersession = $this->createMock(BeaconSupersession::class);
+    $supersession->method('isSuperseded')->willReturn($superseded);
+    $supersession->method('getCacheTags')->willReturn(['config:ys_beacon.settings']);
+
+    return new NotSupersededAccessCheck($supersession);
+  }
+
+  /**
+   * Access is forbidden once Beacon supersedes the legacy AI surfaces.
+   *
+   * Forbidden rather than neutral, so no other access check on the route can
+   * grant what this one denies.
+   *
+   * @covers ::access
+   */
+  public function testAccessForbiddenWhenSuperseded(): void {
+    $result = $this->createAccessCheck(TRUE)->access($this->createMock(AccountInterface::class));
+
+    $this->assertTrue($result->isForbidden());
+  }
+
+  /**
+   * Access is allowed while the legacy surfaces are not superseded.
+   *
+   * Allowed rather than neutral: Drupal requires every route requirement to
+   * return allowed, so a neutral result here would deny the route outright.
+   *
+   * @covers ::access
+   */
+  public function testAccessAllowedWhenNotSuperseded(): void {
+    $result = $this->createAccessCheck(FALSE)->access($this->createMock(AccountInterface::class));
+
+    $this->assertTrue($result->isAllowed());
+  }
+
+  /**
+   * Both outcomes depend on the Beacon settings cache tag.
+   *
+   * @covers ::access
+   */
+  public function testAccessResultsCarryBeaconSettingsCacheTag(): void {
+    foreach ([TRUE, FALSE] as $superseded) {
+      $result = $this->createAccessCheck($superseded)->access($this->createMock(AccountInterface::class));
+
+      $this->assertSame(['config:ys_beacon.settings'], $result->getCacheTags());
+    }
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/tests/src/Unit/BeaconSupersessionTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/tests/src/Unit/BeaconSupersessionTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\Tests\ys_ai\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai\BeaconSupersession;
+use Drupal\ys_beacon\BeaconAuthorization;
+
+/**
+ * Unit tests for BeaconSupersession.
+ *
+ * The legacy YaleSites AI surfaces are superseded once Beacon is
+ * platform-authorized for the site. ys_beacon is an optional dependency: the
+ * authorization service is injected with an optional container reference, so
+ * on a site without Beacon the constructor argument is NULL and nothing is
+ * superseded.
+ *
+ * @coversDefaultClass \Drupal\ys_ai\BeaconSupersession
+ *
+ * @group ys_ai
+ * @group yalesites
+ */
+class BeaconSupersessionTest extends UnitTestCase {
+
+  /**
+   * Builds the service with an authorization service in a given state.
+   */
+  protected function createSupersession(?bool $authorized): BeaconSupersession {
+    if ($authorized === NULL) {
+      return new BeaconSupersession();
+    }
+
+    $authorization = $this->createMock(BeaconAuthorization::class);
+    $authorization->method('isAuthorized')->willReturn($authorized);
+
+    return new BeaconSupersession($authorization);
+  }
+
+  /**
+   * Legacy AI is superseded once Beacon is platform-authorized.
+   *
+   * @covers ::isSuperseded
+   */
+  public function testSupersededWhenBeaconIsAuthorized(): void {
+    $this->assertTrue($this->createSupersession(TRUE)->isSuperseded());
+  }
+
+  /**
+   * Legacy AI stands while Beacon is installed but not yet authorized.
+   *
+   * @covers ::isSuperseded
+   */
+  public function testNotSupersededWhenBeaconIsNotAuthorized(): void {
+    $this->assertFalse($this->createSupersession(FALSE)->isSuperseded());
+  }
+
+  /**
+   * Legacy AI stands on a site where ys_beacon is not installed.
+   *
+   * The optional service reference resolves to NULL there, so ys_ai keeps
+   * working without a hard dependency on ys_beacon.
+   *
+   * @covers ::isSuperseded
+   */
+  public function testNotSupersededWhenBeaconIsAbsent(): void {
+    $this->assertFalse($this->createSupersession(NULL)->isSuperseded());
+  }
+
+  /**
+   * The Beacon settings cache tag is exposed whatever the answer.
+   *
+   * Callers add it to their access results so flipping authorization
+   * invalidates them without a manual cache rebuild.
+   *
+   * @covers ::getCacheTags
+   */
+  public function testCacheTagsCoverBeaconSettings(): void {
+    $this->assertSame(
+      ['config:ys_beacon.settings'],
+      $this->createSupersession(TRUE)->getCacheTags()
+    );
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/tests/src/Unit/IntegrationSettingsFormAlterTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/tests/src/Unit/IntegrationSettingsFormAlterTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Drupal\Tests\ys_ai\Unit;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai\BeaconSupersession;
+
+/**
+ * Tests the Integration Settings form alter that hides the legacy checkboxes.
+ *
+ * The form builds one checkbox per integration plugin definition and its
+ * submit handler writes every one of them back to config. Removing the two
+ * legacy checkboxes outright would therefore write NULL over the stored
+ * values, so they are converted to value elements instead: nothing is
+ * offered in the UI and the stored settings survive a save.
+ *
+ * @group ys_ai
+ * @group yalesites
+ */
+class IntegrationSettingsFormAlterTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 3) . '/ys_ai.module';
+  }
+
+  /**
+   * Registers a supersession service in a given state on the container.
+   */
+  protected function setUpSupersession(bool $superseded): void {
+    $supersession = $this->createMock(BeaconSupersession::class);
+    $supersession->method('isSuperseded')->willReturn($superseded);
+    $supersession->method('getCacheTags')->willReturn(['config:ys_beacon.settings']);
+
+    $container = new ContainerBuilder();
+    $container->set('ys_ai.beacon_supersession', $supersession);
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Builds the integrations form as YsIntegrationSettingsForm would.
+   */
+  protected function buildForm(): array {
+    return [
+      'integrations' => [
+        'ys_ai' => ['#type' => 'checkbox', '#title' => 'AI', '#default_value' => TRUE],
+        'ys_ai_system_instructions' => [
+          '#type' => 'checkbox',
+          '#title' => 'AI System Instructions',
+          '#default_value' => TRUE,
+        ],
+        'ys_beacon' => ['#type' => 'checkbox', '#title' => 'Beacon (AI Chat)', '#default_value' => TRUE],
+      ],
+    ];
+  }
+
+  /**
+   * Runs the alter hook over a freshly built form.
+   */
+  protected function alterForm(array $form): array {
+    $form_state = $this->createMock(FormStateInterface::class);
+    ys_ai_form_ys_integrations_integration_settings_form_alter($form, $form_state, 'ys_integrations_integration_settings_form');
+    return $form;
+  }
+
+  /**
+   * The two legacy checkboxes are no longer offered once superseded.
+   */
+  public function testLegacyCheckboxesAreNotOfferedWhenSuperseded(): void {
+    $this->setUpSupersession(TRUE);
+
+    $form = $this->alterForm($this->buildForm());
+
+    $this->assertSame('value', $form['integrations']['ys_ai']['#type']);
+    $this->assertSame('value', $form['integrations']['ys_ai_system_instructions']['#type']);
+  }
+
+  /**
+   * Saving the form keeps the stored value of each hidden integration.
+   */
+  public function testHiddenCheckboxesKeepTheirStoredValue(): void {
+    $this->setUpSupersession(TRUE);
+
+    $form = $this->alterForm($this->buildForm());
+
+    $this->assertTrue($form['integrations']['ys_ai']['#value']);
+    $this->assertTrue($form['integrations']['ys_ai_system_instructions']['#value']);
+  }
+
+  /**
+   * A stored value of NULL is not what gets written back.
+   *
+   * The form sets #default_value straight from config, so an integration with
+   * no stored key at all defaults to NULL. Passing that through would write
+   * NULL on save — the very thing converting to a value element avoids.
+   */
+  public function testHiddenCheckboxWithNoStoredValueSavesFalse(): void {
+    $this->setUpSupersession(TRUE);
+    $form = $this->buildForm();
+    $form['integrations']['ys_ai']['#default_value'] = NULL;
+
+    $form = $this->alterForm($form);
+
+    $this->assertFalse($form['integrations']['ys_ai']['#value']);
+  }
+
+  /**
+   * Other integrations keep their checkbox.
+   */
+  public function testOtherIntegrationsAreUntouchedWhenSuperseded(): void {
+    $this->setUpSupersession(TRUE);
+
+    $form = $this->alterForm($this->buildForm());
+
+    $this->assertSame('checkbox', $form['integrations']['ys_beacon']['#type']);
+  }
+
+  /**
+   * The form varies on the Beacon settings in both states.
+   *
+   * Including the not-superseded state: a response rendered then must still
+   * be invalidated when authorization is switched on.
+   */
+  public function testFormAlwaysAddsBeaconSettingsCacheTag(): void {
+    foreach ([TRUE, FALSE] as $superseded) {
+      $this->setUpSupersession($superseded);
+
+      $form = $this->alterForm($this->buildForm());
+
+      $this->assertContains('config:ys_beacon.settings', $form['#cache']['tags']);
+    }
+  }
+
+  /**
+   * Every checkbox is still offered on a site Beacon has not superseded.
+   */
+  public function testCheckboxesAreUntouchedWhenNotSuperseded(): void {
+    $this->setUpSupersession(FALSE);
+
+    $form = $this->alterForm($this->buildForm());
+
+    $this->assertSame($this->buildForm()['integrations'], $form['integrations']);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/tests/src/Unit/LegacyRouteGatingTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/tests/src/Unit/LegacyRouteGatingTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\Tests\ys_ai\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests that every ys_ai-owned route is gated on Beacon supersession.
+ *
+ * Menu links follow route access in Drupal, so the requirement is what removes
+ * the "YaleSites AI" tree and the "System Instructions Settings" item under
+ * Configuration > AI Engine. It is asserted over the routing files rather than
+ * per access check because the guarantee is that no route is missed: a
+ * bookmarked URL must not reach a form whose menu link is hidden.
+ *
+ * @group ys_ai
+ * @group yalesites
+ */
+class LegacyRouteGatingTest extends UnitTestCase {
+
+  /**
+   * The route requirement added by ys_ai.
+   */
+  protected const REQUIREMENT = '_ys_ai_not_superseded';
+
+  /**
+   * Every route in both ys_ai routing files carries the requirement.
+   */
+  public function testAllLegacyAiRoutesRequireNotSuperseded(): void {
+    $module_dir = dirname(__DIR__, 3);
+    $routing_files = [
+      $module_dir . '/ys_ai.routing.yml',
+      $module_dir . '/modules/ys_ai_system_instructions/ys_ai_system_instructions.routing.yml',
+    ];
+
+    $checked = [];
+    foreach ($routing_files as $path) {
+      $this->assertFileExists($path);
+      foreach (Yaml::parseFile($path) as $route_name => $route) {
+        $this->assertSame(
+          'TRUE',
+          $route['requirements'][self::REQUIREMENT] ?? NULL,
+          sprintf('Route %s is not gated on %s.', $route_name, self::REQUIREMENT)
+        );
+        $checked[] = $route_name;
+      }
+    }
+
+    // Guards against the files being emptied or renamed out from under the
+    // loop, which would otherwise pass vacuously.
+    $this->assertEqualsCanonicalizing([
+      'ys_ai.settings',
+      'ys_ai_system_instructions.settings',
+      'ys_ai_system_instructions.form',
+      'ys_ai_system_instructions.versions',
+      'ys_ai_system_instructions.view',
+      'ys_ai_system_instructions.revert',
+    ], $checked, 'The set of ys_ai-owned routes changed; confirm each one is gated.');
+  }
+
+  /**
+   * A tagged access check actually answers that requirement.
+   *
+   * Drupal ignores a route requirement no access check applies to, rather than
+   * failing, so a dropped tag or a typo in applies_to would silently reopen
+   * all six routes while the assertions above stayed green.
+   */
+  public function testRequirementIsAnsweredByTaggedAccessCheck(): void {
+    $services = Yaml::parseFile(dirname(__DIR__, 3) . '/ys_ai.services.yml');
+
+    $applies_to = [];
+    foreach ($services['services'] as $service) {
+      foreach ($service['tags'] ?? [] as $tag) {
+        if (($tag['name'] ?? NULL) === 'access_check') {
+          $applies_to[] = $tag['applies_to'] ?? NULL;
+        }
+      }
+    }
+
+    $this->assertContains(self::REQUIREMENT, $applies_to);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/tests/src/Unit/Plugin/ys_integrations/AiIntegrationPluginTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/tests/src/Unit/Plugin/ys_integrations/AiIntegrationPluginTest.php
@@ -9,6 +9,7 @@ use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai\BeaconSupersession;
 use Drupal\ys_ai\Plugin\ys_integrations\AiIntegrationPlugin;
 
 /**
@@ -76,12 +77,14 @@ class AiIntegrationPluginTest extends UnitTestCase {
   /**
    * Builds the plugin under test with the given plugin definition.
    */
-  protected function createPlugin(array $plugin_definition = []): AiIntegrationPlugin {
+  protected function createPlugin(array $plugin_definition = [], bool $superseded = FALSE): AiIntegrationPlugin {
     $plugin_definition += [
       'label' => 'AI',
       'description' => 'Provides integration with the AI engine.',
     ];
-    $plugin = new AiIntegrationPlugin($this->configFactory, $plugin_definition, $this->currentUser);
+    $supersession = $this->createMock(BeaconSupersession::class);
+    $supersession->method('isSuperseded')->willReturn($superseded);
+    $plugin = new AiIntegrationPlugin($this->configFactory, $plugin_definition, $this->currentUser, $supersession);
     $plugin->setStringTranslation($this->getStringTranslationStub());
     return $plugin;
   }
@@ -110,6 +113,39 @@ class AiIntegrationPluginTest extends UnitTestCase {
       ->willReturn($this->mockChatConfig(NULL));
 
     $this->assertFalse($this->createPlugin()->isTurnedOn());
+  }
+
+  /**
+   * IsTurnedOn() is false once Beacon supersedes the legacy AI surfaces.
+   *
+   * The legacy Azure URL is left populated by the assisted cutover, so a site
+   * that has moved to Beacon still satisfies the old test; supersession has to
+   * win over it.
+   *
+   * @covers ::isTurnedOn
+   */
+  public function testIsTurnedOffWhenSupersededDespiteAzureConfigured(): void {
+    $this->configFactory->method('get')
+      ->with('ai_engine_chat.settings')
+      ->willReturn($this->mockChatConfig('https://example.azure.com'));
+
+    $this->assertFalse($this->createPlugin([], TRUE)->isTurnedOn());
+  }
+
+  /**
+   * Build() renders no card at all once superseded.
+   *
+   * Not even the "This integration is not configured." card, which would still
+   * advertise a retired integration on the Integrations page.
+   *
+   * @covers ::build
+   */
+  public function testBuildRendersNothingWhenSuperseded(): void {
+    $this->configFactory->method('get')
+      ->with('ai_engine_chat.settings')
+      ->willReturn($this->mockChatConfig('https://example.azure.com'));
+
+    $this->assertSame([], $this->createPlugin([], TRUE)->build());
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/ys_ai.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/ys_ai.module
@@ -4,3 +4,43 @@
  * @file
  * Module hooks for the ys_ai module.
  */
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_FORM_ID_alter() for the integration settings form.
+ *
+ * Stops offering the two legacy AI integrations once Beacon supersedes them,
+ * so the form matches the Integrations page, which no longer cards them.
+ *
+ * The checkboxes become value elements rather than being removed: the form
+ * writes every plugin definition back to config on save, so a removed element
+ * would write NULL over the stored setting and change what the site would
+ * revert to if Beacon authorization were ever withdrawn.
+ */
+function ys_ai_form_ys_integrations_integration_settings_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+  $supersession = \Drupal::service('ys_ai.beacon_supersession');
+
+  // Which checkboxes this form offers depends on the authorization flag, so
+  // the tag belongs on every response, including the early-return path.
+  $form['#cache']['tags'] = Cache::mergeTags(
+    $form['#cache']['tags'] ?? [],
+    $supersession->getCacheTags()
+  );
+
+  if (!$supersession->isSuperseded()) {
+    return;
+  }
+
+  foreach (['ys_ai', 'ys_ai_system_instructions'] as $integration_id) {
+    if (isset($form['integrations'][$integration_id])) {
+      $element = &$form['integrations'][$integration_id];
+      $element['#type'] = 'value';
+      // An integration with no stored key defaults to NULL; save FALSE for it
+      // rather than writing NULL back over the setting.
+      $element['#value'] = $element['#default_value'] ?? FALSE;
+      unset($element);
+    }
+  }
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/ys_ai.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/ys_ai.routing.yml
@@ -6,3 +6,4 @@ ys_ai.settings:
   requirements:
     _permission: 'configure ys ai user settings'
     _custom_access: 'ys_ai.settings_enabled_access_check::access'
+    _ys_ai_not_superseded: 'TRUE'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/ys_ai.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_ai/ys_ai.services.yml
@@ -3,3 +3,15 @@ services:
     class: Drupal\ys_ai\Access\SettingsEnabledAccessCheck
     arguments: ['@config.factory']
 
+  # ys_beacon is an optional dependency: without it the argument resolves to
+  # NULL and nothing is superseded.
+  ys_ai.beacon_supersession:
+    class: Drupal\ys_ai\BeaconSupersession
+    arguments: ['@?ys_beacon.authorization']
+
+  ys_ai.not_superseded_access_check:
+    class: Drupal\ys_ai\Access\NotSupersededAccessCheck
+    arguments: ['@ys_ai.beacon_supersession']
+    tags:
+      - { name: access_check, applies_to: _ys_ai_not_superseded }
+

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_integrations/src/Controller/YsIntegrationsController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_integrations/src/Controller/YsIntegrationsController.php
@@ -95,7 +95,12 @@ class YsIntegrationsController extends SystemController {
     foreach ($integrations as $id => $integration) {
       if ($integration) {
         $plugin = $this->integrationPluginManager->createInstance($id);
-        $output['#content'][$id] = $plugin->build();
+        // A plugin with nothing to show returns an empty build. The theme
+        // wraps every entry in an admin-item, so keeping those would render
+        // blank cards.
+        if ($build = $plugin->build()) {
+          $output['#content'][$id] = $build;
+        }
       }
     }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_integrations/tests/modules/ys_integrations_test/src/Plugin/ys_integrations/BuiltIntegrationPlugin.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_integrations/tests/modules/ys_integrations_test/src/Plugin/ys_integrations/BuiltIntegrationPlugin.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\ys_integrations_test\Plugin\ys_integrations;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\ys_integrations\Attribute\Integration;
+use Drupal\ys_integrations\IntegrationPluginBase;
+
+/**
+ * Provides a test integration plugin that renders a card.
+ *
+ * The sibling TestIntegrationPlugin inherits the base build(), which returns
+ * an empty array; this one returns content, so the overview controller can be
+ * tested against both an integration that has something to show and one that
+ * has not.
+ */
+#[Integration(
+  id: 'ys_integrations_test_built',
+  label: new TranslatableMarkup('Built Test Integration'),
+  description: new TranslatableMarkup('A test integration that renders a card.'),
+)]
+class BuiltIntegrationPlugin extends IntegrationPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(): array {
+    return ['title' => $this->pluginDefinition['label']];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_integrations/tests/src/Kernel/YsIntegrationsControllerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_integrations/tests/src/Kernel/YsIntegrationsControllerTest.php
@@ -78,13 +78,34 @@ class YsIntegrationsControllerTest extends KernelTestBase {
    * @covers ::systemAdminMenuBlockPage
    */
   public function testEnabledIntegrationIsBuilt(): void {
+    $this->config(self::SETTINGS)->set('ys_integrations_test_built', 1)->save();
+
+    $output = $this->controller->systemAdminMenuBlockPage();
+
+    $this->assertArrayHasKey('ys_integrations_test_built', $output['#content']);
+    $this->assertSame(
+      'Built Test Integration',
+      (string) $output['#content']['ys_integrations_test_built']['title']
+    );
+  }
+
+  /**
+   * An enabled integration with nothing to show contributes no card.
+   *
+   * The theme iterates every entry in #content and wraps each one in an
+   * admin-item, so an empty build left in place renders as a blank card.
+   * Plugins signal "show nothing" by returning an empty array, which is how
+   * an integration that is turned on but not configured, or one that has been
+   * superseded, opts out of the overview.
+   *
+   * @covers ::systemAdminMenuBlockPage
+   */
+  public function testEnabledIntegrationWithEmptyBuildIsSkipped(): void {
     $this->config(self::SETTINGS)->set('ys_integrations_test', 1)->save();
 
     $output = $this->controller->systemAdminMenuBlockPage();
 
-    $this->assertArrayHasKey('ys_integrations_test', $output['#content']);
-    // The test plugin inherits the base build(), which returns an empty array.
-    $this->assertSame([], $output['#content']['ys_integrations_test']);
+    $this->assertArrayNotHasKey('ys_integrations_test', $output['#content']);
   }
 
   /**


### PR DESCRIPTION
## [1482: Hide the legacy YaleSites AI menu, forms, and integration cards once Beacon is platform-authorized](https://github.com/yalesites-org/YaleSites-Internal/issues/1482)

### Description of work
- Hides every `ys_ai`-owned admin surface once `ys_beacon` is installed and `ys_beacon.settings:platform_authorized` is TRUE, so a site only ever shows one AI configuration tree. Before this, a cut-over site showed "YaleSites AI" (legacy) and "YaleSites Beacon" side by side under Integrations, with two competing system instructions editors.
- New `BeaconSupersession` service in `ys_ai` answers "is Beacon superseding legacy AI here?". It takes `ys_beacon.authorization` as an **optional** service reference (`@?`), so `ys_ai` gains no hard dependency on `ys_beacon` and behaves exactly as it does today on a site without Beacon.
- New `NotSupersededAccessCheck` (requirement `_ys_ai_not_superseded`) is applied **additively** to all six `ys_ai`-owned routes, so a bookmarked URL cannot reach a form whose menu link is hidden. Menu links follow route access in Drupal, so this removes all four menu items without editing any `*.links.menu.yml`.
- Both integration plugins report off and render no card, and a `hook_form_FORM_ID_alter()` stops offering their two checkboxes on the Integration Settings form.
- Access results and the altered form carry `config:ys_beacon.settings`, so flipping authorization takes effect with no manual cache rebuild.
- Deliberately **not** gated on `ai_engine_chat.settings:azure_base_url` — the assisted cutover's "Turn off legacy AI Engine" step never clears it, so a site whose legacy chatbot is fully off would still look configured.
- `ai_engine` is unmodified: nothing under `web/modules/contrib` is touched, and contrib's own "AI Engine" item under Configuration and its child forms are left alone.

### Two decisions worth a reviewer's eye
- **A dedicated access check rather than extending the two existing ones.** The issue suggested adding the existing `_ys_ai_system_instructions_access` check to `ys_ai_system_instructions.settings`. That check also requires system instructions to already be *enabled and fully configured*, so applying it there would lock an unauthorized site out of the very form used to configure them — breaking the issue's own "with Beacon absent or unauthorized, everything behaves exactly as today" criterion. The new check answers only the supersession question, and mirrors the existing `BeaconAuthorizedAccessCheck` precedent of an additively-applied authorization check.
- **The hidden checkboxes become `#type => value` instead of being removed.** `YsIntegrationSettingsForm::submitForm()` writes every plugin definition back to config, so removing the elements would store NULL over both settings. Confirmed by saving the form for real on a superseded site: `ys_ai=1` and `ys_ai_system_instructions=1` both survive.

### One fix outside the issue's stated scope
`YsIntegrationsController::systemAdminMenuBlockPage()` now skips integrations whose `build()` returns empty. Returning `[]` did **not** remove the cards — `ys-integrations-block.html.twig` wraps every entry in an `admin-item`, so the two hidden integrations rendered as *blank* cards (measured: 5 `.admin-item` elements, two with empty titles). The defect is pre-existing rather than introduced here: it already affects any integration that is enabled but unconfigured, including `ys_ai_system_instructions`, and an existing kernel test actively asserted that the empty build stays in `#content`. That test was rewritten and a second test plugin added so both branches stay covered. Reverting just the `if ($build = $plugin->build())` guard and those two test changes leaves the rest of this PR working, with blank cards in place of the removed ones.

### Functional testing steps:
- [ ] On a site with legacy AI configured and `platform_authorized` FALSE, confirm Integrations still shows "YaleSites AI" with its "AI settings" and "System Instructions" children, and no Beacon surfaces — unchanged from today.
- [ ] Authorize Beacon on Platform Admin Settings and reload **without** clearing caches: "YaleSites AI" is gone and Beacon is present.
- [ ] As uid 1, visit `/admin/config/yalesites/ys_ai`, `/admin/config/ys-ai/system-instructions`, and `/admin/config/ys-ai/system-instructions/settings` directly — all three return access denied.
- [ ] `/admin/yalesites/integrations` shows a Beacon card and no "AI" or "AI System Instructions" card, and no blank cards.
- [ ] `/admin/yalesites/integration-settings` offers no "AI" or "AI System Instructions" checkbox. Save the form and confirm the stored integration settings are unchanged.
- [ ] Configuration > AI Engine no longer lists "System Instructions Settings", while contrib's own AI Engine items (Chat Settings, Embedding Settings, Feed Settings, Metadata Admin) are still there.
- [ ] Complete the cutover through "Turn off legacy AI Engine" and confirm nothing legacy reappears.
- [ ] Deauthorize Beacon and confirm every legacy surface returns exactly as before.

One correction to the acceptance criteria: they refer to the Integrations page as `/admin/config/yalesites`, which 404s. The real path is `/admin/yalesites/integrations` (`ys_integrations.admin_yalesites_integrations`), with the checkbox form at `/admin/yalesites/integration-settings`.

References yalesites-org/YaleSites-Internal#1482

---
Created with AI
