### PR TITLE
1508: RC: Sitewide alert block shows a contextual edit button on the front end

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/tests/src/Kernel/AlertBlockContextualLinksTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/tests/src/Kernel/AlertBlockContextualLinksTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Drupal\Tests\ys_alert\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\block\BlockViewBuilder;
+use Drupal\block\Entity\Block;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests that a placed alert block renders with no contextual links.
+ *
+ * The Unit test covers what the alter hook does to a render array. This one
+ * covers the part that only real hook discovery can: that the hook is *named*
+ * so core actually calls it for this plugin. The name embeds the plugin's base
+ * id (`block_view_<base_id>_alter`), so renaming the `alert_block` plugin id
+ * would silently stop the hook firing and bring the pencil back. Reading the
+ * plugin id out of the shipped block placement instead of hardcoding it here is
+ * what makes that regression fail this test.
+ *
+ * @see \Drupal\block\BlockViewBuilder::buildPreRenderableBlock()
+ * @see \Drupal\Tests\ys_alert\Unit\AlertBlockContextualLinksTest
+ *
+ * @group yalesites
+ * @group ys_alert
+ */
+class AlertBlockContextualLinksTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'block',
+    'ys_alert',
+  ];
+
+  /**
+   * {@inheritdoc}
+   *
+   * The ys_alert.settings config ships without a schema file.
+   *
+   * @see \Drupal\Tests\ys_alert\Kernel\AlertSettingsFormTest
+   */
+  // phpcs:ignore DrupalPractice.Objects.StrictSchemaDisabled.StrictConfigSchema
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['ys_alert']);
+    $this->container->get('theme_installer')->install(['stark']);
+  }
+
+  /**
+   * The sitewide alert placement ends up with an empty contextual-links set.
+   */
+  public function testPlacedAlertBlockHasNoContextualLinks(): void {
+    $build = $this->buildPlacedBlock($this->alertPluginId(), 'alert_block');
+
+    // Empty rather than absent: core's contextual_preprocess() guards on
+    // !empty(), so this is what stops the pencil rendering for every role.
+    $this->assertArrayHasKey('#contextual_links', $build);
+    $this->assertEmpty($build['#contextual_links']);
+  }
+
+  /**
+   * Other placed blocks keep the "Configure block" link core gives them.
+   *
+   * Guards against the fix over-reaching — the hook is keyed to one plugin, and
+   * this is the control proving it.
+   */
+  public function testOtherPlacedBlocksKeepTheirContextualLinks(): void {
+    $build = $this->buildPlacedBlock('system_powered_by_block', 'powered_by');
+
+    $this->assertArrayHasKey('block', $build['#contextual_links']);
+  }
+
+  /**
+   * Places a block and returns the render array core hands to the alter hooks.
+   *
+   * @param string $plugin_id
+   *   The block plugin to place.
+   * @param string $block_id
+   *   The block config entity id to create.
+   *
+   * @return array
+   *   The pre-renderable block render array, post-alter.
+   */
+  protected function buildPlacedBlock(string $plugin_id, string $block_id): array {
+    Block::create([
+      'id' => $block_id,
+      'plugin' => $plugin_id,
+      'theme' => 'stark',
+      'region' => 'content',
+    ])->save();
+
+    // lazyBuilder() is the path a themed region takes, and it is where core
+    // attaches the contextual links and then invokes the alter hooks.
+    return BlockViewBuilder::lazyBuilder($block_id, 'full');
+  }
+
+  /**
+   * Reads the alert block's plugin id from the placement the profile ships.
+   *
+   * Deliberately not hardcoded — see the class docblock.
+   *
+   * @return string
+   *   The block plugin id used by the sitewide alert placement.
+   */
+  protected function alertPluginId(): string {
+    $placement = dirname(__DIR__, 6) . '/config/sync/block.block.alert_block.yml';
+    $this->assertFileExists($placement);
+
+    return Yaml::parseFile($placement)['plugin'];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/tests/src/Unit/AlertBlockContextualLinksTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/tests/src/Unit/AlertBlockContextualLinksTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Drupal\Tests\ys_alert\Unit;
+
+use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests that the sitewide alert block carries no contextual "configure" link.
+ *
+ * Regression coverage for the bug where hovering the sitewide alert on the
+ * front end revealed Drupal's contextual edit pencil to anyone who can
+ * administer blocks. The pencil pointed at the block instance's configure form
+ * — which only exposes the block label and visibility conditions, not the alert
+ * content — so it was at best confusing and at worst an invitation to unplace
+ * the alert. Alerts are managed only through Alert Settings at
+ * /admin/yalesites/alert.
+ *
+ * Core attaches the group unconditionally to every placed block, then invokes
+ * this alter hook on the same render array.
+ *
+ * Scope: this covers what the hook does to a render array. That core actually
+ * calls it for this plugin — the hook name embeds the plugin's base id — is
+ * covered by the Kernel test, which goes through real hook discovery.
+ *
+ * @see \Drupal\block\BlockViewBuilder::buildPreRenderableBlock()
+ * @see \Drupal\Tests\ys_alert\Kernel\AlertBlockContextualLinksTest
+ *
+ * @group yalesites
+ * @group ys_alert
+ */
+class AlertBlockContextualLinksTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    require_once dirname(__DIR__, 3) . '/ys_alert.module';
+  }
+
+  /**
+   * The block group core attaches is removed, so no pencil is ever rendered.
+   */
+  public function testConfigureLinkIsRemoved(): void {
+    $build = $this->build();
+
+    ys_alert_block_view_alert_block_alter($build, $this->blockPlugin());
+
+    $this->assertArrayNotHasKey('block', $build['#contextual_links']);
+    // Core only renders the contextual placeholder for a non-empty
+    // #contextual_links, so emptying it suppresses the pencil for every role
+    // rather than relying on the configure form's own permission check.
+    // @see contextual_preprocess()
+    $this->assertEmpty($build['#contextual_links']);
+  }
+
+  /**
+   * Only the block group is targeted; anything else on the alert survives.
+   */
+  public function testUnrelatedGroupsAreUntouched(): void {
+    $build = $this->build();
+    $build['#contextual_links']['some_other_group'] = ['route_parameters' => []];
+
+    ys_alert_block_view_alert_block_alter($build, $this->blockPlugin());
+
+    $this->assertSame(
+      ['some_other_group' => ['route_parameters' => []]],
+      $build['#contextual_links']
+    );
+  }
+
+  /**
+   * The hook must not fail on a build that has no contextual links at all.
+   */
+  public function testIsNoOpWhenGroupAbsent(): void {
+    $build = $this->build();
+    unset($build['#contextual_links']);
+    $expected = $build;
+
+    ys_alert_block_view_alert_block_alter($build, $this->blockPlugin());
+
+    $this->assertSame($expected, $build);
+  }
+
+  /**
+   * Builds the render array core hands to the alter hook.
+   *
+   * Mirrors the relevant keys of BlockViewBuilder::buildPreRenderableBlock().
+   *
+   * @return array
+   *   A placed-block render array with core's "block" contextual-links group.
+   */
+  protected function build(): array {
+    return [
+      '#theme' => 'block',
+      '#contextual_links' => [
+        'block' => [
+          'route_parameters' => ['block' => 'alert_block'],
+        ],
+      ],
+      '#plugin_id' => 'alert_block',
+      '#id' => 'alert_block',
+    ];
+  }
+
+  /**
+   * The block plugin core passes as the hook's second argument.
+   *
+   * @return \Drupal\Core\Block\BlockPluginInterface
+   *   A block plugin double.
+   */
+  protected function blockPlugin(): BlockPluginInterface {
+    return $this->createMock(BlockPluginInterface::class);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_alert/ys_alert.module
@@ -7,6 +7,8 @@
  * This modules holds YaleSites Alerts functionality.
  */
 
+use Drupal\Core\Block\BlockPluginInterface;
+
 /**
  * Implements hook_theme().
  */
@@ -36,4 +38,18 @@ function ys_alert_preprocess_page(&$variables) {
   // Via: https://drupal.stackexchange.com/questions/266379/how-to-clear-cache-for-config-entity-after-making-changes
   // Also used: https://github.com/yalesites-org/yalesites-project/blob/4cd183c8f568b771d656478adb3b76985501c3a1/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/ys_themes.module#LL144C1-L144C1
   \Drupal::service('renderer')->addCacheableDependency($variables, $config);
+}
+
+/**
+ * Implements hook_block_view_BASE_ID_alter() for the alert_block plugin.
+ */
+function ys_alert_block_view_alert_block_alter(array &$build, BlockPluginInterface $block) {
+  // Core gives every placed block a "Configure block" contextual link, putting
+  // an edit pencil on the sitewide alert for anyone who can administer blocks.
+  // That form only exposes the block label and visibility conditions, not the
+  // alert content, which is managed in Alert Settings (/admin/yalesites/alert).
+  // Dropping the group leaves #contextual_links empty, so core renders no
+  // placeholder for any role. The form stays reachable from
+  // /admin/structure/block.
+  unset($build['#contextual_links']['block']);
 }


### PR DESCRIPTION
## [1508: RC: Sitewide alert block shows a contextual edit button on the front end](https://github.com/yalesites-org/YaleSites-Internal/issues/1508)

### Description of work
- Adds `hook_block_view_BASE_ID_alter()` in `ys_alert` for the `alert_block` plugin, dropping the `block` contextual-links group so Drupal's contextual edit pencil no longer renders on the sitewide alert on the front end.
- Core attaches a "Configure block" link to *every* placed block. On the alert that pencil opened the block instance form — block label and visibility conditions only — not the alert content, which is managed in Alert Settings at `/admin/yalesites/alert`.
- This removes the control rather than changing any permission: `entity.block.edit_form` stays gated by "administer blocks", and platform admins can still reach the block instance form from `/admin/structure/block`.
- Because core only renders the contextual placeholder for a non-empty `#contextual_links`, emptying the group suppresses the pencil for **every** role rather than relying on a per-role permission check.
- Keying the hook to the single `alert_block` plugin (rather than a global `hook_block_view_alter()` plus a condition) means other placed blocks are structurally unaffected.
- **Answers the open grooming question on the issue:** of the roles on the platform, only `platform_admin` holds "administer blocks", so it was the only role that actually saw the pencil. `site_admin`, `editor`, and `contributor` have "access contextual links" but not "administer blocks", so they received the placeholder attribute but no rendered pencil. After this change the placeholder is not emitted for any of them.
- Covered by a Unit test for the hook body plus a Kernel test that runs real hook discovery and reads the plugin id out of the shipped `block.block.alert_block.yml`, so renaming the `alert_block` plugin id cannot silently break the hook-name coupling and quietly restore the pencil.

### Functional testing steps:
- [ ] As a platform admin, confirm a sitewide alert is active (set one at `/admin/yalesites/alert`).
- [ ] Visit any front-end page where the alert renders and hover over the alert — **no** round edit pencil appears at the upper right.
- [ ] Hover a different placed block (e.g. the footer block) — its contextual pencil **still** appears, with "Configure block" / "Remove block".
- [ ] Confirm Alert Settings at `/admin/yalesites/alert` still loads with the current alert values and still saves.
- [ ] Log in as a site admin (or any non-platform-admin role) and confirm the alert shows no pencil there either.
- [ ] The alert itself is unchanged: headline, message, link, and the dismiss ("X") button all still render and work.
- [ ] If a pencil still shows immediately after deploy, rebuild caches — the block render cache is keyed `entity_view:block:alert_block`, so a pre-fix cached entry can survive until a rebuild. `drush deploy` covers this.

References yalesites-org/YaleSites-Internal#1508

---
Created with AI
