### PR TITLE
1494: RC: Retroactively fix pre-#683 document links that still render double-encoded (%2520)

### DIFF
--- a/patches/contrib/linkit/3436733-5.patch
+++ b/patches/contrib/linkit/3436733-5.patch
@@ -2,13 +2,16 @@ diff --git a/src/Plugin/Field/FieldWidget/LinkitWidget.php b/src/Plugin/Field/Fi
 index c9e4620..0585d09 100644
 --- a/src/Plugin/Field/FieldWidget/LinkitWidget.php
 +++ b/src/Plugin/Field/FieldWidget/LinkitWidget.php
-@@ -216,7 +216,8 @@ class LinkitWidget extends LinkWidget {
+@@ -216,7 +216,11 @@ class LinkitWidget extends LinkWidget {
     */
    public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
      foreach ($values as &$value) {
 -      $value['uri'] = LinkitHelper::uriFromUserInput($value['uri']);
 +      $uri = LinkitHelper::uriFromUserInput($value['uri']);
-+      $value['uri'] = !empty($uri) ? urldecode($uri) : NULL;
++      // rawurldecode() rather than urldecode(): a URL path is not form data, so
++      // a "+" in it is a literal plus and not an encoded space. urldecode()
++      // turned a link to "a+b.pdf" into one to "a b.pdf", which then 404s.
++      $value['uri'] = !empty($uri) ? rawurldecode($uri) : NULL;
        $value += ['options' => $value['attributes']];
      }
      return $values;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/DoubleEncodedLinkUriRepairTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/DoubleEncodedLinkUriRepairTest.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\block_content\Entity\BlockContentType;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+
+/**
+ * Tests the retroactive repair of double-encoded link URIs in field tables.
+ *
+ * Issue #1494: links stored before #683 kept their percent-encoding and render
+ * double-encoded. The repair writes the field tables directly, so this covers
+ * what an entity save would have got wrong: the revision row Layout Builder
+ * renders from, the absence of new revisions, and the "changed" timestamp
+ * staying put.
+ *
+ * @group ys_core
+ * @group yalesites
+ */
+class DoubleEncodedLinkUriRepairTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'link',
+    'text',
+    'block_content',
+  ];
+
+  /**
+   * A URI stored before #683, still holding its percent-encoding.
+   */
+  const BROKEN_URI = 'internal:/sites/default/files/2025-11/YaleSites%20Profile%20Import%20Template.xlsx';
+
+  /**
+   * The same URI as the Linkit widget stores it since #683.
+   */
+  const FIXED_URI = 'internal:/sites/default/files/2025-11/YaleSites Profile Import Template.xlsx';
+
+  /**
+   * An external URI with an escape that must never be rewritten.
+   */
+  const EXTERNAL_URI = 'https://example.com/a%20b.pdf';
+
+  /**
+   * The field's dedicated data table.
+   */
+  protected string $dataTable;
+
+  /**
+   * The field's dedicated revision table.
+   */
+  protected string $revisionTable;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('block_content');
+
+    BlockContentType::create(['id' => 'button_link', 'label' => 'Button link'])->save();
+    FieldStorageConfig::create([
+      'field_name' => 'field_button_link',
+      'entity_type' => 'block_content',
+      'type' => 'link',
+      'cardinality' => 2,
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_button_link',
+      'entity_type' => 'block_content',
+      'bundle' => 'button_link',
+      'label' => 'Button link',
+    ])->save();
+
+    $storage = \Drupal::entityTypeManager()->getStorage('block_content');
+    $definition = \Drupal::service('entity_field.manager')
+      ->getFieldStorageDefinitions('block_content')['field_button_link'];
+    $this->dataTable = $storage->getTableMapping()->getDedicatedDataTableName($definition);
+    $this->revisionTable = $storage->getTableMapping()->getDedicatedRevisionTableName($definition);
+
+    // The helper lives in ys_core.install; load it without enabling ys_core,
+    // which would pull in cas/role_delegation and a much heavier container.
+    // Resolved from this file rather than from \Drupal::root(), so the test
+    // always covers the copy it ships beside instead of whichever checkout
+    // happens to be bootstrapped.
+    require_once __DIR__ . '/../../../ys_core.install';
+  }
+
+  /**
+   * Returns the stored URI for one row of a field table.
+   */
+  protected function storedUri(string $table, int $revision_id, int $delta): ?string {
+    return \Drupal::database()->select($table, 'f')
+      ->fields('f', ['field_button_link_uri'])
+      ->condition('revision_id', $revision_id)
+      ->condition('delta', $delta)
+      ->execute()
+      ->fetchField() ?: NULL;
+  }
+
+  /**
+   * The repair fixes old revisions and never creates a revision of its own.
+   */
+  public function testRepairsBothDataAndRevisionRows(): void {
+    // A block an editor already repaired by re-saving it: its default revision
+    // is correct, but the revision Layout Builder points at is still broken.
+    $resaved = BlockContent::create([
+      'type' => 'button_link',
+      'info' => 'Re-saved block',
+      'reusable' => FALSE,
+      'field_button_link' => [
+        ['uri' => self::BROKEN_URI, 'title' => 'Template'],
+        ['uri' => self::EXTERNAL_URI, 'title' => 'External'],
+      ],
+    ]);
+    $resaved->save();
+    $old_revision_id = (int) $resaved->getRevisionId();
+
+    $resaved->setNewRevision(TRUE);
+    $resaved->get('field_button_link')->set(0, ['uri' => self::FIXED_URI, 'title' => 'Template']);
+    $resaved->save();
+    $current_revision_id = (int) $resaved->getRevisionId();
+    $this->assertNotSame($old_revision_id, $current_revision_id, 'The fixture really has two revisions.');
+
+    // A block nobody has touched: both its tables still hold the broken value.
+    $untouched = BlockContent::create([
+      'type' => 'button_link',
+      'info' => 'Untouched block',
+      'reusable' => FALSE,
+      'field_button_link' => [['uri' => self::BROKEN_URI, 'title' => 'Template']],
+    ]);
+    $untouched->save();
+    $untouched_revision_id = (int) $untouched->getRevisionId();
+
+    $changed_before = [
+      $resaved->id() => $resaved->getChangedTime(),
+      $untouched->id() => $untouched->getChangedTime(),
+    ];
+    $revision_count_before = (int) \Drupal::database()
+      ->select('block_content_revision', 'r')->countQuery()->execute()->fetchField();
+
+    $report = ys_core_repair_double_encoded_link_uris();
+
+    // Every broken row is corrected, in both tables.
+    $this->assertSame(self::FIXED_URI, $this->storedUri($this->revisionTable, $old_revision_id, 0), 'The old revision Layout Builder renders from is corrected.');
+    $this->assertSame(self::FIXED_URI, $this->storedUri($this->dataTable, $untouched_revision_id, 0), 'The default field table is corrected.');
+    $this->assertSame(self::FIXED_URI, $this->storedUri($this->revisionTable, $untouched_revision_id, 0), 'The matching revision row is corrected.');
+    $this->assertSame(3, $report['repaired'], 'Exactly the three broken rows are rewritten.');
+
+    // The already-correct row and the external links are not rewritten.
+    $this->assertSame(self::FIXED_URI, $this->storedUri($this->revisionTable, $current_revision_id, 0), 'An already-correct row is unchanged.');
+    $this->assertSame(self::EXTERNAL_URI, $this->storedUri($this->revisionTable, $old_revision_id, 1), 'An external URI keeps its escapes.');
+    $this->assertSame(self::EXTERNAL_URI, $this->storedUri($this->dataTable, $current_revision_id, 1), 'An external URI keeps its escapes in the data table too.');
+    $this->assertContains(self::EXTERNAL_URI, $report['left_alone_uris'], 'Values left alone are reported for a manual check.');
+
+    // Nothing that an entity save would have disturbed has moved.
+    $revision_count_after = (int) \Drupal::database()
+      ->select('block_content_revision', 'r')->countQuery()->execute()->fetchField();
+    $this->assertSame($revision_count_before, $revision_count_after, 'The repair creates no new revisions.');
+
+    \Drupal::entityTypeManager()->getStorage('block_content')->resetCache();
+    foreach ($changed_before as $id => $changed) {
+      $reloaded = BlockContent::load($id);
+      $this->assertSame($changed, $reloaded->getChangedTime(), 'The changed timestamp does not move.');
+    }
+
+    // The corrected value is what the entity now returns.
+    $this->assertSame(self::FIXED_URI, BlockContent::load($untouched->id())->get('field_button_link')->first()->uri, 'The corrected URI is visible through the entity API.');
+  }
+
+  /**
+   * Running the repair a second time changes nothing.
+   */
+  public function testRepairIsIdempotent(): void {
+    $block = BlockContent::create([
+      'type' => 'button_link',
+      'info' => 'Untouched block',
+      'reusable' => FALSE,
+      'field_button_link' => [['uri' => self::BROKEN_URI, 'title' => 'Template']],
+    ]);
+    $block->save();
+
+    $first = ys_core_repair_double_encoded_link_uris();
+    $this->assertSame(2, $first['repaired'], 'The first run corrects the data and revision rows.');
+
+    $second = ys_core_repair_double_encoded_link_uris();
+    $this->assertSame(0, $second['repaired'], 'A second run has nothing left to correct.');
+    $this->assertSame(self::FIXED_URI, $this->storedUri($this->revisionTable, (int) $block->getRevisionId(), 0), 'The value is not decoded twice.');
+  }
+
+  /**
+   * A dry run reports what it would change without writing anything.
+   */
+  public function testDryRunWritesNothing(): void {
+    $block = BlockContent::create([
+      'type' => 'button_link',
+      'info' => 'Untouched block',
+      'reusable' => FALSE,
+      'field_button_link' => [['uri' => self::BROKEN_URI, 'title' => 'Template']],
+    ]);
+    $block->save();
+
+    $report = ys_core_repair_double_encoded_link_uris(TRUE);
+
+    $this->assertSame(2, $report['repaired'], 'The dry run counts the rows it would correct.');
+    $this->assertSame(self::BROKEN_URI, $this->storedUri($this->dataTable, (int) $block->getRevisionId(), 0), 'The dry run leaves the data untouched.');
+    $this->assertNotEmpty($report['changes'], 'The dry run lists the changes it would make.');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/RestorePlusLinkUriTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/RestorePlusLinkUriTest.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\StreamWrapper\PublicStream;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\block_content\Entity\BlockContentType;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+
+/**
+ * Tests restoring a "+" that the #683 forward fix decoded away as a space.
+ *
+ * Issue #1494 follow-up: patches/contrib/linkit/3436733-5.patch used to call
+ * urldecode(), which reads "+" as an encoded space, so a link to "a+b.pdf" was
+ * saved as "a b.pdf" and 404s. The patch now uses rawurldecode(), but values
+ * already stored through the old one need rewriting.
+ *
+ * The whole point of the repair is that it decides from the filesystem rather
+ * than from the URI, so these fixtures create real files: a space in a file
+ * name is ordinary and must survive untouched.
+ *
+ * @group ys_core
+ * @group yalesites
+ */
+class RestorePlusLinkUriTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'link',
+    'text',
+    'block_content',
+  ];
+
+  /**
+   * The field's dedicated data table.
+   */
+  protected string $dataTable;
+
+  /**
+   * The field's dedicated revision table.
+   */
+  protected string $revisionTable;
+
+  /**
+   * The public files directory, as the repair resolves it.
+   */
+  protected string $filesBasePath;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('block_content');
+
+    BlockContentType::create(['id' => 'button_link', 'label' => 'Button link'])->save();
+    FieldStorageConfig::create([
+      'field_name' => 'field_button_link',
+      'entity_type' => 'block_content',
+      'type' => 'link',
+      'cardinality' => 2,
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_button_link',
+      'entity_type' => 'block_content',
+      'bundle' => 'button_link',
+      'label' => 'Button link',
+    ])->save();
+
+    $storage = \Drupal::entityTypeManager()->getStorage('block_content');
+    $definition = \Drupal::service('entity_field.manager')
+      ->getFieldStorageDefinitions('block_content')['field_button_link'];
+    $this->dataTable = $storage->getTableMapping()->getDedicatedDataTableName($definition);
+    $this->revisionTable = $storage->getTableMapping()->getDedicatedRevisionTableName($definition);
+
+    // Resolved at runtime rather than hardcoded, because the test site's public
+    // files directory is not the platform's.
+    $this->filesBasePath = PublicStream::basePath();
+    $directory = 'public://2026-08';
+    \Drupal::service('file_system')
+      ->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY);
+
+    // The file the editor meant. Its "+" was eaten on save.
+    file_put_contents('public://2026-08/a+b.pdf', 'plus');
+    // A file whose name genuinely contains a space, stored correctly.
+    file_put_contents('public://2026-08/My Report.pdf', 'space');
+
+    // The helper lives in ys_core.install; load it without enabling ys_core,
+    // which would pull in cas/role_delegation and a much heavier container.
+    require_once __DIR__ . '/../../../ys_core.install';
+  }
+
+  /**
+   * Builds an internal link URI pointing into the public files directory.
+   */
+  protected function fileUri(string $relative): string {
+    return 'internal:/' . $this->filesBasePath . '/' . $relative;
+  }
+
+  /**
+   * Returns the stored URI for one row of a field table.
+   */
+  protected function storedUri(string $table, int $revision_id, int $delta): ?string {
+    return \Drupal::database()->select($table, 'f')
+      ->fields('f', ['field_button_link_uri'])
+      ->condition('revision_id', $revision_id)
+      ->condition('delta', $delta)
+      ->execute()
+      ->fetchField() ?: NULL;
+  }
+
+  /**
+   * Creates a non-reusable block holding the given link URIs.
+   */
+  protected function createBlock(string $info, array $uris): BlockContent {
+    $values = [];
+    foreach ($uris as $uri) {
+      $values[] = ['uri' => $uri, 'title' => 'Document'];
+    }
+    $block = BlockContent::create([
+      'type' => 'button_link',
+      'info' => $info,
+      'reusable' => FALSE,
+      'field_button_link' => $values,
+    ]);
+    $block->save();
+    return $block;
+  }
+
+  /**
+   * Only the value whose "+" file exists is rewritten, in both tables.
+   */
+  public function testRestoresOnlyWhereTheFileProvesIt(): void {
+    $corrupted = $this->createBlock('Corrupted', [
+      $this->fileUri('2026-08/a b.pdf'),
+      // A file that really is named with a space: it must survive untouched.
+      $this->fileUri('2026-08/My Report.pdf'),
+    ]);
+    // An old revision, which is what Layout Builder renders an inline block
+    // from, so it has to be corrected too.
+    $old_revision_id = (int) $corrupted->getRevisionId();
+    $corrupted->setNewRevision(TRUE);
+    $corrupted->save();
+    $current_revision_id = (int) $corrupted->getRevisionId();
+    $this->assertNotSame($old_revision_id, $current_revision_id, 'The fixture really has two revisions.');
+
+    // Neither name exists, so there is no evidence and nothing to do.
+    $missing = $this->createBlock('Missing file', [$this->fileUri('2026-08/gone away.pdf')]);
+
+    $changed_before = [
+      $corrupted->id() => $corrupted->getChangedTime(),
+      $missing->id() => $missing->getChangedTime(),
+    ];
+    $revisions_before = (int) \Drupal::database()
+      ->select('block_content_revision', 'r')->countQuery()->execute()->fetchField();
+
+    $report = ys_core_restore_plus_link_uris();
+
+    // Both the data table and every revision row are corrected.
+    $this->assertSame($this->fileUri('2026-08/a+b.pdf'), $this->storedUri($this->dataTable, $current_revision_id, 0), 'The default field table is corrected.');
+    $this->assertSame($this->fileUri('2026-08/a+b.pdf'), $this->storedUri($this->revisionTable, $current_revision_id, 0), 'The matching revision row is corrected.');
+    $this->assertSame($this->fileUri('2026-08/a+b.pdf'), $this->storedUri($this->revisionTable, $old_revision_id, 0), 'The old revision Layout Builder renders from is corrected.');
+    $this->assertSame(3, $report['repaired'], 'Exactly the three rows holding the eaten "+" are rewritten.');
+
+    // A file name that genuinely holds a space is never touched.
+    $this->assertSame($this->fileUri('2026-08/My Report.pdf'), $this->storedUri($this->dataTable, $current_revision_id, 1), 'A real space in a file name survives.');
+    $this->assertSame($this->fileUri('2026-08/My Report.pdf'), $this->storedUri($this->revisionTable, $old_revision_id, 1), 'A real space survives in the revision table too.');
+
+    // With neither file present the value is left alone rather than guessed at,
+    // and reported so a run without the site's files is visible as such.
+    $this->assertSame($this->fileUri('2026-08/gone away.pdf'), $this->storedUri($this->dataTable, (int) $missing->getRevisionId(), 0), 'A link whose file is simply gone is left alone.');
+    $this->assertSame([$this->fileUri('2026-08/gone away.pdf')], $report['undecided_uris'], 'Only the value with no file either way is reported as undecided.');
+
+    // Nothing an entity save would have disturbed has moved.
+    $revisions_after = (int) \Drupal::database()
+      ->select('block_content_revision', 'r')->countQuery()->execute()->fetchField();
+    $this->assertSame($revisions_before, $revisions_after, 'The repair creates no new revisions.');
+
+    \Drupal::entityTypeManager()->getStorage('block_content')->resetCache();
+    foreach ($changed_before as $id => $changed) {
+      $this->assertSame($changed, BlockContent::load($id)->getChangedTime(), 'The changed timestamp does not move.');
+    }
+
+    // The corrected value is what the entity now returns.
+    $this->assertSame($this->fileUri('2026-08/a+b.pdf'), BlockContent::load($corrupted->id())->get('field_button_link')->first()->uri, 'The corrected URI is visible through the entity API.');
+  }
+
+  /**
+   * Running the repair a second time changes nothing.
+   */
+  public function testRepairIsIdempotent(): void {
+    $block = $this->createBlock('Corrupted', [$this->fileUri('2026-08/a b.pdf')]);
+
+    $first = ys_core_restore_plus_link_uris();
+    $this->assertSame(2, $first['repaired'], 'The first run corrects the data and revision rows.');
+
+    $second = ys_core_restore_plus_link_uris();
+    $this->assertSame(0, $second['repaired'], 'A second run has nothing left to correct.');
+    $this->assertSame($this->fileUri('2026-08/a+b.pdf'), $this->storedUri($this->dataTable, (int) $block->getRevisionId(), 0), 'The value is not rewritten twice.');
+  }
+
+  /**
+   * A dry run reports what it would change without writing anything.
+   */
+  public function testDryRunWritesNothing(): void {
+    $block = $this->createBlock('Corrupted', [$this->fileUri('2026-08/a b.pdf')]);
+
+    $report = ys_core_restore_plus_link_uris(TRUE);
+
+    $this->assertSame(2, $report['repaired'], 'The dry run counts the rows it would correct.');
+    $this->assertNotEmpty($report['changes'], 'The dry run lists the changes it would make.');
+    $this->assertSame($this->fileUri('2026-08/a b.pdf'), $this->storedUri($this->dataTable, (int) $block->getRevisionId(), 0), 'The dry run leaves the data untouched.');
+  }
+
+  /**
+   * The repair does not disturb a URI the #683 repair still owns.
+   */
+  public function testLeavesStillEncodedUrisToTheOtherRepair(): void {
+    $encoded = 'internal:/' . $this->filesBasePath . '/2026-08/a%20b.pdf';
+    $block = $this->createBlock('Still encoded', [$encoded]);
+
+    $report = ys_core_restore_plus_link_uris();
+
+    $this->assertSame(0, $report['repaired'], 'A percent-encoded path is not this repair to make.');
+    $this->assertSame($encoded, $this->storedUri($this->dataTable, (int) $block->getRevisionId(), 0), 'The still-encoded value is untouched.');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/DoubleEncodedLinkUriRepairTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/DoubleEncodedLinkUriRepairTest.php
@@ -43,6 +43,13 @@ class DoubleEncodedLinkUriRepairTest extends UnitTestCase {
         'internal:/sites/default/files/Budget%20%28final%29.pdf',
         'internal:/sites/default/files/Budget (final).pdf',
       ],
+      // A plus is what the Linkit autocomplete percent-encodes a file name's
+      // plus to, and rawurlencode() encodes it again into "%252B". Repairing it
+      // to a literal plus is correct: core encodes that back to "%2B".
+      'an encoded plus, the pre-#683 form of a "+" file name' => [
+        'internal:/sites/default/files/2026-08/a%2Bb.pdf',
+        'internal:/sites/default/files/2026-08/a+b.pdf',
+      ],
       'a query string is preserved byte for byte' => [
         'internal:/sites/default/files/My%20Doc.pdf?token=a%26b',
         'internal:/sites/default/files/My Doc.pdf?token=a%26b',

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/DoubleEncodedLinkUriRepairTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/DoubleEncodedLinkUriRepairTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Unit;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests which stored link URIs are treated as double-encoded, and which not.
+ *
+ * Issue #1494: links saved before the Linkit widget started decoding URIs on
+ * save (#683) kept their percent-encoding, so Drupal encoded the path a second
+ * time when building the href and the link 404'd. The repair helper has to
+ * recognise exactly those values without touching anything else.
+ *
+ * @group ys_core
+ * @group yalesites
+ */
+class DoubleEncodedLinkUriRepairTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    // The helper lives in ys_core.install, which defines functions only.
+    require_once __DIR__ . '/../../../ys_core.install';
+  }
+
+  /**
+   * URIs that are stored double-encoded, with the value they repair to.
+   */
+  public static function repairableUriProvider(): array {
+    return [
+      'the reported document link' => [
+        'internal:/sites/default/files/2025-11/YaleSites%20Profile%20Import%20Template.xlsx',
+        'internal:/sites/default/files/2025-11/YaleSites Profile Import Template.xlsx',
+      ],
+      'base scheme is affected the same way' => [
+        'base:sites/default/files/My%20Report.pdf',
+        'base:sites/default/files/My Report.pdf',
+      ],
+      'other encoded characters in a file name' => [
+        'internal:/sites/default/files/Budget%20%28final%29.pdf',
+        'internal:/sites/default/files/Budget (final).pdf',
+      ],
+      'a query string is preserved byte for byte' => [
+        'internal:/sites/default/files/My%20Doc.pdf?token=a%26b',
+        'internal:/sites/default/files/My Doc.pdf?token=a%26b',
+      ],
+      'a fragment is preserved byte for byte' => [
+        'internal:/sites/default/files/My%20Doc.pdf#page%2010',
+        'internal:/sites/default/files/My Doc.pdf#page%2010',
+      ],
+    ];
+  }
+
+  /**
+   * A double-encoded URI is decoded once, in its path only.
+   *
+   * @dataProvider repairableUriProvider
+   */
+  public function testRepairsDoubleEncodedUris(string $stored, string $expected): void {
+    $this->assertSame($expected, ys_core_repair_double_encoded_link_uri($stored));
+  }
+
+  /**
+   * Repairing an already-repaired URI reports nothing left to do.
+   *
+   * @dataProvider repairableUriProvider
+   */
+  public function testRepairIsIdempotent(string $stored, string $expected): void {
+    $this->assertNull(ys_core_repair_double_encoded_link_uri($expected), 'A repaired URI is not decoded a second time.');
+  }
+
+  /**
+   * URIs that must be left exactly as they are.
+   */
+  public static function untouchedUriProvider(): array {
+    return [
+      // Saved after #683: the path already holds a literal space.
+      'an already-correct internal link' => ['internal:/sites/default/files/My File.pdf'],
+      'an internal path with nothing encoded' => ['internal:/node/12'],
+      // External URIs are returned untouched by the unrouted URL assembler, so
+      // their percent-escapes never double-encode.
+      'an external link' => ['https://example.com/a%20b.pdf'],
+      'a mailto link' => ['mailto:someone@example.com?subject=Hello%20there'],
+      'an entity reference URI' => ['entity:node/123'],
+      'a route URI' => ['route:<front>'],
+      // A percent survives decoding, so the value is ambiguous: decoding it
+      // again is what a second run of the update hook would do.
+      'an already multiply-encoded path' => ['internal:/sites/default/files/My%2520Doc.pdf'],
+      'a file name containing a literal percent' => ['internal:/sites/default/files/100%25%20off.pdf'],
+      // rawurldecode() leaves "+" alone, so a file named with one is safe.
+      'a file name containing a plus' => ['internal:/sites/default/files/a+b.pdf'],
+      // Mixing a literal space with an escape is not what core would emit, so
+      // the value is not a cleanly double-encoded one.
+      'a path mixing a literal space with an escape' => ['internal:/sites/default/files/Caf%C3%A9 Menu.pdf'],
+      // Lower-case escapes are not what rawurlencode() produces either.
+      'a path with lower-case hex escapes' => ['internal:/sites/default/files/Caf%c3%a9.pdf'],
+      'an empty string' => [''],
+    ];
+  }
+
+  /**
+   * A URI that is not cleanly double-encoded is left alone.
+   *
+   * @dataProvider untouchedUriProvider
+   */
+  public function testLeavesOtherUrisAlone(string $stored): void {
+    $this->assertNull(ys_core_repair_double_encoded_link_uri($stored));
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/RestorePlusLinkUriTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/RestorePlusLinkUriTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Unit;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests which stored link URIs are candidates for having a "+" restored.
+ *
+ * Issue #1494 follow-up: the forward fix for #683
+ * (patches/contrib/linkit/3436733-5.patch) decoded the URI with urldecode(),
+ * which reads "+" as an encoded space. A link to a file named "a+b.pdf" was
+ * therefore saved as "a b.pdf" and 404s, because the href core builds asks for
+ * a file whose name really does contain a space.
+ *
+ * A space in a file name is ordinary and legitimate, so recognising a candidate
+ * is only half the decision - the caller confirms against the filesystem which
+ * of the two names actually exists. This covers the half that is pure: which
+ * URIs are even shaped like a candidate, and what the two file names are.
+ *
+ * @group ys_core
+ * @group yalesites
+ */
+class RestorePlusLinkUriTest extends UnitTestCase {
+
+  /**
+   * The public files directory, as PublicStream::basePath() reports it.
+   */
+  const BASE_PATH = 'sites/default/files';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    // The helper lives in ys_core.install, which defines functions only.
+    require_once __DIR__ . '/../../../ys_core.install';
+  }
+
+  /**
+   * URIs shaped like a candidate, with the candidate they produce.
+   */
+  public static function candidateUriProvider(): array {
+    return [
+      'a single eaten plus' => [
+        'internal:/sites/default/files/2026-08/a b.pdf',
+        [
+          'uri' => 'internal:/sites/default/files/2026-08/a+b.pdf',
+          'stored_file' => 'public://2026-08/a b.pdf',
+          'plus_file' => 'public://2026-08/a+b.pdf',
+        ],
+      ],
+      'the base scheme, which has no leading slash' => [
+        'base:sites/default/files/a b.pdf',
+        [
+          'uri' => 'base:sites/default/files/a+b.pdf',
+          'stored_file' => 'public://a b.pdf',
+          'plus_file' => 'public://a+b.pdf',
+        ],
+      ],
+      'several eaten pluses' => [
+        'internal:/sites/default/files/a b c.pdf',
+        [
+          'uri' => 'internal:/sites/default/files/a+b+c.pdf',
+          'stored_file' => 'public://a b c.pdf',
+          'plus_file' => 'public://a+b+c.pdf',
+        ],
+      ],
+      'a query string is preserved byte for byte' => [
+        'internal:/sites/default/files/a b.pdf?v=1+2',
+        [
+          'uri' => 'internal:/sites/default/files/a+b.pdf?v=1+2',
+          'stored_file' => 'public://a b.pdf',
+          'plus_file' => 'public://a+b.pdf',
+        ],
+      ],
+      'a fragment is preserved byte for byte' => [
+        'internal:/sites/default/files/a b.pdf#page 2',
+        [
+          'uri' => 'internal:/sites/default/files/a+b.pdf#page 2',
+          'stored_file' => 'public://a b.pdf',
+          'plus_file' => 'public://a+b.pdf',
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * A URI whose path holds a space inside the files directory is a candidate.
+   *
+   * @dataProvider candidateUriProvider
+   */
+  public function testRecognisesCandidates(string $stored, array $expected): void {
+    $this->assertSame($expected, ys_core_restore_plus_link_uri_candidate($stored, self::BASE_PATH));
+  }
+
+  /**
+   * The candidate it produces is never itself a candidate.
+   *
+   * @dataProvider candidateUriProvider
+   */
+  public function testCandidateIsIdempotent(string $stored, array $expected): void {
+    $this->assertNull(
+      ys_core_restore_plus_link_uri_candidate($expected['uri'], self::BASE_PATH),
+      'A URI whose plus is already restored holds no space to convert.'
+    );
+  }
+
+  /**
+   * URIs that are not candidates, whatever the filesystem says.
+   */
+  public static function nonCandidateProvider(): array {
+    return [
+      // Nothing was eaten: there is no space to put a plus back into.
+      'a file name with no space' => ['internal:/sites/default/files/report.pdf'],
+      'a file name that already holds a plus' => ['internal:/sites/default/files/a+b.pdf'],
+      // Outside the public files directory there is no file to check against,
+      // so there is no evidence either way and the value is left alone.
+      'a path outside the files directory' => ['internal:/some page/with a space'],
+      'a path that only looks like the files directory' => ['internal:/sites/default/filesystem/a b.pdf'],
+      // The files directory itself, with no file name below it to restore.
+      'the files directory and nothing else' => ['internal:/sites/default/files/'],
+      // Other schemes never reach the local path encoder.
+      'an external link' => ['https://example.com/a b.pdf'],
+      'a mailto link' => ['mailto:someone@example.com?subject=a b'],
+      'an entity reference URI' => ['entity:node/123'],
+      'a route URI' => ['route:<front>'],
+      // Still percent-encoded, so this is the #683 double-encoding case that
+      // ys_core_repair_double_encoded_link_uri() owns, not this one.
+      'a percent-encoded space' => ['internal:/sites/default/files/a%20b.pdf'],
+      // The space is in the query, which core rebuilds separately and which
+      // this repair never rewrites.
+      'a space only in the query string' => ['internal:/sites/default/files/report.pdf?q=a b'],
+      'a space only in the fragment' => ['internal:/sites/default/files/report.pdf#a b'],
+      'an empty string' => [''],
+    ];
+  }
+
+  /**
+   * A URI that is not shaped like a candidate is left alone.
+   *
+   * @dataProvider nonCandidateProvider
+   */
+  public function testLeavesNonCandidatesAlone(string $stored): void {
+    $this->assertNull(ys_core_restore_plus_link_uri_candidate($stored, self::BASE_PATH));
+  }
+
+  /**
+   * A space belonging to the files directory itself is not a file name's.
+   *
+   * A site whose public files path contains a space would otherwise make every
+   * link below it look like a candidate.
+   */
+  public function testIgnoresSpaceInTheFilesDirectoryItself(): void {
+    $base = 'sites/default/my files';
+
+    $this->assertNull(
+      ys_core_restore_plus_link_uri_candidate('internal:/sites/default/my files/report.pdf', $base),
+      'The directory\'s own space is not treated as an eaten plus.'
+    );
+    $this->assertNull(
+      ys_core_restore_plus_link_uri_candidate('internal:/sites/default/my files/', $base),
+      'A path naming only the directory has no file name to restore.'
+    );
+    // A space in the file name is still restored, and the directory's own space
+    // survives because the path is rebuilt from the stored bytes.
+    $this->assertSame(
+      [
+        'uri' => 'internal:/sites/default/my files/a+b.pdf',
+        'stored_file' => 'public://a b.pdf',
+        'plus_file' => 'public://a+b.pdf',
+      ],
+      ys_core_restore_plus_link_uri_candidate('internal:/sites/default/my files/a b.pdf', $base)
+    );
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
@@ -8,6 +8,7 @@
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
+use Drupal\Core\StreamWrapper\PublicStream;
 use Drupal\taxonomy\Entity\Term;
 
 /**
@@ -1463,6 +1464,32 @@ function ys_core_update_10018() {
 }
 
 /**
+ * Splits a local link URI into the scheme, the path, and what follows it.
+ *
+ * Only "internal:" and "base:" reach the local path encoder in
+ * UnroutedUrlAssembler::buildLocalUrl(), and only their path is ever rewritten:
+ * Url::fromUri() splits the query and fragment off first, so a repair has to
+ * keep everything from the "?" or "#" onwards byte for byte. Both link repairs
+ * below share this boundary, so they share one definition of it.
+ *
+ * @param string $uri
+ *   The stored link URI.
+ *
+ * @return array|null
+ *   NULL for any other scheme, otherwise [$scheme, $path, $suffix].
+ */
+function ys_core_split_link_uri($uri) {
+  if (!is_string($uri) || !preg_match('#^(internal|base):(.*)$#s', $uri, $matches)) {
+    return NULL;
+  }
+  [, $scheme, $remainder] = $matches;
+
+  $path_length = strcspn($remainder, '?#');
+
+  return [$scheme, substr($remainder, 0, $path_length), substr($remainder, $path_length)];
+}
+
+/**
  * Repairs one link URI that Drupal would render double-encoded.
  *
  * Before the Linkit widget started decoding URIs on save (issue #683, applied
@@ -1493,15 +1520,11 @@ function ys_core_update_10018() {
  *   The repaired URI, or NULL when the URI must be left as it is.
  */
 function ys_core_repair_double_encoded_link_uri($uri) {
-  if (!is_string($uri) || !preg_match('#^(internal|base):(.*)$#s', $uri, $matches)) {
+  $parts = ys_core_split_link_uri($uri);
+  if ($parts === NULL) {
     return NULL;
   }
-  [, $scheme, $remainder] = $matches;
-
-  // Keep the query and fragment byte for byte; they never double-encode.
-  $path_length = strcspn($remainder, '?#');
-  $path = substr($remainder, 0, $path_length);
-  $suffix = substr($remainder, $path_length);
+  [$scheme, $path, $suffix] = $parts;
 
   $decoded = rawurldecode($path);
   // Nothing is encoded, so nothing renders double-encoded.
@@ -1524,6 +1547,20 @@ function ys_core_repair_double_encoded_link_uri($uri) {
 /**
  * Repairs every stored link URI that Drupal would render double-encoded.
  *
+ * @param bool $dry_run
+ *   When TRUE, report what would change without writing anything.
+ *
+ * @return array
+ *   A report, as described on ys_core_rewrite_link_uris().
+ */
+function ys_core_repair_double_encoded_link_uris($dry_run = FALSE) {
+  // Only a value holding a percent can be encoded one time too many.
+  return ys_core_rewrite_link_uris('ys_core_repair_double_encoded_link_uri', '%', $dry_run);
+}
+
+/**
+ * Rewrites stored link URIs in place, wherever a rewrite rule matches one.
+ *
  * Writes the field tables directly instead of loading and saving entities. A
  * save would create a new revision, move the "changed" timestamp (polluting
  * the Authoring Dashboard's latest edits) and, for the non-reusable inline
@@ -1540,6 +1577,12 @@ function ys_core_repair_double_encoded_link_uri($uri) {
  * is no batching: this scans a handful of small field tables with one LIKE
  * each and rewrites only the rows that match.
  *
+ * @param callable $rewrite
+ *   Receives one stored URI and returns the value to store in its place, or
+ *   NULL to leave the row exactly as it is.
+ * @param string $needle
+ *   A substring every affected URI must contain, used to narrow the scan to
+ *   the rows that could possibly match.
  * @param bool $dry_run
  *   When TRUE, report what would change without writing anything.
  *
@@ -1547,7 +1590,7 @@ function ys_core_repair_double_encoded_link_uri($uri) {
  *   A report keyed 'repaired', 'left_alone', 'changes', 'left_alone_uris',
  *   'tables' and 'skipped_tables'.
  */
-function ys_core_repair_double_encoded_link_uris($dry_run = FALSE) {
+function ys_core_rewrite_link_uris(callable $rewrite, $needle, $dry_run = FALSE) {
   $database = \Drupal::database();
   $schema = $database->schema();
   $entity_type_manager = \Drupal::entityTypeManager();
@@ -1593,12 +1636,12 @@ function ys_core_repair_double_encoded_link_uris($dry_run = FALSE) {
 
         $rows = $database->select($table, 'f')
           ->fields('f', ['entity_id', 'revision_id', 'delta', 'langcode', $column])
-          ->condition($column, '%' . $database->escapeLike('%') . '%', 'LIKE')
+          ->condition($column, '%' . $database->escapeLike($needle) . '%', 'LIKE')
           ->execute();
 
         foreach ($rows as $row) {
           $stored = $row->{$column};
-          $repaired = ys_core_repair_double_encoded_link_uri($stored);
+          $repaired = $rewrite($stored);
           if ($repaired === NULL) {
             $report['left_alone']++;
             $report['left_alone_uris'][$stored] = $stored;
@@ -1671,6 +1714,157 @@ function ys_core_update_10019() {
   }
 
   return t('Repaired @repaired double-encoded link URI(s) across @tables field table(s); left @left_alone value(s) untouched.', [
+    '@repaired' => $report['repaired'],
+    '@tables' => $report['tables'],
+    '@left_alone' => $report['left_alone'],
+  ]);
+}
+
+/**
+ * Describes how a link URI would look with an eaten "+" put back.
+ *
+ * The forward fix for issue #683 (patches/contrib/linkit/3436733-5.patch) ran
+ * the URI through urldecode(), which reads "+" as an encoded space. A link to a
+ * file named "a+b.pdf" was therefore stored as "a b.pdf", and the href core
+ * builds from it asks for a file whose name really does contain a space, so the
+ * link 404s. That patch now uses rawurldecode(), which leaves "+" alone, but
+ * values already saved through the old one stay wrong until they are rewritten.
+ *
+ * Recognising the shape is only half of the decision, because a space in a file
+ * name is perfectly ordinary: "My Report.pdf" is stored with a literal space by
+ * the same widget and is correct. So this reports the two file names the value
+ * could mean and leaves the caller to confirm against the filesystem which one
+ * actually exists.
+ *
+ * Only a path inside the public files directory is described. Elsewhere there
+ * is no file to check, so there is no evidence either way and nothing should be
+ * rewritten. A path still holding a percent-escape is left to
+ * ys_core_repair_double_encoded_link_uri(), whose case it is.
+ *
+ * Every space becomes a "+", all or nothing, which is the whole of what the old
+ * urldecode() call could have produced from a name of only pluses. A file whose
+ * name mixes a real space with an eaten plus ("a+b c.pdf") is therefore not
+ * recovered - no combination is tried - and is left alone rather than guessed
+ * at. Restoring one of those means re-saving the content.
+ *
+ * @param string $uri
+ *   The stored link URI.
+ * @param string $files_base_path
+ *   The public files directory, as PublicStream::basePath() reports it.
+ *
+ * @return array|null
+ *   NULL when the URI cannot be a decoded "+", otherwise an array keyed:
+ *   - 'uri': the URI with the path's spaces restored to "+".
+ *   - 'stored_file': the stream URI of the file the value names as stored.
+ *   - 'plus_file': the stream URI of the file it would name once restored.
+ */
+function ys_core_restore_plus_link_uri_candidate($uri, $files_base_path) {
+  $parts = ys_core_split_link_uri($uri);
+  if ($parts === NULL) {
+    return NULL;
+  }
+  [$scheme, $path, $suffix] = $parts;
+
+  // A percent-escape survives, so the value mixes a literal space with an
+  // escape. That is not something the old urldecode() produced on its own, so
+  // what it means is ambiguous and it is not rewritten.
+  if (rawurldecode($path) !== $path) {
+    return NULL;
+  }
+
+  // "internal:" paths carry a leading slash and "base:" ones do not.
+  $normalised = '/' . ltrim($path, '/');
+  $prefix = '/' . trim($files_base_path, '/') . '/';
+  if (!str_starts_with($normalised, $prefix)) {
+    return NULL;
+  }
+  $relative = substr($normalised, strlen($prefix));
+
+  // The space has to be in the file name, not in the files directory's own
+  // path: a site whose public files directory contains a space would otherwise
+  // look like a candidate on every link. This also rules out an empty file
+  // name, which holds no space to convert.
+  if (!str_contains($relative, ' ')) {
+    return NULL;
+  }
+
+  $plus_relative = str_replace(' ', '+', $relative);
+  // Rebuilt from the stored bytes so the scheme's own prefix is preserved.
+  $plus_path = substr($path, 0, strlen($path) - strlen($relative)) . $plus_relative;
+
+  return [
+    'uri' => $scheme . ':' . $plus_path . $suffix,
+    'stored_file' => 'public://' . $relative,
+    'plus_file' => 'public://' . $plus_relative,
+  ];
+}
+
+/**
+ * Restores every stored link URI whose "+" was decoded away as a space.
+ *
+ * A value is rewritten only on positive evidence: the file it names as stored
+ * is not there, and the one it would name with its "+" back is. Every other
+ * combination is left alone, so a genuine "My Report.pdf" is never touched, and
+ * a link whose file has simply been deleted is not guessed at either.
+ *
+ * @param bool $dry_run
+ *   When TRUE, report what would change without writing anything.
+ *
+ * @return array
+ *   A report, as described on ys_core_rewrite_link_uris().
+ */
+function ys_core_restore_plus_link_uris($dry_run = FALSE) {
+  $files_base_path = PublicStream::basePath();
+  $undecided = [];
+
+  $rewrite = function ($stored) use ($files_base_path, &$undecided) {
+    $candidate = ys_core_restore_plus_link_uri_candidate($stored, $files_base_path);
+    if ($candidate === NULL) {
+      return NULL;
+    }
+    // The file is there under the name as stored, so the space is genuine.
+    if (file_exists($candidate['stored_file'])) {
+      return NULL;
+    }
+    if (!file_exists($candidate['plus_file'])) {
+      // Neither name is on disk, so there is nothing to decide from. Collected
+      // rather than dropped: this is also what a run against an environment
+      // that has no copy of the files looks like, and the hook only runs once.
+      $undecided[$stored] = $stored;
+      return NULL;
+    }
+    return $candidate['uri'];
+  };
+
+  $report = ys_core_rewrite_link_uris($rewrite, ' ', $dry_run);
+  $report['undecided_uris'] = array_values($undecided);
+
+  return $report;
+}
+
+/**
+ * Restores document links whose "+" was saved as a space after issue #683.
+ */
+function ys_core_update_10020() {
+  $report = ys_core_restore_plus_link_uris();
+  $logger = \Drupal::logger('ys_core');
+
+  foreach ($report['changes'] as $change) {
+    $logger->notice('Restored "+" in link URI: @change', ['@change' => $change]);
+  }
+  if ($report['undecided_uris']) {
+    // Neither the stored name nor its "+" form is on disk. Either the document
+    // was deleted, its name mixes a real space with an eaten "+", or this
+    // environment has no copy of the files. Named so the case is visible: this
+    // hook runs once, so anything it could not decide needs a manual look or a
+    // re-run of ys_core_restore_plus_link_uris() once the files are present.
+    $logger->warning('Left @count link URI(s) with a space alone because no matching file was found either way; re-save the content or re-run the repair once the files are present: @uris', [
+      '@count' => count($report['undecided_uris']),
+      '@uris' => implode(', ', $report['undecided_uris']),
+    ]);
+  }
+
+  return t('Restored @repaired link URI(s) whose "+" had been saved as a space, across @tables field table(s); left @left_alone value(s) containing a space untouched.', [
     '@repaired' => $report['repaired'],
     '@tables' => $report['tables'],
     '@left_alone' => $report['left_alone'],

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.install
@@ -6,6 +6,8 @@
  */
 
 use Drupal\Component\Utility\Xss;
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
 use Drupal\taxonomy\Entity\Term;
 
 /**
@@ -1457,5 +1459,220 @@ function ys_core_update_10018() {
   return t('Uninstalled @module (cleaned: @what).', [
     '@module' => $module,
     '@what' => implode(', ', $cleaned),
+  ]);
+}
+
+/**
+ * Repairs one link URI that Drupal would render double-encoded.
+ *
+ * Before the Linkit widget started decoding URIs on save (issue #683, applied
+ * as patches/contrib/linkit/3436733-5.patch), a file name containing a space
+ * was stored still percent-encoded, e.g.
+ * "internal:/sites/default/files/My%20File.pdf". Drupal percent-encodes the
+ * path again when it builds the href, in
+ * UnroutedUrlAssembler::buildLocalUrl(), so "%20" becomes "%2520" and the link
+ * 404s. Only a re-save repaired it, which is why nothing self-healed.
+ *
+ * Only the path of an "internal:" or "base:" URI is affected. Url::fromUri()
+ * splits the query and fragment off before that encoding happens - the query
+ * is decoded and rebuilt by UrlHelper::buildQuery(), the fragment is appended
+ * verbatim - and buildExternalUrl() returns external URIs untouched. So this
+ * only ever rewrites the path, and only for those two schemes.
+ *
+ * A value is repaired only when its stored path is exactly the canonical
+ * percent-encoding of its decoded form and decoding leaves no percent behind.
+ * That is what "encoded one time too many" looks like, and requiring it keeps
+ * two kinds of value safe: a path that merely contains a percent (a file named
+ * "100% off.pdf"), and one encoded more than twice, which a second run would
+ * otherwise decode again.
+ *
+ * @param string $uri
+ *   The stored link URI.
+ *
+ * @return string|null
+ *   The repaired URI, or NULL when the URI must be left as it is.
+ */
+function ys_core_repair_double_encoded_link_uri($uri) {
+  if (!is_string($uri) || !preg_match('#^(internal|base):(.*)$#s', $uri, $matches)) {
+    return NULL;
+  }
+  [, $scheme, $remainder] = $matches;
+
+  // Keep the query and fragment byte for byte; they never double-encode.
+  $path_length = strcspn($remainder, '?#');
+  $path = substr($remainder, 0, $path_length);
+  $suffix = substr($remainder, $path_length);
+
+  $decoded = rawurldecode($path);
+  // Nothing is encoded, so nothing renders double-encoded.
+  if ($decoded === $path) {
+    return NULL;
+  }
+  // A percent survives decoding, so what the value means is ambiguous.
+  if (str_contains($decoded, '%')) {
+    return NULL;
+  }
+  // Re-encoding has to reproduce the stored path exactly, mirroring how core
+  // builds the href. Anything else is not a cleanly double-encoded value.
+  if (str_replace('%2F', '/', rawurlencode($decoded)) !== $path) {
+    return NULL;
+  }
+
+  return $scheme . ':' . $decoded . $suffix;
+}
+
+/**
+ * Repairs every stored link URI that Drupal would render double-encoded.
+ *
+ * Writes the field tables directly instead of loading and saving entities. A
+ * save would create a new revision, move the "changed" timestamp (polluting
+ * the Authoring Dashboard's latest edits) and, for the non-reusable inline
+ * blocks that hold most of the affected data, leave the parent node's layout
+ * still pointing at the old block revision.
+ *
+ * Both the field data table and the field revision table are rewritten:
+ * Layout Builder renders an inline block from a specific revision id
+ * (InlineBlock::getEntity() calls loadRevision()), so correcting the data
+ * table alone would not change what a visitor sees.
+ *
+ * Every link field on the site is covered, discovered from the field map, so
+ * a site with link fields this platform does not ship is repaired too. There
+ * is no batching: this scans a handful of small field tables with one LIKE
+ * each and rewrites only the rows that match.
+ *
+ * @param bool $dry_run
+ *   When TRUE, report what would change without writing anything.
+ *
+ * @return array
+ *   A report keyed 'repaired', 'left_alone', 'changes', 'left_alone_uris',
+ *   'tables' and 'skipped_tables'.
+ */
+function ys_core_repair_double_encoded_link_uris($dry_run = FALSE) {
+  $database = \Drupal::database();
+  $schema = $database->schema();
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $entity_field_manager = \Drupal::service('entity_field.manager');
+
+  $report = [
+    'repaired' => 0,
+    'left_alone' => 0,
+    'changes' => [],
+    'left_alone_uris' => [],
+    'tables' => 0,
+    'skipped_tables' => [],
+  ];
+  $affected = [];
+
+  foreach ($entity_field_manager->getFieldMapByFieldType('link') as $entity_type_id => $fields) {
+    $storage = $entity_type_manager->getStorage($entity_type_id);
+    if (!$storage instanceof SqlContentEntityStorage) {
+      continue;
+    }
+    $table_mapping = $storage->getTableMapping();
+    $storage_definitions = $entity_field_manager->getFieldStorageDefinitions($entity_type_id);
+
+    foreach (array_keys($fields) as $field_name) {
+      // A field the entity type stores itself has no table to rewrite, and
+      // asking for its column would throw and abort the whole update.
+      if (!isset($storage_definitions[$field_name]) || $storage_definitions[$field_name]->hasCustomStorage()) {
+        continue;
+      }
+      $column = $table_mapping->getFieldColumnName($storage_definitions[$field_name], 'uri');
+
+      // Returns the field's data table and, for a revisionable entity type,
+      // its revision table.
+      foreach ($table_mapping->getAllFieldTableNames($field_name) as $table) {
+        // Only dedicated field tables are handled, which are the ones with a
+        // delta column. A field stored in a shared table is reported rather
+        // than guessed at.
+        if (!$schema->tableExists($table) || !$schema->fieldExists($table, $column) || !$schema->fieldExists($table, 'delta')) {
+          $report['skipped_tables'][] = $table;
+          continue;
+        }
+        $report['tables']++;
+
+        $rows = $database->select($table, 'f')
+          ->fields('f', ['entity_id', 'revision_id', 'delta', 'langcode', $column])
+          ->condition($column, '%' . $database->escapeLike('%') . '%', 'LIKE')
+          ->execute();
+
+        foreach ($rows as $row) {
+          $stored = $row->{$column};
+          $repaired = ys_core_repair_double_encoded_link_uri($stored);
+          if ($repaired === NULL) {
+            $report['left_alone']++;
+            $report['left_alone_uris'][$stored] = $stored;
+            continue;
+          }
+
+          if (!$dry_run) {
+            $database->update($table)
+              ->fields([$column => $repaired])
+              ->condition('entity_id', $row->entity_id)
+              ->condition('revision_id', $row->revision_id)
+              ->condition('delta', $row->delta)
+              ->condition('langcode', $row->langcode)
+              ->execute();
+          }
+
+          $report['repaired']++;
+          $report['changes'][] = sprintf('%s [entity %s, revision %s, delta %s]: %s => %s', $table, $row->entity_id, $row->revision_id, $row->delta, $stored, $repaired);
+          $affected[$entity_type_id][$row->entity_id] = $row->entity_id;
+        }
+      }
+    }
+  }
+
+  $report['left_alone_uris'] = array_values($report['left_alone_uris']);
+  $report['skipped_tables'] = array_values(array_unique($report['skipped_tables']));
+
+  if (!$dry_run && $affected) {
+    $tags = [];
+    foreach ($affected as $entity_type_id => $ids) {
+      // The rows were written underneath the entity storage cache, which keys
+      // its entries by entity id rather than by a per-entity cache tag.
+      $entity_type_manager->getStorage($entity_type_id)->resetCache(array_values($ids));
+      foreach ($ids as $id) {
+        $tags[] = $entity_type_id . ':' . $id;
+      }
+    }
+    // Flushes the render and page caches holding the corrected links, which
+    // pick up the entity's cache tag through EntityViewBuilder::view().
+    Cache::invalidateTags($tags);
+  }
+
+  return $report;
+}
+
+/**
+ * Repairs document links stored double-encoded before issue #683.
+ */
+function ys_core_update_10019() {
+  $report = ys_core_repair_double_encoded_link_uris();
+  $logger = \Drupal::logger('ys_core');
+
+  foreach ($report['changes'] as $change) {
+    $logger->notice('Repaired double-encoded link URI: @change', ['@change' => $change]);
+  }
+  if ($report['left_alone_uris']) {
+    $logger->warning('Left @count link URI(s) containing a percent character untouched; re-save the content to repair them: @uris', [
+      '@count' => count($report['left_alone_uris']),
+      '@uris' => implode(', ', $report['left_alone_uris']),
+    ]);
+  }
+  if ($report['skipped_tables']) {
+    // Link fields kept in shared table storage, such as the menu link content
+    // base field, are outside what this repairs; say so rather than implying
+    // every link on the site was covered.
+    $logger->notice('Skipped @count link table(s) that do not use dedicated field storage, so any double-encoded values there are unchanged: @tables', [
+      '@count' => count($report['skipped_tables']),
+      '@tables' => implode(', ', $report['skipped_tables']),
+    ]);
+  }
+
+  return t('Repaired @repaired double-encoded link URI(s) across @tables field table(s); left @left_alone value(s) untouched.', [
+    '@repaired' => $report['repaired'],
+    '@tables' => $report['tables'],
+    '@left_alone' => $report['left_alone'],
   ]);
 }


### PR DESCRIPTION
## [1494: RC: Retroactively fix pre-#683 document links that still render double-encoded (%2520)](https://github.com/yalesites-org/YaleSites-Internal/issues/1494)

### Description of work

- Adds `ys_core_update_10019()`, a one-time update hook that repairs link URIs stored with their percent-encoding still intact from before yalesites-org/YaleSites-Internal#683. Drupal encodes the path a second time when it builds the href (`UnroutedUrlAssembler::buildLocalUrl()`), so a stored `%20` rendered as `%2520` and the document 404'd. The #683 fix only decodes at save time, so nothing self-healed.
- Writes the field tables directly instead of loading and saving entities, so **no new revisions are created and no `changed` timestamps move** into the Authoring Dashboard's "Latest Edits". Both the field data table and the field revision table are rewritten, because Layout Builder renders an inline block from a specific revision id (`InlineBlock::getEntity()` calls `loadRevision()`).
- Repairs only the **path** of an `internal:`/`base:` URI. `Url::fromUri()` splits the query and fragment off before that encoding happens, and external URIs are returned untouched, so neither can double-encode. A value is rewritten only when its stored path is exactly the canonical encoding of its decoded form **and** decoding leaves no percent behind — which keeps a file named `100% off.pdf` intact and makes the hook strictly idempotent.
- Discovers link fields from the field map rather than a hardcoded list, so a site's own link fields are covered too. Link fields kept in shared table storage (the menu link base field, redirects) are **logged as skipped** rather than silently implied to be covered.
- Invalidates the affected entities' cache tags and resets the entity storage cache, so corrected links appear without a manual cache rebuild.
- Adds Unit coverage for the match rule (22 cases, including the values that must not be touched) and Kernel coverage proving both tables are repaired, no revisions are created, `changed` does not move, the run is idempotent, and a dry run writes nothing.

### Verification performed locally

Run against a real pulled database, on the visual-regression content that reproduces the issue:

- `drush updatedb` reported: `Repaired 7 double-encoded link URI(s) across 32 field table(s); left 0 value(s) untouched.`
- `/blocks-for-visreg/button` went from **3** `%2520` hrefs to **0**, with no manual cache rebuild.
- The corrected URL returns **HTTP 200** with the spreadsheet content type; the double-encoded URL returned **404**.
- `block_content_revision` row count unchanged (450 to 450); all 8 captured `changed` timestamps byte-identical.
- Second run repaired 0 rows; a rescan found 0 remaining candidates.
- **No queue items were created**, confirming Beacon/Search API indexing is not triggered. Direct table writes invoke no entity hooks at all, so this is structural rather than incidental.
- ys_core Kernel suite on MySQL: 17 tests, 0 failures. ys_core Unit suite: 153 tests vs a 131-test baseline (the 22 added), 0 failures.
- `composer code-sniff` exits 0.

### Functional testing steps:

- [ ] Visit a page with a Button Link (or any link field) pointing at a document whose file name contains spaces, saved before the #683 fix
- [ ] Confirm the link's href contains `%20` rather than `%2520`
- [ ] Click the link and confirm the document opens rather than 404ing
- [ ] Confirm the content's "Changed" date has not moved and no new revision was created
- [ ] Confirm links that were already correct, and external links, are unchanged

Added for the `+` rework (`ys_core_update_10020()` and the patch change):

- [ ] Upload a document whose file name contains a `+` and no space, e.g. `annual+report.pdf`
- [ ] Paste that file's path into a Button Link with a literal `+` (not `%2B`) and save
- [ ] Confirm the stored link keeps the `+` (it used to be saved with a space), the rendered href is `annual%2Breport.pdf`, and clicking it opens the document
- [ ] For the retroactive half: with such a document in place, set a link's stored URI to the space form (`annual report.pdf`) and run `drush updatedb`; confirm the `+` is restored and the link resolves
- [ ] Confirm a link to a document whose name genuinely contains a space is **not** rewritten
- [ ] Confirm a link whose document no longer exists is left alone, and appears in the dblog warning naming what could not be decided

### Notes for the reviewer

- **A correction to the ticket's example.** The ticket motivates the revision-table handling with block 126 / revision 217. Querying the layout API shows revision 217 is rendered by no node — it is an orphaned historical revision, and block 126's current revision was already correct. The genuinely load-bearing cases are revisions 218, 220 and 225, which are exactly the three broken hrefs that were rendering. Writing the revision table is still required, but for those rather than for 217.
- **The `+` problem is now fixed here too**, per review feedback. The patch uses `rawurldecode()` so `+` is no longer eaten at save time, and `ys_core_update_10020()` repairs values already stored with a space, deciding from the filesystem which of the two file names exists. The pre-#683 form (`a%2Bb.pdf`) needed no new logic — the 10019 rule already repairs it — and now has test coverage.
- **A separate pre-existing bug, NOT fixed here and not a regression from this PR:** the patch decodes the *whole* URI rather than just the path, and `LinkitHelper::uriFromUserInput()` returns `mailto:` and external input verbatim. So a stored `?token=a%26b` becomes `?token=a&b` (splitting the parameter) and `?q=one%23two` becomes a fragment. `urldecode()` did the same, so this is already live on `master`. It wants its own ticket; see the PR comment for the suggested fix.
- Link fields in shared table storage are not repaired (0 affected rows were found on the test database); the hook logs exactly which tables it skipped so this is visible rather than assumed.

References yalesites-org/YaleSites-Internal#1494

---
Created with AI

