### PR TITLE
1486: RC: Unpublishing a node removes it from Content and Manage views, even when filtered for Unpublished status

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/src/NodeAccessManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/src/NodeAccessManager.php
@@ -13,4 +13,10 @@ class NodeAccessManager {
 
   const YS_NODE_ACCESS_GRANT_ID_PRIVATE = 1;
 
+  const YS_NODE_ACCESS_UNPUBLISHED_REALM = 'ys_node_access_unpublished';
+
+  const YS_NODE_ACCESS_GRANT_ID_UNPUBLISHED_ANY = 0;
+
+  const YS_NODE_ACCESS_UNPUBLISHED_OWNER_REALM = 'ys_node_access_unpublished_owner';
+
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/tests/src/Kernel/NodeAccessGrantsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/tests/src/Kernel/NodeAccessGrantsTest.php
@@ -24,11 +24,17 @@ use Drupal\ys_node_access\NodeAccessManager;
  * (see \Drupal\node\NodeGrantDatabaseStorage::access()) is what actually
  * enforces this, not the hooks in isolation.
  *
- * Two of the tests below (testAnyAuthenticatedUserCanViewAnotherUsers...
- * and testUnpublishedNodeWithoutLoginRequiredFieldIsPubliclyViewable) are
- * paired with a skipped GAP test documenting current behavior that is
- * broader than the module's stated purpose. See the GAP log at
+ * testUnpublishedNodeAccessShouldRespectOwnershipAndPermission (below) and
+ * testUnpublishedNodeWithoutFieldShouldStayPrivate (below) characterize
+ * GAPs logged at
  * ~/Documents/Claude/not_dave/module-tests-20260710/ys_node_access.md.
+ * The over-broad-exposure GAP that report describes (any authenticated user
+ * viewing another's unpublished draft) was since fixed by commit 01ceadd7f
+ * (issue #1396) -- testUnpublishedNodeAccessShouldRespectOwnershipAndPermission
+ * now asserts that fixed behavior, not a skipped GAP. That fix's own
+ * regression -- unpublished nodes disappearing from node-access-gated
+ * listings for everyone, regardless of permissions -- is issue #1486, fixed
+ * by the grants added below.
  *
  * @group yalesites
  * @group ys_node_access
@@ -41,6 +47,8 @@ class NodeAccessGrantsTest extends KernelTestBase {
   protected static $modules = [
     'system',
     'node',
+    'content_moderation',
+    'workflows',
     'field',
     'text',
     'user',
@@ -60,6 +68,13 @@ class NodeAccessGrantsTest extends KernelTestBase {
    * @var \Drupal\user\UserInterface
    */
   protected $authenticated;
+
+  /**
+   * A second authenticated user, used as a draft node's owner.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $owner;
 
   /**
    * {@inheritdoc}
@@ -101,6 +116,8 @@ class NodeAccessGrantsTest extends KernelTestBase {
     $this->anonymous = new AnonymousUserSession();
     $this->authenticated = User::create(['name' => 'authenticated_user', 'uid' => 2]);
     $this->authenticated->save();
+    $this->owner = User::create(['name' => 'owner', 'uid' => 3]);
+    $this->owner->save();
   }
 
   /**
@@ -122,6 +139,28 @@ class NodeAccessGrantsTest extends KernelTestBase {
         ],
       ],
       ys_node_access_node_grants($this->authenticated, 'view')
+    );
+  }
+
+  /**
+   * Tests the anonymous role never reaches the two unpublished realms.
+   *
+   * Even if "view own/any unpublished content" were (mis)granted to the
+   * anonymous role, ys_node_access_node_grants()'s isAuthenticated() guard
+   * must still exclude anonymous -- otherwise a uid-0-owned node (e.g. from
+   * a migration) could become publicly visible via the owner realm.
+   *
+   * @covers ::ys_node_access_node_grants
+   */
+  public function testNodeGrantsExcludeAnonymousFromUnpublishedRealmsEvenIfGranted() {
+    Role::load(RoleInterface::ANONYMOUS_ID)
+      ->grantPermission('view own unpublished content')
+      ->grantPermission('view any unpublished content')
+      ->save();
+
+    $this->assertEquals(
+      [NodeAccessManager::YS_NODE_ACCESS_REALM => [NodeAccessManager::YS_NODE_ACCESS_GRANT_ID_PUBLIC]],
+      ys_node_access_node_grants(new AnonymousUserSession(), 'view')
     );
   }
 
@@ -184,33 +223,95 @@ class NodeAccessGrantsTest extends KernelTestBase {
   }
 
   /**
-   * Tests hook_node_access_records() defers an unpublished node to core.
+   * Tests hook_node_access_records() grants unpublished nodes to viewers.
    *
-   * The module writes a grant_view = 0 record for unpublished nodes: this
-   * keeps its realm's record set non-empty (so core does not fall back to the
-   * default public "all" grant) while granting no view access itself, leaving
-   * unpublished-content access to Drupal core (owner + "view own/any
-   * unpublished content").
+   * Grants go to the owner and to "view any unpublished content" holders,
+   * replacing the grant_view = 0 record the prior approach used -- see
+   * ys_node_access_node_access_records() for why that was insufficient.
+   * Regression test for #1486.
    *
    * @covers ::ys_node_access_node_access_records
    */
-  public function testNodeAccessRecordsUnpublishedDefersToCore() {
+  public function testNodeAccessRecordsUnpublishedGrantsOwnerAndAnyUnpublishedViewers() {
     $node = Node::create([
       'type' => 'protected_type',
       'title' => 'Unpublished',
       'field_login_required' => FALSE,
       'status' => 0,
+      'uid' => $this->owner->id(),
     ]);
 
-    $this->assertEquals([[
-      'realm' => NodeAccessManager::YS_NODE_ACCESS_REALM,
-      'gid' => NodeAccessManager::YS_NODE_ACCESS_GRANT_ID_PRIVATE,
-      'grant_view' => 0,
-      'grant_update' => 0,
-      'grant_delete' => 0,
-      'priority' => 0,
-    ],
+    $this->assertEquals([
+      [
+        'realm' => NodeAccessManager::YS_NODE_ACCESS_UNPUBLISHED_REALM,
+        'gid' => NodeAccessManager::YS_NODE_ACCESS_GRANT_ID_UNPUBLISHED_ANY,
+        'grant_view' => 1,
+        'grant_update' => 0,
+        'grant_delete' => 0,
+        'priority' => 0,
+      ],
+      [
+        'realm' => NodeAccessManager::YS_NODE_ACCESS_UNPUBLISHED_OWNER_REALM,
+        'gid' => $this->owner->id(),
+        'grant_view' => 1,
+        'grant_update' => 0,
+        'grant_delete' => 0,
+        'priority' => 0,
+      ],
     ], ys_node_access_node_access_records($node));
+  }
+
+  /**
+   * Tests unpublished-node grants reach owners and permitted viewers only.
+   *
+   * Owners and "view any unpublished content" holders can see an unpublished
+   * node via the grants system; unrelated authenticated users cannot. This
+   * is the layer admin/content and "Manage <type>" listings actually
+   * enforce (\Drupal\node\NodeGrantDatabaseStorage::access()) -- unlike
+   * $node->access(), which independently allows the "view any unpublished
+   * content" case via content_moderation's hook_entity_access(), outside
+   * the grants system entirely. Regression test for #1486.
+   */
+  public function testUnpublishedNodeVisibleToPermittedUsersViaNodeAccessGrants() {
+    $grant_storage = \Drupal::service('node.grant_storage');
+
+    $node = Node::create([
+      'type' => 'protected_type',
+      'title' => 'Unpublished',
+      'field_login_required' => FALSE,
+      'status' => 0,
+      'uid' => $this->owner->id(),
+    ]);
+    $node->save();
+
+    // A plain authenticated user with neither permission still cannot see
+    // it via the grants system -- this must not reopen the over-exposure
+    // this module's grants were introduced to close.
+    $this->assertFalse($grant_storage->access($node, 'view', $this->authenticated)->isAllowed());
+
+    // A "view any unpublished content" holder (e.g. site_admin/editor) can,
+    // even though they are not the owner. Each permission below is granted
+    // via its own dedicated role (rather than mutating the shared
+    // "authenticated" role) to keep each scenario below isolated.
+    $any_viewer_role = Role::create(['id' => 'ys_test_any_unpub_viewer', 'label' => 'Any unpub viewer']);
+    $any_viewer_role->grantPermission('view any unpublished content')->save();
+    $any_viewer = User::create(['name' => 'any_viewer', 'uid' => 4, 'roles' => [$any_viewer_role->id()]]);
+    $any_viewer->save();
+    $this->assertTrue($grant_storage->access($node, 'view', $any_viewer)->isAllowed());
+
+    // A non-owner holding only "view own unpublished content" (not "view
+    // any") must not reach another user's draft -- the owner realm is keyed
+    // on the node's actual owner uid, not merely on holding the permission.
+    $own_viewer_role = Role::create(['id' => 'ys_test_own_unpub_viewer', 'label' => 'Own unpub viewer']);
+    $own_viewer_role->grantPermission('view own unpublished content')->save();
+    $non_owner = User::create(['name' => 'non_owner', 'uid' => 5, 'roles' => [$own_viewer_role->id()]]);
+    $non_owner->save();
+    $this->assertFalse($grant_storage->access($node, 'view', $non_owner)->isAllowed());
+
+    // The owner can see their own draft via "view own unpublished content".
+    $this->owner->addRole($own_viewer_role->id());
+    $this->owner->save();
+    $this->assertTrue($grant_storage->access($node, 'view', User::load($this->owner->id()))->isAllowed());
   }
 
   /**
@@ -257,15 +358,12 @@ class NodeAccessGrantsTest extends KernelTestBase {
   public function testUnpublishedNodeAccessShouldRespectOwnershipAndPermission() {
     $access_handler = \Drupal::entityTypeManager()->getAccessControlHandler('node');
 
-    $owner = User::create(['name' => 'owner', 'uid' => 3]);
-    $owner->save();
-
     $node = Node::create([
       'type' => 'protected_type',
       'title' => 'Someone else\'s draft',
       'field_login_required' => FALSE,
       'status' => 0,
-      'uid' => $owner->id(),
+      'uid' => $this->owner->id(),
     ]);
     $node->save();
 
@@ -279,7 +377,7 @@ class NodeAccessGrantsTest extends KernelTestBase {
     // just login state.
     Role::load(RoleInterface::AUTHENTICATED_ID)->grantPermission('view own unpublished content')->save();
     $access_handler->resetCache();
-    $this->assertTrue($node->access('view', User::load($owner->id())));
+    $this->assertTrue($node->access('view', User::load($this->owner->id())));
     $access_handler->resetCache();
     $this->assertFalse($node->access('view', User::load($this->authenticated->id())));
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/tests/src/Unit/NodeAccessManagerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/tests/src/Unit/NodeAccessManagerTest.php
@@ -27,11 +27,17 @@ class NodeAccessManagerTest extends UnitTestCase {
    * @covers ::YS_NODE_ACCESS_REALM
    * @covers ::YS_NODE_ACCESS_GRANT_ID_PUBLIC
    * @covers ::YS_NODE_ACCESS_GRANT_ID_PRIVATE
+   * @covers ::YS_NODE_ACCESS_UNPUBLISHED_REALM
+   * @covers ::YS_NODE_ACCESS_GRANT_ID_UNPUBLISHED_ANY
+   * @covers ::YS_NODE_ACCESS_UNPUBLISHED_OWNER_REALM
    */
   public function testConstants() {
     $this->assertSame('ys_node_access', NodeAccessManager::YS_NODE_ACCESS_REALM);
     $this->assertSame(0, NodeAccessManager::YS_NODE_ACCESS_GRANT_ID_PUBLIC);
     $this->assertSame(1, NodeAccessManager::YS_NODE_ACCESS_GRANT_ID_PRIVATE);
+    $this->assertSame('ys_node_access_unpublished', NodeAccessManager::YS_NODE_ACCESS_UNPUBLISHED_REALM);
+    $this->assertSame(0, NodeAccessManager::YS_NODE_ACCESS_GRANT_ID_UNPUBLISHED_ANY);
+    $this->assertSame('ys_node_access_unpublished_owner', NodeAccessManager::YS_NODE_ACCESS_UNPUBLISHED_OWNER_REALM);
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.info.yml
@@ -5,3 +5,4 @@ core_version_requirement: '^9 || ^10'
 package: YaleSites
 dependencies:
   - drupal:node
+  - drupal:content_moderation

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.install
@@ -25,3 +25,14 @@ function ys_node_access_install() {
 function ys_node_access_update_10001() {
   node_access_rebuild();
 }
+
+/**
+ * Rebuild node access grants after the unpublished-listing-visibility fix.
+ *
+ * See ys_node_access_node_access_records() for why the #10001 all-zero
+ * record needed replacing. Rebuild so already-unpublished nodes get the
+ * corrected grant rows, not just nodes saved after this deploy.
+ */
+function ys_node_access_update_10002() {
+  node_access_rebuild();
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.module
@@ -34,6 +34,21 @@ function ys_node_access_node_grants($account, $op) {
       ];
     }
 
+    // Mirror Drupal core's unpublished-content permissions here too -- see
+    // the fuller rationale in ys_node_access_node_access_records() below.
+    if ($account->isAuthenticated()) {
+      if ($account->hasPermission('view any unpublished content')) {
+        $grants[$nodeAccessManager::YS_NODE_ACCESS_UNPUBLISHED_REALM] = [
+          $nodeAccessManager::YS_NODE_ACCESS_GRANT_ID_UNPUBLISHED_ANY,
+        ];
+      }
+      if ($account->hasPermission('view own unpublished content')) {
+        $grants[$nodeAccessManager::YS_NODE_ACCESS_UNPUBLISHED_OWNER_REALM] = [
+          $account->id(),
+        ];
+      }
+    }
+
     return $grants;
   }
 }
@@ -45,18 +60,28 @@ function ys_node_access_node_access_records($node) {
 
   $nodeAccessManager = new NodeAccessManager();
 
-  // Unpublished nodes are left to Drupal core's unpublished-content access
-  // (the owner with "view own unpublished content", or "view any unpublished
-  // content"). This module only CAS-gates published pages, so it must not
-  // hand out a view grant for a draft. A grant_view = 0 record keeps this
-  // realm's record set non-empty -- so core does not add its default public
-  // "all" grant -- while granting nobody view access.
+  // Unpublished nodes are gated by Drupal core's unpublished-content
+  // permissions, not by field_login_required -- a draft is not live yet, so
+  // CAS gating does not apply. Core's own default-grant fallback
+  // (NodeAccessControlHandler::acquireGrants()) only fires for published
+  // nodes, so it cannot be relied on here: this module must grant view
+  // access itself to the node's owner and to "view any unpublished content"
+  // holders, matching hook_node_grants() above, or every node-access-gated
+  // listing (admin/content, "Manage <type>") hides the node from everyone.
   if (!$node->isPublished()) {
     return [
       [
-        'realm' => $nodeAccessManager::YS_NODE_ACCESS_REALM,
-        'gid' => $nodeAccessManager::YS_NODE_ACCESS_GRANT_ID_PRIVATE,
-        'grant_view' => 0,
+        'realm' => $nodeAccessManager::YS_NODE_ACCESS_UNPUBLISHED_REALM,
+        'gid' => $nodeAccessManager::YS_NODE_ACCESS_GRANT_ID_UNPUBLISHED_ANY,
+        'grant_view' => 1,
+        'grant_update' => 0,
+        'grant_delete' => 0,
+        'priority' => 0,
+      ],
+      [
+        'realm' => $nodeAccessManager::YS_NODE_ACCESS_UNPUBLISHED_OWNER_REALM,
+        'gid' => $node->getOwnerId(),
+        'grant_view' => 1,
         'grant_update' => 0,
         'grant_delete' => 0,
         'priority' => 0,


### PR DESCRIPTION
## [1486: RC: Unpublishing a node removes it from Content and Manage views, even when filtered for Unpublished status](https://github.com/yalesites-org/YaleSites-Internal/issues/1486)

### Description of work
- Fixed `ys_node_access` so unpublishing a node no longer hides it from `admin/content`
  and every custom "Manage <type>" view (Pages, Posts, Events, Profiles, Resources),
  regardless of filter.
- Root cause: a prior fix (01ceadd7f, closing #1396) made
  `hook_node_access_records()` return an all-zero grant record for unpublished nodes.
  Drupal core silently discards all-zero grant records, and core's own default-grant
  fallback only applies to published nodes -- so unpublished nodes ended up with zero
  rows in `{node_access}`, hiding them from every node-access-gated listing for everyone
  except bypass-node-access users, regardless of their actual unpublished-content
  permissions.
- `hook_node_grants()`/`hook_node_access_records()` now explicitly grant view access on
  unpublished nodes to the node's owner (via "view own unpublished content") and to
  accounts holding "view any unpublished content" -- mirroring Drupal core's own
  unpublished-content permission model, since core provides no automatic deferral at the
  grants layer. This is strictly narrower than the pre-01ceadd7f shipped state (which
  granted every authenticated user the PRIVATE realm on drafts) and does not reopen the
  over-exposure that fix closed -- verified via kernel tests and an independent
  security-review pass (no gid/realm collisions, anonymous excluded even if misconfigured,
  blast radius matches exactly the four content-management roles).
- Added `hook_update_10002()` to rebuild node access grants for already-unpublished
  content on deploy (same pattern as the prior `_10001` update hook). Note for the
  reviewer: like `_10001`, this runs `node_access_rebuild()` un-batched during
  `drush updatedb`, which briefly empties `{node_access}` before repopulating it --
  consistent with existing precedent, flagging in case deploy tooling should wrap it in
  maintenance mode.
- Declared `content_moderation` as an explicit module dependency -- "view any unpublished
  content" is defined by that module, and without it installed, Drupal silently strips
  the permission from role config on every role save
  (`Role::calculateDependencies()`), not just degrades gracefully. Already a hard
  profile-wide dependency, so this changes nothing in practice but documents the real
  dependency explicitly.

### Functional testing steps:
- [ ] As a `site_admin` or `editor` (not uid 1 / not a "bypass node access" account),
      unpublish a previously-published node.
- [ ] Confirm the node still appears in `admin/content`, both unfiltered and when
      explicitly filtering for "Unpublished" status.
- [ ] Confirm the node still appears in the relevant "Manage <type>" view (e.g.
      `admin/content/manage-pages`).
- [ ] Confirm filtering `admin/content` for "Published" status correctly excludes the
      unpublished node.
- [ ] Confirm filtering by Content type still works as expected.
- [ ] Confirm an anonymous or plain-authenticated user (no elevated role) still cannot
      see the unpublished node anywhere.

References yalesites-org/YaleSites-Internal#1486

---
Created with AI