### PR TITLE
1146: AI: LLM should be aware of the current date and time

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
@@ -41,11 +41,20 @@ Entity save -> Search API tracking -> ys_beacon index (ai_search backend)
 Visitor -> React widget -> POST /api/ys-beacon/v1/conversation
                  - RagRetriever: vector query, chunked results -> citations
                  - SystemPromptBuilder: site system instructions + [docN] sources
+                 - ToolCallHandler: attaches the allow-listed LLM tools
                  - Portkey chat completion, streamed as NDJSON
+                 - if the model asked for a tool: run it, then call Portkey a
+                   second time (no tools) and stream that answer instead
 ```
 
 Submodule `ys_beacon_portkey` provides the `portkey` AI provider plugin
 (OpenAI-compatible, with `x-portkey-*` headers) used for both operations.
+
+The model can call a small set of ys_beacon-owned tools mid-conversation - today
+just one, returning the current date and time, so answers can depend on "now".
+See [docs/AI_FUNCTION_CALL_TOOLS.md](docs/AI_FUNCTION_CALL_TOOLS.md) for how to
+add another; which tools the model may call is an explicit allow-list on the
+`ys_beacon.tool_call_handler` service, not everything registered on the site.
 
 ## Per-site configuration
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/docs/AI_FUNCTION_CALL_TOOLS.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/docs/AI_FUNCTION_CALL_TOOLS.md
@@ -1,0 +1,153 @@
+# Adding an LLM tool ("function call") to ys_beacon
+
+Tracks issue #1146, which added the first one: `GetCurrentDateTime`
+(`src/Plugin/AiFunctionCall/GetCurrentDateTime.php`). This is the reference
+implementation for adding another.
+
+## The pieces
+
+1. **A `Drupal\ai\Plugin\AiFunctionCall` plugin** under
+   `src/Plugin/AiFunctionCall/`, using the `ai` module's `#[FunctionCall]`
+   attribute, `FunctionCallBase`, and `ExecutableFunctionCallInterface`
+   (`GetCurrentDateTime.php` is the pattern to copy). Give the plugin `id` a
+   `ys_beacon:` prefix (the module, not the function group — the attribute's
+   own docblock claims the `id` must be prefixed by `group`; that is wrong,
+   verified against real plugins in contrib, e.g. `ai_search:rag_search` has
+   group `information_tools`). Declare `group: 'information_tools'` if the
+   tool genuinely provides the model contextual information (this is metadata
+   only - see the allow-list below for what actually controls exposure).
+2. **An entry in the allow-list argument of the `ys_beacon.tool_call_handler`
+   service definition, in `ys_beacon.services.yml`** - add the new plugin's
+   id to that array (`ToolCallHandler`'s third constructor argument). **This
+   is the only place that controls what the model can actually call - and
+   `ToolCallHandler` enforces it twice**, not just once: `buildToolsInput()`
+   only ever *offers* the allow-listed plugins, and `executeOne()` separately
+   checks the allow-list again before *executing* a returned call. The second
+   check matters on its own: `FunctionCallPluginManager::
+   convertToolResponseToObject()` resolves a tool call's function_name
+   against every plugin **registered on the site**, not just the ones this
+   handler offered - so without that second check, a model that named an
+   unoffered plugin (via prompt injection, since indexed site content reaches
+   the model) could still have it executed. Do not rely on function-group
+   membership for exposure either:
+   `ai_search`'s own `rag_search` plugin already lives in `information_tools`,
+   and if `ToolCallHandler` ever resolved tools by scanning the group instead
+   of an explicit list, that unrelated plugin would be offered to the model on
+   every Beacon turn - bypassing ys_beacon's own RAG retrieval and citation
+   tracking entirely. Keep the allow-list explicit.
+
+Nothing else needs to change. `ToolCallHandler` (`src/Service/ToolCallHandler.php`)
+already handles, for any allow-listed plugin: building the `ToolsInput` sent to the
+model (`attachTools()`), detecting a returned tool call on either the streamed or
+non-streamed path, executing it, and assembling the follow-up request
+(`followUpInput()`, which wraps `extractToolCalls()` and
+`buildFollowUpMessages()`) - absorbing any failure into a plain-text error result
+rather than breaking the turn. Both `ChatApiController` (streamed, the live chat
+endpoint) and `BeaconAnswerService` (non-streamed, used by `ys_ai_tester`) call the
+same two methods, so a new tool gets both surfaces for free. Keep it that way: the
+shared half belongs on the handler, not copied into a caller.
+
+### Watch the input token budget when adding a tool
+
+`ChatApiController` windows the transcript to the model's context window before the
+first call (`windowTranscriptToBudget()`), and the tool round trip is *not* counted
+against that budget - neither the tool schema attached to the request nor the
+assistant echo and tool result appended for the follow-up call. Today's single tool
+costs roughly 160 tokens all in, comfortably inside the existing
+`SAFETY_MARGIN_TOKENS` (2048), so there is no live overflow. A tool with a large
+`getReadableOutput()` changes that: budget for it explicitly (subtract a tool
+reserve before windowing) rather than assuming the margin absorbs it.
+
+## Round trip, in one turn
+
+1. `attachTools()` puts the allow-listed tools' JSON-schema declarations on the
+   `ChatInput` before the first call to the provider.
+2. If the model's response is a tool call, `extractToolCalls()` reads it off
+   the normalized output (a plain `ChatMessage` for the non-streamed path; a
+   fully-drained `StreamedChatMessageIteratorInterface` for the streamed one -
+   its tool calls are only assembled after the iterator finishes, which the
+   controller's answer-streaming loop already does as a side effect).
+3. `buildFollowUpMessages()` executes the tool (via
+   `FunctionCallPluginManager::convertToolResponseToObject()` +
+   `validateContexts()` + `execute()`) and returns an assistant message
+   echoing the tool call plus one `tool`-role message per call, carrying the
+   result.
+4. `followUpInput()` appends those to the transcript and hands the caller a
+   `ChatInput` with **no tools attached** - so the turn resolves in exactly one
+   extra hop. A tool that legitimately needs to chain into a second tool call
+   is out of scope for this pattern; nothing here loops.
+5. The caller makes that second call and streams or returns its answer. If a
+   turn ends up producing no assistant text at all - a tool call that could not
+   be assembled or run, or a stream that died before its first token -
+   `ChatApiController` reports the turn as failed rather than sending an empty
+   answer, because a blank reply is indistinguishable in the widget from one
+   still arriving.
+
+## Constructor injection for a plugin that needs a service
+
+`FunctionCallBase`'s own `create()` only injects the two managers every
+function-call plugin needs (`ai.context_definition_normalizer`,
+`plugin.manager.ai_data_type_converter`). To inject anything else (a Drupal
+service, like `GetCurrentDateTime`'s `datetime.time` and `date.formatter`),
+override `create()` and pass the extra services as further constructor
+arguments, keeping the two parent-required ones (see
+`RagTool.php` in `ai_search` for the pattern this was copied from,
+and `GetCurrentDateTime::create()` for a worked example).
+
+## Verifying against a real model
+
+Most of the round trip above is covered by tests using a provider double that
+returns a synthetic tool-call message, not a live model - but with a real
+Portkey key configured locally, a real model genuinely does call the tool
+end to end (confirmed live for #1146, via the chat widget). Do this before
+considering a new tool done; a mocked round trip proves the wiring, not that
+a real model reliably calls the tool with sensible arguments.
+
+**A live model surfaces failure modes a mock cannot**, because it can send a
+provider-specific wire shape a mock never would. #1146 hit exactly this:
+a zero-argument tool call (a tool whose only parameters were all optional)
+arrived with a genuinely empty `arguments` string rather than `"{}"`, and both
+of contrib's own assembly points (`StreamedChatMessageIterator::
+assembleToolCalls()`, and `OpenAiBasedProviderClientBase::chat()`'s
+non-streamed branch) unconditionally `Json::decode()` that string before
+constructing a `ToolsFunctionOutput`, whose `$arguments` parameter is
+non-nullable - so a genuinely empty string TypeErrors there, inside contrib
+code this module cannot patch.
+
+**Give every tool at least one required parameter.** This is the actual fix,
+not just a mitigation: a required parameter forces the JSON schema offered to
+the model to mark it `"required"`, so a compliant model can never send an
+empty `arguments` object, which means contrib's `Json::decode()` never sees
+`''`. `GetCurrentDateTime`'s `timezone` context is declared `required: TRUE`
+*and* keeps a `default_value` - Drupal's own `Context::getContextValue()`
+falls back to the default whenever no value was ever explicitly set,
+regardless of `required`, so the plugin still tolerates a model that omits the
+key or sends an invalid timezone (`execute()` catches an invalid
+`\DateTimeZone` and falls back to the default). If a tool has no naturally
+required parameter, add one anyway (e.g. a required enum with a sensible
+default) rather than shipping an all-optional signature.
+
+`ToolCallHandler::extractToolCalls()` and `ChatApiController::emitAnswer()`'s
+streamed drain loop both still catch a failure while assembling tool calls
+(logging and continuing rather than breaking the turn) - keep this as
+defense-in-depth for any other contrib-side assembly failure, but do not treat
+it as a substitute for the required-parameter fix: absorbing the failure
+produces a turn with no tool result and no assistant text, not a working
+tool call. The Kernel test `testExtractToolCallsAbsorbsRealEmptyArgumentsToolCall`
+reproduces the empty-arguments TypeError through the real
+`StreamedChatMessageIterator` to prove the absorption still works, but the
+tool itself is exercised live before being considered done (see above).
+
+**A second contrib sharp edge, on the non-streamed path only:** a model can name
+a `function_name` that was never offered - a hallucination, or prompt injection
+from indexed page content. Contrib builds that call as
+`new ToolsFunctionOutput($input->getChatTools()->getFunctionByName($name), ...)`,
+and `ToolsInput::getFunctionByName()` returns `NULL` for a function it does not
+know. `ToolsFunctionOutput::__construct()` only calls `setName()` when that
+argument is non-`NULL`, leaving its non-nullable `string $name` uninitialized, so
+`getName()` raises an `Error` rather than returning a name to reject. That is why
+`ToolCallHandler::executeOne()` reads the name *inside* its own `try` - otherwise
+the allow-list check would be unreachable in exactly the injected case it exists
+for, and the whole turn would fail instead of the one tool call. The streamed
+path always sets a name, so this is easy to miss when testing only the live
+widget.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Controller/ChatApiController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Controller/ChatApiController.php
@@ -15,6 +15,7 @@ use Drupal\ys_beacon\Service\GuardrailTelemetry;
 use Drupal\ys_beacon\Service\RagRetriever;
 use Drupal\ys_beacon\Service\SuspectTurnLog;
 use Drupal\ys_beacon\Service\SystemPromptBuilder;
+use Drupal\ys_beacon\Service\ToolCallHandler;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -157,6 +158,13 @@ class ChatApiController extends ControllerBase {
   protected SuspectTurnLog $suspectTurnLog;
 
   /**
+   * The tool call handler.
+   *
+   * @var \Drupal\ys_beacon\Service\ToolCallHandler
+   */
+  protected ToolCallHandler $toolCallHandler;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
@@ -171,6 +179,7 @@ class ChatApiController extends ControllerBase {
     $instance->telemetry = $container->get('ys_beacon.guardrail_telemetry');
     $instance->signalDetector = $container->get('ys_beacon.guardrail_signal_detector');
     $instance->suspectTurnLog = $container->get('ys_beacon.suspect_turn_log');
+    $instance->toolCallHandler = $container->get('ys_beacon.tool_call_handler');
     return $instance;
   }
 
@@ -294,8 +303,10 @@ class ChatApiController extends ControllerBase {
 
       // Guardrail telemetry is recorded once, in the finally below, after the
       // answer has been streamed - so counting can never delay the visible
-      // answer, and a turn that failed part-way is still counted.
-      $chat_input = NULL;
+      // answer, and a turn that failed part-way is still counted. Holds one
+      // entry per provider call this turn made (one, or two when a tool call
+      // made a follow-up call happen).
+      $chat_inputs = [];
       // The answer is accumulated only up to the refusal sample the counters
       // classify from, which is never stored or logged.
       $captured = '';
@@ -312,33 +323,32 @@ class ChatApiController extends ControllerBase {
         // object would leave guardrail stops uncounted (nothing in the module
         // does so today).
         $chat_input = new ChatInput($messages);
+        $chat_inputs[] = $chat_input;
+        $this->toolCallHandler->attachTools($chat_input);
         // The AI module's output filter blocks the links the model returns
         // (its allow-list is empty = block-all), so disable it for this
         // response. See withOutputFilteringDisabled() for the safety rationale.
-        $this->withOutputFilteringDisabled(function () use ($provider, $chat_input, $model_id, $emit, $response_id, &$captured) {
-          $output = $provider->chat($chat_input, $model_id, ['ys_beacon']);
-          $normalized = $output->getNormalized();
+        $this->withOutputFilteringDisabled(function () use ($provider, $chat_input, $messages, $model_id, $emit, $response_id, &$captured, &$chat_inputs) {
+          $normalized = $provider->chat($chat_input, $model_id, ['ys_beacon'])->getNormalized();
+          $emitted = $this->emitAnswer($normalized, $response_id, $model_id, $emit, $captured);
 
-          if ($normalized instanceof \Traversable) {
-            foreach ($normalized as $chunk) {
-              $delta = $chunk->getText();
-              if ($delta === '') {
-                continue;
-              }
-              if (mb_strlen($captured) < GuardrailSignalDetector::REFUSAL_SAMPLE_LENGTH) {
-                $captured .= $delta;
-              }
-              $emit($this->envelope($response_id, $model_id, [
-                ['role' => 'assistant', 'content' => $delta],
-              ]));
-            }
+          // A tool call carries no visible answer of its own, so run it and
+          // ask the model again - without tools this time, so the turn
+          // resolves in exactly one hop - for the answer to actually stream.
+          $follow_up_input = $this->toolCallHandler->followUpInput($normalized, $messages);
+          if ($follow_up_input) {
+            $chat_inputs[] = $follow_up_input;
+            $follow_up_normalized = $provider->chat($follow_up_input, $model_id, ['ys_beacon'])->getNormalized();
+            $emitted = $this->emitAnswer($follow_up_normalized, $response_id, $model_id, $emit, $captured) || $emitted;
           }
-          else {
-            $text = $normalized->getText();
-            $captured = mb_substr($text, 0, GuardrailSignalDetector::REFUSAL_SAMPLE_LENGTH);
-            $emit($this->envelope($response_id, $model_id, [
-              ['role' => 'assistant', 'content' => $text],
-            ]));
+
+          // Nothing readable came back on either hop - a stream that failed
+          // part-way, or a tool call contrib could not assemble. Throwing
+          // hands the turn to the caller's error handling, which tells the
+          // widget the assistant is unavailable; without this the visitor
+          // would just get their question, the sources and no answer at all.
+          if (!$emitted) {
+            throw new \RuntimeException('The model returned no answer for this turn.');
           }
         });
       }
@@ -367,7 +377,10 @@ class ChatApiController extends ControllerBase {
 
         $stops = 0;
         try {
-          $stops = $this->recordTurnTelemetry($has_citations, $captured, $chat_input);
+          // Every call this turn made is read, so a guardrail stop on the
+          // tool-informed follow-up answer is counted too - not only one that
+          // occurred on the initial (pre-tool) call.
+          $stops = $this->recordTurnTelemetry($has_citations, $captured, $chat_inputs);
         }
         catch (\Throwable) {
         }
@@ -479,16 +492,17 @@ class ChatApiController extends ControllerBase {
    *   The captured answer text, at most the refusal sample. Only its opening is
    *   inspected, by isRefusal(). Empty when the turn failed before the model
    *   produced anything.
-   * @param \Drupal\ai\OperationType\Chat\ChatInput|null $chat_input
-   *   The input the model was called with, carrying the turn's guardrail
-   *   results, or NULL if the call was never made.
+   * @param \Drupal\ai\OperationType\Chat\ChatInput[] $chat_inputs
+   *   The input(s) the model was called with, carrying each call's guardrail
+   *   results - one entry for an ordinary turn, two when a tool call made a
+   *   follow-up call happen. Empty when the call was never made.
    *
    * @return int
-   *   How many guardrail stops the turn recorded. Returned so the caller can
-   *   decide whether the turn is worth keeping in full, without parsing the
-   *   contrib guardrail results a second time.
+   *   How many guardrail stops the turn recorded across all of its calls.
+   *   Returned so the caller can decide whether the turn is worth keeping in
+   *   full, without parsing the contrib guardrail results a second time.
    */
-  protected function recordTurnTelemetry(bool $has_citations, string $answer, ?ChatInput $chat_input): int {
+  protected function recordTurnTelemetry(bool $has_citations, string $answer, array $chat_inputs): int {
     // The denominator: recorded for every turn that reached the model, so the
     // other counters can be read as rates rather than raw volumes.
     $this->telemetry->recordTurn();
@@ -501,14 +515,89 @@ class ChatApiController extends ControllerBase {
       $this->telemetry->recordRefusal();
     }
 
-    if ($chat_input === NULL) {
-      return 0;
+    $stops = 0;
+    foreach ($chat_inputs as $chat_input) {
+      $stops += $this->telemetry->recordGuardrailResults(
+        $chat_input->getAllGuardrailResults(),
+        array_keys($chat_input->getGuardrailSets())
+      );
+    }
+    return $stops;
+  }
+
+  /**
+   * Streams or emits a normalized chat answer.
+   *
+   * Any tool calls the answer carries are read separately, by passing the
+   * same $normalized to ToolCallHandler::extractToolCalls() once this
+   * returns - a streamed answer's tool calls are only fully assembled after
+   * its iterator has been drained, which the loop below does as a side
+   * effect of streaming the text.
+   *
+   * Reading a streamed answer can itself throw, from inside the loop below:
+   * contrib's StreamedChatMessageIterator::getIterator() assembles the tool
+   * calls automatically once the underlying generator is exhausted, so a tool
+   * call contrib cannot assemble (see ToolCallHandler::extractToolCalls())
+   * surfaces here rather than from the later ::extractToolCalls() call. It is
+   * absorbed so text already streamed still stands - but the caller must
+   * check the return value, because a turn that streamed NOTHING has to be
+   * reported to the client as a failure rather than left as a blank answer.
+   *
+   * @param mixed $normalized
+   *   The provider's normalized chat output: a ChatMessage, or a
+   *   \Traversable streamed iterator.
+   * @param string $response_id
+   *   The response id shared by all lines of this turn.
+   * @param string $model_id
+   *   The model id.
+   * @param callable $emit
+   *   Emits one NDJSON line to the client.
+   * @param string $captured
+   *   The refusal-detection sample, appended to by reference and capped at
+   *   GuardrailSignalDetector::REFUSAL_SAMPLE_LENGTH. Appended rather than
+   *   assigned because a tool turn calls this twice, and the sample means
+   *   "the opening of the answer the visitor saw".
+   *
+   * @return bool
+   *   TRUE if any assistant text was emitted. FALSE means the model produced
+   *   nothing readable, which the caller must surface as an error.
+   */
+  protected function emitAnswer(mixed $normalized, string $response_id, string $model_id, callable $emit, string &$captured): bool {
+    $emitted = FALSE;
+
+    if ($normalized instanceof \Traversable) {
+      try {
+        foreach ($normalized as $chunk) {
+          $delta = $chunk->getText();
+          if ($delta === '') {
+            continue;
+          }
+          $captured = mb_substr($captured . $delta, 0, GuardrailSignalDetector::REFUSAL_SAMPLE_LENGTH);
+          $emit($this->envelope($response_id, $model_id, [
+            ['role' => 'assistant', 'content' => $delta],
+          ]));
+          $emitted = TRUE;
+        }
+      }
+      catch (\Throwable $e) {
+        $this->logger->error('Beacon failed to drain the streamed answer: @message', ['@message' => $e->getMessage()]);
+      }
+      return $emitted;
     }
 
-    return $this->telemetry->recordGuardrailResults(
-      $chat_input->getAllGuardrailResults(),
-      array_keys($chat_input->getGuardrailSets())
-    );
+    $text = $normalized->getText();
+    // An empty answer is the first hop of a tool turn, which carries the tool
+    // call rather than any text. Emitting it would clear the widget's loading
+    // indicator and leave an empty bubble sitting there for the whole
+    // follow-up round trip, so it is skipped - matching the streamed branch.
+    if ($text === '') {
+      return FALSE;
+    }
+    $captured = mb_substr($captured . $text, 0, GuardrailSignalDetector::REFUSAL_SAMPLE_LENGTH);
+    $emit($this->envelope($response_id, $model_id, [
+      ['role' => 'assistant', 'content' => $text],
+    ]));
+    return TRUE;
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/AiFunctionCall/GetCurrentDateTime.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/AiFunctionCall/GetCurrentDateTime.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\ys_beacon\Plugin\AiFunctionCall;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\ai\Attribute\FunctionCall;
+use Drupal\ai\Base\FunctionCallBase;
+use Drupal\ai\PluginManager\AiDataTypeConverterPluginManager;
+use Drupal\ai\Service\FunctionCalling\ExecutableFunctionCallInterface;
+use Drupal\ai\Service\FunctionCalling\FunctionCallInterface;
+use Drupal\ai\Utility\ContextDefinitionNormalizer;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Tells the model the current date and time, in a given or default timezone.
+ *
+ * Reference implementation for ys_beacon's first LLM tool call
+ * (yalesites-org/YaleSites-Internal#1146) - the pattern future ys_beacon
+ * tools should follow.
+ */
+#[FunctionCall(
+  id: 'ys_beacon:current_date_time',
+  function_name: 'ys_beacon_current_date_time',
+  name: 'Current Date and Time',
+  description: 'Returns the current date and time, in a given IANA timezone (e.g. America/New_York, Asia/Tokyo). Use this whenever the answer depends on knowing today\'s date, the current time, or "now". If the user did not specify a timezone, pass America/New_York.',
+  group: 'information_tools',
+  context_definitions: [
+    'timezone' => new ContextDefinition(
+      data_type: 'string',
+      label: new TranslatableMarkup('Timezone'),
+      description: new TranslatableMarkup('An IANA timezone identifier, e.g. America/New_York or Asia/Tokyo. Pass America/New_York if the user did not specify one.'),
+      required: TRUE,
+      default_value: 'America/New_York',
+    ),
+  ],
+)]
+class GetCurrentDateTime extends FunctionCallBase implements ExecutableFunctionCallInterface {
+
+  /**
+   * Yale's site timezone, used when no timezone is given or it is invalid.
+   */
+  protected const DEFAULT_TIMEZONE = 'America/New_York';
+
+  /**
+   * Constructs the plugin.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    ContextDefinitionNormalizer $context_definition_normalizer,
+    ?AiDataTypeConverterPluginManager $data_type_converter_manager,
+    protected TimeInterface $time,
+    protected DateFormatterInterface $dateFormatter,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $context_definition_normalizer, $data_type_converter_manager);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): FunctionCallInterface|static {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('ai.context_definition_normalizer'),
+      $container->get('plugin.manager.ai_data_type_converter'),
+      $container->get('datetime.time'),
+      $container->get('date.formatter'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute() {
+    $timezone_name = $this->getContextValue('timezone') ?: self::DEFAULT_TIMEZONE;
+
+    try {
+      new \DateTimeZone($timezone_name);
+    }
+    catch (\Exception) {
+      $timezone_name = self::DEFAULT_TIMEZONE;
+    }
+
+    $timestamp = $this->time->getCurrentTime();
+
+    $this->setOutput(sprintf(
+      '%s (%s), timezone %s.',
+      $this->dateFormatter->format($timestamp, 'custom', 'l, F j, Y H:i', $timezone_name),
+      $this->dateFormatter->format($timestamp, 'custom', \DateTimeInterface::ATOM, $timezone_name),
+      $timezone_name,
+    ));
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/BeaconAnswerService.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/BeaconAnswerService.php
@@ -21,6 +21,7 @@ class BeaconAnswerService {
     protected AiProviderPluginManager $aiProvider,
     protected RagRetriever $ragRetriever,
     protected SystemPromptBuilder $promptBuilder,
+    protected ToolCallHandler $toolCallHandler,
   ) {
   }
 
@@ -38,7 +39,7 @@ class BeaconAnswerService {
    *   When no default chat provider is configured.
    */
   public function answer(string $question): array {
-    $defaults = $this->aiProvider->getDefaultProviderForOperationType('chat');
+    $defaults = $this->chatDefaults();
     if (empty($defaults['provider_id']) || empty($defaults['model_id'])) {
       throw new \RuntimeException('No default chat provider is configured.');
     }
@@ -49,13 +50,54 @@ class BeaconAnswerService {
       new ChatMessage('user', $question),
     ];
 
-    $provider = $this->aiProvider->createInstance($defaults['provider_id']);
-    $output = $provider->chat(new ChatInput($messages), $defaults['model_id'], ['ys_beacon']);
+    $provider = $this->chatProvider($defaults['provider_id']);
+    $chat_input = new ChatInput($messages);
+    $this->toolCallHandler->attachTools($chat_input);
+
+    $output = $provider->chat($chat_input, $defaults['model_id'], ['ys_beacon']);
+    $normalized = $output->getNormalized();
+
+    $follow_up_input = $this->toolCallHandler->followUpInput($normalized, $messages);
+    if ($follow_up_input) {
+      $output = $provider->chat($follow_up_input, $defaults['model_id'], ['ys_beacon']);
+      $normalized = $output->getNormalized();
+    }
 
     return [
-      'answer' => (string) $output->getNormalized()->getText(),
+      'answer' => (string) $normalized->getText(),
       'citations' => $citations,
     ];
+  }
+
+  /**
+   * Resolves the site's default chat provider and model.
+   *
+   * Extracted as the only touchpoint on the AI module's provider manager
+   * before the call, so a test can substitute the answer.
+   * AiProviderPluginManager is declared final and cannot be mocked.
+   *
+   * @return array|null
+   *   The provider defaults, as
+   *   AiProviderPluginManager::getDefaultProviderForOperationType() returns.
+   */
+  protected function chatDefaults(): ?array {
+    return $this->aiProvider->getDefaultProviderForOperationType('chat');
+  }
+
+  /**
+   * Builds the provider for a turn.
+   *
+   * The companion seam to ::chatDefaults(), and the only other provider
+   * touchpoint.
+   *
+   * @param string $provider_id
+   *   The provider plugin id from ::chatDefaults().
+   *
+   * @return object
+   *   The provider.
+   */
+  protected function chatProvider(string $provider_id): object {
+    return $this->aiProvider->createInstance($provider_id);
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/ToolCallHandler.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/ToolCallHandler.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Drupal\ys_beacon\Service;
+
+use Drupal\ai\OperationType\Chat\ChatInput;
+use Drupal\ai\OperationType\Chat\ChatMessage;
+use Drupal\ai\OperationType\Chat\Tools\ToolsFunctionOutputInterface;
+use Drupal\ai\OperationType\Chat\Tools\ToolsInput;
+use Drupal\ai\Service\FunctionCalling\ExecutableFunctionCallInterface;
+use Drupal\ai\Service\FunctionCalling\FunctionCallPluginManager;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Builds tool declarations for a chat turn and runs a returned tool call.
+ *
+ * Shared by the streamed chat endpoint (ChatApiController) and the
+ * non-streamed tester path (BeaconAnswerService). Both offer the same tools,
+ * detect a returned tool call the same way and build the same follow-up
+ * request (::attachTools(), then ::followUpInput()); all that differs is how
+ * each consumes the answer that comes back - emitted chunk by chunk, or read
+ * off a plain message. The shared half lives here rather than as a copy per
+ * surface, the way ys_beacon.index_status owns the index status its three
+ * surfaces used to each re-implement.
+ *
+ * Which function-call plugins are actually offered to the model is an
+ * explicit allow-list, not everything registered under a function group:
+ * ai_search's own "information_tools" plugin (rag_search) would otherwise be
+ * offered on every Beacon turn, bypassing ys_beacon's own RAG retrieval and
+ * citation tracking.
+ */
+class ToolCallHandler {
+
+  public function __construct(
+    protected FunctionCallPluginManager $functionCallManager,
+    protected LoggerInterface $logger,
+    protected array $exposedFunctionCallIds,
+  ) {
+  }
+
+  /**
+   * Builds the tools declaration for the allow-listed function calls.
+   *
+   * @return \Drupal\ai\OperationType\Chat\Tools\ToolsInput|null
+   *   The tools input, or NULL when none of the allow-listed ids resolve to
+   *   a registered plugin.
+   */
+  public function buildToolsInput(): ?ToolsInput {
+    if (!$this->exposedFunctionCallIds) {
+      return NULL;
+    }
+
+    $definitions = $this->functionCallManager->getDefinitions();
+    $functions = [];
+    foreach ($this->exposedFunctionCallIds as $id) {
+      if (isset($definitions[$id])) {
+        $functions[] = $this->functionCallManager->createInstance($id)->normalize();
+      }
+    }
+    return $functions ? new ToolsInput($functions) : NULL;
+  }
+
+  /**
+   * Attaches the allow-listed tools to a chat input, if any resolve.
+   *
+   * @param \Drupal\ai\OperationType\Chat\ChatInput $chat_input
+   *   The chat input to attach tools to.
+   */
+  public function attachTools(ChatInput $chat_input): void {
+    $tools = $this->buildToolsInput();
+    if ($tools) {
+      $chat_input->setChatTools($tools);
+    }
+  }
+
+  /**
+   * Extracts the tool calls a normalized chat output carries, if any.
+   *
+   * A streamed answer's tool calls are only fully assembled after its
+   * iterator has been drained, so they can only be read from it AFTER a
+   * caller's foreach over the iterator finishes; a plain (non-streamed)
+   * ChatMessage carries them directly. Callers pass whichever they already
+   * have in hand once they are done reading it.
+   *
+   * Reading them can throw from inside contrib, which this module cannot
+   * patch: a tool whose parameters are all optional gets called with an empty
+   * arguments string that contrib JSON-decodes to NULL and passes into a
+   * non-nullable array parameter. Giving every tool a required parameter is
+   * the actual fix - see docs/AI_FUNCTION_CALL_TOOLS.md, which is the one
+   * place that explains this in full - and the catch below is only
+   * defence-in-depth, since absorbing the failure yields a turn with no tool
+   * result rather than a working tool call.
+   *
+   * @param mixed $normalized
+   *   The provider's normalized chat output: a ChatMessage, or a streamed
+   *   iterator. Typed loosely because neither is guaranteed, which is what
+   *   the method_exists() guard below is for.
+   *
+   * @return \Drupal\ai\OperationType\Chat\Tools\ToolsFunctionOutputInterface[]
+   *   Any tool calls the model made in this turn.
+   */
+  public function extractToolCalls(mixed $normalized): array {
+    if (!method_exists($normalized, 'getTools')) {
+      return [];
+    }
+    try {
+      return $normalized->getTools() ?? [];
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Beacon failed to read the model\'s tool calls: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+      return [];
+    }
+  }
+
+  /**
+   * Builds the follow-up request for a turn in which the model called a tool.
+   *
+   * @param mixed $normalized
+   *   The provider's normalized chat output from the turn's first call,
+   *   already fully read (see ::extractToolCalls() for why that matters on
+   *   the streamed path).
+   * @param \Drupal\ai\OperationType\Chat\ChatMessage[] $messages
+   *   The transcript the first call was made with.
+   *
+   * @return \Drupal\ai\OperationType\Chat\ChatInput|null
+   *   The input for the follow-up call, or NULL when the model asked for no
+   *   tool and the turn is already answered. No tools are attached to it, so
+   *   the turn resolves in exactly one extra hop and cannot chain.
+   */
+  public function followUpInput(mixed $normalized, array $messages): ?ChatInput {
+    $tool_calls = $this->extractToolCalls($normalized);
+    if (!$tool_calls) {
+      return NULL;
+    }
+    return new ChatInput(array_merge($messages, $this->buildFollowUpMessages($tool_calls)));
+  }
+
+  /**
+   * Executes the model's tool calls and builds the follow-up messages.
+   *
+   * @param \Drupal\ai\OperationType\Chat\Tools\ToolsFunctionOutputInterface[] $tool_calls
+   *   The tool calls the model returned.
+   *
+   * @return \Drupal\ai\OperationType\Chat\ChatMessage[]
+   *   An assistant message echoing the tool calls, followed by one tool-role
+   *   result message per call - append these to the transcript and call the
+   *   provider again to get the model's answer.
+   */
+  public function buildFollowUpMessages(array $tool_calls): array {
+    $assistant_message = new ChatMessage('assistant', '');
+    $assistant_message->setTools($tool_calls);
+
+    $messages = [$assistant_message];
+    foreach ($tool_calls as $tool_call) {
+      $messages[] = $this->executeOne($tool_call);
+    }
+    return $messages;
+  }
+
+  /**
+   * Executes a single tool call, absorbing any failure.
+   *
+   * A bad or failing tool call must not break the turn: the model gets a
+   * plain-text error result instead, and can decide how to answer around it.
+   *
+   * @param \Drupal\ai\OperationType\Chat\Tools\ToolsFunctionOutputInterface $tool_call
+   *   The tool call to execute.
+   *
+   * @return \Drupal\ai\OperationType\Chat\ChatMessage
+   *   The tool-role result message, tagged with the call's tool id.
+   */
+  protected function executeOne(ToolsFunctionOutputInterface $tool_call): ChatMessage {
+    $name = '';
+
+    try {
+      // Read the name inside the try, because reading it can itself throw for
+      // exactly the prompt-injected call the allow-list below exists to
+      // reject. On the non-streamed path contrib builds the tool call as
+      // new ToolsFunctionOutput($input->getChatTools()->getFunctionByName(
+      // $name), ...) (OpenAiBasedProviderClientBase), and
+      // ToolsInput::getFunctionByName() returns NULL for a function that was
+      // never offered. ToolsFunctionOutput's constructor only calls setName()
+      // when that argument is non-NULL, so its non-nullable string $name is
+      // left uninitialized and getName() raises an Error. The streamed path
+      // always sets a name, so this only bites the non-streamed one.
+      $name = $tool_call->getName();
+
+      // The model is only ever offered the allow-listed tools
+      // (::buildToolsInput()), but FunctionCallPluginManager::
+      // convertToolResponseToObject() resolves a function_name against every
+      // REGISTERED plugin, not just those offered - so a prompt-injected model
+      // naming an unoffered tool (e.g. ai_search's own rag_search, or the ai
+      // module's action_plugin derivatives that wrap node operations) must be
+      // rejected here, before ever reaching it.
+      if (!in_array($name, $this->allowedFunctionNames(), TRUE)) {
+        $this->logger->warning('Beacon tool call @name rejected: not on the allow-list.', ['@name' => $name]);
+        $result = sprintf('The tool %s is not available.', $name);
+      }
+      else {
+        $function = $this->functionCallManager->convertToolResponseToObject($tool_call);
+        $violations = $function->validateContexts();
+        if (count($violations) > 0) {
+          $result = sprintf('Invalid arguments for %s.', $name);
+        }
+        elseif ($function instanceof ExecutableFunctionCallInterface) {
+          $function->execute();
+          $result = $function->getReadableOutput();
+        }
+        else {
+          $result = sprintf('The tool %s cannot be executed.', $name);
+        }
+      }
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Beacon tool call @name failed: @message', [
+        '@name' => $name ?: '(unreadable name)',
+        '@message' => $e->getMessage(),
+      ]);
+      $result = sprintf('The tool %s failed to run.', $name ?: 'requested');
+    }
+
+    // Safe outside the try: ToolsFunctionOutput's constructor always sets the
+    // tool id, unlike the name.
+    $message = new ChatMessage('tool', $result);
+    $message->setToolsId($tool_call->getToolId());
+    return $message;
+  }
+
+  /**
+   * The function names of the allow-listed plugins that actually resolve.
+   *
+   * @return string[]
+   *   The allowed function_name values.
+   */
+  protected function allowedFunctionNames(): array {
+    $definitions = $this->functionCallManager->getDefinitions();
+    $names = [];
+    foreach ($this->exposedFunctionCallIds as $id) {
+      if (isset($definitions[$id])) {
+        $names[] = $definitions[$id]['function_name'];
+      }
+    }
+    return $names;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/Plugin/AiFunctionCall/GetCurrentDateTimeTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/Plugin/AiFunctionCall/GetCurrentDateTimeTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Kernel\Plugin\AiFunctionCall;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\ai\Attribute\FunctionCall;
+use Drupal\ys_beacon\Plugin\AiFunctionCall\GetCurrentDateTime;
+
+/**
+ * Tests the current-date-time AI function-call tool.
+ *
+ * Builds the plugin directly from its own #[FunctionCall] attribute (via
+ * reflection) instead of through the full plugin manager, so the test does
+ * not need to enable ys_beacon's heavy dependency graph (ai_search, Azure
+ * search, Portkey keys) just to exercise one small tool - the same reasoning
+ * GuardrailTelemetryTest uses to avoid installing the whole module.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Plugin\AiFunctionCall\GetCurrentDateTime
+ */
+class GetCurrentDateTimeTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['ai', 'system'];
+
+  /**
+   * Builds the plugin with a fixed "now".
+   *
+   * Uses a real Drupal Context/TypedData stack, so context defaulting and
+   * value conversion are exercised exactly as the framework would drive
+   * them - not simulated.
+   *
+   * @param int $timestamp
+   *   The Unix timestamp ::execute() should treat as "now".
+   *
+   * @return \Drupal\ys_beacon\Plugin\AiFunctionCall\GetCurrentDateTime
+   *   The plugin instance.
+   */
+  protected function plugin(int $timestamp): GetCurrentDateTime {
+    $reflection = new \ReflectionClass(GetCurrentDateTime::class);
+    $attribute = $reflection->getAttributes(FunctionCall::class)[0]->newInstance();
+    $definition = [
+      'id' => $attribute->id,
+      'function_name' => $attribute->function_name,
+      'name' => $attribute->name,
+      'description' => $attribute->description,
+      'group' => $attribute->group,
+      'context_definitions' => $attribute->context_definitions,
+      'class' => GetCurrentDateTime::class,
+      'provider' => 'ys_beacon',
+    ];
+
+    $time = $this->createMock(TimeInterface::class);
+    $time->method('getCurrentTime')->willReturn($timestamp);
+
+    return new GetCurrentDateTime(
+      [],
+      $attribute->id,
+      $definition,
+      $this->container->get('ai.context_definition_normalizer'),
+      $this->container->get('plugin.manager.ai_data_type_converter'),
+      $time,
+      $this->container->get('date.formatter'),
+    );
+  }
+
+  /**
+   * The plugin declares the metadata the issue's acceptance criteria ask for.
+   *
+   * Reads the attribute rather than calling anything, so it covers no method.
+   */
+  public function testDeclaresExpectedMetadata(): void {
+    $reflection = new \ReflectionClass(GetCurrentDateTime::class);
+    $attribute = $reflection->getAttributes(FunctionCall::class)[0]->newInstance();
+
+    $this->assertSame('ys_beacon:current_date_time', $attribute->id);
+    $this->assertSame('information_tools', $attribute->group);
+    $this->assertArrayHasKey('timezone', $attribute->context_definitions);
+    // Required so the model always sends a non-empty arguments object -
+    // an all-optional tool can have a real model send an empty arguments
+    // string, which contrib's own Json::decode('') -> NULL TypeErrors on
+    // (confirmed live, yalesites-org/YaleSites-Internal#1146).
+    $this->assertTrue($attribute->context_definitions['timezone']->isRequired());
+  }
+
+  /**
+   * @covers ::execute
+   */
+  public function testDefaultsToYaleTimezoneWhenOmitted(): void {
+    $timestamp = (new \DateTimeImmutable('2026-01-15T12:00:00+00:00'))->getTimestamp();
+    $expected = (new \DateTimeImmutable('2026-01-15T12:00:00+00:00'))
+      ->setTimezone(new \DateTimeZone('America/New_York'));
+
+    $plugin = $this->plugin($timestamp);
+    $plugin->execute();
+    $output = $plugin->getReadableOutput();
+
+    $this->assertStringContainsString('America/New_York', $output);
+    $this->assertStringContainsString($expected->format('Y-m-d'), $output);
+    $this->assertStringContainsString('07:00', $output);
+  }
+
+  /**
+   * @covers ::execute
+   */
+  public function testHonorsAnExplicitValidTimezone(): void {
+    $timestamp = (new \DateTimeImmutable('2026-01-15T12:00:00+00:00'))->getTimestamp();
+
+    $plugin = $this->plugin($timestamp);
+    $plugin->setContextValue('timezone', 'Asia/Tokyo');
+    $plugin->execute();
+    $output = $plugin->getReadableOutput();
+
+    $this->assertStringContainsString('Asia/Tokyo', $output);
+    // Tokyo is UTC+9 with no DST: 12:00 UTC -> 21:00.
+    $this->assertStringContainsString('21:00', $output);
+  }
+
+  /**
+   * @covers ::execute
+   */
+  public function testFallsBackToYaleTimezoneOnAnInvalidTimezone(): void {
+    $timestamp = (new \DateTimeImmutable('2026-01-15T12:00:00+00:00'))->getTimestamp();
+
+    $plugin = $this->plugin($timestamp);
+    $plugin->setContextValue('timezone', 'Not/AZone');
+    $plugin->execute();
+    $output = $plugin->getReadableOutput();
+
+    $this->assertStringContainsString('America/New_York', $output);
+    $this->assertStringNotContainsString('Not/AZone', $output);
+  }
+
+  /**
+   * A DST-affected date is localized with the correct offset.
+   *
+   * @covers ::execute
+   */
+  public function testHandlesDstCorrectly(): void {
+    // America/New_York is on daylight time (EDT, UTC-4) in July.
+    $timestamp = (new \DateTimeImmutable('2026-07-15T12:00:00+00:00'))->getTimestamp();
+
+    $plugin = $this->plugin($timestamp);
+    $plugin->execute();
+    $output = $plugin->getReadableOutput();
+
+    $this->assertStringContainsString('08:00', $output);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/Service/ToolCallHandlerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/Service/ToolCallHandlerTest.php
@@ -1,0 +1,446 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Kernel\Service;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\ai\OperationType\Chat\ChatInput;
+use Drupal\ai\OperationType\Chat\ChatMessage;
+use Drupal\ai\OperationType\Chat\StreamedChatMessageIterator;
+use Drupal\ai\OperationType\Chat\StreamedChatMessageIteratorInterface;
+use Drupal\ai\OperationType\Chat\Tools\ToolsFunctionOutput;
+use Drupal\ys_beacon\Service\ToolCallHandler;
+use Psr\Log\NullLogger;
+
+/**
+ * Tests tool resolution, execution and follow-up message construction.
+ *
+ * Uses the real plugin.manager.ai.function_calls service
+ * (FunctionCallPluginManager is declared final and cannot be mocked)
+ * together with the "ai" module's own ai:weather test fixture plugin, rather
+ * than a ys_beacon plugin - so this test does not depend on ys_beacon's own
+ * plugin also being correct.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Service\ToolCallHandler
+ */
+class ToolCallHandlerTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['ai', 'ai_test', 'user', 'field', 'system'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // The "ai" module's own function-call plugins are discovered through a
+    // deriver that enumerates core Action plugins, one of which needs the
+    // "user" entity type to exist - required for
+    // FunctionCallPluginManager::getDefinitions() to run at all, regardless
+    // of which plugin the allow-list actually asks for.
+    $this->installEntitySchema('user');
+  }
+
+  /**
+   * Builds the handler under test, allow-listing the given plugin ids.
+   *
+   * @param string[] $exposed_ids
+   *   The function-call plugin ids to expose.
+   *
+   * @return \Drupal\ys_beacon\Service\ToolCallHandler
+   *   The handler.
+   */
+  protected function handler(array $exposed_ids): ToolCallHandler {
+    return new ToolCallHandler(
+      $this->container->get('plugin.manager.ai.function_calls'),
+      new NullLogger(),
+      $exposed_ids,
+    );
+  }
+
+  /**
+   * @covers ::buildToolsInput
+   */
+  public function testBuildToolsInputResolvesOnlyAllowListedPlugins(): void {
+    $tools = $this->handler(['ai:weather'])->buildToolsInput();
+
+    $this->assertNotNull($tools);
+    $rendered = $tools->renderToolsArray();
+    $this->assertCount(1, $rendered);
+    $this->assertSame('weather', $rendered[0]['function']['name']);
+  }
+
+  /**
+   * A plugin not on the allow-list is never offered to the model.
+   *
+   * This is the safety property the allow-list exists for: a registered
+   * plugin (ai:calculator, from the same ai_test module as ai:weather, so it
+   * is genuinely present in this test's plugin registry - not merely absent
+   * because its module isn't installed) must not be offered just because
+   * some other plugin is allow-listed.
+   *
+   * @covers ::buildToolsInput
+   */
+  public function testBuildToolsInputIgnoresNonAllowListedPlugins(): void {
+    $tools = $this->handler(['ai:weather'])->buildToolsInput();
+    $rendered = $tools->renderToolsArray();
+
+    $names = array_column(array_column($rendered, 'function'), 'name');
+    $this->assertContains('weather', $names);
+    $this->assertNotContains('calculator', $names);
+  }
+
+  /**
+   * @covers ::buildToolsInput
+   */
+  public function testBuildToolsInputReturnsNullWhenNothingResolves(): void {
+    $tools = $this->handler(['ys_beacon:not_a_real_tool'])->buildToolsInput();
+    $this->assertNull($tools);
+  }
+
+  /**
+   * A successful tool call becomes an assistant echo plus a tool-role result.
+   *
+   * @covers ::buildFollowUpMessages
+   */
+  public function testBuildFollowUpMessagesExecutesAndReportsTheResult(): void {
+    $tool_call = new ToolsFunctionOutput(NULL, 'call_1', [
+      'city' => 'London',
+      'country' => 'UK',
+      'unit' => 'celsius',
+    ]);
+    $tool_call->setName('weather');
+
+    $messages = $this->handler(['ai:weather'])->buildFollowUpMessages([$tool_call]);
+
+    $this->assertCount(2, $messages);
+    $this->assertSame('assistant', $messages[0]->getRole());
+    $this->assertSame([$tool_call], $messages[0]->getTools());
+
+    $this->assertSame('tool', $messages[1]->getRole());
+    $this->assertSame('call_1', $messages[1]->getToolsId());
+    $this->assertSame('15°C', $messages[1]->getText());
+  }
+
+  /**
+   * A tool call naming an unknown function does not break the turn.
+   *
+   * Rejected by the same allow-list check as
+   * ::testAllowListIsEnforcedAtExecutionNotJustAtOffer() - a name that does
+   * not resolve to any registered plugin is just as much "not allowed" as
+   * one that resolves to a real, non-allow-listed plugin. Kept as a separate
+   * test because it is the more obvious/first case a reader would reach for.
+   *
+   * @covers ::buildFollowUpMessages
+   */
+  public function testUnknownToolNameProducesAnErrorResultInsteadOfThrowing(): void {
+    $tool_call = new ToolsFunctionOutput(NULL, 'call_1', []);
+    $tool_call->setName('not_a_real_function');
+
+    $messages = $this->handler(['ai:weather'])->buildFollowUpMessages([$tool_call]);
+
+    $this->assertSame('tool', $messages[1]->getRole());
+    $this->assertStringContainsString('not available', $messages[1]->getText());
+  }
+
+  /**
+   * A tool call missing a required argument reports invalid arguments.
+   *
+   * @covers ::buildFollowUpMessages
+   */
+  public function testMissingRequiredArgumentIsReportedRatherThanExecuted(): void {
+    // Weather requires city and country; neither is supplied.
+    $tool_call = new ToolsFunctionOutput(NULL, 'call_1', []);
+    $tool_call->setName('weather');
+
+    $messages = $this->handler(['ai:weather'])->buildFollowUpMessages([$tool_call]);
+
+    $this->assertSame('tool', $messages[1]->getRole());
+    $this->assertStringContainsString('Invalid arguments', $messages[1]->getText());
+  }
+
+  /**
+   * A tool call naming a registered but non-allow-listed plugin is rejected.
+   *
+   * FunctionCallPluginManager::convertToolResponseToObject() resolves a
+   * function_name against every registered plugin, not just the ones this
+   * handler's allow-list actually offers - a prompt-injected model could name
+   * a real plugin it was never told about. This is the load-bearing test for
+   * that guard: ai:calculator is genuinely registered (same module as
+   * ai:weather), but only ai:weather is on this handler's allow-list.
+   *
+   * @covers ::buildFollowUpMessages
+   */
+  public function testAllowListIsEnforcedAtExecutionNotJustAtOffer(): void {
+    $tool_call = new ToolsFunctionOutput(NULL, 'call_1', ['a' => 1, 'b' => 2]);
+    $tool_call->setName('calculator');
+
+    $messages = $this->handler(['ai:weather'])->buildFollowUpMessages([$tool_call]);
+
+    $this->assertSame('tool', $messages[1]->getRole());
+    $this->assertStringContainsString('not available', $messages[1]->getText());
+  }
+
+  /**
+   * @covers ::attachTools
+   */
+  public function testAttachToolsSetsChatToolsWhenSomethingResolves(): void {
+    $chat_input = new ChatInput([new ChatMessage('user', 'hi')]);
+    $this->handler(['ai:weather'])->attachTools($chat_input);
+
+    $this->assertNotNull($chat_input->getChatTools());
+  }
+
+  /**
+   * @covers ::attachTools
+   */
+  public function testAttachToolsLeavesChatToolsUnsetWhenNothingResolves(): void {
+    $chat_input = new ChatInput([new ChatMessage('user', 'hi')]);
+    $this->handler(['ys_beacon:not_a_real_tool'])->attachTools($chat_input);
+
+    $this->assertNull($chat_input->getChatTools());
+  }
+
+  /**
+   * @covers ::extractToolCalls
+   */
+  public function testExtractToolCallsReadsToolsFromPlainMessage(): void {
+    $tool_call = new ToolsFunctionOutput(NULL, 'call_1', []);
+    $tool_call->setName('weather');
+    $message = new ChatMessage('assistant', '');
+    $message->setTools([$tool_call]);
+
+    $extracted = $this->handler(['ai:weather'])->extractToolCalls($message);
+
+    $this->assertSame([$tool_call], $extracted);
+  }
+
+  /**
+   * @covers ::extractToolCalls
+   */
+  public function testExtractToolCallsReturnsEmptyForAnOrdinaryMessage(): void {
+    $message = new ChatMessage('assistant', 'Just an answer.');
+
+    $this->assertSame([], $this->handler(['ai:weather'])->extractToolCalls($message));
+  }
+
+  /**
+   * Builds a real StreamedChatMessageIterator yielding a tool-call chunk.
+   *
+   * Overrides doIterate() (the base class's own extension point, with a
+   * placeholder default implementation - not abstract) so the SAME
+   * production assembly code (StreamedChatMessageIterator::
+   * assembleToolCalls(), reached via ::getTools()) that a real provider's
+   * response drives runs here too - this is deliberately not a bare stub
+   * with a hand-rolled getTools().
+   *
+   * @param string $arguments_json
+   *   The raw (already JSON-encoded) arguments string the delta carries -
+   *   exactly the value contrib passes straight to Json::decode().
+   *
+   * @return \Drupal\ai\OperationType\Chat\StreamedChatMessageIteratorInterface
+   *   The iterator, not yet drained.
+   */
+  protected function streamedToolCallIterator(string $arguments_json): StreamedChatMessageIteratorInterface {
+    $tool_delta = new class($arguments_json) {
+
+      /**
+       * Constructs the raw tool-call delta double.
+       */
+      public function __construct(protected string $argumentsJson) {
+      }
+
+      /**
+       * Matches the shape contrib's own assembleToolCalls() reads.
+       */
+      public function toArray(): array {
+        return [
+          'id' => 'call_1',
+          'function' => [
+            'name' => 'weather',
+            'arguments' => $this->argumentsJson,
+          ],
+        ];
+      }
+
+    };
+
+    // The tool delta is assigned via a public property, not a constructor
+    // parameter: StreamedChatMessageIteratorInterface declares __construct()
+    // as part of its contract, so a subclass adding a second constructor
+    // parameter is a fatal LSP violation, not just a lint complaint.
+    $iterator = new class(new \ArrayIterator([])) extends StreamedChatMessageIterator {
+
+      /**
+       * The tool-call delta this stream yields from doIterate().
+       *
+       * @var object
+       */
+      public object $toolDelta;
+
+      /**
+       * {@inheritdoc}
+       */
+      public function doIterate(): \Generator {
+        yield $this->createStreamedChatMessage('assistant', '', [], [$this->toolDelta]);
+        $this->setFinishReason('tool_calls');
+      }
+
+    };
+    $iterator->toolDelta = $tool_delta;
+
+    return $iterator;
+  }
+
+  /**
+   * A real streamed iterator's tool call is only readable after draining.
+   *
+   * @covers ::extractToolCalls
+   */
+  public function testExtractToolCallsAssemblesRealStreamedToolCall(): void {
+    $iterator = $this->streamedToolCallIterator('{"unit":"celsius"}');
+
+    // Before draining (nothing has iterated it yet), contrib has nothing to
+    // assemble from.
+    $this->assertSame([], $iterator->getTools());
+
+    // Drain it exactly as ChatApiController::emitAnswer() does.
+    iterator_to_array($iterator);
+
+    $extracted = $this->handler(['ai:weather'])->extractToolCalls($iterator);
+
+    $this->assertCount(1, $extracted);
+    $this->assertSame('weather', $extracted[0]->getName());
+  }
+
+  /**
+   * Reproduces the exact live failure mode found via a real model.
+   *
+   * A zero-argument tool call whose delta carries a genuinely empty
+   * arguments string - not "{}" - makes contrib's own assembleToolCalls()
+   * TypeError (Json::decode('') -> NULL, passed into ToolsFunctionOutput's
+   * non-nullable $arguments parameter). Reproduced through the real
+   * StreamedChatMessageIterator rather than a hand-rolled throw.
+   *
+   * Note WHERE it throws, because it decides which code has to catch it:
+   * getIterator() assembles the tool calls once the generator is exhausted,
+   * so the TypeError comes out of the drain itself - the caller's foreach -
+   * and not out of the later ::extractToolCalls() call. That is why
+   * ChatApiController::emitAnswer() wraps its streaming loop; catching it in
+   * ::extractToolCalls() alone would never have run. Both layers are needed:
+   * this asserts the drain throws, and that ::extractToolCalls() then still
+   * answers "no tool calls" instead of throwing a second time.
+   *
+   * @covers ::extractToolCalls
+   */
+  public function testExtractToolCallsAbsorbsRealEmptyArgumentsToolCall(): void {
+    $iterator = $this->streamedToolCallIterator('');
+
+    $threw = FALSE;
+    try {
+      iterator_to_array($iterator);
+    }
+    catch (\TypeError) {
+      // Contrib's own bug, thrown from inside the drain - see above.
+      $threw = TRUE;
+    }
+    $this->assertTrue($threw, 'Expected contrib to TypeError while assembling the tool call.');
+
+    $this->assertSame([], $this->handler(['ai:weather'])->extractToolCalls($iterator));
+  }
+
+  /**
+   * A failure while assembling tool calls is absorbed, not fatal.
+   *
+   * Confirmed live against a real model
+   * (yalesites-org/YaleSites-Internal#1146): a zero-argument tool call can
+   * arrive as a genuinely empty arguments string, which contrib's own
+   * assembly (Json::decode('') -> NULL) TypeErrors on before this handler
+   * ever sees the call. That happens inside contrib
+   * code this module cannot patch, so the failure is simulated here via a
+   * double whose getTools() throws, the same shape the real exception takes.
+   *
+   * @covers ::extractToolCalls
+   */
+  public function testExtractToolCallsAbsorbsAnAssemblyFailure(): void {
+    $normalized = new class {
+
+      /**
+       * Simulates contrib's own tool-call assembly throwing.
+       */
+      public function getTools(): array {
+        throw new \TypeError('Argument #3 ($arguments) must be of type array, null given.');
+      }
+
+    };
+
+    $this->assertSame([], $this->handler(['ai:weather'])->extractToolCalls($normalized));
+  }
+
+  /**
+   * An answer carrying no tool call needs no follow-up request.
+   *
+   * @covers ::followUpInput
+   */
+  public function testFollowUpInputIsNullWithoutToolCall(): void {
+    $normalized = new ChatMessage('assistant', 'An ordinary answer.');
+
+    $this->assertNull($this->handler(['ai:weather'])->followUpInput($normalized, []));
+  }
+
+  /**
+   * The follow-up request appends the tool result to the given transcript.
+   *
+   * @covers ::followUpInput
+   */
+  public function testFollowUpInputAppendsResultsToTheTranscript(): void {
+    $tool_call = new ToolsFunctionOutput(NULL, 'call_1', []);
+    $normalized = new ChatMessage('assistant', '');
+    $normalized->setTools([$tool_call]);
+
+    $transcript = [new ChatMessage('user', 'What time is it?')];
+    $input = $this->handler(['ai:weather'])->followUpInput($normalized, $transcript);
+
+    $this->assertInstanceOf(ChatInput::class, $input);
+    $messages = $input->getMessages();
+    // The original turn, then the assistant echo, then the tool result.
+    $this->assertCount(3, $messages);
+    $this->assertSame('What time is it?', $messages[0]->getText());
+    $this->assertSame('tool', $messages[2]->getRole());
+    // No tools are attached, so the turn cannot chain into a second one.
+    $this->assertNull($input->getChatTools());
+  }
+
+  /**
+   * A tool call whose name cannot even be read is absorbed, not fatal.
+   *
+   * The non-streamed path builds a tool call as
+   * new ToolsFunctionOutput($input->getChatTools()->getFunctionByName($name),
+   * ...), and ToolsInput::getFunctionByName() returns NULL for a function that
+   * was never offered - which is exactly what a hallucinating or
+   * prompt-injected model produces. ToolsFunctionOutput's constructor only
+   * sets its non-nullable string $name when that argument is non-NULL, so
+   * getName() then raises an Error. Reading the name must therefore happen
+   * where the handler's own failure handling covers it, or the allow-list
+   * rejection it guards would be unreachable in precisely the injected case
+   * it exists for, and the whole turn would fail instead.
+   *
+   * @covers ::buildFollowUpMessages
+   */
+  public function testBuildFollowUpMessagesAbsorbsUnreadableToolCallName(): void {
+    // Exactly what contrib constructs for an un-offered function name.
+    $tool_call = new ToolsFunctionOutput(NULL, 'call_1', []);
+
+    $messages = $this->handler(['ai:weather'])->buildFollowUpMessages([$tool_call]);
+
+    // The assistant echo plus one tool result, and the turn survives.
+    $this->assertCount(2, $messages);
+    $this->assertSame('tool', $messages[1]->getRole());
+    $this->assertStringContainsString('failed to run', $messages[1]->getText());
+    $this->assertSame('call_1', $messages[1]->getToolsId());
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/ChatApiSuspectTurnWiringTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/ChatApiSuspectTurnWiringTest.php
@@ -7,8 +7,12 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Flood\FloodInterface;
 use Drupal\Tests\UnitTestCase;
+use Drupal\ai\OperationType\Chat\ChatInput;
 use Drupal\ai\OperationType\Chat\ChatMessage;
 use Drupal\ai\OperationType\Chat\ChatOutput;
+use Drupal\ai\OperationType\Chat\StreamedChatMessageIterator;
+use Drupal\ai\OperationType\Chat\Tools\ToolsFunctionOutputInterface;
+use Drupal\ai\OperationType\Chat\Tools\ToolsInput;
 use Drupal\ai\Service\HostnameFilter;
 use Drupal\ys_beacon\Controller\ChatApiController;
 use Drupal\ys_beacon\Service\GuardrailSignalDetector;
@@ -16,6 +20,7 @@ use Drupal\ys_beacon\Service\GuardrailTelemetry;
 use Drupal\ys_beacon\Service\RagRetriever;
 use Drupal\ys_beacon\Service\SuspectTurnLog;
 use Drupal\ys_beacon\Service\SystemPromptBuilder;
+use Drupal\ys_beacon\Service\ToolCallHandler;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -70,11 +75,13 @@ class ChatApiSuspectTurnWiringTest extends UnitTestCase {
    *   The answer the provider double returns.
    * @param int $stops
    *   How many guardrail stops the telemetry double reports for the turn.
+   * @param object|null $toolCallHandler
+   *   A ToolCallHandler double, or a default with no tools if omitted.
    *
    * @return \Drupal\ys_beacon\Controller\ChatApiController
    *   The controller.
    */
-  protected function controller(string $answer, int $stops = 0): ChatApiController {
+  protected function controller(string $answer, int $stops = 0, ?object $toolCallHandler = NULL): ChatApiController {
     $provider = new class($answer) {
 
       /**
@@ -92,7 +99,28 @@ class ChatApiSuspectTurnWiringTest extends UnitTestCase {
 
     };
 
-    $controller = new class($provider) extends ChatApiController {
+    $controller = $this->controllerWith($provider);
+    $this->wireCollaborators($controller, $stops, $toolCallHandler);
+
+    return $controller;
+  }
+
+  /**
+   * Builds a bare controller subclass whose provider is the given double.
+   *
+   * The subclass overrides ::chatDefaults()/::chatProvider() - the two seams
+   * that let a test substitute a provider double, since AiProviderPluginManager
+   * is declared final and cannot be mocked. Collaborators still need
+   * ::wireCollaborators() before the controller is usable.
+   *
+   * @param object $provider
+   *   The provider double, exposing chat($input, $model_id, $tags): ChatOutput.
+   *
+   * @return \Drupal\ys_beacon\Controller\ChatApiController
+   *   The controller, with its provider double in place.
+   */
+  protected function controllerWith(object $provider): ChatApiController {
+    return new class($provider) extends ChatApiController {
 
       /**
        * Constructs the controller with the provider double in place.
@@ -115,7 +143,75 @@ class ChatApiSuspectTurnWiringTest extends UnitTestCase {
       }
 
     };
+  }
 
+  /**
+   * Builds a controller whose provider double returns a tool call first.
+   *
+   * @param \Drupal\ai\OperationType\Chat\ChatMessage $firstMessage
+   *   The message the provider double returns on the first ::chat() call -
+   *   typically one with ::setTools() populated.
+   * @param string $followUpAnswer
+   *   The plain-text answer the provider double returns on every call after
+   *   the first.
+   * @param object $toolCallHandler
+   *   The ToolCallHandler double.
+   *
+   * @return array{0: \Drupal\ys_beacon\Controller\ChatApiController, 1: object}
+   *   The controller, and the provider double (exposing ->calls and
+   *   ->receivedInputs, for assertions the caller cannot make on the
+   *   controller directly).
+   */
+  protected function controllerWithToolCall(ChatMessage $firstMessage, string $followUpAnswer, object $toolCallHandler): array {
+    $provider = new class($firstMessage, $followUpAnswer) {
+
+      /**
+       * The number of times chat() was called.
+       */
+      public int $calls = 0;
+
+      /**
+       * The chat inputs the double was called with, in call order.
+       */
+      public array $receivedInputs = [];
+
+      /**
+       * Constructs the provider double.
+       */
+      public function __construct(protected ChatMessage $firstMessage, protected string $followUpAnswer) {
+      }
+
+      /**
+       * Answers the turn, returning a tool call on the first call only.
+       */
+      public function chat($input, string $model_id, array $tags = []): ChatOutput {
+        $this->calls++;
+        $this->receivedInputs[] = $input;
+        if ($this->calls === 1) {
+          return new ChatOutput($this->firstMessage, NULL, []);
+        }
+        return new ChatOutput(new ChatMessage('assistant', $this->followUpAnswer), NULL, []);
+      }
+
+    };
+
+    $controller = $this->controllerWith($provider);
+    $this->wireCollaborators($controller, 0, $toolCallHandler);
+
+    return [$controller, $provider];
+  }
+
+  /**
+   * Wires every collaborator ::conversation() needs, except the provider.
+   *
+   * @param \Drupal\ys_beacon\Controller\ChatApiController $controller
+   *   The controller to wire, already holding its provider double.
+   * @param int $stops
+   *   How many guardrail stops the telemetry double reports for the turn.
+   * @param object|null $toolCallHandler
+   *   A ToolCallHandler double, or a default with no tools if omitted.
+   */
+  protected function wireCollaborators(ChatApiController $controller, int $stops, ?object $toolCallHandler): void {
     $settings = $this->createMock(ImmutableConfig::class);
     $settings->method('get')->willReturnCallback(fn ($name) => match ($name) {
       'enable_chat' => TRUE,
@@ -144,6 +240,11 @@ class ChatApiSuspectTurnWiringTest extends UnitTestCase {
 
     $this->telemetry->method('recordGuardrailResults')->willReturn($stops);
 
+    if ($toolCallHandler === NULL) {
+      $toolCallHandler = $this->createMock(ToolCallHandler::class);
+      $toolCallHandler->method('followUpInput')->willReturn(NULL);
+    }
+
     // The signal detector is dependency-free pure text classification, so the
     // real one is used: mocking it would mean asserting against the test's own
     // idea of what looks like an injection attempt rather than the shipped
@@ -159,14 +260,13 @@ class ChatApiSuspectTurnWiringTest extends UnitTestCase {
       'telemetry' => $this->telemetry,
       'signalDetector' => new GuardrailSignalDetector(),
       'suspectTurnLog' => $this->suspectTurnLog,
+      'toolCallHandler' => $toolCallHandler,
     ];
     foreach ($properties as $name => $value) {
       $property = (new \ReflectionClass(ChatApiController::class))->getProperty($name);
       $property->setAccessible(TRUE);
       $property->setValue($controller, $value);
     }
-
-    return $controller;
   }
 
   /**
@@ -313,6 +413,196 @@ class ChatApiSuspectTurnWiringTest extends UnitTestCase {
     $this->telemetry->expects($this->once())->method('recordTurn');
 
     $this->runTurn($this->controller('An answer.'), 'When do applications open?');
+  }
+
+  /**
+   * A tool call is executed and a follow-up call streams the real answer.
+   *
+   * @covers ::conversation
+   */
+  public function testToolCallExecutesAndStreamsTheFollowUpAnswer(): void {
+    $toolCall = $this->createMock(ToolsFunctionOutputInterface::class);
+    $firstMessage = new ChatMessage('assistant', '');
+    $firstMessage->setTools([$toolCall]);
+
+    $followUpToolMessage = new ChatMessage('tool', 'Monday, January 5, 2026 09:00.');
+    $toolCallHandler = $this->createMock(ToolCallHandler::class);
+    // Returns the follow-up request built from the transcript it was handed,
+    // so this also proves ::conversation() passes the turn's real transcript
+    // through rather than rebuilding one for the second call.
+    $toolCallHandler->expects($this->once())
+      ->method('followUpInput')
+      ->willReturnCallback(
+        fn (mixed $normalized, array $messages) => new ChatInput(array_merge($messages, [$followUpToolMessage]))
+      );
+
+    [$controller, $provider] = $this->controllerWithToolCall(
+      $firstMessage,
+      "Today's date is January 5, 2026.",
+      $toolCallHandler,
+    );
+
+    $streamed = $this->runTurn($controller, "What's today's date?");
+
+    $this->assertSame(2, $provider->calls);
+    $this->assertStringContainsString("Today's date is January 5, 2026.", $streamed);
+  }
+
+  /**
+   * The follow-up call never carries tools, keeping the turn to one hop.
+   *
+   * @covers ::conversation
+   */
+  public function testFollowUpCallDoesNotAttachToolsAgain(): void {
+    $toolCall = $this->createMock(ToolsFunctionOutputInterface::class);
+    $firstMessage = new ChatMessage('assistant', '');
+    $firstMessage->setTools([$toolCall]);
+
+    $toolCallHandler = $this->createMock(ToolCallHandler::class);
+    // A callback double, not an unstubbed mock: an unstubbed attachTools()
+    // silently no-ops, which would let the "no tools on the follow-up"
+    // assertion below pass even if the controller stopped calling
+    // ::attachTools() for the FIRST call too - this way it only holds if the
+    // first call genuinely got tools and the second genuinely did not.
+    $toolCallHandler->method('attachTools')->willReturnCallback(
+      fn (ChatInput $input) => $input->setChatTools(new ToolsInput([]))
+    );
+    $toolCallHandler->method('followUpInput')->willReturnCallback(
+      fn (mixed $normalized, array $messages) => new ChatInput(
+        array_merge($messages, [new ChatMessage('tool', 'Result.')])
+      )
+    );
+
+    [$controller, $provider] = $this->controllerWithToolCall($firstMessage, 'Final answer.', $toolCallHandler);
+    $this->runTurn($controller, 'A question needing the tool.');
+
+    $this->assertCount(2, $provider->receivedInputs);
+    $this->assertNotNull($provider->receivedInputs[0]->getChatTools());
+    $this->assertNull($provider->receivedInputs[1]->getChatTools());
+  }
+
+  /**
+   * A guardrail stop on the tool-informed follow-up call is still counted.
+   *
+   * @covers ::conversation
+   */
+  public function testGuardrailResultsAreAggregatedAcrossTheFollowUpCall(): void {
+    $toolCall = $this->createMock(ToolsFunctionOutputInterface::class);
+    $firstMessage = new ChatMessage('assistant', '');
+    $firstMessage->setTools([$toolCall]);
+
+    $toolCallHandler = $this->createMock(ToolCallHandler::class);
+    $toolCallHandler->method('followUpInput')->willReturnCallback(
+      fn (mixed $normalized, array $messages) => new ChatInput(
+        array_merge($messages, [new ChatMessage('tool', 'Result.')])
+      )
+    );
+
+    $this->telemetry->expects($this->exactly(2))->method('recordGuardrailResults');
+
+    [$controller] = $this->controllerWithToolCall($firstMessage, 'Final answer.', $toolCallHandler);
+    $this->runTurn($controller, 'A question needing the tool.');
+  }
+
+  /**
+   * A turn that produces no answer tells the client so, instead of nothing.
+   *
+   * Attaching tools means a turn can now end with the model having produced
+   * only a tool call that could not be assembled or run - and an answer that
+   * silently streams zero text is indistinguishable, in the widget, from one
+   * that is still arriving. The visitor must get the same unavailable message
+   * a hard failure produces rather than their question, the sources and a
+   * blank space.
+   *
+   * @covers ::conversation
+   */
+  public function testTurnThatStreamsNoAnswerReportsFailureToTheClient(): void {
+    $streamed = $this->runTurn($this->controller(''), 'A question the model does not answer.');
+
+    $this->assertStringContainsString('The assistant is currently unavailable.', $streamed);
+  }
+
+  /**
+   * An empty first hop is not emitted as an answer of its own.
+   *
+   * The tool-call hop carries no text; emitting it would clear the widget's
+   * loading indicator and leave an empty bubble for the whole follow-up round
+   * trip.
+   *
+   * @covers ::conversation
+   */
+  public function testEmptyToolCallHopEmitsNoAssistantContent(): void {
+    $toolCall = $this->createMock(ToolsFunctionOutputInterface::class);
+    $firstMessage = new ChatMessage('assistant', '');
+    $firstMessage->setTools([$toolCall]);
+
+    $toolCallHandler = $this->createMock(ToolCallHandler::class);
+    $toolCallHandler->method('followUpInput')->willReturnCallback(
+      fn (mixed $normalized, array $messages) => new ChatInput(
+        array_merge($messages, [new ChatMessage('tool', 'Result.')])
+      )
+    );
+
+    [$controller] = $this->controllerWithToolCall($firstMessage, 'The real answer.', $toolCallHandler);
+    $streamed = $this->runTurn($controller, 'A question needing the tool.');
+
+    // Exactly one assistant line - the follow-up answer, not an empty one
+    // ahead of it.
+    $this->assertSame(1, substr_count($streamed, '"role":"assistant"'));
+    $this->assertStringContainsString('The real answer.', $streamed);
+  }
+
+  /**
+   * A streamed answer that dies mid-drain tells the client, instead of nothing.
+   *
+   * Contrib assembles a turn's tool calls when the stream's generator is
+   * exhausted, so a tool call it cannot assemble throws from inside the
+   * drain. That is absorbed so any text already streamed still stands - but
+   * when the failure lands before a single token, the visitor must be told
+   * the assistant is unavailable rather than watching an empty answer.
+   *
+   * @covers ::conversation
+   */
+  public function testStreamFailingBeforeAnyTextReportsFailureToTheClient(): void {
+    // Subclasses the real iterator and overrides doIterate() rather than
+    // mocking the interface: getIterator() is deprecated in ai:1.2.0, so a
+    // mock of it makes the suite emit a deprecation notice of its own.
+    $normalized = new class(new \ArrayIterator([])) extends StreamedChatMessageIterator {
+
+      /**
+       * Throws the way contrib does when it cannot assemble a tool call.
+       */
+      public function doIterate(): \Generator {
+        throw new \TypeError('Argument #3 ($arguments) must be of type array, null given.');
+        // phpcs:ignore
+        yield;
+      }
+
+    };
+
+    $provider = new class($normalized) {
+
+      /**
+       * Constructs the provider double with its streamed answer.
+       */
+      public function __construct(protected object $normalized) {
+      }
+
+      /**
+       * Answers the turn with a stream that throws when read.
+       */
+      public function chat($input, string $model_id, array $tags = []): ChatOutput {
+        return new ChatOutput($this->normalized, NULL, []);
+      }
+
+    };
+
+    $controller = $this->controllerWith($provider);
+    $this->wireCollaborators($controller, 0, NULL);
+
+    $streamed = $this->runTurn($controller, 'A question needing the tool.');
+
+    $this->assertStringContainsString('The assistant is currently unavailable.', $streamed);
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/Plugin/AiFunctionCall/GetCurrentDateTimeRegistrationTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/Plugin/AiFunctionCall/GetCurrentDateTimeRegistrationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit\Plugin\AiFunctionCall;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ai\Attribute\FunctionCall;
+use Drupal\ys_beacon\Plugin\AiFunctionCall\GetCurrentDateTime;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Guards against the allow-list and the plugin's own id silently drifting.
+ *
+ * ToolCallHandlerTest deliberately avoids enabling ys_beacon's own (heavy)
+ * module dependency graph, so nothing else asserts that the id configured in
+ * ys_beacon.services.yml actually matches this plugin's own attribute - a
+ * typo in either place would silently disable the tool (buildToolsInput()
+ * returns NULL for an unresolved id) with nothing failing anywhere else.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Plugin\AiFunctionCall\GetCurrentDateTime
+ */
+class GetCurrentDateTimeRegistrationTest extends UnitTestCase {
+
+  /**
+   * The configured allow-list contains this plugin's own attribute id.
+   */
+  public function testIsOnTheServicesYmlAllowList(): void {
+    $reflection = new \ReflectionClass(GetCurrentDateTime::class);
+    $attribute = $reflection->getAttributes(FunctionCall::class)[0]->newInstance();
+
+    $path = dirname(__DIR__, 5) . '/ys_beacon.services.yml';
+    $this->assertFileExists($path);
+    $services = Yaml::parseFile($path);
+    $allow_list = $services['services']['ys_beacon.tool_call_handler']['arguments'][2];
+
+    $this->assertContains($attribute->id, $allow_list);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/Service/BeaconAnswerServiceTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/Service/BeaconAnswerServiceTest.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit\Service;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ai\OperationType\Chat\ChatInput;
+use Drupal\ai\OperationType\Chat\ChatMessage;
+use Drupal\ai\OperationType\Chat\ChatOutput;
+use Drupal\ai\OperationType\Chat\Tools\ToolsFunctionOutputInterface;
+use Drupal\ai\OperationType\Chat\Tools\ToolsInput;
+use Drupal\ys_beacon\Service\BeaconAnswerService;
+use Drupal\ys_beacon\Service\RagRetriever;
+use Drupal\ys_beacon\Service\SystemPromptBuilder;
+use Drupal\ys_beacon\Service\ToolCallHandler;
+
+/**
+ * Tests the non-streamed answer path used by ys_ai_tester.
+ *
+ * AiProviderPluginManager is declared final and cannot be mocked, so the
+ * service under test exposes the same chatDefaults()/chatProvider() seams
+ * ChatApiController uses, overridden here with a provider double - matching
+ * the pattern ChatApiSuspectTurnWiringTest establishes for the same reason.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Service\BeaconAnswerService
+ */
+class BeaconAnswerServiceTest extends UnitTestCase {
+
+  /**
+   * Builds the service with a provider double and mocked collaborators.
+   *
+   * @param object $provider
+   *   The provider double, exposing chat($input, $model_id, $tags): ChatOutput.
+   * @param \Drupal\ys_beacon\Service\ToolCallHandler|\PHPUnit\Framework\MockObject\MockObject|null $tool_call_handler
+   *   The tool call handler double, or a default mock with no tools if omitted.
+   *
+   * @return \Drupal\ys_beacon\Service\BeaconAnswerService
+   *   The service under test.
+   */
+  protected function service(object $provider, ?object $tool_call_handler = NULL): BeaconAnswerService {
+    $ragRetriever = $this->createMock(RagRetriever::class);
+    $ragRetriever->method('retrieve')->willReturn([]);
+
+    $promptBuilder = $this->createMock(SystemPromptBuilder::class);
+    $promptBuilder->method('build')->willReturn('System prompt.');
+
+    if ($tool_call_handler === NULL) {
+      $tool_call_handler = $this->createMock(ToolCallHandler::class);
+      $tool_call_handler->method('followUpInput')->willReturn(NULL);
+    }
+
+    return new class($provider, $ragRetriever, $promptBuilder, $tool_call_handler) extends BeaconAnswerService {
+
+      /**
+       * Constructs the service double, bypassing the real provider manager.
+       */
+      public function __construct(
+        protected object $testProvider,
+        RagRetriever $ragRetriever,
+        SystemPromptBuilder $promptBuilder,
+        ToolCallHandler $toolCallHandler,
+      ) {
+        $this->ragRetriever = $ragRetriever;
+        $this->promptBuilder = $promptBuilder;
+        $this->toolCallHandler = $toolCallHandler;
+      }
+
+      /**
+       * {@inheritdoc}
+       */
+      protected function chatDefaults(): ?array {
+        return ['provider_id' => 'test_provider', 'model_id' => 'test-model'];
+      }
+
+      /**
+       * {@inheritdoc}
+       */
+      protected function chatProvider(string $provider_id): object {
+        return $this->testProvider;
+      }
+
+    };
+  }
+
+  /**
+   * An ordinary question is answered in a single call, with no follow-up.
+   *
+   * @covers ::answer
+   */
+  public function testAnswersOrdinaryQuestionWithoutToolCall(): void {
+    $provider = new class() {
+
+      /**
+       * The number of times chat() was called.
+       */
+      public int $calls = 0;
+
+      /**
+       * The chat input the double was last called with.
+       */
+      public ChatInput $receivedInput;
+
+      /**
+       * Answers the turn, as ProviderProxy::chat() would.
+       */
+      public function chat($input, string $model_id, array $tags = []): ChatOutput {
+        $this->calls++;
+        $this->receivedInput = $input;
+        return new ChatOutput(new ChatMessage('assistant', 'Yale College applications open in August.'), NULL, []);
+      }
+
+    };
+
+    $result = $this->service($provider)->answer('When do applications open?');
+
+    $this->assertSame('Yale College applications open in August.', $result['answer']);
+    $this->assertSame(1, $provider->calls);
+  }
+
+  /**
+   * The handler's tools are attached before the (single) call is made.
+   *
+   * Uses a callback double rather than an unstubbed mock, so this actually
+   * fails if ::answer() stopped calling ::attachTools() - an unstubbed
+   * ToolCallHandler mock's attachTools() is a silent no-op, which would let
+   * this pass either way.
+   *
+   * @covers ::answer
+   */
+  public function testAttachesToolsBeforeCallingTheProvider(): void {
+    $toolCallHandler = $this->createMock(ToolCallHandler::class);
+    $toolCallHandler->method('followUpInput')->willReturn(NULL);
+    $toolCallHandler->method('attachTools')->willReturnCallback(
+      fn (ChatInput $input) => $input->setChatTools(new ToolsInput([]))
+    );
+
+    $provider = new class() {
+
+      /**
+       * The chat input the double was called with.
+       */
+      public ChatInput $receivedInput;
+
+      /**
+       * Answers the turn, as ProviderProxy::chat() would.
+       */
+      public function chat($input, string $model_id, array $tags = []): ChatOutput {
+        $this->receivedInput = $input;
+        return new ChatOutput(new ChatMessage('assistant', 'An answer.'), NULL, []);
+      }
+
+    };
+
+    $this->service($provider, $toolCallHandler)->answer('Any question.');
+
+    $this->assertNotNull($provider->receivedInput->getChatTools());
+  }
+
+  /**
+   * A tool call is executed and a follow-up call produces the final answer.
+   *
+   * @covers ::answer
+   */
+  public function testExecutesToolCallAndReturnsFollowUpAnswer(): void {
+    $toolCall = $this->createMock(ToolsFunctionOutputInterface::class);
+
+    $firstMessage = new ChatMessage('assistant', '');
+    $firstMessage->setTools([$toolCall]);
+
+    $followUpToolMessage = new ChatMessage('tool', 'Monday, January 5, 2026 09:00.');
+
+    $toolCallHandler = $this->createMock(ToolCallHandler::class);
+    $toolCallHandler->method('attachTools')->willReturnCallback(
+      fn (ChatInput $input) => $input->setChatTools(new ToolsInput([]))
+    );
+    // Returns the follow-up request built from the transcript it was handed,
+    // so the assertions below also prove ::answer() passes the real transcript
+    // through rather than rebuilding one.
+    $toolCallHandler->expects($this->once())
+      ->method('followUpInput')
+      ->willReturnCallback(
+        fn (mixed $normalized, array $messages) => new ChatInput(array_merge($messages, [$followUpToolMessage]))
+      );
+
+    $provider = new class($firstMessage) {
+
+      /**
+       * The number of times chat() was called.
+       */
+      public int $calls = 0;
+
+      /**
+       * The chat inputs the double was called with, in call order.
+       */
+      public array $receivedInputs = [];
+
+      /**
+       * Constructs the double with the first call's response.
+       */
+      public function __construct(protected ChatMessage $firstMessage) {
+      }
+
+      /**
+       * Answers the turn, returning a tool call on the first call only.
+       */
+      public function chat($input, string $model_id, array $tags = []): ChatOutput {
+        $this->calls++;
+        $this->receivedInputs[] = $input;
+        if ($this->calls === 1) {
+          return new ChatOutput($this->firstMessage, NULL, []);
+        }
+        return new ChatOutput(new ChatMessage('assistant', "Today's date is January 5, 2026."), NULL, []);
+      }
+
+    };
+
+    $result = $this->service($provider, $toolCallHandler)->answer("What's today's date?");
+
+    $this->assertSame("Today's date is January 5, 2026.", $result['answer']);
+    $this->assertSame(2, $provider->calls);
+    // The follow-up call never carries tools, keeping the turn to one hop -
+    // the first call does, proving attachTools() ran for it too, not just
+    // that it was never called at all.
+    $this->assertNotNull($provider->receivedInputs[0]->getChatTools());
+    $this->assertNull($provider->receivedInputs[1]->getChatTools());
+    // The follow-up request carries the tool result appended to the original
+    // transcript, not a transcript of its own.
+    $this->assertContains($followUpToolMessage, $provider->receivedInputs[1]->getMessages());
+  }
+
+  /**
+   * No configured provider is a hard failure, unchanged from before tools.
+   *
+   * @covers ::answer
+   */
+  public function testThrowsWhenNoProviderConfigured(): void {
+    $ragRetriever = $this->createMock(RagRetriever::class);
+    $promptBuilder = $this->createMock(SystemPromptBuilder::class);
+    $toolCallHandler = $this->createMock(ToolCallHandler::class);
+
+    $service = new class(
+      $ragRetriever,
+      $promptBuilder,
+      $toolCallHandler,
+    ) extends BeaconAnswerService {
+
+      /**
+       * Constructs the service double with no provider configured.
+       */
+      public function __construct(
+        RagRetriever $ragRetriever,
+        SystemPromptBuilder $promptBuilder,
+        ToolCallHandler $toolCallHandler,
+      ) {
+        $this->ragRetriever = $ragRetriever;
+        $this->promptBuilder = $promptBuilder;
+        $this->toolCallHandler = $toolCallHandler;
+      }
+
+      /**
+       * {@inheritdoc}
+       */
+      protected function chatDefaults(): ?array {
+        return [];
+      }
+
+    };
+
+    $this->expectException(\RuntimeException::class);
+    $service->answer('Anything');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.services.yml
@@ -25,6 +25,14 @@ services:
       - '@ai.provider'
       - '@ys_beacon.rag_retriever'
       - '@ys_beacon.prompt_builder'
+      - '@ys_beacon.tool_call_handler'
+
+  ys_beacon.tool_call_handler:
+    class: Drupal\ys_beacon\Service\ToolCallHandler
+    arguments:
+      - '@plugin.manager.ai.function_calls'
+      - '@logger.channel.ys_beacon'
+      - ['ys_beacon:current_date_time']
 
   ys_beacon.markdown_converter:
     class: Drupal\ys_beacon\Service\MarkdownConverter


### PR DESCRIPTION
## [1146: AI: LLM should be aware of the current date and time](https://github.com/yalesites-org/YaleSites-Internal/issues/1146)

### Description of work
- Adds `GetCurrentDateTime`, an `ai` module `#[FunctionCall]` plugin in the existing `information_tools` group, returning the current date and time in an IANA timezone (defaults to `America/New_York`). Uses the `datetime.time` and `date.formatter` services rather than a bare `\DateTime`, so it is testable and DST-correct.
- Adds `ToolCallHandler`, a shared service that offers the tools, detects a returned tool call on either transport, executes it, and assembles the follow-up request. Both `ChatApiController` (streamed, the live widget) and `BeaconAnswerService` (non-streamed, used by `ys_ai_tester`) call the same two methods, so a future tool gets both surfaces for free.
- Adds `docs/AI_FUNCTION_CALL_TOOLS.md` as the reference for adding the next tool, and updates the module README's request-pipeline diagram, which previously showed only a single provider call.
- Which plugins the model may call is an explicit allow-list in `ys_beacon.services.yml`, not a scan of the `information_tools` group — `ai_search`'s own `rag_search` already lives in that group and would otherwise be offered on every turn, bypassing Beacon's RAG retrieval and citations. It is enforced twice: on offer, and again before execute, because `FunctionCallPluginManager` resolves a `function_name` against every plugin registered on the site (including the `ai` module's `action_plugin__*` derivatives that wrap node operations). This endpoint is public and unauthenticated and indexed page content reaches the model, so the second check matters.
- `timezone` is declared **required** despite having a default — a deliberate deviation from the AC's "optional" wording. A tool whose parameters are all optional gets a zero-argument call, which a real model sends as an empty `arguments` string rather than `"{}"`; contrib then `Json::decode()`s it to `NULL` and TypeErrors inside `ToolsFunctionOutput`, in code this module cannot patch. Drupal's `Context::getContextValue()` still falls back to the default when the key is absent, so omitting it remains safe.
- Guardrail telemetry now sums across both provider calls, so a stop on the tool-informed answer is counted rather than missed.
- Fixes a silent failure found in review: a turn producing no assistant text now reports itself as failed. Absorbing a mid-stream error kept already-streamed text intact, but when the failure landed before the first token the visitor got their question, the sources, and a permanently blank answer — indistinguishable in the widget from one still arriving.
- Fixes a second bug found in review: the execute-time allow-list check was unreachable on the non-streamed path in exactly the prompt-injected case it exists for. Contrib builds an un-offered function name into a `ToolsFunctionOutput` whose non-nullable `$name` is never initialised, so reading it raised an `Error` that escaped and failed the whole turn instead of the one tool call.
- Known limitation, documented rather than fixed: the tool round trip is not counted against the transcript's input-token budget. Today's tool costs roughly 160 tokens, comfortably inside the existing 2048-token safety margin, so there is no live overflow — a future tool with a large `getReadableOutput()` would need an explicit reserve.
- Automated coverage: Unit 314 tests / 707 assertions, Kernel 80 tests / 357 assertions (full suite), `composer code-sniff` clean on both standards.

### Functional testing steps:
- [ ] Open the Beacon chat widget and ask "What is today's date and time right now?" — the answer should give today's actual date and the current Eastern time, not a guess from the model's training cutoff.
- [ ] Ask "What events are coming up soon on this site? Are there any still in the future?" — the answer should reason relative to today's date (for example, correctly describing 2025-dated events as past) and still include citations.
- [ ] Ask an ordinary content question that has nothing to do with dates, such as "What trainings does YaleSites offer?" — the answer and its `[docN]` citations should be unchanged from before this branch.
- [ ] Confirm a question the assistant should decline, such as "What time is it in Tokyo?", is still refused as off-topic for the site. Beacon's own system-prompt scope guardrail handles this; the tool itself supports non-Eastern timezones and is exercised directly by the automated tests.
- [ ] Check `drush watchdog:show --extended` after the above and confirm no `ys_beacon` errors were logged for those turns.
- [ ] In the AI Tester (`ys_ai_tester`), run a date-sensitive question and confirm the non-streamed path also returns a correctly dated answer.

References yalesites-org/YaleSites-Internal#1146
