### PR TITLE
1487: RC: Dashboard announcements feed is hardcoded to production yalesites.yale.edu, blocking RC testing

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/schema/ys_core.schema.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/schema/ys_core.schema.yml
@@ -7,7 +7,7 @@ ys_core.dashboard_settings:
       label: 'Show platform announcements on the dashboard'
     announcements_feed_url:
       type: string
-      label: 'Announcements feed URL override (set via drush; falls back to the platform feed when empty)'
+      label: 'Announcements feed URL override (platform admin only; falls back to the platform feed when empty)'
     announcements_limit:
       type: integer
       label: 'Maximum number of announcements to display'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/DashboardAnnouncements.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/DashboardAnnouncements.php
@@ -25,8 +25,10 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  * The feed follows the JSON Feed 1.1 spec. The YaleSites platform team
  * publishes announcements on yalesites.yale.edu and exposes them as a JSON
  * feed; each downstream site points
- * `ys_core.dashboard_settings:announcements_feed_url` at that endpoint. When no
- * URL is configured the dashboard simply omits the announcements section.
+ * `ys_core.dashboard_settings:announcements_feed_url` at that endpoint (via
+ * the "Dashboard Announcements Feed" section of the Platform Admin Settings
+ * page). When no URL is configured the dashboard falls back to the
+ * production feed.
  *
  * @see https://www.jsonfeed.org/version/1.1/
  */
