### PR TITLE
1495: RC: Post pages show duplicate, garbled social-share image tags

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.token.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.media.image.token.yml
@@ -1,6 +1,6 @@
 uuid: e028a28f-6a60-4b9c-b646-c60c91a5e034
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - core.entity_view_mode.media.token

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/MediaImageTokenTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/MediaImageTokenTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\Core\Serialization\Yaml;
+use Drupal\file\Entity\File;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\media\MediaInterface;
+use Drupal\Tests\media\Traits\MediaTypeCreationTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Tests that an image media token resolves to a bare URL, not rendered markup.
+ *
+ * Social-sharing metatags build og:image from the image field of the teaser
+ * media, e.g. [node:field_teaser_media:entity:field_media_image]. Metatag
+ * declares og:image multi-valued and splits the tag value on
+ * metatag.settings:separator (a comma), so that token has to resolve to a bare
+ * URL and nothing else.
+ *
+ * The media image "token" view display is what guarantees that: the token
+ * module only uses it when the display is enabled, otherwise it falls back to
+ * core's default image formatter and the token resolves to a whole <img> tag
+ * with the alt text inside it.
+ *
+ * @group ys_core
+ * @group yalesites
+ */
+class MediaImageTokenTest extends KernelTestBase {
+
+  use MediaTypeCreationTrait;
+  use UserCreationTrait;
+
+  /**
+   * Alt text from the reported case: its commas are what split the tag.
+   */
+  private const ALT_TEXT = 'Red, yellow, and white sculpture against a wintery background';
+
+  /**
+   * The file name of the fixture image.
+   */
+  private const FILE_NAME = 'sculpture-in-snow.jpg';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'file',
+    'field',
+    'image',
+    'media',
+    'token',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('media');
+    $this->installSchema('file', 'file_usage');
+    $this->installConfig(['system', 'field', 'file', 'media']);
+
+    $this->createMediaType('image', ['id' => 'image']);
+
+    // Install the profile's own view mode and display rather than a fixture
+    // copy, so this test fails if the shipped config stops resolving tokens to
+    // a bare URL. The view mode is required: saving the display resolves its
+    // config dependency on the mode entity.
+    $this->installProfileConfig('entity_view_mode', 'core.entity_view_mode.media.token');
+    $this->installProfileConfig('entity_view_display', 'core.entity_view_display.media.image.token');
+
+    // Rendering an image field checks view access on the referenced file.
+    $this->container->get('current_user')
+      ->setAccount($this->createUser(['access content']));
+  }
+
+  /**
+   * Reads a config file from the profile's sync directory.
+   */
+  private function readConfig(string $name): array {
+    return Yaml::decode(file_get_contents(
+      \Drupal::root() . '/profiles/custom/yalesites_profile/config/sync/' . $name . '.yml'
+    ));
+  }
+
+  /**
+   * Creates a config entity of the given type from the profile's own export.
+   */
+  private function installProfileConfig(string $entity_type_id, string $config_name): void {
+    $data = $this->readConfig($config_name);
+    // Layout Builder's per-display settings have no bearing on how a token
+    // renders, and validating their schema would mean installing Layout Builder
+    // and its three dependencies into this test.
+    unset($data['_core'], $data['third_party_settings']);
+    $this->container->get('entity_type.manager')
+      ->getStorage($entity_type_id)
+      ->create($data)
+      ->save();
+  }
+
+  /**
+   * Creates an image media whose alt text contains commas.
+   */
+  private function createImageMedia(): MediaInterface {
+    $file = File::create([
+      'uri' => 'public://' . self::FILE_NAME,
+      'filename' => self::FILE_NAME,
+    ]);
+    $file->save();
+
+    $media = $this->container->get('entity_type.manager')
+      ->getStorage('media')
+      ->create([
+        'bundle' => 'image',
+        'name' => self::FILE_NAME,
+        'field_media_image' => [
+          'target_id' => $file->id(),
+          'alt' => self::ALT_TEXT,
+        ],
+      ]);
+    $media->save();
+
+    return $media;
+  }
+
+  /**
+   * Replaces the given token for the given media.
+   */
+  private function replaceImageToken(MediaInterface $media, string $token): string {
+    return (string) $this->container->get('token')
+      ->replace($token, ['media' => $media]);
+  }
+
+  /**
+   * The image token resolves to a bare URL, not markup carrying alt text.
+   *
+   * The separator assertion is the invariant that actually failed: og:image is
+   * split on it, so a value containing one becomes several malformed tags.
+   */
+  public function testImageTokenResolvesToBareUrl(): void {
+    $separator = $this->readConfig('metatag.settings')['separator'];
+    $this->assertNotEmpty($separator, 'Metatag should define a multi-value separator.');
+    $this->assertStringContainsString($separator, self::ALT_TEXT, 'The fixture alt text should contain the separator.');
+
+    $output = trim($this->replaceImageToken($this->createImageMedia(), '[media:field_media_image]'));
+
+    // Asserted first so an empty replacement fails here rather than passing the
+    // negative assertions vacuously.
+    $this->assertStringContainsString(self::FILE_NAME, $output, 'The token should resolve to the image URL.');
+    $this->assertStringNotContainsString('<', $output, 'The token should resolve to a URL, not rendered markup.');
+    $this->assertStringNotContainsString($separator, $output, 'The URL must not contain the multi-value separator.');
+  }
+
+  /**
+   * The alt property token still resolves, so og:image:alt keeps working.
+   *
+   * Property tokens do not route through a view display, so this guards against
+   * a wrong fix that strips alt text rather than against this config changing.
+   */
+  public function testAltPropertyTokenStillResolves(): void {
+    $this->assertSame(
+      self::ALT_TEXT,
+      trim($this->replaceImageToken($this->createImageMedia(), '[media:field_media_image:alt]')),
+    );
+  }
+
+}


