### PR TITLE
1491: Beacon: fresh-site config:import deletes ys_beacon.settings immediately after hook_install seeds it

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_beacon_portkey/tests/src/Unit/PortkeyDeployProvisionTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_beacon_portkey/tests/src/Unit/PortkeyDeployProvisionTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ys_beacon_portkey\Unit;
+
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Config\MemoryStorage;
+use Drupal\Core\Config\TypedConfigManagerInterface;
+use Drupal\Core\Extension\ModuleExtensionList;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests that the deploy hook restores settings config:import just deleted.
+ *
+ * Ys_beacon_portkey.settings is covered by the same ys_beacon* config_ignore
+ * entry as its parent module and is deleted the same way: config:import is
+ * what installs the module on a site that does not have it yet, and the
+ * changelist the importer recalculates afterwards reads the freshly seeded
+ * object as a delete. ys_beacon.deploy.php carries the full trace
+ * (yalesites-org/YaleSites-Internal#1491).
+ *
+ * Without the settings the provider has no api_key pointer and cannot load
+ * its key, so Beacon cannot reach the LLM at all.
+ *
+ * @group ys_beacon
+ */
+class PortkeyDeployProvisionTest extends UnitTestCase {
+
+  /**
+   * The config factory backing the hook under test.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  private ConfigFactory $configFactory;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 3) . '/ys_beacon_portkey.install';
+    require_once dirname(__DIR__, 3) . '/ys_beacon_portkey.deploy.php';
+
+    // ConfigFactory subscribes to its own save events to drop the config it has
+    // cached; without that wiring a read after a write returns a stale object,
+    // which is a harness artifact rather than anything the hook does.
+    $dispatcher = new EventDispatcher();
+    $this->configFactory = new ConfigFactory(
+      new MemoryStorage(),
+      $dispatcher,
+      $this->createMock(TypedConfigManagerInterface::class)
+    );
+    $dispatcher->addSubscriber($this->configFactory);
+
+    // Points at the real module root, so the restore reads the shipped file.
+    $list = $this->createMock(ModuleExtensionList::class);
+    $list->method('getPath')
+      ->with('ys_beacon_portkey')
+      ->willReturn($this->moduleRoot());
+
+    $container = new ContainerBuilder();
+    $container->set('config.factory', $this->configFactory);
+    $container->set('extension.list.module', $list);
+    // The hook loads the install file through the module handler; setUp() has
+    // already required it, so the stub only has to accept the call.
+    $container->set(
+      'module_handler',
+      $this->createMock(ModuleHandlerInterface::class)
+    );
+    $container->set(
+      'cache_tags.invalidator',
+      $this->createMock(CacheTagsInvalidatorInterface::class)
+    );
+    $container->set('string_translation', $this->getStringTranslationStub());
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * The module directory holding the shipped config/install file.
+   *
+   * @return string
+   *   The absolute path to the ys_beacon_portkey module root.
+   */
+  private function moduleRoot(): string {
+    return dirname(__DIR__, 3);
+  }
+
+  /**
+   * The shipped defaults, parsed from the real config/install file.
+   *
+   * @return array
+   *   The shipped defaults.
+   */
+  private function shippedDefaults(): array {
+    return Yaml::parseFile(
+      $this->moduleRoot() . '/config/install/ys_beacon_portkey.settings.yml'
+    );
+  }
+
+  /**
+   * Settings deleted by the import are restored with the shipped defaults.
+   */
+  public function testRestoresSettingsDeletedByConfigImport(): void {
+    $this->assertTrue(
+      $this->configFactory->get('ys_beacon_portkey.settings')->isNew(),
+      'The settings object starts absent, as on a site the import cleared.'
+    );
+
+    ys_beacon_portkey_deploy_10001();
+
+    $restored = $this->configFactory->get('ys_beacon_portkey.settings');
+    $this->assertFalse($restored->isNew(), 'The object is recreated.');
+    $this->assertSame(
+      $this->shippedDefaults(),
+      $restored->getRawData(),
+      'The shipped defaults are restored verbatim.'
+    );
+
+    // The provider resolves its key through this pointer; without it Beacon
+    // cannot authenticate to the gateway.
+    $this->assertSame(
+      'portkey_llm_api_key',
+      $restored->get('api_key'),
+      'The api_key pointer is restored.'
+    );
+  }
+
+  /**
+   * A configured provider is left completely untouched.
+   */
+  public function testLeavesConfiguredProviderUntouched(): void {
+    $saved = [
+      'api_key' => 'site_specific_key',
+      'host' => 'https://example.test/v1',
+    ];
+    $this->configFactory->getEditable('ys_beacon_portkey.settings')
+      ->setData($saved)
+      ->save();
+
+    ys_beacon_portkey_deploy_10001();
+
+    $this->assertSame(
+      $saved,
+      $this->configFactory->get('ys_beacon_portkey.settings')->getRawData(),
+      'A configured provider is not rewritten.'
+    );
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_beacon_portkey/ys_beacon_portkey.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_beacon_portkey/ys_beacon_portkey.deploy.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @file
+ * Drush deploy hooks for ys_beacon_portkey module.
+ */
+
+/**
+ * Implements hook_deploy_NAME().
+ *
+ * Restores ys_beacon_portkey.settings when the config import has just deleted
+ * it.
+ *
+ * The provider's settings are covered by the same ys_beacon* config_ignore
+ * entry as the parent module and are deleted by the same mechanism: the module
+ * is listed in synced core.extension, so on a site that does not have Beacon
+ * yet config:import installs it, hook_install() seeds the settings, and the
+ * changelist the importer recalculates afterwards sees that fresh object as a
+ * delete. See ys_beacon.deploy.php for the full trace and for why the deploy
+ * phase is the one that can make the write stick
+ * (yalesites-org/YaleSites-Internal#1491).
+ *
+ * Without these settings the provider has no api_key pointer, so it cannot
+ * load its key and Beacon cannot reach the LLM at all.
+ *
+ * Inert on every site whose settings survived, which is the overwhelming
+ * majority.
+ */
+function ys_beacon_portkey_deploy_10001() {
+  // Deploy hooks run from ys_beacon_portkey.deploy.php; the seeding helper
+  // lives in the install file, which is not loaded for us. The helper owns the
+  // "is this provider configured?" test and reports whether it wrote, so the
+  // predicate is not restated here against a different view of the config -
+  // \Drupal::config() applies settings.php overrides, getEditable() does not.
+  \Drupal::moduleHandler()->loadInclude('ys_beacon_portkey', 'install');
+
+  return _ys_beacon_portkey_seed_settings()
+    ? t('Restored ys_beacon_portkey.settings deleted by the import.')
+    : t('Portkey settings are present; nothing to restore.');
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_beacon_portkey/ys_beacon_portkey.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_beacon_portkey/ys_beacon_portkey.install
@@ -15,16 +15,18 @@ use Drupal\Core\Config\FileStorage;
  * it, so the provider can be left with no api_key pointer and fail to load its
  * key. The shipped config/install file is the single source of truth here.
  */
-function _ys_beacon_portkey_seed_settings(): void {
+function _ys_beacon_portkey_seed_settings(): bool {
   $config = \Drupal::configFactory()->getEditable('ys_beacon_portkey.settings');
   // Only seed an unconfigured provider; never clobber a populated config.
   if ($config->get('api_key')) {
-    return;
+    return FALSE;
   }
   $path = \Drupal::service('extension.list.module')->getPath('ys_beacon_portkey') . '/config/install';
   if ($data = (new FileStorage($path))->read('ys_beacon_portkey.settings')) {
     $config->setData($data)->save();
+    return TRUE;
   }
+  return FALSE;
 }
 
 /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconDeployProvisionTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconDeployProvisionTest.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Config\MemoryStorage;
+use Drupal\Core\Config\TypedConfigManagerInterface;
+use Drupal\Core\Extension\ModuleExtensionList;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests that the deploy hook restores settings config:import just deleted.
+ *
+ * Seeding ys_beacon.settings from hook_install() cannot survive the install
+ * path a first-time site actually takes: config:import is what installs the
+ * module there, and the changelist the importer recalculates afterwards reads
+ * the freshly seeded object as a delete. ys_beacon.deploy.php carries the full
+ * trace and the reasoning for fixing it in the deploy phase
+ * (yalesites-org/YaleSites-Internal#1491).
+ *
+ * The config factory here is real, over a memory storage, so the guard and
+ * the restore are exercised against genuine Config read/write semantics; only
+ * the module extension list is stubbed, and it points at the real module root
+ * so the assertions run against the actual shipped defaults.
+ *
+ * @group ys_beacon
+ */
+class BeaconDeployProvisionTest extends UnitTestCase {
+
+  /**
+   * The config factory backing the hook under test.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  private ConfigFactory $configFactory;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 3) . '/ys_beacon.install';
+    require_once dirname(__DIR__, 3) . '/ys_beacon.deploy.php';
+
+    // ConfigFactory subscribes to its own save events to drop the config it has
+    // cached; without that wiring a read after a write returns a stale object,
+    // which is a harness artifact rather than anything the hook does.
+    $dispatcher = new EventDispatcher();
+    $this->configFactory = new ConfigFactory(
+      new MemoryStorage(),
+      $dispatcher,
+      $this->createMock(TypedConfigManagerInterface::class)
+    );
+    $dispatcher->addSubscriber($this->configFactory);
+
+    // Points at the real module root, so the restore reads the shipped file.
+    $list = $this->createMock(ModuleExtensionList::class);
+    $list->method('getPath')
+      ->with('ys_beacon')
+      ->willReturn($this->moduleRoot());
+
+    $container = new ContainerBuilder();
+    $container->set('config.factory', $this->configFactory);
+    $container->set('extension.list.module', $list);
+    // The hook loads the install file through the module handler; setUp() has
+    // already required it, so the stub only has to accept the call.
+    $container->set(
+      'module_handler',
+      $this->createMock(ModuleHandlerInterface::class)
+    );
+    $container->set(
+      'cache_tags.invalidator',
+      $this->createMock(CacheTagsInvalidatorInterface::class)
+    );
+    $container->set('string_translation', $this->getStringTranslationStub());
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * The module directory holding the shipped config/install file.
+   *
+   * @return string
+   *   The absolute path to the ys_beacon module root.
+   */
+  private function moduleRoot(): string {
+    return dirname(__DIR__, 3);
+  }
+
+  /**
+   * The shipped defaults, parsed from the real config/install file.
+   *
+   * @return array
+   *   The shipped defaults.
+   */
+  private function shippedDefaults(): array {
+    return Yaml::parseFile(
+      $this->moduleRoot() . '/config/install/ys_beacon.settings.yml'
+    );
+  }
+
+  /**
+   * Settings deleted by the import are restored with the shipped defaults.
+   */
+  public function testRestoresSettingsDeletedByConfigImport(): void {
+    $this->assertTrue(
+      $this->configFactory->get('ys_beacon.settings')->isNew(),
+      'The settings object starts absent, as on a site the import cleared.'
+    );
+
+    ys_beacon_deploy_10001();
+
+    $restored = $this->configFactory->get('ys_beacon.settings');
+    $this->assertFalse($restored->isNew(), 'The object is recreated.');
+    $this->assertSame(
+      $this->shippedDefaults(),
+      $restored->getRawData(),
+      'The shipped defaults are restored verbatim.'
+    );
+
+    // Both ship on and are read without a runtime fallback, so an absent
+    // settings object silently inverts them: streaming turns off and the AI
+    // metadata fields disappear from every content and media form.
+    $this->assertTrue($restored->get('streaming'), 'Streaming is back on.');
+    $this->assertTrue(
+      $restored->get('enable_metadata_fields'),
+      'Metadata fields are back on.'
+    );
+
+    // Restoring defaults must never switch a site on.
+    $this->assertFalse($restored->get('enable_chat'), 'Chat stays off.');
+    $this->assertFalse(
+      $restored->get('platform_authorized'),
+      'Beacon stays unauthorized.'
+    );
+  }
+
+  /**
+   * An existing site's saved settings are left completely untouched.
+   *
+   * The hook runs once on every site, including the overwhelming majority
+   * whose settings the import never touched, so it must be inert there.
+   */
+  public function testLeavesExistingSettingsUntouched(): void {
+    // A legacy chat is present and holds different values, so the guard on the
+    // overlay is genuinely exercised: without it the deploy hook would stamp
+    // these over the editor's own choices.
+    $this->configFactory->getEditable('ai_engine_chat.settings')
+      ->setData([
+        'floating_button_text' => 'Ask YaleSites',
+        'disclaimer' => 'Legacy disclaimer',
+      ])
+      ->save();
+    $this->configFactory->getEditable('ai_engine_metadata.settings')
+      ->setData(['enable' => FALSE])
+      ->save();
+
+    $saved = $this->shippedDefaults();
+    $saved['streaming'] = FALSE;
+    $saved['enable_chat'] = TRUE;
+    $saved['floating_button_text'] = 'Editor chose this';
+    $saved['enable_metadata_fields'] = TRUE;
+    $this->configFactory->getEditable('ys_beacon.settings')
+      ->setData($saved)
+      ->save();
+
+    ys_beacon_deploy_10001();
+
+    $this->assertSame(
+      $saved,
+      $this->configFactory->get('ys_beacon.settings')->getRawData(),
+      'A complete settings object is not rewritten, legacy values and all.'
+    );
+  }
+
+  /**
+   * A settings object recreated with only a few keys has its gaps filled.
+   *
+   * After the import deletes the settings, the next runtime write recreates
+   * the object holding only its own keys - a platform admin switching Beacon
+   * on through BeaconPlatformAdminSetting writes three. An existence check
+   * would call that healthy and leave the rest reading NULL for good, and
+   * because a deploy hook runs once per site it would never get another
+   * chance.
+   */
+  public function testFillsGapsInPartiallyRecreatedObject(): void {
+    $this->configFactory->getEditable('ys_beacon.settings')
+      ->setData([
+        'platform_authorized' => TRUE,
+        'enable_chat' => TRUE,
+        'enable_metadata_fields' => TRUE,
+      ])
+      ->save();
+
+    ys_beacon_deploy_10001();
+
+    $healed = $this->configFactory->get('ys_beacon.settings');
+    // The site's live state is preserved - the hook must not switch it off.
+    $this->assertTrue($healed->get('enable_chat'), 'The live chat toggle survives.');
+    $this->assertTrue($healed->get('platform_authorized'), 'Authorization survives.');
+    // ... and the keys that were reading NULL are back.
+    $this->assertTrue($healed->get('streaming'), 'Streaming comes back on.');
+    $this->assertSame(5, $healed->get('top_k'), 'top_k comes back.');
+    $this->assertCount(
+      count($this->shippedDefaults()),
+      $healed->getRawData(),
+      'Every shipped key is present.'
+    );
+  }
+
+  /**
+   * A restore keeps the values hook_install() copied from the legacy chat.
+   *
+   * Hook_install() overlays the editor-facing display settings from the
+   * legacy ai_engine chat onto the shipped defaults. Those values are written
+   * into the very object the import then deletes, so restoring the shipped
+   * defaults alone would silently reset a migrated site's button text,
+   * prompts, disclaimer and footer. The dev database this was reproduced on
+   * carries exactly that state: floating_button_text reads 'Ask YaleSites'
+   * from the legacy chat, not the shipped 'Beacon Chat'.
+   */
+  public function testRestoreKeepsLegacyAiEngineValues(): void {
+    $this->configFactory->getEditable('ai_engine_chat.settings')
+      ->setData([
+        'floating_button_text' => 'Ask YaleSites',
+        'disclaimer' => 'Legacy disclaimer',
+      ])
+      ->save();
+    $this->configFactory->getEditable('ai_engine_metadata.settings')
+      ->setData(['enable' => FALSE])
+      ->save();
+
+    ys_beacon_deploy_10001();
+
+    $restored = $this->configFactory->get('ys_beacon.settings');
+    $this->assertSame(
+      'Ask YaleSites',
+      $restored->get('floating_button_text'),
+      'The legacy button text survives the restore.'
+    );
+    $this->assertSame(
+      'Legacy disclaimer',
+      $restored->get('disclaimer'),
+      'The legacy disclaimer survives the restore.'
+    );
+    $this->assertFalse(
+      $restored->get('enable_metadata_fields'),
+      'The legacy metadata visibility choice survives the restore.'
+    );
+
+    // The overlay must land ON TOP of the shipped defaults, not instead of
+    // them: hoisting the getEditable() above the seed would wipe every key the
+    // legacy chat does not carry, and only these assertions would catch it.
+    $this->assertTrue($restored->get('streaming'), 'Streaming still ships on.');
+    $this->assertSame(5, $restored->get('top_k'), 'Untouched defaults survive.');
+
+    // Guards the premise: these differ from the shipped defaults, so the
+    // assertions above cannot pass by accident.
+    $defaults = $this->shippedDefaults();
+    $this->assertSame('Beacon Chat', $defaults['floating_button_text']);
+    $this->assertTrue($defaults['enable_metadata_fields']);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconSettingsSeedTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconSettingsSeedTest.php
@@ -85,7 +85,7 @@ class BeaconSettingsSeedTest extends UnitTestCase {
   public function testSeedsShippedDefaultsWhenAbsent(): void {
     $captured = NULL;
     $config = $this->createMock(Config::class);
-    $config->method('isNew')->willReturn(TRUE);
+    $config->method('getRawData')->willReturn([]);
     $config->expects($this->once())
       ->method('setData')
       ->with($this->callback(function (array $data) use (&$captured): bool {
@@ -112,16 +112,65 @@ class BeaconSettingsSeedTest extends UnitTestCase {
   }
 
   /**
-   * An existing configuration is left completely untouched.
+   * A complete existing configuration is left completely untouched.
    */
   public function testDoesNotClobberExistingSettings(): void {
     $config = $this->createMock(Config::class);
-    $config->method('isNew')->willReturn(FALSE);
+    // Every shipped key already present, so there is no gap to fill.
+    $config->method('getRawData')->willReturn($this->shippedDefaults());
     $config->expects($this->never())->method('setData');
     $config->expects($this->never())->method('save');
     $this->setContainer($config);
 
-    _ys_beacon_seed_settings();
+    $this->assertFalse(_ys_beacon_seed_settings(), 'Nothing was written.');
+  }
+
+  /**
+   * A partially recreated configuration has only its gaps filled.
+   *
+   * Once the config import has deleted the settings
+   * (yalesites-org/YaleSites-Internal#1491), the next runtime write recreates
+   * the object holding only that writer's own keys -
+   * BeaconPlatformAdminSetting::submitSettings() writes three,
+   * BeaconIndexManager::propagateConnection() two. Those keys are the site's
+   * real state and must survive; every other shipped default has to come back,
+   * or it reads NULL for good.
+   */
+  public function testFillsGapsWithoutOverwritingExistingKeys(): void {
+    $existing = [
+      'enable_chat' => TRUE,
+      'platform_authorized' => TRUE,
+      'azure_index_name' => 'site-specific-index',
+    ];
+
+    $captured = NULL;
+    $config = $this->createMock(Config::class);
+    $config->method('getRawData')->willReturn($existing);
+    $config->expects($this->once())
+      ->method('setData')
+      ->with($this->callback(function (array $data) use (&$captured): bool {
+        $captured = $data;
+        return TRUE;
+      }))
+      ->willReturnSelf();
+    $config->expects($this->once())->method('save')->willReturnSelf();
+    $this->setContainer($config);
+
+    $this->assertTrue(_ys_beacon_seed_settings(), 'A gap was filled.');
+
+    // The site's own values win over the shipped defaults.
+    $this->assertTrue($captured['enable_chat'], 'The live chat toggle survives.');
+    $this->assertTrue($captured['platform_authorized'], 'Authorization survives.');
+    $this->assertSame('site-specific-index', $captured['azure_index_name']);
+
+    // Everything the partial write never set is restored.
+    $this->assertTrue($captured['streaming'], 'Streaming comes back on.');
+    $this->assertSame(5, $captured['top_k'], 'top_k comes back.');
+    $shipped_keys = array_keys($this->shippedDefaults());
+    $captured_keys = array_keys($captured);
+    sort($shipped_keys);
+    sort($captured_keys);
+    $this->assertSame($shipped_keys, $captured_keys, 'The full shipped key set is present.');
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.deploy.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @file
+ * Drush deploy hooks for ys_beacon module.
+ */
+
+/**
+ * Implements hook_deploy_NAME().
+ *
+ * Restores ys_beacon.settings when the config import has just deleted it.
+ *
+ * ys_beacon.settings is config-ignored (ys_beacon*) and deliberately absent
+ * from config/sync, so on a site that does not have Beacon yet nothing in sync
+ * can create it. ys_beacon is listed in synced core.extension, so config:import
+ * is what installs the module there, and _ys_beacon_seed_settings() creates the
+ * object from the shipped file during hook_install(). The import then deletes
+ * it again: once the extension phase has installed the module,
+ * ConfigImporter::processConfigurations() recalculates the changelist through
+ * $this->storageComparer->reset() (ConfigImporter.php:656), and that
+ * recalculation compares active storage - which now holds the seeded object -
+ * against the already-transformed sync storage, which does not. That reads as a
+ * delete, and config_ignore cannot veto it, because
+ * ImportStorageTransformer::transform() returns the cached import storage while
+ * the importer holds its lock. The ys_beacon* ignore is therefore only ever
+ * evaluated before the module exists, when there is nothing to protect
+ * (yalesites-org/YaleSites-Internal#1491).
+ *
+ * The deploy phase is the one that can make the write stick: `drush deploy`
+ * runs deploy hooks after config:import, so no changelist is recalculated
+ * afterwards. A hook_post_update_NAME() would not do, on two counts - it runs
+ * inside `drush updatedb`, before the import, and
+ * UpdateRegistry::onConfigSave() registers a newly installed extension's
+ * post_update functions as already invoked, so it would never fire on the very
+ * sites that need it. Drush builds the deploy registry ad hoc in
+ * DeployHookCommands::getRegistry() rather than as a container service, so it
+ * has no such subscriber and a new module's deploy hooks stay pending.
+ *
+ * This complements rather than replaces ys_core_update_10017(), which installs
+ * the Beacon stack during the updatedb phase so the import never installs it at
+ * all. That hook is one-shot: it cannot run on a site whose ys_core schema has
+ * already passed 10017 but which does not have Beacon installed, and that is
+ * exactly the site this restores.
+ *
+ * Writes nothing on a site whose settings are already complete, which is the
+ * overwhelming majority.
+ */
+function ys_beacon_deploy_10001() {
+  // Deploy hooks run from ys_beacon.deploy.php; the provisioning helpers live
+  // in the install file, which is not loaded for us.
+  \Drupal::moduleHandler()->loadInclude('ys_beacon', 'install');
+
+  // Only a wholly absent object is the state hook_install() would have left,
+  // so only then is the legacy ai_engine overlay re-applied. A settings object
+  // that exists but is missing keys was recreated by a runtime write after the
+  // import deleted it; re-running the overlay there would stamp legacy values
+  // over an editor's own, so it only gets the missing defaults filled in.
+  if (\Drupal::config('ys_beacon.settings')->isNew()) {
+    _ys_beacon_provision_settings();
+    return t('Restored ys_beacon.settings deleted by the configuration import.');
+  }
+
+  return _ys_beacon_seed_settings()
+    ? t('Filled in Beacon settings defaults missing from an incomplete configuration.')
+    : t('Beacon settings are complete; nothing to restore.');
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.install
@@ -162,6 +162,47 @@ function ys_beacon_schema() {
  * cannot do it (yalesites-org/YaleSites-Internal#1459).
  */
 function ys_beacon_install() {
+  _ys_beacon_provision_settings();
+
+  // Copy the legacy system instructions version history. Values are stored
+  // unescaped (escaping only ever happened on the legacy API wire), and the
+  // legacy service guarantees at most one is_active = 1 row.
+  // Deployment ordering matters: uninstalling ys_ai_system_instructions
+  // drops its table, so it must stay installed until after ys_beacon has
+  // been installed (a same-deploy swap would silently skip this copy).
+  $database = \Drupal::database();
+  if ($database->schema()->tableExists('ys_ai_system_instructions')) {
+    $rows = $database->select('ys_ai_system_instructions', 's')
+      ->fields('s', ['instructions', 'version', 'created_by', 'created_date', 'is_active', 'notes'])
+      ->orderBy('id')
+      ->execute()
+      ->fetchAll(\PDO::FETCH_ASSOC);
+    foreach ($rows as $row) {
+      $database->insert('ys_beacon_system_instructions')->fields($row)->execute();
+    }
+  }
+
+  // Seed default system instructions on a fresh install (no legacy history to
+  // copy). The helper no-ops when versions already exist, so migrations and
+  // existing installs are never overwritten.
+  _ys_beacon_seed_default_instructions($database);
+}
+
+/**
+ * Provisions ys_beacon.settings: shipped defaults plus legacy chat values.
+ *
+ * Split out of hook_install() so ys_beacon_deploy_10001() can re-run the whole
+ * provisioning after config:import, which deletes the object hook_install()
+ * created moments earlier on a site receiving Beacon for the first time. See
+ * ys_beacon.deploy.php for why the import does that and why the deploy phase is
+ * the one that can make the write stick.
+ *
+ * Seed and overlay have to travel together: the legacy values are written into
+ * the very object the import deletes, so restoring the shipped defaults on
+ * their own would silently reset a migrated site's button text, prompts,
+ * disclaimer and footer.
+ */
+function _ys_beacon_provision_settings(): void {
   // Seed the shipped defaults before anything else, so the legacy copy below
   // overlays them instead of writing into a config object that never existed.
   _ys_beacon_seed_settings();
@@ -202,33 +243,10 @@ function ys_beacon_install() {
   if ($changed) {
     $settings->save();
   }
-
-  // Copy the legacy system instructions version history. Values are stored
-  // unescaped (escaping only ever happened on the legacy API wire), and the
-  // legacy service guarantees at most one is_active = 1 row.
-  // Deployment ordering matters: uninstalling ys_ai_system_instructions
-  // drops its table, so it must stay installed until after ys_beacon has
-  // been installed (a same-deploy swap would silently skip this copy).
-  $database = \Drupal::database();
-  if ($database->schema()->tableExists('ys_ai_system_instructions')) {
-    $rows = $database->select('ys_ai_system_instructions', 's')
-      ->fields('s', ['instructions', 'version', 'created_by', 'created_date', 'is_active', 'notes'])
-      ->orderBy('id')
-      ->execute()
-      ->fetchAll(\PDO::FETCH_ASSOC);
-    foreach ($rows as $row) {
-      $database->insert('ys_beacon_system_instructions')->fields($row)->execute();
-    }
-  }
-
-  // Seed default system instructions on a fresh install (no legacy history to
-  // copy). The helper no-ops when versions already exist, so migrations and
-  // existing installs are never overwritten.
-  _ys_beacon_seed_default_instructions($database);
 }
 
 /**
- * Seeds ys_beacon.settings from the shipped defaults when it does not exist.
+ * Fills any shipped default missing from ys_beacon.settings.
  *
  * Ys_beacon.settings is config_ignored, so it is deliberately absent from
  * config/sync. That matters on the install path this module actually takes on a
@@ -243,17 +261,36 @@ function ys_beacon_install() {
  *
  * Reading the shipped file directly sidesteps that, and is the same approach
  * _ys_beacon_portkey_seed_settings() already takes for the same reason.
+ *
+ * This fills gaps rather than only creating an absent object, because the
+ * settings can also come back partially populated. Once the import has deleted
+ * them (yalesites-org/YaleSites-Internal#1491), the next runtime write
+ * recreates the object holding only the handful of keys that writer sets -
+ * BeaconPlatformAdminSetting::submitSettings() writes three, and
+ * BeaconIndexManager::propagateConnection() two. An existence test would call
+ * that healthy and leave every other key reading NULL for good. Existing values
+ * always win, so this stays safe to call on a configured site.
+ *
+ * @return bool
+ *   TRUE when a missing default was written, FALSE when nothing was needed.
  */
-function _ys_beacon_seed_settings(): void {
+function _ys_beacon_seed_settings(): bool {
   $config = \Drupal::configFactory()->getEditable('ys_beacon.settings');
-  // Never clobber an existing configuration; this only fills in an absent one.
-  if (!$config->isNew()) {
-    return;
-  }
   $path = \Drupal::service('extension.list.module')->getPath('ys_beacon') . '/config/install';
-  if ($data = (new FileStorage($path))->read('ys_beacon.settings')) {
-    $config->setData($data)->save();
+  $shipped = (new FileStorage($path))->read('ys_beacon.settings');
+  if (!$shipped) {
+    return FALSE;
   }
+
+  // Union, not merge: a key the site already holds is never overwritten.
+  $current = $config->getRawData();
+  $filled = $current + $shipped;
+  if ($filled === $current) {
+    return FALSE;
+  }
+
+  $config->setData($filled)->save();
+  return TRUE;
 }
 
 /**


### PR DESCRIPTION
## [1491: Beacon: fresh-site config:import deletes ys_beacon.settings immediately after hook_install seeds it](https://github.com/yalesites-org/YaleSites-Internal/issues/1491)

### Description of work

- Adds `hook_deploy_NAME()` to `ys_beacon` and `ys_beacon_portkey` so their config-ignored settings are restored after `config:import` deletes them. `drush deploy` runs deploy hooks after the import, so nothing recalculates a changelist afterwards and the write sticks.
- Extracts `_ys_beacon_provision_settings()` out of `ys_beacon_install()` so the deploy hook can re-run the shipped-defaults seed **together with** the legacy `ai_engine` overlay. They have to travel together: the legacy values are written into the very object the import deletes, so restoring defaults alone would silently reset a migrated site's button text, prompts, disclaimer and footer.
- Changes `_ys_beacon_seed_settings()` from create-if-absent to a **union gap-fill** (`$current + $shipped`, existing values always win). Once the import has deleted the settings, the next runtime write recreates the object holding only its own keys — three from `BeaconPlatformAdminSetting::submitSettings()`, two from `BeaconIndexManager::propagateConnection()`. An existence test would call that healthy and, because a deploy hook runs once per site, leave every other key reading NULL for good.
- Tests: `BeaconDeployProvisionTest` (4) and `PortkeyDeployProvisionTest` (2) are new; `BeaconSettingsSeedTest` gains a gap-fill case. They use a real `ConfigFactory` over `MemoryStorage`, so the guards run against genuine Config read/write semantics.

**Note on the issue's root-cause trace:** the changelist recalculation is in `ConfigImporter::processConfigurations()` (the `storageComparer->reset()` at `ConfigImporter.php:656`), not `processExtensions()`. The causal chain in the issue is correct; only the function name is off.

**Why a deploy hook and not `hook_post_update_NAME()`** (the issue offered either): `hook_post_update_NAME()` runs inside `drush updatedb`, *before* the import, so it could not make the write stick — and it would never fire on the sites that need it, because `UpdateRegistry::onConfigSave()` registers a newly installed extension's post_update functions as already invoked. Drush builds the deploy registry ad hoc in `DeployHookCommands::getRegistry()` rather than as a container service, so it carries no such subscriber and a new module's deploy hooks stay pending. Confirmed on a live deploy: `ys_beacon` was installed mid-import and its deploy hook still ran in that same run.

**Relationship to `ys_core_update_10017()`:** that hook installs the Beacon stack during `updatedb` so the import never installs it at all, and it covers sites still below `ys_core` schema 10017. It is one-shot, so it cannot help a site whose schema has already passed 10017 without Beacon installed — which is the site this restores. The two are complementary; nothing is removed.

### Functional testing steps:

- [ ] On an environment whose database has **never had Beacon** (`drush config:get ys_beacon.settings` returns nothing and `ys_beacon` is not installed), run `drush deploy`.
- [ ] Watch the output: `config:import` will still log `Synchronized configuration: delete ys_beacon.settings.` — that part is core behaviour and is expected. Then confirm the deploy-hook phase logs `Deploy hook started: ys_beacon_deploy_10001` followed by `Restored ys_beacon.settings deleted by the configuration import.`
- [ ] `drush config:get ys_beacon.settings` now returns the full object. Confirm `streaming: true`, `enable_metadata_fields: true`, `top_k: 5`.
- [ ] Confirm the site was **not** switched on: `enable_chat: false` and `platform_authorized: false`.
- [ ] `drush config:get ys_beacon_portkey.settings` returns its 7 keys with `api_key: portkey_llm_api_key`.
- [ ] On a **migrated** site (one that still has `ai_engine_chat.settings`), confirm the restored `floating_button_text` keeps the legacy value rather than reverting to the shipped `Beacon Chat`.
- [ ] On a healthy existing site, run `drush deploy` and confirm the hook reports `Beacon settings are complete; nothing to restore.` and changes nothing.

References yalesites-org/YaleSites-Internal#1491

---
Created with AI
