### PR TITLE
Bump atomic to v1.80.0

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -116,7 +116,7 @@
     "jjj/chosen": "2.2.1",
     "smalot/pdfparser": "2.11.0",
     "yalesites-org/ai_engine": "1.2.18",
-    "yalesites-org/atomic": "1.79.0",
+    "yalesites-org/atomic": "1.80.0",
     "yalesites-org/yale_cas": "v1.3.0"
   },
   "minimum-stability": "dev",


### PR DESCRIPTION
Bumps the `yalesites-org/atomic` dependency in the installation profile's `composer.json` to v1.80.0.

Atomic release: https://github.com/yalesites-org/atomic/releases/tag/v1.80.0