@@ -54,9 +56,10 @@ class DashboardAnnouncements {
    * The canonical platform announcements feed URL.
    *
    * Used when `ys_core.dashboard_settings:announcements_feed_url` is empty,
-   * which is the default. The config key exists as a per-site override (set
-   * via drush, e.g. for staging environments) and is intentionally not
-   * exposed in the dashboard settings form.
+   * which is the default. The config key exists as a per-site override,
+   * settable by a platform admin on the "Dashboard Announcements Feed"
+   * section of the Platform Admin Settings page (e.g. to point an RC/test
+   * site's dashboard at a specific feed).
    */
   const PLATFORM_FEED_URL = 'https://yalesites.yale.edu/api/dashboard-announcements';
 
@@ -94,6 +97,19 @@ class DashboardAnnouncements {
   }
 
   /**
+   * Returns the feed URL actually in effect for this site.
+   *
+   * The configured override when set, otherwise the production platform
+   * feed. Shared by the fetch path and by the Platform Admin Settings
+   * "Dashboard Announcements Feed" field, so both agree on what "no
+   * override configured" resolves to.
+   */
+  public function getEffectiveFeedUrl(): string {
+    $feed_url = $this->configFactory->get('ys_core.dashboard_settings')->get('announcements_feed_url');
+    return trim((string) $feed_url) ?: self::PLATFORM_FEED_URL;
+  }
+
+  /**
    * Returns announcements to display on the dashboard.
    *
    * @return array
@@ -108,7 +124,7 @@ class DashboardAnnouncements {
     if ($config->get('announcements_enabled') === FALSE) {
       return [];
     }
-    $feed_url = trim((string) $config->get('announcements_feed_url')) ?: self::PLATFORM_FEED_URL;
+    $feed_url = $this->getEffectiveFeedUrl();
 
     $store = $this->keyValueExpirable->get(self::STORE_COLLECTION);
     $cached = $store->get(self::STORE_KEY);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/PlatformAdminSetting/AnnouncementsFeedPlatformAdminSetting.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/PlatformAdminSetting/AnnouncementsFeedPlatformAdminSetting.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Drupal\ys_core\Plugin\PlatformAdminSetting;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\ys_core\Attribute\PlatformAdminSetting;
+use Drupal\ys_core\DashboardAnnouncements;
+use Drupal\ys_core\PlatformAdminSettingBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Platform admin control for which feed the dashboard consumes.
+ *
+ * Exposes `ys_core.dashboard_settings:announcements_feed_url` - previously
+ * settable only via drush - so a platform admin can point this site's
+ * editorial dashboard at a specific feed (another RC/test site's own
+ * `/api/dashboard-announcements` endpoint, or its own) instead of the
+ * production default. Without this, RC testing could never verify the
+ * announcements feature end to end: the dashboard always consumed
+ * production's feed regardless of what a test site published
+ * (yalesites-org/YaleSites-Internal#1487).
+ *
+ * The field always displays the real effective URL (the stored override, or
+ * the production default when none is set) so a platform admin can see at a
+ * glance what the dashboard is currently pulling from. Submitting that shown
+ * default back unchanged is normalized to blank rather than pinned into
+ * config, so a routine save of this page never converts "no override" into
+ * an explicit one.
+ */
+#[PlatformAdminSetting(
+  id: 'announcements_feed',
+  label: new TranslatableMarkup('Dashboard Announcements Feed'),
+)]
+class AnnouncementsFeedPlatformAdminSetting extends PlatformAdminSettingBase {
+
+  /**
+   * The dashboard announcements service.
+   *
+   * @var \Drupal\ys_core\DashboardAnnouncements
+   */
+  protected DashboardAnnouncements $announcements;
+
+  /**
+   * Constructs an AnnouncementsFeedPlatformAdminSetting object.
+   *
+   * @param array $configuration
+   *   The plugin configuration.
+   * @param string $plugin_id
+   *   The plugin id.
+   * @param mixed $plugin_definition
+   *   The plugin definition.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\ys_core\DashboardAnnouncements $announcements
+   *   The dashboard announcements service.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    ConfigFactoryInterface $config_factory,
+    AccountInterface $current_user,
+    DashboardAnnouncements $announcements,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $config_factory, $current_user);
+    $this->announcements = $announcements;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory'),
+      $container->get('current_user'),
+      $container->get('ys_core.dashboard_announcements'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildSettings(array $form, FormStateInterface $form_state): array {
+    $form['announcements_feed_url'] = [
+      '#type' => 'url',
+      '#title' => $this->t('Feed source URL'),
+      '#default_value' => $this->announcements->getEffectiveFeedUrl(),
+      '#description' => $this->t("This is a testing/override control, not something most sites should touch. It lets a platform admin point this site's editorial dashboard at a specific announcements feed - for example another RC/test site's own <code>/api/dashboard-announcements</code> endpoint - so the full announcement loop can be verified without drush access. Leave it set to the URL shown above (the production feed) unless deliberately testing against a different source; clearing the field also falls back to the production feed."),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitSettings(array &$form, FormStateInterface $form_state): void {
+    $value = trim((string) $form_state->getValue([$this->getPluginId(), 'announcements_feed_url']));
+    // A resubmission of the displayed production default is not a
+    // deliberate override, so it is stored as blank (the same effective
+    // value) rather than pinned into config.
+    if ($value === DashboardAnnouncements::PLATFORM_FEED_URL) {
+      $value = '';
+    }
+
+    $config = $this->configFactory->getEditable('ys_core.dashboard_settings');
+    if ((string) $config->get('announcements_feed_url') === $value) {
+      // No effective change: skip the write and the cache-clearing HTTP
+      // refetch it would otherwise force on the next toolbar badge render.
+      return;
+    }
+
+    $config->set('announcements_feed_url', $value)->save();
+
+    // Drop the cached feed so a changed source takes effect immediately,
+    // consistent with DashboardSettingsForm's save behavior.
+    $this->announcements->clearCache();
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/AnnouncementsFeedPlatformAdminSettingTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/AnnouncementsFeedPlatformAdminSettingTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Unit;
+
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_core\DashboardAnnouncements;
+use Drupal\ys_core\Plugin\PlatformAdminSetting\AnnouncementsFeedPlatformAdminSetting;
+
+/**
+ * Tests the dashboard announcements feed platform admin setting plugin.
+ *
+ * @group ys_core
+ * @coversDefaultClass \Drupal\ys_core\Plugin\PlatformAdminSetting\AnnouncementsFeedPlatformAdminSetting
+ */
+class AnnouncementsFeedPlatformAdminSettingTest extends UnitTestCase {
+
+  /**
+   * Builds the plugin with the given collaborators.
+   */
+  private function plugin(ConfigFactoryInterface $config_factory, ?DashboardAnnouncements $announcements = NULL): AnnouncementsFeedPlatformAdminSetting {
+    $plugin = new AnnouncementsFeedPlatformAdminSetting(
+      [],
+      'announcements_feed',
+      [],
+      $config_factory,
+      $this->createMock(AccountInterface::class),
+      $announcements ?? $this->createMock(DashboardAnnouncements::class),
+    );
+    $plugin->setStringTranslation($this->getStringTranslationStub());
+    return $plugin;
+  }
+
+  /**
+   * A DashboardAnnouncements double reporting the given effective feed URL.
+   */
+  private function announcementsWithEffectiveUrl(string $url): DashboardAnnouncements {
+    $announcements = $this->createMock(DashboardAnnouncements::class);
+    $announcements->method('getEffectiveFeedUrl')->willReturn($url);
+    return $announcements;
+  }
+
+  /**
+   * Builds a config factory whose editable config records set() calls.
+   *
+   * @param array $tracked
+   *   Populated with each set() key/value pair, by reference.
+   * @param string $stored
+   *   The value get('announcements_feed_url') should report as already
+   *   stored, simulating the config state before this submit.
+   */
+  private function trackingConfigFactory(array &$tracked, string $stored = ''): ConfigFactoryInterface {
+    $config = $this->createMock(Config::class);
+    $config->method('get')->with('announcements_feed_url')->willReturn($stored);
+    $config->method('set')->willReturnCallback(function (string $key, $value) use (&$tracked, $config) {
+      $tracked[$key] = $value;
+      return $config;
+    });
+    $config->method('save')->willReturnSelf();
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('getEditable')->with('ys_core.dashboard_settings')->willReturn($config);
+    return $factory;
+  }
+
+  /**
+   * The field is a core #type => url element.
+   *
+   * Format validation and its inline error are handled by Drupal core, not
+   * custom code.
+   *
+   * @covers ::buildSettings
+   */
+  public function testFieldIsUrlType(): void {
+    $plugin = $this->plugin($this->createMock(ConfigFactoryInterface::class));
+
+    $form = $plugin->buildSettings([], new FormState());
+
+    $this->assertSame('url', $form['announcements_feed_url']['#type']);
+  }
+
+  /**
+   * The field's default value is whatever DashboardAnnouncements reports.
+   *
+   * That shared accessor is also used to actually fetch the feed, so the
+   * displayed default can never disagree with what the dashboard uses.
+   *
+   * @covers ::buildSettings
+   */
+  public function testDefaultValueShowsProductionUrlWhenUnset(): void {
+    $plugin = $this->plugin(
+      $this->createMock(ConfigFactoryInterface::class),
+      $this->announcementsWithEffectiveUrl(DashboardAnnouncements::PLATFORM_FEED_URL),
+    );
+
+    $form = $plugin->buildSettings([], new FormState());
+
+    $this->assertSame(DashboardAnnouncements::PLATFORM_FEED_URL, $form['announcements_feed_url']['#default_value']);
+  }
+
+  /**
+   * A stored override is shown verbatim.
+   *
+   * @covers ::buildSettings
+   */
+  public function testDefaultValueShowsStoredOverride(): void {
+    $plugin = $this->plugin(
+      $this->createMock(ConfigFactoryInterface::class),
+      $this->announcementsWithEffectiveUrl('https://rc-test.example.edu/api/dashboard-announcements'),
+    );
+
+    $form = $plugin->buildSettings([], new FormState());
+
+    $this->assertSame('https://rc-test.example.edu/api/dashboard-announcements', $form['announcements_feed_url']['#default_value']);
+  }
+
+  /**
+   * Submitting a distinct URL stores it and clears the feed cache.
+   *
+   * @covers ::submitSettings
+   */
+  public function testSubmitStoresOverrideAndClearsCache(): void {
+    $set = [];
+    $factory = $this->trackingConfigFactory($set, '');
+
+    $announcements = $this->createMock(DashboardAnnouncements::class);
+    $announcements->expects($this->once())->method('clearCache');
+
+    $plugin = $this->plugin($factory, $announcements);
+
+    $form_state = new FormState();
+    $form_state->setValue(['announcements_feed', 'announcements_feed_url'], 'https://rc-test.example.edu/api/dashboard-announcements');
+    $form = [];
+    $plugin->submitSettings($form, $form_state);
+
+    $this->assertSame('https://rc-test.example.edu/api/dashboard-announcements', $set['announcements_feed_url']);
+  }
+
+  /**
+   * Submitting the shown production default normalizes back to blank.
+   *
+   * Replacing a real prior override with the displayed production default
+   * must store blank, not the literal production URL - that would pin an
+   * explicit override into config/sync for a value that is supposed to mean
+   * "no override" (yalesites-org/YaleSites-Internal#1487).
+   *
+   * @covers ::submitSettings
+   */
+  public function testSubmitNormalizesProductionUrlBackToBlank(): void {
+    $set = [];
+    $factory = $this->trackingConfigFactory($set, 'https://old-override.example.edu/api/dashboard-announcements');
+
+    $announcements = $this->createMock(DashboardAnnouncements::class);
+    $announcements->expects($this->once())->method('clearCache');
+
+    $plugin = $this->plugin($factory, $announcements);
+
+    $form_state = new FormState();
+    $form_state->setValue(['announcements_feed', 'announcements_feed_url'], DashboardAnnouncements::PLATFORM_FEED_URL);
+    $form = [];
+    $plugin->submitSettings($form, $form_state);
+
+    $this->assertSame('', $set['announcements_feed_url']);
+  }
+
+  /**
+   * Clearing an existing override stores blank.
+   *
+   * @covers ::submitSettings
+   */
+  public function testSubmitClearingExistingOverrideStoresBlank(): void {
+    $set = [];
+    $factory = $this->trackingConfigFactory($set, 'https://old-override.example.edu/api/dashboard-announcements');
+
+    $announcements = $this->createMock(DashboardAnnouncements::class);
+    $announcements->expects($this->once())->method('clearCache');
+
+    $plugin = $this->plugin($factory, $announcements);
+
+    $form_state = new FormState();
+    $form_state->setValue(['announcements_feed', 'announcements_feed_url'], '');
+    $form = [];
+    $plugin->submitSettings($form, $form_state);
+
+    $this->assertSame('', $set['announcements_feed_url']);
+  }
+
+  /**
+   * A resubmission with no effective change skips the write and cache clear.
+   *
+   * Resaving the page without touching this field submits the displayed
+   * production default, which normalizes to the same blank value already
+   * stored. That must not write config or clear the feed cache - doing so
+   * would force the next dashboard toolbar render to pay a synchronous
+   * refetch of the announcements feed for no reason.
+   *
+   * @covers ::submitSettings
+   */
+  public function testSubmitSkipsWriteAndCacheClearWhenUnchanged(): void {
+    $config = $this->createMock(Config::class);
+    $config->method('get')->with('announcements_feed_url')->willReturn('');
+    $config->expects($this->never())->method('set');
+    $config->expects($this->never())->method('save');
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('getEditable')->with('ys_core.dashboard_settings')->willReturn($config);
+
+    $announcements = $this->createMock(DashboardAnnouncements::class);
+    $announcements->expects($this->never())->method('clearCache');
+
+    $plugin = $this->plugin($factory, $announcements);
+
+    $form_state = new FormState();
+    $form_state->setValue(['announcements_feed', 'announcements_feed_url'], DashboardAnnouncements::PLATFORM_FEED_URL);
+    $form = [];
+    $plugin->submitSettings($form, $form_state);
+  }
+
+}


### PR DESCRIPTION
## [1487: RC: Dashboard announcements feed is hardcoded to production yalesites.yale.edu, blocking RC testing](https://github.com/yalesites-org/YaleSites-Internal/issues/1487)

### Description of work
- Added a new `PlatformAdminSetting` plugin ("Dashboard Announcements Feed") exposing the previously drush-only `announcements_feed_url` config key as a field on the Platform Admin Settings page (`/admin/yalesites/platform-admin-settings`), so a platform admin can point a site's dashboard at a specific feed (e.g. another RC/test site's own `/api/dashboard-announcements` endpoint) to verify the full announcement loop without drush access.
- The field always displays the real effective URL (stored override, or the production default) via a new `DashboardAnnouncements::getEffectiveFeedUrl()` accessor shared with the actual fetch path, so the displayed default and the fetched URL can never disagree.
- Resubmitting that shown default (or leaving the field alone) normalizes back to blank internally rather than pinning the literal production URL into config, so a routine save of this page never turns "no override" into an explicit one that would go stale if the production URL ever changes.
- Validation and its inline, accessible error come from Drupal core's `#type => 'url'` element - already the established pattern for URL fields in this codebase - so no custom validation code was needed.
- Scope note: intentionally left the existing "Announcements source" fieldset (publish toggle + tag, in `DashboardSettingsForm.php`) where it is. Whether to also migrate that into a Platform Admin Settings plugin is flagged as an open question for review, not addressed in this PR.

