### PR TITLE
1490: RC: Site-wide error when adding a cloned page to the same Content Collection as its original before first save

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookCollectionDeleteTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookCollectionDeleteTest.php
@@ -50,6 +50,13 @@ class BookCollectionDeleteTest extends KernelTestBase {
     $this->installSchema('book', ['book']);
     $this->installConfig(['node', 'book', 'field']);
 
+    // ys_book keeps custom menu link titles in a column it adds to contrib
+    // book's table from ys_book_update_10001(). installSchema() only builds
+    // contrib book's own hook_schema(), so run the update hook to match a
+    // real site -- without it every book node save fails on a missing column.
+    $this->container->get('module_handler')->loadInclude('ys_book', 'install');
+    ys_book_update_10001();
+
     // The delete route is gated on 'administer book outlines'; build the router
     // so the confirm form's cancel link can resolve the collections overview.
     $this->container->get('router.builder')->rebuild();

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookLinkRepeatSaveTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookLinkRepeatSaveTest.php
@@ -1,0 +1,413 @@
+<?php
+
+namespace Drupal\Tests\ys_book\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Tests that saving a node twice in one request keeps one collection link.
+ *
+ * Quick Node Clone saves a cloned node twice: once to obtain a node ID, then
+ * again to attach the Layout Builder blocks that need that ID
+ * (QuickNodeCloneNodeForm::save()). Both saves carry the book values the clone
+ * form posted.
+ *
+ * Those posted values contain `original_bid => 0`, because
+ * ys_book_entity_prepare_form() clears $node->book on the clone route (the
+ * #1068 fix), which sends book_node_prepare_form() down its
+ * BookManager::getLinkDefaults() branch and past its own original_bid
+ * correction. BookManager::updateOutline() reads an empty original_bid as
+ * "this outline link is new" on *every* pass, so the second save re-INSERTs
+ * the {book} row the first save already wrote. {book} is keyed on nid, so that
+ * is a duplicate-key error: the whole second save rolls back, the editor gets
+ * a site-wide error, and the clone is left behind without the Layout Builder
+ * layout the second save existed to attach.
+ *
+ * @see yalesites-org/YaleSites-Internal#1490
+ *
+ * @group ys_book
+ * @group yalesites
+ */
+class BookLinkRepeatSaveTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'node',
+    'book',
+    'custom_book_block',
+    'ys_book',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installSchema('node', 'node_access');
+    $this->installSchema('book', ['book']);
+    $this->installConfig(['node', 'book', 'field']);
+
+    // ys_book keeps custom menu link titles in a column it adds to contrib
+    // book's table from ys_book_update_10001(). installSchema() only builds
+    // contrib book's own hook_schema(), so run the update hook to match a
+    // real site -- without it every book node save fails on a missing column.
+    $this->container->get('module_handler')->loadInclude('ys_book', 'install');
+    ys_book_update_10001();
+
+    NodeType::create(['type' => 'page', 'name' => 'Page'])->save();
+
+    $this->container->get('current_user')
+      ->setAccount($this->createUser(['administer book outlines', 'access content']));
+  }
+
+  /**
+   * Builds the book values a node add/clone form posts for an unlinked node.
+   *
+   * Derived from BookManager::getLinkDefaults() rather than hardcoded, so this
+   * keeps matching the real form if contrib book changes its defaults.
+   * book_node_prepare_form() unions the defaults onto any bid/pid already set
+   * (`$node->book += $book_manager->getLinkDefaults($node_ref)`), and
+   * BookManager::addFormElements() posts nid, has_children, original_bid and
+   * parent_depth_limit straight back as '#type' => 'value' elements.
+   *
+   * @param array $selected
+   *   The values the editor picked in the sidebar, e.g. bid and pid.
+   *
+   * @return array
+   *   The full book array as the form submits it.
+   */
+  private function postedBookValues(array $selected): array {
+    return $selected + $this->container->get('book.manager')->getLinkDefaults('new');
+  }
+
+  /**
+   * Creates a collection root and returns it.
+   */
+  private function createCollectionRoot(string $title = 'Collection Root'): Node {
+    $root = Node::create([
+      'type' => 'page',
+      'title' => $title,
+      'status' => 1,
+      'book' => ['bid' => 'new'],
+    ]);
+    $root->save();
+
+    return $root;
+  }
+
+  /**
+   * Returns the {book} row for a node, or NULL when it has none.
+   */
+  private function bookRow(int $nid): ?array {
+    $row = $this->container->get('database')
+      ->select('book', 'b')
+      ->fields('b')
+      ->condition('nid', $nid)
+      ->execute()
+      ->fetchAssoc();
+
+    return $row ?: NULL;
+  }
+
+  /**
+   * Counts every row in the outline table.
+   */
+  private function bookRowCount(): int {
+    return (int) $this->container->get('database')
+      ->select('book', 'b')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+  }
+
+  /**
+   * Saves a node a second time the way Quick Node Clone does.
+   *
+   * QuickNodeCloneNodeForm::save() re-saves the same entity object, in sync
+   * mode and without forcing a new revision, to attach Layout Builder blocks
+   * now that a node ID exists.
+   */
+  private function saveAgainAsQuickNodeClone(Node $node): void {
+    $node->setNewRevision(FALSE);
+    $node->setSyncing(TRUE)->save();
+  }
+
+  /**
+   * The reported bug: a second save must not re-INSERT the outline row.
+   *
+   * Before the fix the second save throws EntityStorageException with
+   * "SQLSTATE[23000] ... Duplicate entry '<nid>' for key 'PRIMARY'".
+   */
+  public function testRepeatSaveDoesNotDuplicateBookLink(): void {
+    $root = $this->createCollectionRoot();
+    $bid = (int) $root->id();
+
+    $clone = Node::create([
+      'type' => 'page',
+      'title' => 'Clone of Child Original',
+      'status' => 1,
+      'book' => $this->postedBookValues(['bid' => $bid, 'pid' => $bid]),
+    ]);
+    $clone->save();
+
+    $this->saveAgainAsQuickNodeClone($clone);
+
+    $row = $this->bookRow((int) $clone->id());
+    $this->assertNotNull($row, 'The clone is still linked into the collection.');
+    $this->assertSame($bid, (int) $row['bid'], 'The clone belongs to the chosen collection.');
+    $this->assertSame($bid, (int) $row['pid'], 'The clone is parented to the collection root.');
+    $this->assertSame(2, (int) $row['depth'], 'The clone sits one level below the root.');
+    $this->assertSame(
+      2,
+      $this->bookRowCount(),
+      'Only the root and the clone are in the outline.'
+    );
+  }
+
+  /**
+   * The second save must commit, not roll back.
+   *
+   * This is the data-loss half of #1490. Quick Node Clone deliberately strips
+   * layout_builder__layout before the first save and restores it in the
+   * second, so when the second save rolls back the clone is left published
+   * with no layout at all. Layout Builder is out of scope for a kernel test,
+   * so a plain field change stands in for the restored layout: if the second
+   * save is rolled back, the change is lost.
+   */
+  public function testRepeatSavePersistsChangesMadeBeforeTheSecondSave(): void {
+    $root = $this->createCollectionRoot();
+    $bid = (int) $root->id();
+
+    $clone = Node::create([
+      'type' => 'page',
+      'title' => 'Before second save',
+      'status' => 1,
+      'book' => $this->postedBookValues(['bid' => $bid, 'pid' => $bid]),
+    ]);
+    $clone->save();
+
+    $clone->setTitle('Restored by second save');
+    $this->saveAgainAsQuickNodeClone($clone);
+
+    $storage = $this->container->get('entity_type.manager')->getStorage('node');
+    $storage->resetCache();
+    $this->assertSame(
+      'Restored by second save',
+      $storage->load($clone->id())->label(),
+      'The second save committed instead of rolling back.'
+    );
+  }
+
+  /**
+   * Choosing "- Create a new collection -" on a clone survives both saves.
+   *
+   * UpdateOutline() takes its `bid === 'new'` branch, which skips the
+   * original_bid backfill entirely, so this path hits the same duplicate
+   * INSERT as joining an existing collection.
+   */
+  public function testRepeatSaveOnNewCollectionRootDoesNotDuplicate(): void {
+    $clone = Node::create([
+      'type' => 'page',
+      'title' => 'Clone that starts its own collection',
+      'status' => 1,
+      'book' => $this->postedBookValues(['bid' => 'new']),
+    ]);
+    $clone->save();
+
+    $this->saveAgainAsQuickNodeClone($clone);
+
+    $nid = (int) $clone->id();
+    $row = $this->bookRow($nid);
+    $this->assertNotNull($row, 'The clone became its own collection root.');
+    $this->assertSame($nid, (int) $row['bid'], 'The new collection is keyed on the clone.');
+    $this->assertSame(0, (int) $row['pid'], 'A collection root has no parent.');
+    $this->assertSame(1, (int) $row['depth'], 'A collection root sits at depth 1.');
+    $this->assertSame(1, $this->bookRowCount(), 'Exactly one outline row exists.');
+  }
+
+  /**
+   * Cloning a page that is in no collection still saves twice cleanly.
+   *
+   * UpdateOutline() returns early on an empty bid, so no outline row is
+   * written and the fix must not invent one.
+   */
+  public function testRepeatSaveWithoutCollectionCreatesNoBookLink(): void {
+    $clone = Node::create([
+      'type' => 'page',
+      'title' => 'Clone with no collection',
+      'status' => 1,
+      'book' => $this->postedBookValues(['bid' => 0]),
+    ]);
+    $clone->save();
+
+    $this->saveAgainAsQuickNodeClone($clone);
+
+    $this->assertNull($this->bookRow((int) $clone->id()), 'The clone joined no collection.');
+    $this->assertSame(0, $this->bookRowCount(), 'The outline table is untouched.');
+  }
+
+  /**
+   * A single save still creates the outline row.
+   *
+   * The fix must not turn a genuine first INSERT into a no-op UPDATE.
+   */
+  public function testSingleSaveStillCreatesBookLink(): void {
+    $root = $this->createCollectionRoot();
+    $bid = (int) $root->id();
+
+    $child = Node::create([
+      'type' => 'page',
+      'title' => 'Ordinary new child page',
+      'status' => 1,
+      'book' => $this->postedBookValues(['bid' => $bid, 'pid' => $bid]),
+    ]);
+    $child->save();
+
+    $row = $this->bookRow((int) $child->id());
+    $this->assertNotNull($row, 'A normally created page still joins the collection.');
+    $this->assertSame($bid, (int) $row['bid']);
+    $this->assertSame(2, (int) $row['depth']);
+  }
+
+  /**
+   * The documented workaround still works: save first, assign afterwards.
+   *
+   * This is the case the fix must stay inert for. The node is no longer new
+   * and posts original_bid = 0, but it has no outline row yet, so the save
+   * must still INSERT one.
+   */
+  public function testCollectionAssignedAfterFirstSaveStillCreatesLink(): void {
+    $root = $this->createCollectionRoot();
+    $bid = (int) $root->id();
+
+    $page = Node::create([
+      'type' => 'page',
+      'title' => 'Saved before joining a collection',
+      'status' => 1,
+    ]);
+    $page->save();
+    $this->assertNull($this->bookRow((int) $page->id()), 'It starts outside any collection.');
+
+    // Manage Settings > Content Collection posts the same shape for a saved
+    // node that has no link yet, keyed on the real nid rather than 'new'.
+    $page->book = ['bid' => $bid, 'pid' => $bid]
+      + $this->container->get('book.manager')->getLinkDefaults($page->id());
+    $page->save();
+
+    $row = $this->bookRow((int) $page->id());
+    $this->assertNotNull($row, 'The workaround still adds the page to the collection.');
+    $this->assertSame($bid, (int) $row['bid']);
+    $this->assertSame(2, (int) $row['depth']);
+  }
+
+  /**
+   * Moving a page between collections still updates its existing row.
+   *
+   * Guards against the fix pinning a page to the collection it first joined.
+   */
+  public function testMovingBetweenCollectionsUpdatesExistingLink(): void {
+    $first = $this->createCollectionRoot('First collection');
+    $second = $this->createCollectionRoot('Second collection');
+
+    $page = Node::create([
+      'type' => 'page',
+      'title' => 'Page that moves',
+      'status' => 1,
+      'book' => $this->postedBookValues(['bid' => (int) $first->id(), 'pid' => (int) $first->id()]),
+    ]);
+    $page->save();
+    $this->assertSame((int) $first->id(), (int) $this->bookRow((int) $page->id())['bid']);
+
+    $page->book = [
+      'bid' => (int) $second->id(),
+      'pid' => (int) $second->id(),
+    ] + $this->container->get('book.manager')->getLinkDefaults($page->id());
+    $page->save();
+
+    $row = $this->bookRow((int) $page->id());
+    $this->assertSame(
+      (int) $second->id(),
+      (int) $row['bid'],
+      'The page moved to the second collection.'
+    );
+    $this->assertSame(3, $this->bookRowCount(), 'Both roots and the moved page, no duplicates.');
+  }
+
+  /**
+   * An already-linked page re-saved twice keeps its single row.
+   *
+   * Any module that re-saves a node in the same request hits the same path as
+   * Quick Node Clone; editing an existing collection member must survive it.
+   */
+  public function testRepeatSaveOfExistingCollectionMemberIsStable(): void {
+    $root = $this->createCollectionRoot();
+    $bid = (int) $root->id();
+
+    $child = Node::create([
+      'type' => 'page',
+      'title' => 'Existing member',
+      'status' => 1,
+      'book' => $this->postedBookValues(['bid' => $bid, 'pid' => $bid]),
+    ]);
+    $child->save();
+
+    $child->setTitle('Existing member, edited');
+    $child->save();
+    $this->saveAgainAsQuickNodeClone($child);
+
+    $row = $this->bookRow((int) $child->id());
+    $this->assertNotNull($row, 'The page is still in the collection.');
+    $this->assertSame($bid, (int) $row['bid']);
+    $this->assertSame(2, $this->bookRowCount(), 'Still just the root and the child.');
+  }
+
+  /**
+   * A clone nested under a child keeps the right materialised path.
+   *
+   * The duplicate INSERT in #1490 carried p1/p2 for a depth-2 page; deeper
+   * placements go through the same code, so pin the depth-3 path too.
+   */
+  public function testRepeatSaveKeepsDeepPlacementPath(): void {
+    $root = $this->createCollectionRoot();
+    $bid = (int) $root->id();
+
+    $child = Node::create([
+      'type' => 'page',
+      'title' => 'Child',
+      'status' => 1,
+      'book' => $this->postedBookValues(['bid' => $bid, 'pid' => $bid]),
+    ]);
+    $child->save();
+
+    $grandchild = Node::create([
+      'type' => 'page',
+      'title' => 'Clone placed under the child',
+      'status' => 1,
+      'book' => $this->postedBookValues(['bid' => $bid, 'pid' => (int) $child->id()]),
+    ]);
+    $grandchild->save();
+
+    $this->saveAgainAsQuickNodeClone($grandchild);
+
+    $row = $this->bookRow((int) $grandchild->id());
+    $this->assertNotNull($row, 'The deep clone kept its link.');
+    $this->assertSame(3, (int) $row['depth'], 'It sits two levels below the root.');
+    $this->assertSame($bid, (int) $row['p1'], 'The path starts at the collection root.');
+    $this->assertSame((int) $child->id(), (int) $row['p2'], 'Then its parent.');
+    $this->assertSame((int) $grandchild->id(), (int) $row['p3'], 'Then itself.');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookLinkRepeatSaveTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookLinkRepeatSaveTest.php
@@ -2,10 +2,14 @@
 
 namespace Drupal\Tests\ys_book\Kernel;
 
+use Drupal\Core\Form\FormState;
+use Drupal\Core\Routing\RouteObjectInterface;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Route;
 
 /**
  * Tests that saving a node twice in one request keeps one collection link.
@@ -46,8 +50,17 @@ class BookLinkRepeatSaveTest extends KernelTestBase {
     'node',
     'book',
     'custom_book_block',
+    'quick_node_clone',
     'ys_book',
   ];
+
+  /**
+   * The route the page clone form is served from.
+   *
+   * Ys_book_entity_prepare_form() matches on this name, so a rename in contrib
+   * would silently stop the clearing from happening.
+   */
+  private const CLONE_ROUTE = 'quick_node_clone.node.quick_clone';
 
   /**
    * {@inheritdoc}
@@ -67,10 +80,91 @@ class BookLinkRepeatSaveTest extends KernelTestBase {
     $this->container->get('module_handler')->loadInclude('ys_book', 'install');
     ys_book_update_10001();
 
+    // Needed so the clone route can be looked up by name.
+    $this->container->get('router.builder')->rebuild();
+
     NodeType::create(['type' => 'page', 'name' => 'Page'])->save();
+
+    // YaleSites puts Content Collections on the page type; contrib book
+    // defaults to its own 'book' type. BookNodeOutlineAccessCheck branches on
+    // this, and book_node_prepare_form() bails out early when it denies, so
+    // the wrong value here would quietly stop exercising the real path.
+    $this->config('book.settings')
+      ->set('allowed_types', ['page'])
+      ->set('child_type', 'page')
+      ->save();
+
+    // Consume uid 1 so the account under test is an ordinary user. Uid 1
+    // bypasses every permission check, which would let these tests pass
+    // through a route no real editor takes.
+    $this->createUser();
 
     $this->container->get('current_user')
       ->setAccount($this->createUser(['administer book outlines', 'access content']));
+  }
+
+  /**
+   * Runs the real prepare-form hooks for a node, on a given route.
+   *
+   * Replicates EntityForm::prepareInvokeAll() (EntityForm.php:129-130), which
+   * invokes entity_prepare_form and then node_prepare_form, and puts a request
+   * for the route on the stack so ys_book_entity_prepare_form()'s route check
+   * sees what it would see in a real request. That makes the resulting
+   * $node->book the genuine article rather than a hand-built approximation.
+   *
+   * @param \Drupal\node\Entity\Node $node
+   *   The node the form is being built for.
+   * @param string $route_name
+   *   The route to pretend we are on.
+   * @param string $operation
+   *   The form operation, e.g. 'quick_clone' or 'default'.
+   */
+  private function runPrepareFormHooks(Node $node, string $route_name, string $operation): void {
+    $request = Request::create('/test-form-route');
+    $request->attributes->set(RouteObjectInterface::ROUTE_NAME, $route_name);
+    $request->attributes->set(RouteObjectInterface::ROUTE_OBJECT, new Route('/test-form-route'));
+    $this->container->get('request_stack')->push($request);
+
+    $form_state = new FormState();
+    $module_handler = $this->container->get('module_handler');
+    foreach (['entity_prepare_form', 'node_prepare_form'] as $hook) {
+      $module_handler->invokeAllWith(
+        $hook,
+        function (callable $implementation) use ($node, $operation, $form_state) {
+          $implementation($node, $operation, $form_state);
+        }
+      );
+    }
+
+    $this->container->get('request_stack')->pop();
+  }
+
+  /**
+   * Builds a collection root with one child, the way an editor would.
+   *
+   * Mirrors steps 1 and 2 of the reported reproduction: a page made into a
+   * collection, then a page nested under it.
+   *
+   * @return \Drupal\node\Entity\Node[]
+   *   The root and the child, both reloaded so book_node_load() has populated
+   *   their book property exactly as it would be on a real edit form.
+   */
+  private function createRootAndChild(): array {
+    $root = $this->createCollectionRoot('Book Parent');
+    $bid = (int) $root->id();
+
+    $child = Node::create([
+      'type' => 'page',
+      'title' => 'Child Original',
+      'status' => 1,
+      'book' => $this->postedBookValues(['bid' => $bid, 'pid' => $bid]),
+    ]);
+    $child->save();
+
+    $storage = $this->container->get('entity_type.manager')->getStorage('node');
+    $storage->resetCache();
+
+    return [$storage->load($root->id()), $storage->load($child->id())];
   }
 
   /**
@@ -408,6 +502,126 @@ class BookLinkRepeatSaveTest extends KernelTestBase {
     $this->assertSame($bid, (int) $row['p1'], 'The path starts at the collection root.');
     $this->assertSame((int) $child->id(), (int) $row['p2'], 'Then its parent.');
     $this->assertSame((int) $grandchild->id(), (int) $row['p3'], 'Then itself.');
+  }
+
+  /**
+   * The clone route still exists under the name ys_book matches on.
+   *
+   * Ys_book_entity_prepare_form() only clears the stale collection data when
+   * the route name matches exactly. If contrib renamed the route, the clearing
+   * would silently stop happening and #1068 would regress with no other signal.
+   */
+  public function testCloneRouteStillExists(): void {
+    $route = $this->container->get('router.route_provider')
+      ->getRouteByName(self::CLONE_ROUTE);
+
+    $this->assertSame(
+      '/clone/{node}/quick_clone',
+      $route->getPath(),
+      'The page clone route is still where ys_book expects it.'
+    );
+  }
+
+  /**
+   * The real clone form leaves original_bid empty. This is the precondition.
+   *
+   * Every other test here builds the posted book array from
+   * BookManager::getLinkDefaults(). This one proves that is what the actual
+   * hook chain produces on the clone route: ys_book_entity_prepare_form()
+   * clears $node->book, so book_node_prepare_form() takes its getLinkDefaults()
+   * branch (original_bid => 0) instead of its else branch, which would have set
+   * original_bid to the real bid and made the duplicate INSERT impossible.
+   *
+   * If this ever fails, the simulation in the other tests has drifted from
+   * reality and they are no longer guarding anything.
+   */
+  public function testCloneFormPrepareHooksLeaveOriginalBidEmpty(): void {
+    [, $child] = $this->createRootAndChild();
+
+    $clone = $child->createDuplicate();
+    $this->runPrepareFormHooks($clone, self::CLONE_ROUTE, 'quick_clone');
+
+    $this->assertTrue($clone->isNew(), 'The clone is a genuinely new entity.');
+    $this->assertEmpty(
+      $clone->book['original_bid'],
+      'The clone form posts an empty original_bid -- the condition behind #1490.'
+    );
+    $this->assertSame(
+      'new',
+      $clone->book['nid'],
+      'The clone form posts nid "new", not the original node ID. The ticket '
+      . 'claimed the clone shares the original ID; it does not.'
+    );
+  }
+
+  /**
+   * An ordinary edit form is left alone: original_bid keeps the real value.
+   *
+   * Guards the other side of ys_book_entity_prepare_form()'s route check. If
+   * the clearing ever leaked onto the normal node edit form, every save of an
+   * existing collection member would start looking like a fresh insert.
+   */
+  public function testOrdinaryEditFormKeepsOriginalBid(): void {
+    [$root, $child] = $this->createRootAndChild();
+
+    $this->runPrepareFormHooks($child, 'entity.node.edit_form', 'default');
+
+    $this->assertSame(
+      (int) $root->id(),
+      (int) $child->book['original_bid'],
+      'Editing an existing collection member keeps its real original_bid.'
+    );
+  }
+
+  /**
+   * End to end over the reported reproduction steps.
+   *
+   * 1. Create a page and make it a collection root.
+   * 2. Create a page and nest it under that root.
+   * 3. Clone the child.
+   * 4. During the clone, nest it under the same root.
+   * 5. Save.
+   *
+   * Unlike the other tests this feeds on the book array the real prepare-form
+   * hooks produce, so the whole chain is exercised: our clearing, contrib's
+   * defaults, and the repeat save. The clone form itself cannot be driven here
+   * because BrowserTestBase does not run in this environment, so the double
+   * save is still stood in for.
+   */
+  public function testReportedReproductionStepsSaveCleanly(): void {
+    [$root, $child] = $this->createRootAndChild();
+    $bid = (int) $root->id();
+
+    // Step 3: clone the child.
+    $clone = $child->createDuplicate();
+    $this->runPrepareFormHooks($clone, self::CLONE_ROUTE, 'quick_clone');
+
+    // Step 4: the editor picks the same collection as the original. Only bid
+    // and pid come from the editor; the rest of the book array is posted back
+    // as the hidden values the form was built with.
+    $clone->book['bid'] = $bid;
+    $clone->book['pid'] = $bid;
+
+    // Step 5: save, then save again the way Quick Node Clone does.
+    $clone->setTitle('Clone of Child Original');
+    $clone->save();
+    $this->saveAgainAsQuickNodeClone($clone);
+
+    $row = $this->bookRow((int) $clone->id());
+    $this->assertNotNull($row, 'The clone joined the collection.');
+    $this->assertSame($bid, (int) $row['bid'], 'It is in the same collection as the original.');
+    $this->assertSame($bid, (int) $row['pid'], 'It is nested under the same parent.');
+    $this->assertSame(2, (int) $row['depth']);
+    $this->assertSame(
+      3,
+      $this->bookRowCount(),
+      'Root, original child and clone -- no duplicated or orphaned rows.'
+    );
+
+    // The original is untouched.
+    $original = $this->bookRow((int) $child->id());
+    $this->assertSame($bid, (int) $original['bid'], 'The original page kept its place.');
+    $this->assertSame(2, (int) $original['depth']);
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.module
@@ -610,10 +610,14 @@ function _ys_book_admin_edit_submit($form, FormStateInterface $form_state) {
 /**
  * Implements hook_ENTITY_TYPE_presave() for node entities.
  *
- * Prevents nested navigation position conflicts by automatically resetting
- * the navigation position to default when a node is nested under another book.
+ * Keeps a node saved more than once in one request from re-inserting its
+ * collection link, and prevents nested navigation position conflicts by
+ * automatically resetting the navigation position to default when a node is
+ * nested under another book.
  */
 function ys_book_node_presave($node) {
+  _ys_book_keep_existing_collection_link($node);
+
   // Only process nodes that have the navigation position field.
   if (!$node->hasField('field_collection_nav_position')) {
     return;
@@ -636,20 +640,49 @@ function ys_book_node_presave($node) {
   // Check if this node is a book root (bid == nid) or a child (bid != nid).
   $is_book_root = ($node->book['bid'] === 'new') || ($node->book['bid'] == $node->id());
 
-  \Drupal::logger('ys_book')->notice('Presave: bid=@bid, bid_type=@bid_type, nid=@nid, nav=@nav, is_new=@new, is_root=@root, book_keys=@keys', [
-    '@bid' => $node->book['bid'] ?? 'unset',
-    '@bid_type' => gettype($node->book['bid'] ?? NULL),
-    '@nid' => $node->id() ?? 'NULL',
-    '@nav' => $nav_position,
-    '@new' => $node->isNew() ? 'yes' : 'no',
-    '@root' => $is_book_root ? 'yes' : 'no',
-    '@keys' => implode(',', array_keys($node->book ?? [])),
-  ]);
-
   if (!$is_book_root) {
     // This node is a child in a book but has a non-default nav position.
     // Reset to the default.
     $node->set('field_collection_nav_position', 'in_content');
+  }
+}
+
+/**
+ * Points a repeat save at the collection link the first save already wrote.
+ *
+ * Quick Node Clone saves a cloned node twice in one request: once to get a
+ * node ID, then again to attach the Layout Builder blocks that need it. Both
+ * saves carry the book values the clone form posted, and those contain
+ * original_bid = 0 -- ys_book_entity_prepare_form() clears $node->book on the
+ * clone route, which sends book_node_prepare_form() down its
+ * BookManager::getLinkDefaults() branch and past its own original_bid
+ * correction.
+ *
+ * BookManager::updateOutline() reads an empty original_bid as "this outline
+ * link is new" on every pass, so the second save tries to INSERT the {book}
+ * row the first save already wrote. {book} is keyed on nid, so that is a
+ * duplicate-key error: the second save rolls back, the editor gets a
+ * site-wide error, and the clone is left published without the layout the
+ * second save existed to attach.
+ *
+ * Naming the link the node already has makes updateOutline() take its UPDATE
+ * path instead. Guarded on a link actually existing, so a genuine first
+ * INSERT -- including the save-first-then-assign-a-collection workaround --
+ * still creates one.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node being saved.
+ *
+ * @see yalesites-org/YaleSites-Internal#1490
+ */
+function _ys_book_keep_existing_collection_link(NodeInterface $node): void {
+  if ($node->isNew() || empty($node->book['bid']) || !empty($node->book['original_bid'])) {
+    return;
+  }
+
+  $existing = \Drupal::service('book.manager')->loadBookLink($node->id(), FALSE);
+  if ($existing && !empty($existing['bid'])) {
+    $node->book['original_bid'] = $existing['bid'];
   }
 }
 


### PR DESCRIPTION
## [1490: RC: Site-wide error when adding a cloned page to the same Content Collection as its original before first save](https://github.com/yalesites-org/YaleSites-Internal/issues/1490)

> [!IMPORTANT]
> **This deviates from the acceptance criteria on the issue — please read before reviewing.**
> The AC asked to *disable* the Content Collection section on the clone form. Reproducing the bug showed the ticket's stated mechanism is not what happens, and the real cause is fixable in our own module in about ten lines. Disabling the section would have permanently removed an editor capability to route around a bug we can simply fix. Approved by Dave before implementation; details below.

### Description of work

**The ticket's stated mechanism does not hold.** It says the clone "still shares an ID with the original node until the first save completes." It does not — the clone is a genuinely new entity and gets its own node ID.

**What actually happens.** The `{book}` row for *the clone* is INSERTed twice in one request:

1. **Quick Node Clone saves the cloned node twice.** `QuickNodeCloneNodeForm::save()` strips `layout_builder__layout` before the first save, calls `$node->save()`, then restores the layout and calls `$node->setSyncing(TRUE)->save()` so inline blocks can be linked now that a node ID exists. Any page with a customised layout takes that second save.
2. **The clone form posts `book[original_bid] = 0`.** Our own `ys_book_entity_prepare_form()` clears `$node->book` on the clone route (the #1068 fix). That sends contrib `book_node_prepare_form()` down its `getLinkDefaults()` branch, which sets `original_bid` to `0`, and past book's own correction — that correction is guarded by `!isset(...)`, and `isset(0)` is TRUE.
3. **`BookManager::updateOutline()` derives insert-vs-update from `empty($node->book['original_bid'])`**, so it treats the link as new on *every* pass.

Save #1 writes the row and commits. Save #2 re-INSERTs it, hits the `nid` primary key, and the whole second save rolls back — taking the layout restore with it.

- Backfill `original_bid` from the `{book}` row the node already has, in a new `_ys_book_keep_existing_collection_link()` called from `ys_book_node_presave()`, so `updateOutline()` takes its UPDATE path. Guarded on that row existing, so a genuine first INSERT — including the save-first-then-assign-via-Manage-Settings workaround — still creates one.
- No contrib module was patched.
- **Bonus cleanup:** removed a stray debug logger left in `ys_book_node_presave()` that dumped `bid`/`nid`/type/`is_new`/`is_root` to watchdog on every book node save with a non-default nav position. To undo, restore the block at `ys_book.module:639-647` from `develop`.

**Second symptom, not in the ticket:** the failure also leaves corrupt content behind — the clone stays published with **no Layout Builder layout at all**. The fix makes the second save commit, so the layout survives.

### Evidence

- Failed INSERT parameters were `nid=88, bid=86, pid=86, depth=2, p1=86, p2=88`. Node 87 was the original, node 88 the clone — so it is the **clone's** row inserted twice. No collision on the original's ID anywhere in the log.
- Node 88 created at `09:59:58`; exception at `10:00:00`. The node and its first `{book}` row had committed two seconds before the failure.
- Node 87 had 3 rows in both `node__layout_builder__layout` and `node_revision__layout_builder__layout`; node 88 had **zero in both**.

### Tests

`BookLinkRepeatSaveTest` — 13 kernel tests covering the duplicate INSERT, the second save committing, the "create a new collection" variant, deep placement paths, and the regression cases the guard must stay inert for.

Four of them drive the **real prepare-form hook chain** rather than a constructed `book` array, so the whole path is guarded — our #1068 clearing, contrib's `getLinkDefaults()`, and the repeat save:

- `testReportedReproductionStepsSaveCleanly` — the reported steps end to end: collection root → nest a child → clone the child → nest the clone under the same root → save.
- `testCloneFormPrepareHooksLeaveOriginalBidEmpty` — proves the real form posts `original_bid = 0`. This is the precondition the rest of the suite rests on; if it ever fails, the other tests have drifted from reality.
- `testOrdinaryEditFormKeepsOriginalBid` — the clearing must **not** leak onto ordinary edit forms.
- `testCloneRouteStillExists` — `ys_book_entity_prepare_form()` matches the clone route by name, so a contrib rename would silently regress #1068 with no other signal.

**With the fix deliberately disabled, 7 of the 13 fail** with `SQLSTATE[23000] ... Duplicate entry '<nid>' for key 'PRIMARY': INSERT INTO {book}` — the same error class reported. The rest are precondition/inert-guard tests that correctly pass either way.

| Run | Result |
|---|---|
| Baseline on `develop` | `Tests: 12, Assertions: 113, Errors: 7` |
| This branch | `OK (25 tests, 327 assertions)` |
| Fix disabled (proof) | `Tests: 13, Assertions: 129, Errors: 7` |

Two test-environment corrections were needed, both making the kernel test *more* faithful to the real site: `book.settings` now matches YaleSites (`allowed_types: [page]`) because `BookNodeOutlineAccessCheck` branches on it and contrib's default would make `book_node_prepare_form()` bail out early; and the account under test is no longer uid 1, which was bypassing every permission check.

The 7 baseline errors are pre-existing `SQLSTATE[42S22]: Unknown column 'title'`: `ys_book` adds a `title` column to contrib book's table only from `ys_book_update_10001()`, and `KernelTestBase::installSchema()` builds only contrib book's own `hook_schema()`. Both kernel tests now run that update hook in `setUp()` — reusing the real hook rather than copying the column spec. **Test-only change; no production code path altered.** Per Dave, no `ys_book_install()` was added, since new sites are not provisioned by a fresh `site:install`.

`lando composer code-sniff` (both standards, whole custom tree): exit 0.

### Functional testing steps:

- [ ] Create a Content Collection with a root page and a child page, and give the child page a customised Layout Builder layout (add a block or two). The layout matters — without it Quick Node Clone only saves once and the bug does not appear.
- [ ] Clone the child page (More Actions > Clone, or `/clone/{nid}/quick_clone`).
- [ ] On the clone form, expand **Content Collection** and select the *same* collection as the original.
- [ ] Publish. **Expected:** it saves cleanly and redirects to the new node — no site-wide error.
- [ ] Confirm the clone kept its Layout Builder layout (the blocks from the original are present).
- [ ] Confirm the clone appears in the collection navigation on the front end.
- [ ] Regression: clone a page that is in **no** collection — still saves normally.
- [ ] Regression: clone a page and choose **"- Create a new collection -"** — saves, and the clone becomes its own collection root.
- [ ] Regression: the documented workaround still works — save a page first, then add it to a collection via Manage Settings > Content Collection.
- [ ] Regression: move an existing page between two collections — it moves rather than erroring.

References yalesites-org/YaleSites-Internal#1490

---

Created with AI
