### PR TITLE
1501: RC: Saving a Site-Wide Alert as Emergency looks like it fails until a popup is confirmed

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/css/ys_alert.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/css/ys_alert.css
@@ -54,9 +54,19 @@
 }
 
 /* Module custom styles */
+
+/*
+ * The title bar lays the emergency icon out beside the title. "align-items"
+ * centres the two against each other and "gap" supplies the separation: Gin
+ * sets "margin: 0" on .ui-dialog-title at the same specificity as the
+ * ".confirm-dialog .ui-dialog-title" this file used to rely on, and loads after
+ * it, so a margin set that way is silently dropped.
+ */
 .confirm-dialog.ui-dialog .ui-dialog-titlebar {
   background-color: #D52020;
   display: flex;
+  align-items: center;
+  gap: 19px;
 }
 
 .confirm-dialog .ui-dialog-titlebar::before {
@@ -67,15 +77,8 @@
   width: 28px;
   height: 24px;
   display: inline-block;
-}
-
-.confirm-dialog .ui-dialog-title {
-  margin-left: 19px;
-  padding-top: 3px;
-}
-
-.confirm-dialog.ui-dialog .ui-dialog-titlebar-close {
-  top: 12px;
+  /* The title is width:100%, so the icon is squashed without this. */
+  flex-shrink: 0;
 }
 
 .confirm-dialog.ui-dialog .ui-widget-content.ui-dialog-content {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/js/confirm_type_modal.js
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/js/confirm_type_modal.js
@@ -1,15 +1,54 @@
 /**
  * @file
- * JavaScript for alert settings form confirmation modal.
+ * Confirmation modal for publishing an emergency site-wide alert.
+ *
+ * Saving the alert settings form is deliberately paused when the Emergency
+ * type is selected, so the editor has to confirm before an emergency alert
+ * goes live. The pause is easy to miss, so an inline warning is written into
+ * the form as well and stays there until the alert is confirmed.
  */
 
-(function (Drupal) {
-  // Open a confimation modal window when trying to create an emergancy alert.
-  function confirm() {
-    const content =
-      "<div>Please be aware that you have selected the Emergency Alert option. We strongly reccomend that you only use this alert option in the case of an emergency, such as lockdown/safety information, severe weather that requires people to take shelter, or other events with possible detrimental effects on one's safety.</div>";
-    var confirmationDialog = Drupal.dialog(content, {
-      dialogClass: "confirm-dialog",
+/* global once */
+
+(() => {
+  /**
+   * Writes the "not saved yet" warning into the form's live region.
+   *
+   * @param {HTMLElement} region
+   *   The empty live region rendered by AlertSettings::buildForm().
+   */
+  function showPendingNotice(region) {
+    const message = new Drupal.Message(region);
+    // Clear first so a repeated save attempt re-announces the warning.
+    message.clear();
+    message.add(
+      Drupal.t(
+        "Your changes have not been saved yet. An emergency alert has to be confirmed before it goes live: choose Confirm in the confirmation window to publish it, or Cancel to keep editing."
+      ),
+      { type: "warning", id: "ys-alert-emergency-pending" }
+    );
+  }
+
+  /**
+   * Builds the emergency confirmation dialog.
+   *
+   * @param {HTMLFormElement} form
+   *   The alert settings form, submitted once the editor confirms.
+   *
+   * @return {Drupal.dialog~dialogDefinition}
+   *   The dialog instance.
+   */
+  function buildDialog(form) {
+    const content = document.createElement("div");
+    content.textContent = Drupal.t(
+      "Please be aware that you have selected the Emergency Alert option. We strongly recommend that you only use this alert option in the case of an emergency, such as lockdown/safety information, severe weather that requires people to take shelter, or other events with possible detrimental effects on one's safety."
+    );
+
+    const dialog = Drupal.dialog(content, {
+      // jQuery UI only honours "dialogClass" in back-compat mode, which Drupal
+      // does not enable, so use the supported "classes" option instead. The
+      // default "ui-corner-all" is repeated here because "classes" replaces it.
+      classes: { "ui-dialog": "ui-corner-all confirm-dialog" },
       resizable: true,
       closeOnEscape: false,
       width: 600,
@@ -19,28 +58,45 @@
           text: Drupal.t("Cancel"),
           class: "button--secondary button",
           click() {
-            confirmationDialog.close();
+            dialog.close();
           },
         },
         {
           text: Drupal.t("Confirm"),
           class: "button--primary button",
           click() {
-            document.querySelector("form.ys-alert-settings").submit();
+            form.submit();
           },
         },
       ],
     });
-    confirmationDialog.showModal();
+
+    return dialog;
   }
 
-  // Add click event to the submit button.
-  const submitButton = document.querySelector("#edit-submit");
-  submitButton.addEventListener("click", function (event) {
-    // Launch the modal if the user selected the 'emergancy' alert.
-    if (document.querySelector("#edit-type-emergency").checked) {
-      event.preventDefault();
-      confirm();
-    }
-  });
-})(Drupal);
+  Drupal.behaviors.ysAlertConfirmTypeModal = {
+    attach(context) {
+      once("ys-alert-confirm-type", "form.ys-alert-settings", context).forEach(
+        (form) => {
+          const submitButton = form.querySelector("#edit-submit");
+          const emergency = form.querySelector("#edit-type-emergency");
+          const region = form.querySelector(".ys-alert-emergency-notice");
+
+          if (!submitButton || !emergency || !region) {
+            return;
+          }
+
+          submitButton.addEventListener("click", (event) => {
+            if (!emergency.checked) {
+              return;
+            }
+            // Hold the save back until the editor confirms in the dialog.
+            event.preventDefault();
+            showPendingNotice(region);
+            buildDialog(form).showModal();
+          });
+        }
+      );
+    },
+  };
+})();

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/src/Form/AlertSettings.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/src/Form/AlertSettings.php
@@ -137,6 +137,17 @@ class AlertSettings extends ConfigFormBase {
       ],
     ];
 
+    // Holds the warning shown when an emergency save is paused for
+    // confirmation. Rendered empty on purpose: the JavaScript writes the
+    // message into it, and a screen reader only announces changes made inside
+    // a live region that was already on the page.
+    $form['emergency_confirm_notice'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['ys-alert-emergency-notice'],
+      ],
+    ];
+
     // The description is rebuilt with a callback when type field changes.
     $type = $form_state->getValue('type') ?? $config->get('alert.type') ?? '';
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/tests/src/Kernel/AlertSettingsFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/tests/src/Kernel/AlertSettingsFormTest.php
@@ -70,6 +70,41 @@ class AlertSettingsFormTest extends KernelTestBase {
   }
 
   /**
+   * Tests the live region that announces a paused emergency save.
+   *
+   * Saving an emergency alert is deliberately held back until the editor
+   * confirms it in a modal. The form renders an empty live region so the
+   * JavaScript has somewhere to write that warning: a screen reader only
+   * announces changes made inside a live region that already existed, so the
+   * region cannot be created at the same moment its text appears.
+   *
+   * @covers ::buildForm
+   */
+  public function testBuildFormRendersEmergencyConfirmationLiveRegion() {
+    $form_state = new FormState();
+    $form = $this->buildFormObject()->buildForm([], $form_state);
+
+    $this->assertArrayHasKey('emergency_confirm_notice', $form);
+    $notice = $form['emergency_confirm_notice'];
+    $this->assertContains('ys-alert-emergency-notice', $notice['#attributes']['class']);
+
+    // Rendered empty; the JavaScript supplies the message.
+    $this->assertArrayNotHasKey('#markup', $notice);
+
+    // The cue belongs with the alert type control it is about, not at the
+    // bottom of the form where an editor would never look for it.
+    $keys = array_keys($form);
+    $this->assertGreaterThan(
+      array_search('type', $keys, TRUE),
+      array_search('emergency_confirm_notice', $keys, TRUE)
+    );
+    $this->assertLessThan(
+      array_search('headline', $keys, TRUE),
+      array_search('emergency_confirm_notice', $keys, TRUE)
+    );
+  }
+
+  /**
    * @covers ::updateAlertDescriptionWrapperCallback
    */
   public function testUpdateAlertDescriptionWrapperCallback() {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.libraries.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.libraries.yml
@@ -7,3 +7,5 @@ confirm_type_modal:
   dependencies:
     - core/drupal.ajax
     - core/drupal.dialog
+    - core/drupal.message
+    - core/once


### PR DESCRIPTION
## [1501: RC: Saving a Site-Wide Alert as Emergency looks like it fails until a popup is confirmed](https://github.com/yalesites-org/YaleSites-Internal/issues/1501)

### Description of work

Selecting the **Emergency** alert type and clicking **Save configuration** looked like nothing happened. The save is paused on purpose so the editor has to confirm publishing an emergency alert, but the only sign of that was the confirmation window itself — so an editor who missed it assumed the form was broken and clicked Save again or gave up.

Two separate things were wrong:

- **The page said nothing.** The form now renders a live region beside the alert type control, and the click handler writes a themed warning into it: *"Your changes have not been saved yet. An emergency alert has to be confirmed before it goes live…"* It is built with core's `Drupal.Message` API, so the admin theme styles it, it carries `role="alert"` and a visible "Warning message" label rather than relying on colour, and it is announced through `Drupal.announce()`. The region is rendered **empty** by the form on purpose — a screen reader only announces changes made inside a live region that already existed. The warning **stays after Cancel**, so the form no longer looks silently unsaved.

- **The window did not look like an emergency.** `Drupal.dialog()` was passed `dialogClass: 'confirm-dialog'`, but jQuery UI only honours `dialogClass` in back-compat mode (`$.uiBackCompat`), which Drupal does not enable — and nothing in core maps it onto the supported `classes` option. The class never reached the dialog, so **every `.confirm-dialog` rule in `css/ys_alert.css` was dead code**: no red title bar, no emergency icon. It rendered as a small generic dialog, which is exactly why it was easy to miss. Passing the class through `classes` makes that existing styling apply.

Focus needed no new code. jQuery UI already moves focus into the dialog on open, traps Tab, and returns focus to the Save button on close; this was verified in the browser rather than assumed.

The file is also converted to a `Drupal.behaviors` implementation with `once()` — the idiom used elsewhere in the profile — so the listener binds once and is scoped to the form instead of to whatever `#edit-submit` the document happens to contain.

The confirmation step itself is unchanged: it exists to slow down accidental emergency publishing, and this only makes its presence unmissable.

**Deliberately not changed:** `form.submit()` was kept rather than switched to `form.requestSubmit()`. `requestSubmit()` would run constraint validation, but with an empty required Headline the browser's validation bubble renders *behind* the modal overlay — the save would then silently do nothing, which is the very bug this ticket is about.

### Functional testing steps:

- [ ] Go to **/admin/yalesites/alert**, select **Emergency**, and click **Save configuration**.
- [ ] Confirm a warning appears **on the page**, directly under the Emergency option: "Your changes have not been saved yet…" — visible immediately, alongside the modal.
- [ ] Confirm the confirmation window now renders with the **red title bar and emergency icon** (previously it was an unstyled generic dialog).
- [ ] Confirm focus lands **inside** the dialog on open (on Cancel), that Tab cycles only within the dialog, and that closing returns focus to the Save button.
- [ ] Click **Cancel**: the form stays on the page, unsaved, with Emergency still selected, and the inline warning remains explaining why nothing saved. `drush config:get ys_alert.settings alert.type` still shows the previous type.
- [ ] Click **Save** then **Confirm**: the alert saves as before — `drush config:get ys_alert.settings alert.type` shows `emergency` and the usual "The configuration options have been saved." appears.
- [ ] Select a non-Emergency type (Announcement or Marketing) and Save: **no modal and no warning** appear, and it saves normally.
- [ ] Click Save twice in a row with Emergency selected: only **one** warning is shown, not a stack.

Header alignment (added after review feedback):

- [ ] With the confirmation window open, confirm the close **X** is **vertically centred** in the red title bar — previously it sat noticeably high, with part of it above the red area.
- [ ] Confirm the ⚠ emergency icon is **separated from the title text** by a clear gap and shares its centre line, rather than being jammed against it.
- [ ] Confirm the icon is not squashed or distorted.
- [ ] Narrow the window to roughly phone width and confirm the title does not collide with or run underneath the close button.

References yalesites-org/YaleSites-Internal#1501

---
Created with AI

