### PR TITLE
1498: RC: Resource pages can never show AI Metadata fields, unlike Page, Post, Profile, and Event

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/metatag.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/metatag.settings.yml
@@ -1,28 +1,23 @@
 entity_type_groups:
   media:
     document:
-      ai_engine: ai_engine
       ys_beacon: ys_beacon
   node:
     event:
       basic: basic
-      ai_engine: ai_engine
       ys_beacon: ys_beacon
     page:
       basic: basic
-      ai_engine: ai_engine
       ys_beacon: ys_beacon
     post:
       basic: basic
-      ai_engine: ai_engine
       ys_beacon: ys_beacon
     profile:
       basic: basic
-      ai_engine: ai_engine
       ys_beacon: ys_beacon
     resource:
       basic: basic
-      ai_engine: ai_engine
+      ys_beacon: ys_beacon
 separator: ','
 tag_trim_method: beforeValue
 use_maxlength: true

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconMetatagGroupsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconMetatagGroupsTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests which metatag groups the shipped config exposes per bundle.
+ *
+ * The metatag.settings:entity_type_groups map gates which groups a bundle's
+ * edit form can render, so a bundle listed here without ys_beacon can never
+ * show the AI Metadata fields however the platform toggle is set. A bundle
+ * dropped from the map entirely is not safe either: MetatagFirehose falls back
+ * to rendering every group when a bundle has no entry, and the settings form
+ * drops a bundle whose groups are all unchecked. So the expected bundle set is
+ * pinned as well as its contents. That file belongs to the profile rather than
+ * to this module, but the invariant it has to hold is this module's: every
+ * bundle gets the ys_beacon group, and none reference the superseded ai_engine
+ * group.
+ *
+ * @group ys_beacon
+ */
+class BeaconMetatagGroupsTest extends UnitTestCase {
+
+  /**
+   * Returns the per-bundle group lists from the synced metatag config.
+   */
+  private function bundleGroups(): array {
+    $path = dirname(__DIR__, 6) . '/config/sync/metatag.settings.yml';
+    $this->assertFileExists($path);
+
+    $bundle_groups = [];
+    foreach (Yaml::parseFile($path)['entity_type_groups'] as $entity_type => $bundles) {
+      foreach ($bundles as $bundle => $groups) {
+        $bundle_groups["$entity_type.$bundle"] = array_keys($groups);
+      }
+    }
+    $this->assertNotEmpty($bundle_groups);
+    return $bundle_groups;
+  }
+
+  /**
+   * Every bundle exposing metatags can show the AI Metadata group.
+   */
+  public function testEveryMetatagBundleExposesTheBeaconGroup(): void {
+    $bundle_groups = $this->bundleGroups();
+
+    // Pinned rather than derived: a bundle silently dropped from the map would
+    // otherwise satisfy the loop below while rendering every metatag group on
+    // its form. Adding a bundle here should be a deliberate edit.
+    $this->assertEqualsCanonicalizing([
+      'media.document',
+      'node.event',
+      'node.page',
+      'node.post',
+      'node.profile',
+      'node.resource',
+    ], array_keys($bundle_groups));
+
+    foreach ($bundle_groups as $bundle => $groups) {
+      $this->assertContains('ys_beacon', $groups, "$bundle is missing the ys_beacon metatag group");
+    }
+  }
+
+  /**
+   * No bundle still references the superseded ai_engine group.
+   *
+   * This module supersedes ai_engine_metadata: it redefines the same tag IDs
+   * under its own group and ys_beacon_metatag_groups_alter() drops the leftover
+   * ai_engine group outright, so the key resolves to nothing.
+   */
+  public function testNoBundleReferencesTheLegacyAiEngineGroup(): void {
+    foreach ($this->bundleGroups() as $bundle => $groups) {
+      $this->assertNotContains('ai_engine', $groups, "$bundle still references the superseded ai_engine metatag group");
+    }
+  }
+
+}


### PR DESCRIPTION
## [1498: RC: Resource pages can never show AI Metadata fields, unlike Page, Post, Profile, and Event](https://github.com/yalesites-org/YaleSites-Internal/issues/1498)

### Description of work

- Adds `ys_beacon: ys_beacon` to the `node.resource` entry in `metatag.settings:entity_type_groups`. That map gates which metatag groups a bundle's edit form may render, and Resource was the only bundle without the group — so Resource pages could never show the AI Metadata fields even with "Show AI metadata fields on content forms" turned on, while Page, Post, Profile and Event all could. The platform toggle is off by default, which is why the gap went unnoticed.
- Removes the superseded `ai_engine` group key from all six bundle entries (`media.document`, `node.event`, `node.page`, `node.post`, `node.profile`, `node.resource`).
- Adds a unit test guarding both halves of the invariant, so a future config re-export cannot silently reintroduce either problem.

**One correction to the issue's premise, for the reviewer's benefit:** the issue states that `ai_engine` "no longer resolves to a real metatag group plugin." Legacy contrib `ai_engine_metadata` *does* still define a real group plugin with that id; it resolves to nothing at runtime because **our own** `ys_beacon_metatag_groups_alter()` deliberately unsets it. Removing the key is correct either way — verified at runtime that the group has no definition and no tags — but the reason is "we suppress it," not "it never existed."

**Existing metadata values are preserved, which matters because ai_engine is removed in a later release.** Verified rather than assumed: `ys_beacon` redefines the same three tag IDs (`ai_disable_indexing`, `ai_description`, `ai_tags`) that `ai_engine_metadata` used, and metatag stores values **flat, keyed by tag ID, with no group key in storage** — confirmed by writing values and reading the raw column back as `{"ai_description":...,"ai_disable_indexing":...,"ai_tags":...}`, then confirming they render in the ys_beacon-group fields on the form. So no copy/migration hook was ever needed, and none exists. Also worth noting for that later release: neither `ai_engine` nor `ai_engine_metadata` ships a `.install` file, so there is no `hook_uninstall` that could purge stored metatag values on removal.

**No update hook is needed.** `metatag.settings` is a simple settings object that `config:import` replaces wholesale during `drush deploy`, and there is no per-entity data to migrate. An update hook would in fact be counterproductive here, since `updatedb` runs before `config:import` and the synced file would immediately overwrite it.

### Functional testing steps:

- [ ] Enable "Show AI metadata fields on content forms" at `/admin/config/yalesites/ys-beacon/admin`.
- [ ] Edit a **Resource** node, open the **Metadata** tab in the sidebar, and confirm **"AI Metadata"** now appears alongside **"Basic tags"**. Expand it and confirm all three fields render: the "Disable indexing for AI feeds." toggle, "AI Description", and "AI Tags".
- [ ] Confirm **Page, Post, Profile and Event** node forms are unchanged — still "Basic tags" + "AI Metadata".
- [ ] Confirm a **Document media** edit form still shows "AI Metadata". This is the bundle most at risk from dropping the `ai_engine` key, since `ai_engine` and `ys_beacon` were its only two entries (it has never had `basic`).
- [ ] Restore the "Show AI metadata fields on content forms" toggle to its original state.
- [ ] Confirm `drush config:status` reports no drift for `metatag.settings`.

References yalesites-org/YaleSites-Internal#1498

---
Created with AI

https://pr-1436-yalesites-platform.pantheonsite.io/node/67/edit?destination=/admin/content/manage-resources
<img width="1897" height="865" alt="Screenshot 2026-08-10 at 12 21 37 PM" src="https://github.com/user-attachments/assets/96f2c066-b53c-4e98-a1a9-8f972995f710" />