### PR DESCRIPTION
## [1495: RC: Post pages show duplicate, garbled social-share image tags](https://github.com/yalesites-org/YaleSites-Internal/issues/1495)

### Description of work

- Post pages emitted **three** `<meta property="og:image">` tags instead of one, two of them garbled with alt-text fragments merged into the URL, e.g. `content="https://host.siteyellow"`. Sharing a Post link to Slack, iMessage, Facebook or LinkedIn could produce a broken preview, no preview, or unpredictable results depending on which tag the receiving app read.
- Root cause is a chain of three things:
  - metatag builds `og:image` from the teaser media's image field, via the token `[node:field_teaser_media:entity:field_media_image]`.
  - `token_get_token_view_display()` uses the `media.image.token` view display **only when that display is enabled**. Ours shipped `status: false`, so token fell back to the image field's default `image` formatter and the token resolved to a whole `<img>` tag with the alt text inside it.
  - metatag declares `og:image` multi-valued and splits the value on `metatag.settings:separator`, which is a comma. Every comma in the alt text therefore shattered that one `<img>` tag into several malformed `og:image` values.
- **The fix is one config line:** `core.entity_view_display.media.image.token.yml`, `status: false` → `status: true`. That routes the token through the `image_url` formatter, which returns a bare URL — no markup, and no comma for metatag to split on.
- That display already existed and was already configured for exactly this purpose. It was created with `status: false` by `b176ad82d`, **the same commit that added `og_image`**, so it has never once been used. This is a latent export defect from that commit, not a deliberate disable being reverted.
- Adds a kernel test (`ys_core/tests/src/Kernel/MediaImageTokenTest.php`) that installs the shipped view mode and display from the profile's own `config/sync` rather than a fixture copy — so it fails if that config regresses — and asserts the resolved token value contains no markup and no instance of metatag's separator.

**Why this approach over the alternatives:**

- *Patching metatag* — its `<img src="` detection is genuinely broken (it requires `src` to be the first attribute, but core emits `<img loading="lazy" src="…">`), but that is contrib we would then carry a patch for forever.
- *Rewriting the token in metatag config* — same diff size, but leaves the display disabled, so the next image token added anywhere hits the same bug.

Blast radius was checked before choosing: across all ~1400 files in `config/sync`, the bare `field_media_image` token is used in exactly one place, and `mode: token` has exactly one consumer — the display being enabled. No view, formatter, or custom PHP/Twig consumes an image-field token. So this changes exactly one output today while fixing the whole class.

### Functional testing steps:

- [ ] View source on a Post whose image alt text contains a comma — `/posts/2023-05-24-article-with-mostly-text` in starterkit content. Confirm **exactly one** `og:image` tag, with a valid, complete, untruncated URL.
- [ ] Confirm `og:image:alt` on that same page still carries the full alt text, commas included.
- [ ] Spot-check a Post whose image alt text has **no** comma (e.g. `/posts/2024-01-31-is-drupal-worth-it`) — one valid `og:image`, no regression.
- [ ] Spot-check another content type sharing the same metatag config — a Page (`/my-page`), an Event (`/events/dinner-with-dad`), and a Profile (`/profile/tom-foolery`) — one valid `og:image` each.
- [ ] Confirm the site front page is unchanged (it emits no `og:image`, because `metatag.metatag_defaults.front` defines no image key — this is pre-existing and unrelated).

**Testing evidence from this branch (local Lando):**

| Check | Result |
| --- | --- |
| Reported Post | 3 `og:image` tags → **1**, valid and complete; `og:image:alt` unchanged |
| No-comma Post, Page, Event, Profile | one valid `og:image` each |
| Front page | 0 `og:image` before **and** after — real baseline, captured with the display verifiably disabled |
| `composer code-sniff` (Drupal + DrupalPractice, all custom dirs) | **exit 0**, no findings |
| `ys_core` Unit suite | **131 tests, 184 assertions, 0 failures** |
| `ys_core` Kernel suite | **OK (21 tests, 362 assertions)** |
| New kernel test | confirmed **red before** the fix, **green after** |

Config was applied through the real deploy path (`drush config:import --partial`), which also proves the exported file imports cleanly. No update hook is needed: the config object has existed in active config on every site since 2023, so this is an update rather than a create, and nothing in `config_ignore.settings.yml` or `ys_beacon`'s config-ignore additions matches `core.entity_view_display.*`.

### Notes for QA

- **Social platforms cache scraped Open Graph data server-side.** Facebook, LinkedIn and X will keep showing the old garbled preview for Post URLs that were already shared, even after this deploys. Force a re-scrape (Facebook Sharing Debugger / LinkedIn Post Inspector) before concluding the fix did not work.

### Known residual (out of scope here)

- metatag 2.2.0's own img-tag detection is broken against core's attribute order, so it still comma-splits any `og:image` value containing a comma. This change removes the realistic trigger (alt-text prose, where commas are common) but a comma in an uploaded image's **filename** could still split the tag. Fixing that properly means a contrib patch or an upstream issue.
- The token display uses `image_style: ''` (original image), so `og:image` can be a full-size image. That behaviour is **unchanged** by this PR — the previous `image` formatter also carried no image style. Verified by comparing the same pages before and after: `/my-page` emitted `…/2023-04/s-l400.jpg` in both states, and the reported Post's one well-formed tag was `…/starterkit/2014_02_03_11-24-40_DSC_8938_4.jpg` in both. Same bytes, same URL. A purpose-built 1200x630 style would still be a reasonable follow-up, since social platforms drop cards over roughly 5 MB.

References yalesites-org/YaleSites-Internal#1495

---

Created with AI
