### PR TITLE
1493: RC: MathJax multi-row LaTeX renders flattened — typogrify strips the \\ row separator before MathJax runs

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/README.md
@@ -29,10 +29,13 @@ page loads.
 
 - A single dollar sign (`$`) does **not** start math, so ordinary text such as
   "Tickets are $5" is unaffected.
-- Because the Text block also applies typographic replacement (Typogrify),
-  prefer LaTeX macros over literal punctuation inside math — e.g. use `\prime`
-  and `\ldots` rather than `'` and `...` so the source is not altered before
-  MathJax renders it.
+- Punctuation inside the delimiters is left exactly as typed. Multi-row
+  constructs work as they do in standard LaTeX — `\\` ends a row and `&`
+  separates columns:
+
+  ```
+  $$\begin{bmatrix} a & b \\ c & d \end{bmatrix}$$
+  ```
 
 ## For developers
 
@@ -40,5 +43,11 @@ page loads.
   decide whether to load the library (unit tested).
 - `Plugin\Filter\YsMathjaxFilter` — extends the contrib `MathjaxFilter`;
   attaches the library via the parent only when `hasMath()` is TRUE.
+- `Plugin\Filter\YsTypogrifyFilter` — extends the contrib `TypogrifyFilter` and
+  masks math regions so typographic replacement cannot rewrite LaTeX before
+  MathJax sees it. `ys_mathjax_filter_info_alter()` swaps it in for the
+  `typogrify` plugin, so the protection applies to every text format that runs
+  typogrify (`basic_html`, `heading_html`, `restricted_html`), not just the ones
+  with the MathJax filter enabled.
 - Delimiters and MathJax options are configured in `mathjax.settings`
   (`config_type: 0`, single-dollar inline math disabled).

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/src/MathDelimiterDetector.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/src/MathDelimiterDetector.php
@@ -24,6 +24,19 @@ class MathDelimiterDetector {
   const MATH_PATTERN = '/\\\\[([]|\$\$|<math[\s>\/]/i';
 
   /**
+   * Matches a complete math region, delimiters included.
+   *
+   * The same delimiter pairs as MATH_PATTERN, but matched closed rather than
+   * open, so a caller can pick math out of surrounding prose. Keep the two in
+   * step: both describe the delimiters configured in `mathjax.settings`.
+   *
+   * MathML is deliberately absent. `<math>` is already in SmartyPants'
+   * skip-tag list, and Basic HTML's filter_html strips the element long before
+   * any of this runs.
+   */
+  const MATH_REGION_PATTERN = '/\$\$.*?\$\$|\\\\\[.*?\\\\\]|\\\\\(.*?\\\\\)/s';
+
+  /**
    * Checks whether the given text contains math notation.
    *
    * @param string $text

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/src/Plugin/Filter/YsTypogrifyFilter.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/src/Plugin/Filter/YsTypogrifyFilter.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\ys_mathjax\Plugin\Filter;
+
+use Drupal\typogrify\Plugin\Filter\TypogrifyFilter;
+use Drupal\ys_mathjax\MathDelimiterDetector;
+
+/**
+ * Applies typographic refinements to everything except math notation.
+ *
+ * Typogrify rewrites the punctuation that LaTeX is built from: SmartyPants
+ * turns `\\` (end of row) into `&#92;` and `\,` (thin space) into a comma, and
+ * the configured quote conversions turn `''` (double prime) into a right
+ * double quote. MathJax runs in the browser, long after every text filter, so
+ * it never sees the original notation and multi-row constructs such as
+ * `bmatrix` collapse onto one line.
+ *
+ * Reordering filters cannot fix this: the MathJax filter only wraps the text
+ * and attaches the library, so the LaTeX still reaches typogrify as plain text
+ * whichever order they run in. Instead this subclass masks each math region
+ * with an inert placeholder, lets typogrify do its real work on the
+ * surrounding prose, and restores the math verbatim. It replaces the contrib
+ * typogrify filter for every text format via ys_mathjax_filter_info_alter().
+ *
+ * Two consequences worth knowing:
+ * - Masking restores exactly the bytes typogrify was handed, which have already
+ *   been through filter_html at weight -10 in every format that runs typogrify,
+ *   so it cannot reintroduce anything sanitisation removed. A future format
+ *   that ran typogrify *without* filter_html would not have that guarantee.
+ * - A pair of stray delimiters (two lone `$$`, say) masks the prose between
+ *   them, which then skips typographic replacement. The text is restored
+ *   verbatim, so nothing is corrupted, and MathJax would treat that span as
+ *   math on the client for the same reason.
+ *
+ * @see \Drupal\ys_mathjax\MathDelimiterDetector
+ */
+class YsTypogrifyFilter extends TypogrifyFilter {
+
+  /**
+   * Builds the placeholder that stands in for the nth math region.
+   *
+   * Lowercase letters only. Typogrify rewrites punctuation, backslashes,
+   * quotes and runs of capitals, so those are all out — and so are digits:
+   * SmartyPants::smartNumbers() matches a bare `\d+` with no word boundary,
+   * so with the format's "Digit grouping in numbers" setting turned on it
+   * would wrap the index in `<span class="number">`, split the placeholder,
+   * and lose the math entirely on restore. Hence the index is spelled with
+   * letters rather than interpolated as a number.
+   *
+   * @param int $index
+   *   Zero-based position of the math region within the text.
+   *
+   * @return string
+   *   A token that survives every typogrify transformation unchanged.
+   */
+  private static function placeholder(int $index): string {
+    return 'ysmathmask' . strtr((string) $index, '0123456789', 'abcdefghij') . 'ysmathmask';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function process($text, $langcode) {
+    $math = [];
+    $masked = preg_replace_callback(
+      MathDelimiterDetector::MATH_REGION_PATTERN,
+      function (array $match) use (&$math): string {
+        $placeholder = self::placeholder(count($math));
+        $math[$placeholder] = $match[0];
+        return $placeholder;
+      },
+      $text
+    );
+
+    // Losing the field's whole content to a PCRE limit would be far worse than
+    // losing the row separator, so fall back to unmasked processing.
+    if ($masked === NULL) {
+      return parent::process($text, $langcode);
+    }
+
+    $result = parent::process($masked, $langcode);
+
+    if ($math) {
+      $result->setProcessedText(strtr($result->getProcessedText(), $math));
+    }
+
+    return $result;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/tests/src/Unit/YsTypogrifyFilterTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/tests/src/Unit/YsTypogrifyFilterTest.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace Drupal\Tests\ys_mathjax\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\typogrify\Plugin\Filter\TypogrifyFilter;
+use Drupal\ys_mathjax\Plugin\Filter\YsTypogrifyFilter;
+
+/**
+ * Unit tests for YsTypogrifyFilter.
+ *
+ * @coversDefaultClass \Drupal\ys_mathjax\Plugin\Filter\YsTypogrifyFilter
+ * @group ys_mathjax
+ * @group yalesites
+ */
+class YsTypogrifyFilterTest extends UnitTestCase {
+
+  /**
+   * Typogrify settings as stored by the YaleSites text formats.
+   *
+   * Mirrors the `typogrify` filter settings in filter.format.basic_html.yml,
+   * filter.format.heading_html.yml and filter.format.restricted_html.yml,
+   * which are identical to one another.
+   */
+  private const FORMAT_SETTINGS = [
+    'smartypants_enabled' => 1,
+    'smartypants_hyphens' => 2,
+    'space_hyphens' => 0,
+    'wrap_ampersand' => 0,
+    'widont_enabled' => 0,
+    'space_to_nbsp' => 1,
+    'hyphenate_shy' => 0,
+    'wrap_abbr' => 0,
+    'wrap_caps' => 0,
+    'wrap_initial_quotes' => 1,
+    'wrap_numbers' => 0,
+    'ligatures' => [],
+    'arrows' => [],
+    'fractions' => [],
+    'quotes' => [',,' => ',,', "''" => "''"],
+  ];
+
+  /**
+   * Builds a typogrify filter instance of the given class.
+   *
+   * @param string $class
+   *   The filter class to instantiate.
+   * @param array $overrides
+   *   Settings to override on top of the stored format settings.
+   *
+   * @return \Drupal\typogrify\Plugin\Filter\TypogrifyFilter
+   *   The configured filter.
+   */
+  private function filter(string $class, array $overrides = []): TypogrifyFilter {
+    $settings = $overrides + self::FORMAT_SETTINGS;
+
+    return new $class(
+      ['settings' => $settings],
+      'typogrify',
+      [
+        'id' => 'typogrify',
+        'provider' => 'typogrify',
+        'weight' => 10,
+        'settings' => $settings,
+      ]
+    );
+  }
+
+  /**
+   * Runs text through a typogrify filter instance of the given class.
+   *
+   * An explicit langcode keeps TypogrifyFilter from reaching for the language
+   * manager service, which a unit test has no container for.
+   *
+   * @param string $class
+   *   The filter class to instantiate.
+   * @param string $text
+   *   The text to process.
+   *
+   * @return string
+   *   The processed text.
+   */
+  private function process(string $class, string $text): string {
+    return $this->filter($class)->process($text, 'en')->getProcessedText();
+  }
+
+  /**
+   * Tests that LaTeX inside math delimiters survives typogrify untouched.
+   *
+   * @param string $text
+   *   Markup containing math notation.
+   * @param string $fragment
+   *   The LaTeX fragment that must survive verbatim.
+   *
+   * @dataProvider mathProvider
+   * @covers ::process
+   */
+  public function testMathIsNotTypogrified(string $text, string $fragment): void {
+    $this->assertStringContainsString($fragment, $this->process(YsTypogrifyFilter::class, $text));
+
+    // Guard against passing for the wrong reason: the stock filter has to
+    // actually destroy this fragment, otherwise the case proves nothing.
+    $this->assertStringNotContainsString(
+      $fragment,
+      $this->process(TypogrifyFilter::class, $text),
+      'Expected the unmodified typogrify filter to corrupt this fragment.'
+    );
+  }
+
+  /**
+   * Provides math markup and the LaTeX fragment that must survive.
+   *
+   * @return array
+   *   Cases keyed by description: [text, fragment].
+   */
+  public static function mathProvider(): array {
+    return [
+      'bmatrix row separator' => [
+        '<p>$$\begin{bmatrix} a &amp; b \\\\ c &amp; d \end{bmatrix}$$</p>',
+        '\\\\',
+      ],
+      'pmatrix row separator' => [
+        '<p>$$\begin{pmatrix} 1 &amp; 2 \\\\ 3 &amp; 4 \end{pmatrix}$$</p>',
+        '\\\\',
+      ],
+      'aligned system of equations' => [
+        '<p>\[\begin{aligned} x + y &amp;= 2 \\\\ x - y &amp;= 0 \end{aligned}\]</p>',
+        '\\\\',
+      ],
+      'array row separator' => [
+        '<p>$$\begin{array}{cc} a &amp; b \\\\ c &amp; d \end{array}$$</p>',
+        '\\\\',
+      ],
+      'inline paren delimiters' => [
+        '<p>The identity \(a \\\\ b\) holds.</p>',
+        '\\\\',
+      ],
+      'thin space' => [
+        '<p>$$\int_0^1 x\,dx$$</p>',
+        '\,',
+      ],
+      'double prime' => [
+        "<p>The second derivative \\(f''(x)\\) is positive.</p>",
+        "f''(x)",
+      ],
+    ];
+  }
+
+  /**
+   * Tests that text outside math delimiters is still typogrified.
+   *
+   * @covers ::process
+   */
+  public function testTypographyStillAppliedOutsideMath(): void {
+    $processed = $this->process(
+      YsTypogrifyFilter::class,
+      '<p>She said "yes" -- and then $$a \\\\ b$$ appeared.</p>'
+    );
+
+    // Straight quotes and the double hyphen are still converted.
+    $this->assertStringNotContainsString('"yes"', $processed);
+    $this->assertStringNotContainsString(' -- ', $processed);
+    // The math itself is untouched.
+    $this->assertStringContainsString('$$a \\\\ b$$', $processed);
+  }
+
+  /**
+   * Tests that math-free text is processed exactly as typogrify would.
+   *
+   * @param string $text
+   *   Math-free markup.
+   *
+   * @dataProvider mathFreeProvider
+   * @covers ::process
+   */
+  public function testMathFreeTextMatchesTypogrify(string $text): void {
+    $this->assertSame(
+      $this->process(TypogrifyFilter::class, $text),
+      $this->process(YsTypogrifyFilter::class, $text)
+    );
+  }
+
+  /**
+   * Provides math-free markup that must round-trip identically.
+   *
+   * @return array
+   *   Cases keyed by description: [text].
+   */
+  public static function mathFreeProvider(): array {
+    return [
+      'prose with quotes and dashes' => ['<p>He said "hello" -- twice.</p>'],
+      'a single dollar amount' => ['<p>Tickets are $5 each.</p>'],
+      'a path with backslashes' => ['<p>Open C:\\\\Users\\\\me now.</p>'],
+      'an unbalanced display delimiter' => ['<p>The $$ sign is odd.</p>'],
+      'an unbalanced inline delimiter' => ['<p>Half an expression \(x + y.</p>'],
+      'empty markup' => ['<p></p>'],
+    ];
+  }
+
+  /**
+   * Tests that the placeholder survives every typogrify transformation.
+   *
+   * The stored formats leave the optional transformations off, but each is a
+   * checkbox on the text format's settings form. If one of them can rewrite
+   * the placeholder, the math it stands for is dropped on restore and the
+   * reader sees the placeholder instead — worse than the bug being fixed. The
+   * digit-grouping option is the one that bites: SmartyPants matches a bare
+   * `\d+` with no word boundary.
+   *
+   * @param array $overrides
+   *   Typogrify settings to switch on.
+   *
+   * @dataProvider aggressiveSettingsProvider
+   * @covers ::process
+   */
+  public function testMathSurvivesEveryTypogrifyOption(array $overrides): void {
+    $processed = $this->filter(YsTypogrifyFilter::class, $overrides)
+      ->process('<p>Given $$\begin{bmatrix} a &amp; b \\\\ c &amp; d \end{bmatrix}$$ we proceed.</p>', 'en')
+      ->getProcessedText();
+
+    $this->assertStringContainsString('\\\\', $processed);
+    $this->assertStringNotContainsString('ysmathmask', $processed);
+  }
+
+  /**
+   * Provides each optional typogrify transformation, switched on.
+   *
+   * @return array
+   *   Cases keyed by setting name: [overrides].
+   */
+  public static function aggressiveSettingsProvider(): array {
+    return [
+      'wrap_numbers span' => [['wrap_numbers' => 3]],
+      'wrap_numbers just wrap' => [['wrap_numbers' => 4]],
+      'wrap_caps' => [['wrap_caps' => 1]],
+      'wrap_abbr' => [['wrap_abbr' => 3]],
+      'widont' => [['widont_enabled' => 1]],
+      'hyphenate_shy' => [['hyphenate_shy' => 1]],
+      'space_hyphens' => [['space_hyphens' => 1]],
+      'wrap_ampersand' => [['wrap_ampersand' => 1]],
+      'everything at once' => [[
+        'wrap_numbers' => 3,
+        'wrap_caps' => 1,
+        'wrap_abbr' => 3,
+        'widont_enabled' => 1,
+        'hyphenate_shy' => 1,
+        'space_hyphens' => 1,
+        'wrap_ampersand' => 1,
+      ],
+      ],
+    ];
+  }
+
+  /**
+   * Tests that the typogrify library is still attached.
+   *
+   * @covers ::process
+   */
+  public function testLibraryIsStillAttached(): void {
+    $result = $this->filter(YsTypogrifyFilter::class)->process('<p>$$a \\\\ b$$</p>', 'en');
+
+    $this->assertSame(['typogrify/typogrify'], $result->getAttachments()['library']);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/ys_mathjax.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/ys_mathjax.info.yml
@@ -6,3 +6,4 @@ package: YaleSites
 dependencies:
   - drupal:filter
   - mathjax:mathjax
+  - typogrify:typogrify

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/ys_mathjax.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/ys_mathjax.module
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Hook implementations for the YaleSites MathJax module.
+ */
+
+use Drupal\ys_mathjax\Plugin\Filter\YsTypogrifyFilter;
+
+/**
+ * Implements hook_filter_info_alter().
+ *
+ * Swaps in a typogrify filter that leaves math notation alone, so LaTeX still
+ * reaches MathJax intact in every text format that runs typogrify.
+ */
+function ys_mathjax_filter_info_alter(&$info) {
+  if (isset($info['typogrify'])) {
+    $info['typogrify']['class'] = YsTypogrifyFilter::class;
+  }
+}


### PR DESCRIPTION
## [1493: RC: MathJax multi-row LaTeX renders flattened — typogrify strips the \\ row separator before MathJax runs](https://github.com/yalesites-org/YaleSites-Internal/issues/1493)

### Description of work

- `ys_mathjax` now supplies a `TypogrifyFilter` subclass that masks each MathJax-delimited region (`$$…$$`, `\[…\]`, `\(…\)` — exactly the delimiters in `mathjax.settings`) with an inert placeholder, lets typogrify do its real work on the surrounding prose, and restores the math verbatim. `hook_filter_info_alter()` swaps it in for the `typogrify` plugin.
- Applies to `basic_html`, `heading_html` and `restricted_html` at once, with **no text-format config change** — so there is no config export in this PR and nothing to re-import.
- Fixes more than the row separator. Confirmed damage on `develop`, all three formats: `\\` → `&#92;`, `\,` → `&#x2c;`, and `f''(x)` → `f&rdquo;(x)` (the `''` quote conversion enabled in our formats destroys double-prime notation — not catalogued in the issue).
- Removes the README note that told editors to work around this ("prefer `\prime` and `\ldots` rather than `'` and `...`"), replacing it with the multi-row example that now works.

#### Two acceptance criteria in the issue rest on a wrong premise — please sanity-check my reasoning

1. **"Run `filter_ys_mathjax` before `typogrify`" cannot work.** `mathjax`'s filter does no LaTeX processing server-side — it wraps the text in a div and attaches the JS library (`web/modules/contrib/mathjax/src/Plugin/Filter/MathjaxFilter.php`). TeX→MathML happens in the browser, after every text filter. So the relative order of the two filters is irrelevant; typogrify rewrites the raw LaTeX either way. That route is rejected, and no filter weights are changed.
2. **`filter_ys_mathjax` is only enabled in `basic_html`.** `heading_html` and `restricted_html` have `typogrify` but no MathJax filter. Math in those formats still renders client-side *if* MathJax was loaded by a `basic_html` field elsewhere on the page, so fixing typogrify in all three is still right — but enabling the MathJax filter in the other two formats is #982 scope and is **not** done here.

#### Why this shape

- **Not a contrib patch to `typogrify`**: it would hard-code our math delimiters into a contrib module and need re-rolling on every update. The subclass lives in our module and is unit tested.
- **Not repairing the entities afterwards** in `YsMathjaxFilter` (weight 100): that only reverses `processEscapes()`, leaving the quote, dash and ellipsis conversions that also corrupt math.
- **Not a second "protect" filter at a low weight**: that puts placeholder state across filter boundaries and needs config changes in three formats. Here the placeholder never leaves the filter's own `process()` call.
- `smartypants_enabled` is untouched — typogrify keeps doing its real work.

### Verification performed

Local Lando, all three formats, via `check_markup()` on 11 cases each:

| | `develop` | this branch |
|---|---|---|
| cases preserved | 18 / 33 | **33 / 33** |
| `bmatrix` / `pmatrix` / `array` / `aligned` | `\\` → `&#92;` | intact |
| `\,` thin space | → `&#x2c;` | intact |
| `f''(x)` | → `f&rdquo;(x)` | intact |
| prose (`"yes"`, `--`, `...`, `$5`) | typogrified | **identical, unchanged** |

Rendered page, real Text block, MathJax MathML (the accessibility criterion):

| construct | `develop` | this branch |
|---|---|---|
| bmatrix | 1 `<mtr>` / 3 `<mtd>` | **2 `<mtr>` / 4 `<mtd>`** |
| pmatrix | 1 `<mtr>` / 3 `<mtd>` | **2 `<mtr>` / 4 `<mtd>`** |
| array | 1 `<mtr>` / 3 `<mtd>` | **2 `<mtr>` / 4 `<mtd>`** |
| aligned | 1 `<mtr>` / 3 `<mtd>` | **2 `<mtr>` / 4 `<mtd>`** |

`develop` reproduced the issue's claim exactly (one row of three cells), so assistive tech was announcing a mathematically different matrix. No `merror` in any expression; single-line inline and display equations unchanged.

- 33 Unit tests pass (was 9). Each math case also asserts the *stock* filter corrupts that fragment, so a case cannot pass for the wrong reason.
- `composer code-sniff` (Drupal + DrupalPractice) and `composer lint:php` exit 0.
- `npm run lint:styles` fails with 1536 pre-existing errors, all in `web/themes/contrib/atomic/_yale-packages/tokens/build/scss/tokens.scss` — a generated file in the local gyst'd atomic clone that is absent in CI. This diff contains no style files.

### Reviewer notes

- **A code review caught a real bug in my first attempt.** The placeholder was `ysmathmask0ysmathmask`; `SmartyPants::smartNumbers()` matches a bare `\d+` with **no word boundary**, so with the format's "Digit grouping in numbers" option enabled (off today, but a checkbox on the settings form) it wrapped the `0` in `<span class="number">`, the restore missed, and the math was **deleted** and replaced by visible gibberish — worse than the bug being fixed. Verified live: `ysmathmask<span class="number">0</span>ysmathmask`. The index is now spelled with letters, and `testMathSurvivesEveryTypogrifyOption` turns on each optional typogrify transformation in turn as a regression guard.
- **Not spot-checked per-field.** The issue asks for two rich-text surfaces beyond the Text block. I verified at the `check_markup()` layer for all three formats instead, which is the code path every rich-text field funnels through — exhaustive over formats rather than a sample of fields. Say the word if you want the per-field checks anyway.
- **Security**: masking restores the exact bytes typogrify was handed, and `filter_html` runs at weight `-10` in all three formats, so it cannot reintroduce anything sanitisation removed. Typogrify's incidental `<`→`&lt;` is redundant here because `Xss::split()` already returns `&lt;` for a stray `<`. No config change means no `full_html`-style format is affected.
- **Uncovered**: the `preg_replace_callback` returning `NULL` fallback (a PCRE limit) has no test — it silently reverts to today's broken behaviour. I left the logger out rather than add dependency injection to this filter for one line; happy to add it if you'd rather have it diagnosable.

### Functional testing steps:

- [ ] On a page, add a **Text** block containing `$$\begin{bmatrix} a & b \\ c & d \end{bmatrix}$$` and save.
- [ ] View the published page — the matrix renders as **two rows**, not one flat row.
- [ ] Repeat with `pmatrix`, `array`, and an `aligned` system of equations (`\[\begin{aligned} x + y &= 2 \\ x - y &= 0 \end{aligned}\]`) — all stack correctly.
- [ ] Check `$$\int_0^1 x\,dx$$` — the `\,` renders as a thin space, not a comma.
- [ ] Regression-check single-line math still renders: `\(E = mc^2\)` inline and `$$a^2 + b^2 = c^2$$` display.
- [ ] Confirm typography elsewhere on the page is unaffected — straight quotes still become curly, `--` still becomes a dash, `...` still becomes an ellipsis.
- [ ] Confirm ordinary prose is untouched: "Tickets are $5 each" shows no math treatment.

References yalesites-org/YaleSites-Internal#1493

---

Created with AI

<img width="624" height="192" alt="Screenshot 2026-08-10 at 3 29 05 PM" src="https://github.com/user-attachments/assets/1265a203-bc20-4477-af4d-47cc8c911ed6" />