### Functional testing steps:
- [ ] As a platform admin (or user 1), visit `/admin/yalesites/platform-admin-settings` and confirm a "Dashboard Announcements Feed" section appears with a "Feed source URL" field pre-filled with `https://yalesites.yale.edu/api/dashboard-announcements`.
- [ ] Enter an invalid value (e.g. `not-a-url`) and save - confirm an inline "The URL ... is not valid." error appears on the field.
- [ ] Enter a distinct URL (e.g. another site's `/api/dashboard-announcements` endpoint) and save - confirm it's stored (`drush config:get ys_core.dashboard_settings announcements_feed_url`) and that the editorial dashboard's Announcements section now reflects that feed.
- [ ] Re-enter the exact URL shown as the default (the production feed) and save - confirm `announcements_feed_url` is stored as blank (not pinned to the literal URL).
- [ ] Save the page again without touching the field - confirm no error and the value is unchanged.

References yalesites-org/YaleSites-Internal#1487

---
Created with AI

<img width="604" height="276" alt="Screenshot 2026-08-07 at 9 03 03 AM" src="https://github.com/user-attachments/assets/669bc7d1-b191-4431-b9d8-80402ec036c7" />
<img width="195" height="87" alt="Screenshot 2026-08-07 at 9 02 57 AM" src="https://github.com/user-attachments/assets/f54283bb-0e37-4215-a1d4-aa3057d9c8a5" />
<img width="819" height="494" alt="Screenshot 2026-08-07 at 9 03 08 AM" src="https://github.com/user-attachments/assets/24a0b104-feaa-4fca-9ecc-1118b162d12c" />

