### PR TITLE
986: [Events] Research: Check import from Localist for issues

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -7,7 +7,6 @@ use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
 use Drupal\calendar_link\Twig\CalendarLinkTwigExtension;
-use Drupal\improve_line_breaks_filter\TextReplacement;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -143,20 +142,42 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
   /**
    * Removes Localist's empty filler paragraphs from an event description.
    *
-   * Localist pads descriptions with empty paragraphs, usually <p>&nbsp;</p>,
-   * and they reach the page verbatim: the event page prints this description
-   * as a plain string instead of rendering the field, so no text format and
-   * none of the platform's filters ever run on it. Each one shows up as an
-   * extra blank line. Reusing improve_line_breaks' own replacement, rather
-   * than filtering the description through a text format, keeps the <b>, <i>
-   * and <u> tags Localist emits and basic_html does not allow.
+   * Localist's editor pads descriptions with empty paragraphs between real
+   * ones, and they reach the page verbatim: the event page prints this
+   * description as a plain string instead of rendering the field, so no text
+   * format and none of the platform's filters ever run on it. Each one shows
+   * up as an extra blank line.
+   *
+   * This used to delegate to improve_line_breaks_filter's own replacement,
+   * the same one the platform applies to editor-authored rich text sitewide.
+   * That turned out to be a no-op on real Localist data: its pattern
+   * (/<p>(&nbsp;|\s)*<\/p>/ui) only matches a bare <p> with no attributes,
+   * and Localist's editor attaches a text-align style to essentially
+   * everything it emits, including its filler paragraphs, e.g.
+   * <p style="text-align:start">&nbsp;</p>. Matching an optional attribute
+   * list ourselves is a small enough addition that writing the pattern
+   * directly is simpler than working around contrib's shape - and keeps the
+   * <b>, <i> and <u> tags Localist emits and basic_html does not allow,
+   * which is why this still isn't done by filtering through a text format.
+   *
+   * "Blank" covers plain whitespace and every way Localist can represent a
+   * non-breaking space: the HTML entity (&nbsp;), its numeric character
+   * reference (&#160;), and the literal UTF-8 character (U+00A0). Only the
+   * entity form appears in real data; the other two are the same concept and
+   * cost nothing to also handle.
+   *
+   * Trade-off accepted: contrib's version skipped over <pre>, <code>,
+   * <script> and <iframe> content, so an empty-looking <p> quoted inside one
+   * of those tags would not be touched. A plain regex does not make that
+   * distinction. Measured against all 38 real event descriptions on the
+   * pr-1426 Pantheon multidev: zero contain any of those four tags, so this
+   * does not affect real data today.
    *
    * @param string|null $description
    *   The description as stored by the Localist migration.
    *
    * @return string|null
-   *   The description without empty paragraphs, NULL if there was none, or the
-   *   description unchanged if the clean-up could not run.
+   *   The description without empty paragraphs, or NULL if there was none.
    *
    * @see https://github.com/yalesites-org/YaleSites-Internal/issues/986
    */
@@ -165,18 +186,14 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
       return NULL;
     }
 
-    // The delegate matches with the /u modifier and appends the result to its
-    // output, so on invalid UTF-8 preg_replace() returns NULL, that NULL is
-    // concatenated as '', and the whole description disappears with nothing
-    // logged. Leave such a description alone instead. This should not be
-    // reachable through the importer - the Localist JSON parser rejects
-    // invalid UTF-8 - but silent total content loss is the wrong failure mode
-    // to leave sitting behind a public method.
-    if (!mb_check_encoding($description, 'UTF-8')) {
-      return $description;
-    }
-
-    return (new TextReplacement())->processImproveLineBreaks($description, TRUE);
+    // No /u modifier, so the only non-ASCII byte sequence in the pattern -
+    // the UTF-8 encoding of U+00A0 - is matched byte-for-byte rather than as
+    // a Unicode code point. That means invalid UTF-8 elsewhere in the
+    // description cannot make preg_replace() fail the way it could with the
+    // contrib delegate this replaced, so no encoding guard is needed here.
+    $nonBreakingSpace = "\xC2\xA0";
+    $blank = '(?:\s|&nbsp;|&#160;|' . $nonBreakingSpace . ')*';
+    return preg_replace('/<p(?:\s+[^>]*)?>' . $blank . '<\/p>/i', '', $description);
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -214,7 +214,10 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
     $ticketCost = $node->field_ticket_cost->first() ? $node->field_ticket_cost->first()->getValue()['value'] : NULL;
     $costButtonText = $ticketCost ? 'Buy Tickets' : 'Register';
     $storedDescription = $node->field_event_description->first() ? $node->field_event_description->first()->getValue()['value'] : NULL;
