### PR TITLE
1489: RC: Dashboard Resources links should open in a new tab

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/dashboard.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/dashboard.css
@@ -99,3 +99,30 @@
 .ys-dashboard__resources .more-link {
   margin-block-start: 0.75rem;
 }
+
+/* Atomic's link-purpose library marks up new-tab links on front-end pages, but
+   it ships in atomic/global and the dashboard is admin-themed, so it never runs
+   here. Draw its "opens in new window" icon ourselves, keyed on the attribute so
+   any new-tab link on the page is covered. The glyph is the same Font Awesome
+   arrow-up-right-from-square link-purpose uses, inlined as a mask so it takes
+   the link's own color (including Gin dark mode) without pulling Font Awesome
+   into the admin UI. The matching screen reader text lives in the template --
+   generated content is not a reliable way to expose it.
+   Glyph: Font Awesome Free 6 "arrow-up-right-from-square" (CC BY 4.0).
+   @see component-library-twig/lib/link-treatment/link-treatment.js */
+.ys-dashboard a[target="_blank"]::after {
+  --ys-dashboard-new-tab-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath d='M304 24c0 13.3 10.7 24 24 24H430.1L207 271c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l223-223V184c0 13.3 10.7 24 24 24s24-10.7 24-24V24c0-13.3-10.7-24-24-24H328c-13.3 0-24 10.7-24 24zM72 32C32.2 32 0 64.2 0 104V440c0 39.8 32.2 72 72 72H408c39.8 0 72-32.2 72-72V312c0-13.3-10.7-24-24-24s-24 10.7-24 24V440c0 13.3-10.7 24-24 24H72c-13.3 0-24-10.7-24-24V104c0-13.3 10.7-24 24-24H200c13.3 0 24-10.7 24-24s-10.7-24-24-24H72z'/%3E%3C/svg%3E");
+
+  content: "";
+  display: inline-block;
+  inline-size: 0.7em;
+  block-size: 0.7em;
+  margin-inline-start: 0.35em;
+  background-color: currentColor;
+  -webkit-mask-image: var(--ys-dashboard-new-tab-icon);
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-image: var(--ys-dashboard-new-tab-icon);
+  mask-repeat: no-repeat;
+  mask-size: contain;
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-dashboard.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-dashboard.html.twig
@@ -1,4 +1,11 @@
 {{ attach_library('ys_core/dashboard') }}
+
+{# The dashboard is an admin-themed page, so Atomic's link-purpose library never
+   runs here to announce links that leave the editor's session. Every link below
+   that opens a new tab carries this message itself; the matching icon comes from
+   the dashboard's own CSS. #}
+{% set opens_in_new_window %}<span class="visually-hidden"> ({{ 'Link opens in new window'|t }})</span>{% endset %}
+
 <div class="ys-dashboard">
 
   {# Top row: announcements on the left, resources / feedback / platform info on the right. #}
@@ -37,20 +44,20 @@
         <h2 id="ys-dashboard-resources-heading">{{ 'Resources'|t }}</h2>
         <ul>
           <li>
-            <a href="https://yalesites.yale.edu/explore-resources/learn-the-basics">{{ 'Learn the Basics'|t }}</a> &mdash;
+            <a href="https://yalesites.yale.edu/explore-resources/learn-the-basics" target="_blank" rel="noopener noreferrer">{{ 'Learn the Basics'|t }}{{ opens_in_new_window }}</a> &mdash;
             {{ 'Navigate the interface, create content, and start building your site with confidence.'|t }}
           </li>
           <li>
-            <a href="https://yalesites.yale.edu/explore-resources/user-guide">{{ 'User Guide'|t }}</a> &mdash;
+            <a href="https://yalesites.yale.edu/explore-resources/user-guide" target="_blank" rel="noopener noreferrer">{{ 'User Guide'|t }}{{ opens_in_new_window }}</a> &mdash;
             {{ 'Detailed step-by-step instructions for all platform features, including content creation, sitewide settings, and going live.'|t }}
           </li>
           <li>
-            <a href="https://yalesites.yale.edu/trainings#officehours">{{ 'Office Hours'|t }}</a> &mdash;
+            <a href="https://yalesites.yale.edu/trainings#officehours" target="_blank" rel="noopener noreferrer">{{ 'Office Hours'|t }}{{ opens_in_new_window }}</a> &mdash;
             {{ 'Connect live with the YaleSites team to ask questions and get hands-on help.'|t }}
           </li>
         </ul>
         <div class="more-link">
-          <a href="https://yalesites.yale.edu/resource-library">{{ 'Find more resources'|t }}</a>
+          <a href="https://yalesites.yale.edu/resource-library" target="_blank" rel="noopener noreferrer">{{ 'Find more resources'|t }}{{ opens_in_new_window }}</a>
         </div>
       </section>
 
@@ -67,7 +74,7 @@
 
         <section class="ys-dashboard__section ys-dashboard__actions" aria-labelledby="ys-dashboard-siteimprove-heading">
           <h2 id="ys-dashboard-siteimprove-heading" class="visually-hidden">{{ 'Siteimprove'|t }}</h2>
-          <a href="https://my2.siteimprove.com/Auth/Saml2/66356571" target="_blank" rel="noopener noreferrer" class="button button--primary ys-dashboard__action-button">{{ 'Siteimprove'|t }}</a>
+          <a href="https://my2.siteimprove.com/Auth/Saml2/66356571" target="_blank" rel="noopener noreferrer" class="button button--primary ys-dashboard__action-button">{{ 'Siteimprove'|t }}{{ opens_in_new_window }}</a>
           <p class="ys-dashboard__action-help">{{ 'Access your Siteimprove dashboard here. For more information about how to use Siteimprove, visit our <a href=":url">Getting Started with Siteimprove guide</a>.'|t({':url': 'https://yalesites.yale.edu/explore-resources/working-with-content/getting-started-with-siteimprove'}) }}</p>
         </section>
       </div>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/DashboardNewTabLinksTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/DashboardNewTabLinksTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the new-tab behaviour of the editorial dashboard's outbound links.
+ *
+ * The Resources links are reference material editors check alongside active
+ * editing work, so following one must not drop them out of their Drupal
+ * session.
+ *
+ * The dashboard lives under /admin, which core's AdminRouteSubscriber marks as
+ * an admin route, so it renders in ys_admin_theme rather than atomic. Atomic's
+ * link-purpose library (component-library-twig's link-treatment.js, shipped in
+ * atomic/global) is what normally adds the icon and the "Link opens in new
+ * window" message to any [target="_blank"] link, and it is never attached to
+ * an admin-themed page. Every new-tab link on the dashboard therefore has to
+ * carry its own screen reader announcement.
+ *
+ * @group ys_core
+ * @group yalesites
+ */
+class DashboardNewTabLinksTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'views', 'twig_tweak', 'ys_core'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * The Resources section links, which all point off-platform.
+   */
+  protected const RESOURCE_LINKS = [
+    'https://yalesites.yale.edu/explore-resources/learn-the-basics',
+    'https://yalesites.yale.edu/explore-resources/user-guide',
+    'https://yalesites.yale.edu/trainings#officehours',
+    'https://yalesites.yale.edu/resource-library',
+  ];
+
+  /**
+   * Renders the dashboard and returns an XPath query over its markup.
+   */
+  protected function renderDashboard(): \DOMXPath {
+    $build = [
+      '#theme' => 'ys_dashboard',
+      '#platform_version' => '1.0.0',
+      '#announcements' => [],
+    ];
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+
+    $dom = new \DOMDocument();
+    // The dashboard is a fragment, and Views may emit markup DOMDocument warns
+    // about; neither is what this test is asserting on.
+    @$dom->loadHTML('<?xml encoding="utf-8" ?>' . $html);
+
+    return new \DOMXPath($dom);
+  }
+
+  /**
+   * Every Resources link opens in a new tab, safely.
+   */
+  public function testResourceLinksOpenInNewTab(): void {
+    $xpath = $this->renderDashboard();
+
+    foreach (self::RESOURCE_LINKS as $href) {
+      $links = $xpath->query(sprintf('//a[@href="%s"]', $href));
+      $this->assertCount(1, $links, sprintf('Found exactly one %s link.', $href));
+
+      $link = $links->item(0);
+      $this->assertSame('_blank', $link->getAttribute('target'), sprintf('%s opens in a new tab.', $href));
+      // Without rel, the opened tab can reach back through window.opener.
+      $this->assertSame('noopener noreferrer', $link->getAttribute('rel'), sprintf('%s opens the new tab safely.', $href));
+    }
+  }
+
+  /**
+   * Any dashboard link that opens a new tab announces that to screen readers.
+   *
+   * Asserted across every [target="_blank"] link rather than only the Resources
+   * ones, because nothing on an admin-themed page supplies this automatically.
+   */
+  public function testEveryNewTabLinkIsAnnounced(): void {
+    $xpath = $this->renderDashboard();
+
+    $links = $xpath->query('//a[@target="_blank"]');
+    $this->assertGreaterThanOrEqual(
+      count(self::RESOURCE_LINKS) + 1,
+      $links->count(),
+      'The Resources links and the Siteimprove link all open in a new tab.'
+    );
+
+    foreach ($links as $link) {
+      $announcement = $xpath->query('.//*[contains(concat(" ", normalize-space(@class), " "), " visually-hidden ")]', $link);
+      $this->assertGreaterThan(
+        0,
+        $announcement->count(),
+        sprintf('The new-tab link to %s carries a visually hidden announcement.', $link->getAttribute('href'))
+      );
+      $this->assertStringContainsStringIgnoringCase(
+        'opens in new window',
+        $announcement->item(0)->textContent,
+        sprintf('The new-tab link to %s says it opens in a new window.', $link->getAttribute('href'))
+      );
+    }
+  }
+
+}


### PR DESCRIPTION
## [1489: RC: Dashboard Resources links should open in a new tab](https://github.com/yalesites-org/YaleSites-Internal/issues/1489)

### Description of work

- The four **Resources** links on the editorial Dashboard (Learn the Basics, User Guide, Office Hours, Find more resources) now open in a new tab with `target="_blank" rel="noopener noreferrer"`, matching the Siteimprove link in the same template. Following one no longer drops the editor out of their Drupal session.
- **Answered the ticket's open question about `link-purpose`: it does not run here, and the ticket's suspicion was right.** Atomic's link-purpose library (`component-library-twig`'s `link-treatment.js`) ships in `atomic/global`, which only the Atomic theme attaches. The Dashboard lives under `/admin`, which core's `AdminRouteSubscriber` marks as an admin route, so the page renders in `ys_admin_theme`. Confirmed against the rendered page: `drupalSettings.theme` is `"ys_admin_theme"` and there are **zero** atomic assets on it. Using the Siteimprove link as the baseline test case, as the ticket asked: it already had `target="_blank"` and had **no** icon and **no** screen reader announcement, for exactly this reason.
- Rather than pull a front-end bundle into the admin UI, the Dashboard now supplies the affordance itself:
  - A single Twig capture block holds the visually hidden announcement, so the string is defined once. Its wording matches link-purpose's own `newWindow` message, so the Dashboard announces what front-end pages announce.
  - One CSS rule keyed on `.ys-dashboard a[target="_blank"]` draws link-purpose's own `arrow-up-right-from-square` glyph as an inlined SVG mask tinted with `currentColor`, so it follows Gin light/dark without requiring Font Awesome in admin.
  - Keying the icon on the attribute rather than a per-link class means every new-tab link on the page is covered, now and later.
- The screen reader text lives in the markup, not in CSS generated content, because generated content is not a reliable way to expose an accessible name.
- Added a kernel test (`DashboardNewTabLinksTest`) that renders the dashboard and asserts the `target`/`rel` on each Resources link, and asserts across **every** `[target="_blank"]` link that it carries the hidden announcement.

**Slightly beyond the four links named in the AC, deliberately:** the existing **Siteimprove** link got the same hidden announcement. It is in the same template, already opened a new tab, and was unannounced for the identical root cause — the ticket names it as the baseline that must render correctly.

**One thing I did *not* change, and want a call on:** the "Getting Started with Siteimprove guide" link further down the same template (`ys-dashboard.html.twig`, in the Siteimprove help text) points at the same documentation site and still opens in the current tab. It is not in the Acceptance Criteria, and because it is built inside a `|t()` string with a `:url` placeholder, giving it `target`/`rel` means restructuring a translatable string. Happy to do it in this PR if you want it — say the word.

### Notes for the reviewer

- No config change, no new library, no new dependency. Three files: the Twig template, the module's existing `dashboard.css`, and a new test.
- `composer code-sniff` (the real CI gate) passes, but note it does **not** cover `.twig` or `.css`, and `npm run lint:styles` globs `*.scss` only — so a green gate says nothing about two of the three files here. Pre-existing coverage gap, flagged so it is not mistaken for coverage.
- Full `ys_core` suites after the change: Kernel `OK (20 tests, 342 assertions)`, Unit `131 tests, 1 skipped`, zero failures in both.
- **The accessibility AC asks for real screen reader verification, which I could not do.** I confirmed the *computed accessible name* in the browser's accessibility tree — all five links report `"<label> (Link opens in new window)"`, which keeps the visible label a prefix of the accessible name (WCAG 2.5.3) — but that is not the same as listening to VoiceOver/NVDA/JAWS. Please tick that box yourself. Gin **dark mode** is also unverified; the icon uses `currentColor` so it should follow, but I did not toggle it.

### Functional testing steps:

- [ ] Go to **/admin/yalesites/dashboard**.
- [ ] In the **Resources** panel, confirm each of *Learn the Basics*, *User Guide*, *Office Hours*, and *Find more resources* shows a small "opens in new window" arrow icon after the link text.
- [ ] Click one and confirm it opens in a **new browser tab**, leaving your Drupal session on the original tab.
- [ ] Confirm the **Siteimprove** button also shows the icon (white, inside the blue button) and still opens in a new tab.
- [ ] With a screen reader (VoiceOver / NVDA / JAWS), tab to each of those links and confirm it is announced as e.g. "Learn the Basics (Link opens in new window)" **before** activating it.
- [ ] Switch Gin to **dark mode** and confirm the icon is still visible and takes the link colour.
- [ ] Confirm no icon appears on links that do *not* open a new tab (e.g. the Announcements headlines, the "Report feedback" button).

---

Created with AI

References yalesites-org/YaleSites-Internal#1489