### PR TITLE
1496: RC: Quick Links block: malformed link URL crashes the page with a 500 error

### DIFF
--- a/patches/contrib/gin_lb/3387157-mr-73.patch
+++ b/patches/contrib/gin_lb/3387157-mr-73.patch
@@ -1,0 +1,13 @@
+diff --git a/src/HookHandler/Preprocess.php b/src/HookHandler/Preprocess.php
+index d0d42acbb1e618a2ba9d39c4564e8e3f5979ac22..20c3f9efaee412e6615aa756bed506bbca37a8a9 100644
+--- a/src/HookHandler/Preprocess.php
++++ b/src/HookHandler/Preprocess.php
+@@ -116,7 +116,7 @@ class Preprocess implements ContainerInjectionInterface {
+           '#type' => 'html_tag',
+           '#tag' => 'h4',
+           '#value' => $variables['element']['#title'],
+-          '#attributes' => $header_attributes,
++          '#attributes' => new Attribute($header_attributes),
+         ];
+ 
+         if ($variables['disabled']) {

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -150,6 +150,9 @@
       "drupal/gin": {
         "fix description toggle for CKEditor fields https://www.drupal.org/project/gin/issues/3316265": "patches/contrib/gin/3316265-mr-227.patch"
       },
+      "drupal/gin_lb": {
+        "Pass the field table header cell an Attribute object so Claro can preprocess it instead of fatalling https://www.drupal.org/project/gin_lb/issues/3387157": "patches/contrib/gin_lb/3387157-mr-73.patch"
+      },
       "drupal/layout_builder_browser": {
         "Add grouping of reusable blocks (3409153) and add fallback images (3408935) - can't use both patches from d.o would cause merge conflict, combined patch": "patches/contrib/layout_builder_browser/3408935-and-3409153-9.patch"
       },

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/GinLbHeaderAttributesTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/GinLbHeaderAttributesTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Drupal\Tests\ys_layouts\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Template\Attribute;
+use Drupal\Tests\UnitTestCase;
+use Drupal\gin_lb\HookHandler\Preprocess;
+use Drupal\gin_lb\Service\ContextValidatorInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Tests that gin_lb leaves Claro a usable field table header attribute object.
+ *
+ * Regression test for the HTTP 500 an editor hit when a Layout Builder block
+ * form re-rendered a multi-value field after a validation failure — e.g.
+ * adding a Quick Links block with a mistyped protocol such as
+ * "htp://example.com". Core builds the field table's header cell with a
+ * \Drupal\Core\Template\Attribute object, but gin_lb replaced that cell
+ * wholesale using a plain PHP array. Claro's preprocess runs after every
+ * module preprocess and calls ->removeClass() on it, fatalling with "Call to
+ * a member function removeClass() on array".
+ *
+ * The fix is the upstream gin_lb patch for
+ * https://www.drupal.org/project/gin_lb/issues/3387157, carried in
+ * patches/contrib/gin_lb/ because YaleSites pins gin_lb 2.0.0-beta1 and the
+ * fix only shipped in 3.0.x.
+ *
+ * These tests fail if that patch is dropped, but only on a local PHPUnit run —
+ * this project's CI runs no PHPUnit (composer unit-test is a stub), so nothing
+ * automated re-verifies the patch is still registered.
+ *
+ * @group yalesites
+ * @group ys_layouts
+ */
+class GinLbHeaderAttributesTest extends UnitTestCase {
+
+  /**
+   * The gin_lb preprocess hook handler under test.
+   *
+   * @var \Drupal\gin_lb\HookHandler\Preprocess
+   */
+  protected Preprocess $preprocess;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // claro_preprocess_field_multiple_value_form() is the function that
+    // fatalled, so load the theme that declares it.
+    if (!function_exists('claro_preprocess_field_multiple_value_form')) {
+      require_once DRUPAL_ROOT . '/core/themes/claro/claro.theme';
+    }
+
+    $this->preprocess = new Preprocess(
+      $this->createMock(RequestStack::class),
+      $this->createMock(ConfigFactoryInterface::class),
+      $this->createMock(ContextValidatorInterface::class)
+    );
+  }
+
+  /**
+   * Claro can still preprocess a header cell that gin_lb has rebuilt.
+   */
+  public function testHeaderAttributesSurviveClaroPreprocess(): void {
+    $variables = $this->buildVariables();
+
+    $this->preprocess->preprocessFieldMultipleValueForm($variables);
+    claro_preprocess_field_multiple_value_form($variables);
+
+    $this->assertGinLbRebuiltTheHeader($variables);
+
+    $attributes = $variables['table']['#header'][0]['data']['#attributes'];
+    $this->assertInstanceOf(Attribute::class, $attributes);
+
+    // Claro's addClass() only lands if it received an Attribute object.
+    $classes = explode(' ', (string) $attributes['class']);
+    $this->assertContains('form-item__label', $classes);
+    $this->assertContains('form-item__label--multiple-value-form', $classes);
+  }
+
+  /**
+   * The required-field marker classes gin_lb sets are preserved.
+   */
+  public function testRequiredMarkerClassesArePreserved(): void {
+    $variables = $this->buildVariables();
+
+    $this->preprocess->preprocessFieldMultipleValueForm($variables);
+    claro_preprocess_field_multiple_value_form($variables);
+
+    $this->assertGinLbRebuiltTheHeader($variables);
+
+    $attributes = $variables['table']['#header'][0]['data']['#attributes'];
+    $classes = explode(' ', (string) $attributes['class']);
+    $this->assertContains('js-form-required', $classes);
+    $this->assertContains('form-required', $classes);
+  }
+
+  /**
+   * A disabled multi-value field is preprocessed without fatalling too.
+   *
+   * Gin_lb and Claro both walk every header cell in their disabled branch, so
+   * this covers the other path through the code the patch touches.
+   */
+  public function testDisabledFieldHeaderSurvivesClaroPreprocess(): void {
+    $variables = $this->buildVariables();
+    $variables['element']['#disabled'] = TRUE;
+
+    $this->preprocess->preprocessFieldMultipleValueForm($variables);
+    claro_preprocess_field_multiple_value_form($variables);
+
+    $this->assertGinLbRebuiltTheHeader($variables);
+
+    $attributes = $variables['table']['#header'][0]['data']['#attributes'];
+    $this->assertInstanceOf(Attribute::class, $attributes);
+    $this->assertContains(
+      'tabledrag-disabled',
+      $variables['table']['#attributes']['class']
+    );
+  }
+
+  /**
+   * Asserts gin_lb's branch ran, so the calling test cannot pass vacuously.
+   *
+   * Only gin_lb adds the glb-table class. Without this anchor a test could
+   * pass on Claro's output alone — Claro also adds tabledrag-disabled and the
+   * form-item__label classes, and the fixture seeds its own Attribute object.
+   *
+   * @param array $variables
+   *   The preprocessed variables.
+   */
+  protected function assertGinLbRebuiltTheHeader(array $variables): void {
+    $this->assertContains(
+      'glb-table',
+      $variables['table']['#attributes']['class']
+    );
+  }
+
+  /**
+   * Builds the variables core hands a multi-value field form template.
+   *
+   * Mirrors the shape template_preprocess_field_multiple_value_form() produces
+   * for a required, unlimited-cardinality field inside a gin_lb-styled Layout
+   * Builder form.
+   *
+   * @return array
+   *   The preprocess variables.
+   *
+   * @see template_preprocess_field_multiple_value_form()
+   */
+  protected function buildVariables(): array {
+    return [
+      'element' => [
+        '#field_name' => 'field_links',
+        '#title' => 'Links',
+        '#required' => TRUE,
+        '#gin_lb_form' => TRUE,
+      ],
+      'multiple' => TRUE,
+      'table' => [
+        '#type' => 'table',
+        '#header' => [
+          [
+            'data' => [
+              '#type' => 'html_tag',
+              '#tag' => 'h4',
+              '#value' => 'Links',
+              '#attributes' => new Attribute([
+                'class' => ['label', 'js-form-required', 'form-required'],
+              ]),
+            ],
+            'colspan' => 2,
+            'class' => ['field-label'],
+          ],
+          [],
+          'Order',
+        ],
+        '#rows' => [],
+        '#attributes' => [
+          'id' => 'field-links-values',
+          'class' => ['field-multiple-table'],
+        ],
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
## [1496: RC: Quick Links block: malformed link URL crashes the page with a 500 error](https://github.com/yalesites-org/YaleSites-Internal/issues/1496)

### Description of work
- Adding a Quick Links block with a mistyped protocol (`htp://example.com`) returned an HTTP 500 instead of a validation message, so a single typo looked to an editor like the whole site had broken. Reproduced on a real Layout Builder add-block form before changing anything.
- **The issue's stated cause is wrong, and the fix location changed accordingly.** The ticket blames the Linkit widget and asks for a patch to core's `claro.theme`. Linkit is only an `#after_build` callback on that element. The actual contract violation is in contrib **gin_lb**: core's `template_preprocess_field_multiple_value_form()` builds the field table's header cell with a `Drupal\Core\Template\Attribute` object, but `Preprocess::preprocessFieldMultipleValueForm()` replaces that cell wholesale with a render array whose `#attributes` is a plain PHP array — despite its own comment claiming it repeats core's logic. Theme-layer preprocess always runs after every module preprocess, so Claro then calls `->removeClass()` on that array and fatals with "Call to a member function removeClass() on array".
- Only the validation-error re-render crashes. That is when the theme hook resolves to the field-specific suggestion whose preprocess chain includes Claro's; the initial render uses gin_lb's own suggestion and never reaches it. This is why the block is normally addable at all.
- Carries the upstream gin_lb fix verbatim ([issue 3387157](https://www.drupal.org/project/gin_lb/issues/3387157), MR !73) as `patches/contrib/gin_lb/3387157-mr-73.patch`, registered under `extra.patches` in the profile's `composer.json`. Upstream fixed this in gin_lb 3.0.x and we pin `2.0.0-beta1`, so it has to be a patch.
- **The core-vs-narrower decision the AC asked for:** patched gin_lb, not core. gin_lb is the layer that breaks the contract Claro relies on, and this avoids carrying a sixth core patch that would need re-rolling on every core update. Reversible by dropping this patch and instead guarding `claro.theme` lines 1079-1080 via a `patches/drupal-core/` patch.
- **Scope note:** this preprocess runs for *every* multi-value field on the platform, so the same crash class is removed from other Layout Builder block forms too, not just Quick Links.
- **Deliberately out of scope:** the malformed URL is still rejected without a message visible *in the dialog* — the text `The path 'htp://example.com' is invalid.` appears on the next page load instead. That orphaned-message behaviour is sibling issue yalesites-org/YaleSites-Internal#1497 (case 3), not this ticket. So this PR fixes the crash and leaves the message placement alone.
- Adds `GinLbHeaderAttributesTest` (3 unit tests) that drives gin_lb's real handler and then Claro's real function, anchored on a class only gin_lb emits so it cannot pass vacuously. Note this project's CI runs no PHPUnit, so it only guards the patch on a local run.

### Verification already done on local Lando
- **Before:** HTTP 500, page title `Call to a member function removeClass() on array (500 Internal Server Error)`. **After:** HTTP 200, the form re-renders and the offending field carries `aria-invalid="true"` plus the `error` class.
- The new tests fail before the patch with exactly the production error (`Error: Call to a member function removeClass() on array` at `claro.theme:1079`) and pass after: `OK (3 tests, 10 assertions)`.
- **No change to the normal render path:** a fresh Quick Links form is byte-identical before and after the patch — same table classes and same `<h4 class="form-item__label form-item__label--multiple-value-form js-form-required form-required">`.
- **Second multi-value field** (Accordion, unlimited paragraphs): initial render fine, and a forced server-side validation error re-renders at 200 with fields correctly marked invalid.
- **Update path:** an already-saved Quick Links block set to `htp://example.com` returns 200 with validation errors — no crash introduced where there was none.
- **No rendered-output change from the patch:** gin_lb's later `$header_attributes['class'][] = 'is-disabled'` mutates the local array *after* it is copied into the header cell, and `Attribute::__construct()` stores by value, so that line remains the dead no-op it already was. `AttributeArray::__toString()` applies `array_unique()`, so Claro re-adding the same classes cannot duplicate them.
- `lando composer code-sniff` (the CI gate): **exit 0**.
- `ys_layouts` suite with the patch applied: **116 tests, 115 pass, 1 failure**. That failure (`BlockContextualLinks::testRemoveStaysLastAndLabelsDropTheWordBlock`) is **pre-existing and unrelated** — a stale expectation that omits the `ys_layouts_block_detach` "Make non-reusable" link. Confirmed independent of this change by reversing the patch and re-running that file alone: it fails identically.

### Functional testing steps:
- [ ] Edit any page, open **Layout Builder**, and click **Add block** in a content section, then choose **Quick Links**.
- [ ] Click **Add another item** twice so there are three link rows (the block requires 3-9 links).
- [ ] In the first row enter the URL `htp://example.com` with any link text, and fill the other two rows with valid links such as `https://example.com` and `/about`.
- [ ] Click **Add block**. Confirm the form comes back with the first URL field flagged invalid, and **not** an error screen reading "Call to a member function removeClass() on array". Before this fix this step produced an HTTP 500.
- [ ] Confirm the message `The path 'htp://example.com' is invalid.` is shown. It currently appears on the next page load rather than inside the dialog — that placement is yalesites-org/YaleSites-Internal#1497, not this ticket.
- [ ] Correct the first URL to `https://example.com`, click **Add block** again, and confirm the block saves and renders normally on the page.
- [ ] Regression: open an existing Quick Links block's **Configure** form, set one URL to `htp://example.com`, and save. Confirm a validation error rather than a crash.
- [ ] Regression: add an **Accordion** block and submit it with its required fields empty. Confirm normal validation errors, not a 500.
- [ ] Regression: confirm a normal multi-value field form still looks right — the "Links" heading above the table should be styled as usual, not unstyled or duplicated.

References yalesites-org/YaleSites-Internal#1496

---
Created with AI

<img width="1848" height="764" alt="Screenshot 2026-08-11 at 5 28 05 AM" src="https://github.com/user-attachments/assets/b90ad6cc-31a9-408c-b2c8-cadced876ce1" />