-    $description = $this->stripEmptyParagraphs($storedDescription);
+    // Only Localist's own import fills in field_localist_id, so this leaves
+    // a manually-authored event's description untouched even if an editor's
+    // own empty paragraph happens to match the filler shape.
+    $description = $localistId ? $this->stripEmptyParagraphs($storedDescription) : $storedDescription;
     $room = $node->field_event_room->first() ? $node->field_event_room->first()->getValue()['value'] : NULL;
     $externalEventWebsiteUrl = ($node->field_event_cta->first()) ? Url::fromUri($node->field_event_cta->first()->getValue()['uri'])->toString() : NULL;
     $externalEventWebsiteTitle = ($node->field_event_cta->first()) ? $node->field_event_cta->first()->getValue()['title'] : NULL;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/src/MetaFieldsManager.php
@@ -7,6 +7,7 @@ use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
 use Drupal\calendar_link\Twig\CalendarLinkTwigExtension;
+use Drupal\improve_line_breaks_filter\TextReplacement;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -140,6 +141,45 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
   }
 
   /**
+   * Removes Localist's empty filler paragraphs from an event description.
+   *
+   * Localist pads descriptions with empty paragraphs, usually <p>&nbsp;</p>,
+   * and they reach the page verbatim: the event page prints this description
+   * as a plain string instead of rendering the field, so no text format and
+   * none of the platform's filters ever run on it. Each one shows up as an
+   * extra blank line. Reusing improve_line_breaks' own replacement, rather
+   * than filtering the description through a text format, keeps the <b>, <i>
+   * and <u> tags Localist emits and basic_html does not allow.
+   *
+   * @param string|null $description
+   *   The description as stored by the Localist migration.
+   *
+   * @return string|null
+   *   The description without empty paragraphs, NULL if there was none, or the
+   *   description unchanged if the clean-up could not run.
+   *
+   * @see https://github.com/yalesites-org/YaleSites-Internal/issues/986
+   */
+  public function stripEmptyParagraphs(?string $description): ?string {
+    if ($description === NULL) {
+      return NULL;
+    }
+
+    // The delegate matches with the /u modifier and appends the result to its
+    // output, so on invalid UTF-8 preg_replace() returns NULL, that NULL is
+    // concatenated as '', and the whole description disappears with nothing
+    // logged. Leave such a description alone instead. This should not be
+    // reachable through the importer - the Localist JSON parser rejects
+    // invalid UTF-8 - but silent total content loss is the wrong failure mode
+    // to leave sitting behind a public method.
+    if (!mb_check_encoding($description, 'UTF-8')) {
+      return $description;
+    }
+
+    return (new TextReplacement())->processImproveLineBreaks($description, TRUE);
+  }
+
+  /**
    * Gets event all fields.
    */
   public function getEventData($node) {
@@ -156,7 +196,8 @@ class MetaFieldsManager implements ContainerFactoryPluginInterface {
     $ticketLink = $node->field_ticket_registration_url->first() ? $node->field_ticket_registration_url->first()->getValue()['uri'] : NULL;
     $ticketCost = $node->field_ticket_cost->first() ? $node->field_ticket_cost->first()->getValue()['value'] : NULL;
     $costButtonText = $ticketCost ? 'Buy Tickets' : 'Register';
-    $description = $node->field_event_description->first() ? $node->field_event_description->first()->getValue()['value'] : NULL;
+    $storedDescription = $node->field_event_description->first() ? $node->field_event_description->first()->getValue()['value'] : NULL;
+    $description = $this->stripEmptyParagraphs($storedDescription);
     $room = $node->field_event_room->first() ? $node->field_event_room->first()->getValue()['value'] : NULL;
     $externalEventWebsiteUrl = ($node->field_event_cta->first()) ? Url::fromUri($node->field_event_cta->first()->getValue()['uri'])->toString() : NULL;
     $externalEventWebsiteTitle = ($node->field_event_cta->first()) ? $node->field_event_cta->first()->getValue()['title'] : NULL;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/tests/src/Unit/MetaFieldsManagerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/tests/src/Unit/MetaFieldsManagerTest.php
@@ -14,10 +14,15 @@ use Drupal\ys_localist\MetaFieldsManager;
  * See MetaFieldsManager::stripEmptyParagraphs() for why the description needs
  * cleaning at all (yalesites-org/YaleSites-Internal#986).
  *
- * The fixtures are shaped after real payloads from
- * events.yale.edu/api/2/events, sampled while diagnosing the issue: 11 of 15
- * descriptions carried an empty paragraph, and all 15 styled text with
- * <b>/<i>/<u> while none used <strong>/<em>.
+ * Most fixtures here are synthetic. testStripsFillerFromRealFixture() is the
+ * exception: it pins the actual stored value of field_event_description on
+ * node 109, read directly off the pr-1426 Pantheon multidev. A census of all
+ * 41 event nodes there (38 with a description) found 14 empty filler
+ * paragraphs across 6 nodes, in exactly two shapes - 7 bare <p>&nbsp;</p> and
+ * 7 <p style="text-align:start">&nbsp;</p> - and zero of the nested-span or
+ * bare-<br>-only shapes covered in testLeavesNonBareEmptyParagraphsAlone.
+ * That attributed shape is exactly what the original contrib-delegating
+ * implementation missed: its regex only ever matched a bare <p>.
  *
  * @coversDefaultClass \Drupal\ys_localist\MetaFieldsManager
  *
@@ -57,6 +62,18 @@ class MetaFieldsManagerTest extends UnitTestCase {
       'nbsp filler between paragraphs' => [
         "<p>First.</p>\n\n<p>&nbsp;</p>\n\n<p>Second.</p>",
         "<p>First.</p>\n\n\n\n<p>Second.</p>",
+      ],
+      'attributed nbsp filler between paragraphs' => [
+        "<p>First.</p>\n\n<p style=\"text-align:start\">&nbsp;</p>\n\n<p>Second.</p>",
+        "<p>First.</p>\n\n\n\n<p>Second.</p>",
+      ],
+      'numeric character reference filler' => [
+        '<p>First.</p><p>&#160;</p><p>Second.</p>',
+        '<p>First.</p><p>Second.</p>',
+      ],
+      'literal non-breaking space filler' => [
+        "<p>First.</p><p>\u{00A0}</p><p>Second.</p>",
+        '<p>First.</p><p>Second.</p>',
       ],
       'genuinely empty paragraph' => [
         '<p>First.</p><p></p><p>Second.</p>',
@@ -125,13 +142,22 @@ class MetaFieldsManagerTest extends UnitTestCase {
   }
 
   /**
-   * Preformatted content is left alone, because whitespace matters there.
+   * Preformatted content is not protected; measured to not matter today.
+   *
+   * The contrib implementation this replaced skipped over <pre>, <code>,
+   * <script> and <iframe> content specifically so a filler-shaped <p> quoted
+   * inside one of those tags would not be touched. A plain regex has no such
+   * awareness and strips it anywhere it appears - including here. That
+   * trade-off was accepted after measuring all 38 real event descriptions on
+   * the pr-1426 multidev: none contain any of those four tags, so nothing
+   * real is affected today. If that ever changes, this test is where it
+   * becomes visible.
    *
    * @covers ::stripEmptyParagraphs
    */
-  public function testLeavesPreformattedContentAlone(): void {
-    $description = "<pre><p>&nbsp;</p></pre>";
-    $this->assertSame($description, $this->metaFieldsManager->stripEmptyParagraphs($description));
+  public function testDoesNotProtectPreformattedContent(): void {
+    $description = '<pre><p>&nbsp;</p></pre>';
+    $this->assertSame('<pre></pre>', $this->metaFieldsManager->stripEmptyParagraphs($description));
   }
 
   /**
@@ -159,24 +185,66 @@ class MetaFieldsManagerTest extends UnitTestCase {
   }
 
   /**
-   * Only bare empty paragraphs are stripped, which is the shared definition.
+   * The exact stored description of a real event, byte for byte.
    *
-   * These variants are deliberately left alone: the point of delegating to
-   * improve_line_breaks is that Localist descriptions and editor-authored rich
-   * text agree on what an empty paragraph is, and widening the pattern here
-   * would break that. None of these shapes appears in the sampled live
-   * payloads - 51 empty paragraphs, all of them bare - so this documents the
-   * boundary rather than papering over it. If Localist ever starts emitting
-   * one of these, this test is where it becomes visible.
+   * Read from field_event_description on node 109 of the pr-1426 Pantheon
+   * multidev. Both empty paragraphs here carry a text-align style - the
+   * shape the original contrib-delegating implementation never matched,
+   * because getEventData() sees this value before anything downstream
+   * strips the style attribute at render time.
+   *
+   * @covers ::stripEmptyParagraphs
+   */
+  public function testStripsFillerFromRealFixture(): void {
+    $p1 = '<p style="text-align:start"><span style="font-size:11pt"><span><span><span><span style="font-style:normal"><span><span><span style="text-decoration:none"><b><span>DCP | 1995 | Directed by Todd Haynes | USA | 119 minutes | English </span></b></span></span></span></span></span></span></span></span></p>';
+    $p2 = '<p style="text-align:start"><span style="font-size:11pt"><span><span><span><span style="font-style:normal"><span><span><span style="text-decoration:none"><span><span><span>Free admission. No registration required.</span></span></span></span></span></span></span></span></span></span></span></p>';
+    $filler = '<p style="text-align:start">&nbsp;</p>';
+    $p4 = '<p style="text-align:start"><span style="font-size:11pt"><span><span><span><span style="font-style:normal"><span><span><span style="text-decoration:none"><span><span>A mysterious illness alienates Carol White (Julianne Moore) from her suburban enclave in the<i> </i>San Fernando Valley. Is the culprit industrial pollution or perhaps her own psyche? After medical professionals offer no clarity about her worsening symptoms, she seeks solace and protection through alternative means. SAFE exemplifies an ambivalence found throughout Todd Haynes&rsquo; filmography, especially in his most recent feature, MAY DECEMBER (2023), which also stars Julianne Moore. In a 1996 issue of BFI&rsquo;s <i>Sight and Sound</i>, Haynes clarifies that the film alludes to the AIDS epidemic, but themes of ecological disaster and the allure of New Age healing will strike viewers today as prescient. SAFE sidesteps heavy-handed messages, instead prompting us to consider how illness and industrial pollution are bound up with identity and belonging, within and beyond the suburbs of California.</span></span></span></span></span></span></span></span></span></span></p>';
+    $p6 = '<p><b style="font-style:normal; text-align:start; text-decoration:none"><span style="font-size:11pt"><span><span><span>Cinema of Contamination </span></span></span></span></b><span style="font-size:11pt; text-align:start"><span style="font-style:normal"><span><span><span style="text-decoration:none"><span><span><span>stages contact, confrontations, and entanglements with enigmatic toxins and landscapes. Spanning suburban California, the Andean mountain range, a forbidden zone, and a poisonous forest, the series examines how to make meaning within ecological collapse and in the aftermath of dictatorship and war.</span></span></span></span></span></span></span></span></p>';
+
+    $description = $p1 . "\n\n" . $p2 . "\n\n" . $filler . "\n\n" . $p4 . "\n\n" . $filler . "\n\n" . $p6 . "\n";
+    $expected = $p1 . "\n\n" . $p2 . "\n\n\n\n" . $p4 . "\n\n\n\n" . $p6 . "\n";
+
+    // Pin the fixture to the exact byte count read off the multidev so a
+    // transcription slip here is loud, not silently self-consistent.
+    $this->assertSame(2510, strlen($description), 'Fixture must match the real stored value byte for byte.');
+
+    $output = $this->metaFieldsManager->stripEmptyParagraphs($description);
+
+    $this->assertSame($expected, $output);
+    $this->assertLessThan(strlen($description), strlen($output));
+
+    // Confirm no tag other than the two filler <p> elements was touched.
+    $tags = ['<p', '<b', '<i', '<span', '<a ', '<br'];
+    foreach ($tags as $tag) {
+      $before = substr_count($description, $tag);
+      $after = substr_count($output, $tag);
+      if ($tag === '<p') {
+        $this->assertSame($before - 2, $after, "Expected exactly 2 fewer '$tag' after stripping.");
+      }
+      else {
+        $this->assertSame($before, $after, "'$tag' count must not change.");
+      }
+    }
+  }
+
+  /**
+   * Nested or non-whitespace filler is left alone; only blank content is.
+   *
+   * "Blank" means whitespace and the three ways of writing a non-breaking
+   * space (@see stripEmptyParagraphs()) - not any element, however trivial.
+   * A <span> wrapping the filler, or a lone <br>, do not count, even though
+   * both render as an empty-looking paragraph. Real data on the pr-1426
+   * multidev never contains either shape (zero nested-filler paragraphs
+   * across all 38 real descriptions), so this documents an intentional
+   * boundary rather than a gap being papered over.
    *
    * @covers ::stripEmptyParagraphs
    */
   public function testLeavesNonBareEmptyParagraphsAlone(): void {
     $variants = [
-      '<p style="text-align:center">&nbsp;</p>',
       '<p><span>&nbsp;</span></p>',
       '<p><br /></p>',
-      '<p>&#160;</p>',
     ];
 
     foreach ($variants as $variant) {
@@ -185,21 +253,23 @@ class MetaFieldsManagerTest extends UnitTestCase {
   }
 
   /**
-   * A clean-up failure returns the description rather than discarding it.
+   * Invalid UTF-8 elsewhere in the description no longer loses content.
    *
-   * Invalid UTF-8 makes the delegate's preg_replace() return NULL, which it
-   * concatenates as '' - so without the guard a single bad byte would wipe an
-   * entire event description and return an empty string, not NULL, with no
-   * error anywhere. Not reachable through the importer today (the Localist JSON
-   * parser rejects invalid UTF-8), but silent total content loss is the wrong
-   * failure mode to leave in place.
+   * The contrib delegate this replaced matched with the /u modifier and
+   * appended its result to the description, so a single invalid byte made
+   * preg_replace() return NULL, which concatenated as '' and silently wiped
+   * the entire description. This implementation never uses /u - the pattern
+   * needs no Unicode-aware matching, since its one non-ASCII case (a literal
+   * U+00A0) is matched by its UTF-8 bytes directly - so preg_replace() has no
+   * such failure mode, and the guard that worked around it was removed.
    *
    * @covers ::stripEmptyParagraphs
    */
-  public function testKeepsTheDescriptionWhenCleanUpFails(): void {
+  public function testStripsFillerEvenWithInvalidUtf8Bytes(): void {
     $invalidUtf8 = "<p>Yale\x92s event</p>\n<p>&nbsp;</p>\n<p>Second paragraph.</p>";
+    $expected = "<p>Yale\x92s event</p>\n\n<p>Second paragraph.</p>";
 
-    $this->assertSame($invalidUtf8, $this->metaFieldsManager->stripEmptyParagraphs($invalidUtf8));
+    $this->assertSame($expected, $this->metaFieldsManager->stripEmptyParagraphs($invalidUtf8));
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/tests/src/Unit/MetaFieldsManagerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/tests/src/Unit/MetaFieldsManagerTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Drupal\Tests\ys_localist\Unit;
+
+use Drupal\Core\Datetime\DateFormatter;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_localist\LocalistManager;
+use Drupal\ys_localist\MetaFieldsManager;
+
+/**
+ * Unit tests for the Localist event description clean-up.
+ *
+ * See MetaFieldsManager::stripEmptyParagraphs() for why the description needs
+ * cleaning at all (yalesites-org/YaleSites-Internal#986).
+ *
+ * The fixtures are shaped after real payloads from
+ * events.yale.edu/api/2/events, sampled while diagnosing the issue: 11 of 15
+ * descriptions carried an empty paragraph, and all 15 styled text with
+ * <b>/<i>/<u> while none used <strong>/<em>.
+ *
+ * @coversDefaultClass \Drupal\ys_localist\MetaFieldsManager
+ *
+ * @group yalesites
+ * @group ys_localist
+ */
+class MetaFieldsManagerTest extends UnitTestCase {
+
+  /**
+   * The manager under test.
+   *
+   * @var \Drupal\ys_localist\MetaFieldsManager
+   */
+  protected $metaFieldsManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->metaFieldsManager = new MetaFieldsManager(
+      $this->createMock(DateFormatter::class),
+      $this->createMock(EntityTypeManager::class),
+      $this->createMock(LocalistManager::class),
+    );
+  }
+
+  /**
+   * Empty filler paragraphs Localist emits between real paragraphs.
+   *
+   * @return array
+   *   Test cases: description in, description expected out.
+   */
+  public static function fillerParagraphCases(): array {
+    return [
+      'nbsp filler between paragraphs' => [
+        "<p>First.</p>\n\n<p>&nbsp;</p>\n\n<p>Second.</p>",
+        "<p>First.</p>\n\n\n\n<p>Second.</p>",
+      ],
+      'genuinely empty paragraph' => [
+        '<p>First.</p><p></p><p>Second.</p>',
+        '<p>First.</p><p>Second.</p>',
+      ],
+      'nothing to strip is left alone' => [
+        "<p>First.</p>\n\n<p>Second.</p>",
+        "<p>First.</p>\n\n<p>Second.</p>",
+      ],
+    ];
+  }
+
+  /**
+   * Filler paragraphs are removed, real content is not.
+   *
+   * @dataProvider fillerParagraphCases
+   * @covers ::stripEmptyParagraphs
+   */
+  public function testStripsFillerParagraphs(string $description, string $expected): void {
+    $this->assertSame($expected, $this->metaFieldsManager->stripEmptyParagraphs($description));
+  }
+
+  /**
+   * A missing description stays missing rather than becoming an empty string.
+   *
+   * @covers ::stripEmptyParagraphs
+   */
+  public function testLeavesMissingDescriptionAlone(): void {
+    $this->assertNull($this->metaFieldsManager->stripEmptyParagraphs(NULL));
+    $this->assertSame('', $this->metaFieldsManager->stripEmptyParagraphs(''));
+  }
+
+  /**
+   * Localist's own formatting tags survive.
+   *
+   * Basic_html allows none of <b>, <i> or <u>, so this is what would break if
+   * the clean-up were ever "simplified" into a text format: the styling on
+   * essentially every imported event would silently flatten.
+   *
+   * @covers ::stripEmptyParagraphs
+   */
+  public function testKeepsLocalistFormattingTags(): void {
+    $description = '<p><b>Bold</b> and <i>italic</i> and <u>underline</u>'
+      . ' <span style="font-size:12pt"><span>sized</span></span>'
+      . ' <a href="https://example.yale.edu/x">a link</a></p>';
+
+    $this->assertSame($description, $this->metaFieldsManager->stripEmptyParagraphs($description));
+  }
+
+  /**
+   * A soft line break stays exactly one line break.
+   *
+   * Localist serializes a soft break as the tag plus a literal newline. The
+   * clean-up must not touch it: nothing on this render path converts newlines
+   * to markup, so a break here is already correct and adding to it is the very
+   * doubling the ticket complains about.
+   *
+   * @covers ::stripEmptyParagraphs
+   */
+  public function testKeepsSoftLineBreaksIntact(): void {
+    $description = "<p>First line<br />\nSecond line</p>";
+    $output = $this->metaFieldsManager->stripEmptyParagraphs($description);
+
+    $this->assertSame($description, $output);
+    $this->assertSame(1, preg_match_all('#<br\s*/?>#i', $output));
+  }
+
+  /**
+   * Preformatted content is left alone, because whitespace matters there.
+   *
+   * @covers ::stripEmptyParagraphs
+   */
+  public function testLeavesPreformattedContentAlone(): void {
+    $description = "<pre><p>&nbsp;</p></pre>";
+    $this->assertSame($description, $this->metaFieldsManager->stripEmptyParagraphs($description));
+  }
+
+  /**
+   * A real-shaped Localist description loses only its filler.
+   *
+   * @covers ::stripEmptyParagraphs
+   */
+  public function testCleansRealShapedDescription(): void {
+    $description = '<p><b><span style="font-size:12pt"><span>&ldquo;Tracing the Rosebud Orchid&rdquo;&nbsp;'
+      . "will be on view at Haas Arts Library from June 8 through Nov. 8.</span></span></b></p>\n\n"
+      . "<p>&nbsp;</p>\n\n"
+      . '<p><span style="font-size:12pt"><span>Artists have long looked to the natural world.</span></span></p>';
+
+    $output = $this->metaFieldsManager->stripEmptyParagraphs($description);
+
+    $this->assertStringNotContainsString('<p>&nbsp;</p>', $output);
+    $this->assertStringContainsString('Tracing the Rosebud Orchid', $output);
+    $this->assertStringContainsString('Artists have long looked to the natural world.', $output);
+    $this->assertStringContainsString('<b>', $output, 'Bold styling must survive');
+    // The clean-up must not touch attributes. Whether inline styling survives
+    // all the way to the page is a separate matter - core runs the rendered
+    // value through Xss::filterAdmin(), which drops style attributes - but that
+    // is not this method's business to pre-empt.
+    $this->assertStringContainsString('style="font-size:12pt"', $output);
+  }
+
+  /**
+   * Only bare empty paragraphs are stripped, which is the shared definition.
+   *
+   * These variants are deliberately left alone: the point of delegating to
+   * improve_line_breaks is that Localist descriptions and editor-authored rich
+   * text agree on what an empty paragraph is, and widening the pattern here
+   * would break that. None of these shapes appears in the sampled live
+   * payloads - 51 empty paragraphs, all of them bare - so this documents the
+   * boundary rather than papering over it. If Localist ever starts emitting
+   * one of these, this test is where it becomes visible.
+   *
+   * @covers ::stripEmptyParagraphs
+   */
+  public function testLeavesNonBareEmptyParagraphsAlone(): void {
+    $variants = [
+      '<p style="text-align:center">&nbsp;</p>',
+      '<p><span>&nbsp;</span></p>',
+      '<p><br /></p>',
+      '<p>&#160;</p>',
+    ];
+
+    foreach ($variants as $variant) {
+      $this->assertSame($variant, $this->metaFieldsManager->stripEmptyParagraphs($variant));
+    }
+  }
+
+  /**
+   * A clean-up failure returns the description rather than discarding it.
+   *
+   * Invalid UTF-8 makes the delegate's preg_replace() return NULL, which it
+   * concatenates as '' - so without the guard a single bad byte would wipe an
+   * entire event description and return an empty string, not NULL, with no
+   * error anywhere. Not reachable through the importer today (the Localist JSON
+   * parser rejects invalid UTF-8), but silent total content loss is the wrong
+   * failure mode to leave in place.
+   *
+   * @covers ::stripEmptyParagraphs
+   */
+  public function testKeepsTheDescriptionWhenCleanUpFails(): void {
+    $invalidUtf8 = "<p>Yale\x92s event</p>\n<p>&nbsp;</p>\n<p>Second paragraph.</p>";
+
+    $this->assertSame($invalidUtf8, $this->metaFieldsManager->stripEmptyParagraphs($invalidUtf8));
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/ys_localist.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/ys_localist.info.yml
@@ -5,7 +5,6 @@ package: YaleSites
 core_version_requirement: ^10
 dependencies:
   - drupal:migrate
-  - improve_line_breaks_filter:improve_line_breaks_filter
   - migrate_plus:migrate_plus
   - migrate_tools:migrate_tools
   - ys_core

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/ys_localist.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_localist/ys_localist.info.yml
@@ -5,6 +5,7 @@ package: YaleSites
 core_version_requirement: ^10
 dependencies:
   - drupal:migrate
+  - improve_line_breaks_filter:improve_line_breaks_filter
   - migrate_plus:migrate_plus
   - migrate_tools:migrate_tools
   - ys_core


### PR DESCRIPTION
## [986: [Events] Research: Check import from Localist for issues](https://github.com/yalesites-org/YaleSites-Internal/issues/986)

### Description of work

Imported Localist event descriptions render an extra blank line wherever Localist's editor left an empty `<p>&nbsp;</p>` behind. A census of the stored `field_event_description` value on 38 real imported event nodes found 14 filler paragraphs across 6 of them, in two shapes: 7 bare `<p>&nbsp;</p>` and 7 `<p style="text-align:start">&nbsp;</p>`.

- **The importer is not introducing anything.** `ys_localist/migrations/localist_events.yml` maps the description straight from the Localist payload with no process plugin, so the stored value is byte-for-byte what Localist sent.
- **The cause is that the description is never filtered on the way to the page.** `EventMetaBlock` hands the stored value to the `ys_event_meta_block` template as a plain string, so no text format ever runs on it. Nothing strips the filler paragraphs, so they reach the browser verbatim.
- **Fix:** `MetaFieldsManager::stripEmptyParagraphs()` runs a regex directly against the stored description, matching `<p>` (with or without attributes) whose only content is whitespace or any of the three ways to write a non-breaking space (`&nbsp;`, `&#160;`, literal U+00A0), and removes it.
- An earlier version of this fix delegated to contrib `improve_line_breaks_filter`'s own replacement, the same one the platform applies to editor-authored rich text sitewide. That turned out to be a no-op on real Localist output: its pattern only matches a bare `<p>` with no attributes, and Localist's editor attaches a `text-align` style to essentially everything it emits, including its filler paragraphs. Caught by checking a genuinely-imported event on a multidev before merging, not by the local/synthetic fixtures used up to that point. The regex is now written directly against this project's data instead of relying on contrib's narrower shape.
- **Scoped to Localist-sourced events only.** `getEventData()` runs for every Event node regardless of how it was created, and `field_event_description` is a normal `basic_html` field any editor can type or paste into. The clean-up is gated on `field_localist_id`, which only the Localist migration ever populates, so a manually-authored event's description is left untouched even if it happens to contain the same filler shape. Cross-checked against `ys_campus_groups`'s migration, which uses its own `field_event_id`/`field_event_source` and never sets `field_localist_id`, so this does not affect Campus Groups events either.

**Why not just render the description through its text format** (the obvious alternative): `basic_html` allows `<strong>`/`<em>` but not `<b>`, `<i>` or `<u>`, and allows `<span>` without attributes. Of the 38 real stored descriptions, 27 use `<b>`/`<i>`/`<u>` and only 1 uses `<strong>`/`<em>`, so filtering would flatten the styling on nearly every imported event. `testKeepsLocalistFormattingTags()` pins that so this can't quietly be "simplified" into a text format later.

**Trade-off accepted:** the contrib delegate this replaced skipped over `<pre>`, `<code>`, `<script>` and `<iframe>` content, so a filler-shaped `<p>` quoted inside one of those tags would not have been touched. The direct regex has no such awareness and strips it anywhere it appears. Measured against all 38 real event descriptions: none contain any of those four tags, so this does not affect real data today. `testDoesNotProtectPreformattedContent()` documents the boundary in case that ever changes.

**Deliberately out of scope.** While diagnosing this I confirmed a separate latent bug: in `basic_html` and `restricted_html`, `filter_html` rewrites `<br />` to `<br>` before `filter_autop` runs, which defeats core's `(?<!<br />)` guard and doubles any line break followed by a newline. It is real and reproducible, but it does **not** affect event descriptions, because they never enter that pipeline, so fixing it here would have meant a sitewide filter change with no bearing on this ticket. It deserves its own issue.

Verified against the real service (not just PHPUnit mocks): a genuinely Localist-imported event still has its filler stripped, and a manually-created event with the same filler shape is left byte-for-byte untouched. `ys_localist` suite `OK (69 tests, 135 assertions)`; `composer code-sniff` exits 0.

### Functional testing steps:
- [ ] On a site with Localist events imported, open an event whose Localist description has a blank line between paragraphs (in Localist's own editor those paragraphs look normally spaced).
- [ ] Confirm the Drupal event page now shows a normal single paragraph gap rather than a doubled/empty one.
- [ ] Confirm soft line breaks *within* a paragraph still break the line, and are neither doubled nor lost.
- [ ] Confirm bold, italic and underline styling coming from Localist still renders, this is what a text-format-based fix would have destroyed.
- [ ] Confirm a native (non-Localist) Drupal event still renders its description normally, including one with a manually-added blank paragraph.

References yalesites-org/YaleSites-Internal#986

---
Created with AI
