### PR TITLE
1497: RC: Quick Links: several malformed URLs save silently as broken or dead links

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/LayoutBuilderBlockFormMessagesTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/LayoutBuilderBlockFormMessagesTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\Core\Form\FormState;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests that Layout Builder block forms render their own validation messages.
+ *
+ * Regression test for a rejected value leaving the editor with no explanation.
+ * The Layout Builder configure-block submit button carries no #ajax, so a
+ * server-side validation failure re-renders the form as a standalone Layout
+ * Builder page, and Gin's page--layout-builder.html.twig never prints the
+ * highlighted region that holds the site's messages block. The error text ("The
+ * path 'htp://example.com' is invalid.") therefore stayed in the messenger
+ * queue and surfaced later on an unrelated page load, leaving only a
+ * red-outlined field with no visible text — which also gives screen reader
+ * users no error at all.
+ *
+ * Placing a status_messages element in the form itself makes the message render
+ * wherever the form is rendered, in the dialog or as a standalone page.
+ *
+ * @group ys_core
+ */
+class LayoutBuilderBlockFormMessagesTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'ys_core',
+  ];
+
+  /**
+   * Builds a Layout Builder block form array and its form state.
+   *
+   * The admin label default must be non-empty: ys_core_form_alter() only
+   * reaches into the form object for the current component when it is missing,
+   * which a bare form state cannot supply.
+   */
+  protected function blockForm(string $plugin_id): array {
+    $form = [
+      'settings' => [
+        'label' => ['#default_value' => 'Quick Links'],
+        'block_form' => [],
+      ],
+    ];
+    $form_state = new FormState();
+    $form_state->setBuildInfo(['args' => [NULL, NULL, NULL, $plugin_id]]);
+    return [$form, $form_state];
+  }
+
+  /**
+   * Both configure-block forms carry a status_messages element.
+   */
+  public function testConfigureBlockFormCarriesMessagesElement(): void {
+    foreach (['layout_builder_add_block', 'layout_builder_update_block'] as $form_id) {
+      [$form, $form_state] = $this->blockForm('inline_block:quick_links');
+
+      $this->assertArrayNotHasKey(
+        'status_messages',
+        $form,
+        "The messages element must come from the alter, not the fixture ($form_id)."
+      );
+
+      ys_core_form_alter($form, $form_state, $form_id);
+
+      $this->assertArrayHasKey(
+        'status_messages',
+        $form,
+        "A rejected value must be explained inside the block form ($form_id)."
+      );
+      $this->assertSame('status_messages', $form['status_messages']['#type']);
+      // It has to outrank the form's own fields so the editor sees it without
+      // scrolling the off-canvas panel.
+      $this->assertLessThan(0, $form['status_messages']['#weight']);
+    }
+  }
+
+  /**
+   * Core's own Ajax error element replaces ours instead of joining it.
+   *
+   * The element has to reuse the key core assigns in
+   * AjaxFormHelperTrait::ajaxSubmit(). Two elements would otherwise reduce to
+   * the same lazy-builder placeholder, and the renderer substitutes every
+   * occurrence of it — so a second element means the editor sees the error
+   * twice and a screen reader announces it twice.
+   */
+  public function testCoreAjaxMessagesElementDoesNotDuplicateOurs(): void {
+    [$form, $form_state] = $this->blockForm('inline_block:quick_links');
+    ys_core_form_alter($form, $form_state, 'layout_builder_update_block');
+
+    // Exactly what core does when an Ajax submit fails validation.
+    $form['status_messages'] = [
+      '#type' => 'status_messages',
+      '#weight' => -1000,
+    ];
+
+    $messages = array_filter(
+      $form,
+      fn ($element) => is_array($element)
+        && ($element['#type'] ?? NULL) === 'status_messages'
+    );
+
+    $this->assertCount(
+      1,
+      $messages,
+      'The form must carry one status_messages element, not two.'
+    );
+  }
+
+  /**
+   * The messages element is not added to unrelated forms.
+   */
+  public function testUnrelatedFormIsNotAltered(): void {
+    [$form, $form_state] = $this->blockForm('inline_block:quick_links');
+
+    ys_core_form_alter($form, $form_state, 'user_login_form');
+
+    $this->assertArrayNotHasKey('ys_core_status_messages', $form);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/LayoutBuilderBlockFormMessagesTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/LayoutBuilderBlockFormMessagesTest.php
@@ -13,10 +13,14 @@ use Drupal\KernelTests\KernelTestBase;
  * server-side validation failure re-renders the form as a standalone Layout
  * Builder page, and Gin's page--layout-builder.html.twig never prints the
  * highlighted region that holds the site's messages block. The error text ("The
- * path 'htp://example.com' is invalid.") therefore stayed in the messenger
+ * path 'hxxp://example.com' is invalid.") therefore stayed in the messenger
  * queue and surfaced later on an unrelated page load, leaving only a
  * red-outlined field with no visible text — which also gives screen reader
  * users no error at all.
+ *
+ * The example is deliberately "hxxp" rather than "htp": a scheme one edit from
+ * http is now auto-corrected by _ys_core_normalize_bare_domain_uri(), so it no
+ * longer reaches validation at all. Two edits still does.
  *
  * Placing a status_messages element in the form itself makes the message render
  * wherever the form is rendered, in the dialog or as a standalone page.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/LinkUriNormalizationTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/LinkUriNormalizationTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Unit;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the link URI normalisation applied to every core link widget.
+ *
+ * Regression coverage for malformed URLs that Drupal accepts and stores but
+ * cannot resolve, so they publish as dead or broken links with no warning to
+ * the editor:
+ * - A protocol-relative "//example.com" is rewritten by the core link widget
+ *   to "internal://example.com". That passes validation and renders as an
+ *   anchor with an empty href — styled exactly like a working link, but going
+ *   nowhere.
+ * - A single-slash "https:/example.com" already declares a scheme, so it is
+ *   stored verbatim and rendered as a literal, broken href.
+ *
+ * Both are normalised to a valid absolute URL, the same auto-correct behaviour
+ * the bare-domain case already uses, rather than being rejected.
+ *
+ * @group ys_core
+ */
+class LinkUriNormalizationTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 3) . '/ys_core.module';
+  }
+
+  /**
+   * Malformed URIs are corrected and well-formed ones are left alone.
+   *
+   * @dataProvider uriProvider
+   */
+  public function testNormalization(string $input, string $expected): void {
+    $this->assertSame($expected, _ys_core_normalize_bare_domain_uri($input));
+  }
+
+  /**
+   * Provides link field input with the URI it should normalise to.
+   *
+   * @return array
+   *   Each case: [entered value, expected normalised value].
+   */
+  public static function uriProvider(): array {
+    return [
+      // Protocol-relative: the scheme the editor omitted is supplied.
+      'protocol relative host' => ['//example.com', 'https://example.com'],
+      'protocol relative with path' => ['//example.com/a/b?x=1#f', 'https://example.com/a/b?x=1#f'],
+      'protocol relative with port' => ['//example.com:8080/a', 'https://example.com:8080/a'],
+
+      // A scheme missing its authority delimiter gets it back.
+      'https single slash' => ['https:/example.com', 'https://example.com'],
+      'http single slash' => ['http:/example.com', 'http://example.com'],
+      'https single slash with path' => ['https:/example.com/a/b', 'https://example.com/a/b'],
+      'https no slash' => ['https:example.com', 'https://example.com'],
+      // Core compares the scheme against its allowed-protocol list with a
+      // case-sensitive in_array(), so an upper-case scheme must be lowered or
+      // the corrected value is still rejected as an invalid path.
+      'mixed case scheme is lowered' => ['HTTPS:/example.com', 'https://example.com'],
+
+      // The bare-domain behaviour this extends must keep working.
+      'bare domain' => ['google.com', 'https://google.com'],
+      'bare domain with path' => ['www.example.org/path?x=1', 'https://www.example.org/path?x=1'],
+
+      // Valid input must pass through untouched.
+      'well formed https' => ['https://example.com', 'https://example.com'],
+      'well formed http' => ['http://example.com', 'http://example.com'],
+      'well formed https with path' => ['https://yale.edu/about', 'https://yale.edu/about'],
+      'internal path' => ['/about', '/about'],
+      'fragment' => ['#anchor', '#anchor'],
+      'query' => ['?page=2', '?page=2'],
+      'front token' => ['<front>', '<front>'],
+      'nolink token' => ['<nolink>', '<nolink>'],
+      'mailto' => ['mailto:someone@example.com', 'mailto:someone@example.com'],
+      'tel' => ['tel:+12035551212', 'tel:+12035551212'],
+      'internal scheme' => ['internal:/about', 'internal:/about'],
+      'entity scheme' => ['entity:node/1', 'entity:node/1'],
+      'route scheme' => ['route:<front>', 'route:<front>'],
+      'empty string' => ['', ''],
+      'scheme only' => ['https:', 'https:'],
+
+      // Shapes we deliberately do not try to guess at.
+      'three slashes left alone' => ['///example.com', '///example.com'],
+      'non http scheme single slash left alone' => ['ftp:/example.com', 'ftp:/example.com'],
+    ];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/LinkUriNormalizationTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/LinkUriNormalizationTest.php
@@ -16,8 +16,11 @@ use Drupal\Tests\UnitTestCase;
  *   nowhere.
  * - A single-slash "https:/example.com" already declares a scheme, so it is
  *   stored verbatim and rendered as a literal, broken href.
+ * - A mistyped scheme, "htp://example.com", is rejected outright with "The
+ *   path '…' is invalid." — the editor is told the whole address is wrong
+ *   rather than the one character that is.
  *
- * Both are normalised to a valid absolute URL, the same auto-correct behaviour
+ * All are normalised to a valid absolute URL, the same auto-correct behaviour
  * the bare-domain case already uses, rather than being rejected.
  *
  * @group ys_core
@@ -85,10 +88,79 @@ class LinkUriNormalizationTest extends UnitTestCase {
       'empty string' => ['', ''],
       'scheme only' => ['https:', 'https:'],
 
+      // A scheme one keystroke away from http(s) is the scheme the editor
+      // meant; core rejects the whole value instead of the one wrong
+      // character, so correct it rather than making them find it.
+      'dropped t' => ['htp://example.com', 'http://example.com'],
+      'dropped h' => ['ttp://example.com', 'http://example.com'],
+      'doubled p' => ['htpp://example.com', 'http://example.com'],
+      'truncated scheme' => ['htt://example.com', 'http://example.com'],
+      'doubled h' => ['hhtp://example.com', 'http://example.com'],
+      'extra t' => ['htttp://example.com', 'http://example.com'],
+      // One edit from "https" resolves to https, not http, so a secure URL is
+      // not silently downgraded to a plaintext one.
+      'dropped t on https' => ['htps://example.com', 'https://example.com'],
+      'dropped h on https' => ['ttps://example.com', 'https://example.com'],
+      'mistyped scheme keeps the rest of the URL' => ['htp://example.com/a/b?x=1#f', 'http://example.com/a/b?x=1#f'],
+      'mistyped scheme with a single slash' => ['htp:/example.com', 'http://example.com'],
+      'mistyped scheme with no slash' => ['htp:example.com', 'http://example.com'],
+      'mistyped scheme upper case' => ['HTP://example.com', 'http://example.com'],
+
       // Shapes we deliberately do not try to guess at.
       'three slashes left alone' => ['///example.com', '///example.com'],
       'non http scheme single slash left alone' => ['ftp:/example.com', 'ftp:/example.com'],
+      // Two edits away is a different word, not a typo. A defanged URL is the
+      // common real-world case and must survive as typed.
+      'defanged scheme left alone' => ['hxxp://example.com', 'hxxp://example.com'],
+      'unknown scheme left alone' => ['foo://example.com', 'foo://example.com'],
+      // Correcting a scheme must never manufacture an executable one.
+      'javascript scheme left alone' => ['javascript:alert(1)', 'javascript:alert(1)'],
+      'data scheme left alone' => ['data:text/html,hello', 'data:text/html,hello'],
+      // A mistyped scheme with nothing after it is not a URL to correct.
+      'mistyped scheme with no host left alone' => ['htp://', 'htp://'],
+      // A host:port must not be mistaken for a scheme by the correction. Note
+      // this shape is already left untouched before this change — the
+      // "declares a scheme" guard matches "example.com:" — so a bare domain
+      // carrying a port is still not normalised. That is a pre-existing gap,
+      // not the behaviour we want; it is asserted here only to pin that the
+      // scheme correction does not make it worse.
+      'bare domain with port left alone' => ['example.com:8080/a', 'example.com:8080/a'],
     ];
+  }
+
+  /**
+   * A protocol the site permits is never rewritten as if it were a typo.
+   *
+   * The correction is bounded to a single edit from "http"/"https" precisely
+   * so it cannot capture a scheme the editor meant. This is the guard on that
+   * bound: widen it to two edits and "ftp", "nntp" and "rtsp" all start being
+   * rewritten to "http".
+   *
+   * @dataProvider allowedProtocolProvider
+   */
+  public function testAllowedProtocolsAreNeverRewritten(string $scheme): void {
+    $uri = $scheme . '://example.com';
+    $this->assertSame($uri, _ys_core_normalize_bare_domain_uri($uri));
+  }
+
+  /**
+   * Provides every protocol this site allows.
+   *
+   * The list is UrlHelper::getAllowedProtocols() as configured here, read back
+   * from the running site rather than assumed. It is hardcoded because a unit
+   * test has no container: UrlHelper falls back to its ['http', 'https']
+   * default, which would silently shrink this test's coverage to two cases.
+   *
+   * @return array
+   *   Each case: [scheme].
+   */
+  public static function allowedProtocolProvider(): array {
+    $protocols = [
+      'http', 'https', 'ftp', 'news', 'nntp', 'tel', 'telnet', 'mailto', 'irc',
+      'ssh', 'sftp', 'webcal', 'rtsp',
+    ];
+
+    return array_combine($protocols, array_map(fn($p) => [$p], $protocols));
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -377,7 +377,8 @@ function ys_core_preprocess_block(&$variables) {
  * cannot resolve, publishing a link that looks live and goes nowhere: a
  * protocol-relative "//example.com" (saved as "internal://example.com", which
  * renders with an empty href) and a single-slash "https:/example.com" (rendered
- * as a literal, broken href).
+ * as a literal, broken href). It also corrects a scheme misspelt by a single
+ * character, "htp://example.com", which core rejects outright.
  *
  * @see \Drupal\link\Plugin\Field\FieldWidget\LinkWidget::validateUriElement()
  * @see _ys_core_normalize_bare_domain_uri()
@@ -416,10 +417,11 @@ function _ys_core_normalize_link_uri(array &$element, FormStateInterface $form_s
 /**
  * Corrects a web address typed in a shape Drupal cannot resolve.
  *
- * Three shapes are rewritten to a valid absolute URL:
+ * Four shapes are rewritten to a valid absolute URL:
  * - a bare host, "google.com" or "www.example.org/path?x=1";
  * - a protocol-relative URL, "//example.com";
- * - an http(s) URL missing its authority delimiter, "https:/example.com".
+ * - an http(s) URL missing its authority delimiter, "https:/example.com";
+ * - a misspelt http(s) scheme, "htp://example.com".
  *
  * Values that are empty, internal paths ("/", "#", "?"), route tokens
  * ("<front>", "<nolink>"), or already scheme-qualified ("https://", "mailto:",
@@ -455,6 +457,18 @@ function _ys_core_normalize_bare_domain_uri(string $uri): string {
     return $uri;
   }
 
+  // A mistyped scheme such as "htp://example.com" is a scheme core does not
+  // allow, so the value is rejected wholesale with "The path '…' is invalid."
+  // — which names the whole address rather than the one wrong character, and
+  // leaves the editor to find it. Correct it to the scheme it is a single
+  // keystroke away from.
+  if (preg_match('~^([a-z][a-z0-9+.\-]*):/{0,2}([^/].*)$~i', $trimmed, $matches)) {
+    $corrected = _ys_core_correct_mistyped_http_scheme($matches[1]);
+    if ($corrected !== NULL) {
+      return $corrected . '://' . $matches[2];
+    }
+  }
+
   // Anything that already declares a scheme is left untouched.
   if (preg_match('/^[a-z][a-z0-9+.\-]*:/i', $trimmed)) {
     return $uri;
@@ -467,6 +481,41 @@ function _ys_core_normalize_bare_domain_uri(string $uri): string {
   }
 
   return $uri;
+}
+
+/**
+ * Resolves a misspelt web scheme to the one the editor meant.
+ *
+ * Only a scheme within a single edit of "http" or "https" is treated as a
+ * typo. That bound is the safety property, not a heuristic: every protocol
+ * Drupal allows here — ftp, news, nntp, tel, telnet, mailto, irc, ssh, sftp,
+ * webcal, rtsp — is at least two edits from both, as are "javascript" and
+ * "data", so no scheme an editor deliberately typed can be rewritten and no
+ * executable scheme can be manufactured. LinkUriNormalizationTest pins this.
+ *
+ * @param string $scheme
+ *   The scheme as typed, without the colon.
+ *
+ * @return string|null
+ *   "http" or "https" when the scheme is a misspelling of one of them, or
+ *   NULL when it must be left exactly as typed.
+ */
+function _ys_core_correct_mistyped_http_scheme(string $scheme): ?string {
+  $scheme = strtolower($scheme);
+  // Both are already correct, and each is one edit from the other, so they
+  // have to be excluded before the distance test rather than by it.
+  if ($scheme === 'http' || $scheme === 'https') {
+    return NULL;
+  }
+
+  $to_http = levenshtein($scheme, 'http');
+  $to_https = levenshtein($scheme, 'https');
+  if (min($to_http, $to_https) > 1) {
+    return NULL;
+  }
+
+  // Ties resolve to https so a secure address is never downgraded.
+  return $to_http < $to_https ? 'http' : 'https';
 }
 
 /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -280,6 +280,22 @@ function ys_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   ];
 
   if (in_array($form_id, $layout_builder_block_forms)) {
+    // Explain a rejected value where the editor is working. The configure-block
+    // submit carries no #ajax, so a server-side validation failure leaves the
+    // off-canvas dialog and re-renders this form as a standalone Layout Builder
+    // page — and Gin's page--layout-builder.html.twig prints only pre_content
+    // and content, never the highlighted region that holds the site's messages
+    // block. The rejection therefore stayed queued and surfaced later on an
+    // unrelated page, leaving the editor a red-outlined field with no text, and
+    // screen reader users no error at all. This deliberately reuses the key
+    // core's own Ajax error path assigns in AjaxFormHelperTrait::ajaxSubmit():
+    // where that path does run it overwrites this element rather than adding a
+    // second one, which would render the message twice and announce it twice.
+    $form['status_messages'] = [
+      '#type' => 'status_messages',
+      '#weight' => -100,
+    ];
+
     $block_type_name = ys_core_get_block_type($form, $form_state);
     $limited_block_types = [
       'tabs',
@@ -357,7 +373,14 @@ function ys_core_preprocess_block(&$variables) {
  * runs before the core handler and rewrites bare domains to an explicit
  * "https://" URL, matching the editor's intent.
  *
+ * The same handler corrects two mistypings that Drupal accepts and stores but
+ * cannot resolve, publishing a link that looks live and goes nowhere: a
+ * protocol-relative "//example.com" (saved as "internal://example.com", which
+ * renders with an empty href) and a single-slash "https:/example.com" (rendered
+ * as a literal, broken href).
+ *
  * @see \Drupal\link\Plugin\Field\FieldWidget\LinkWidget::validateUriElement()
+ * @see _ys_core_normalize_bare_domain_uri()
  */
 function ys_core_field_widget_single_element_form_alter(array &$element, FormStateInterface $form_state, array $context) {
   $widget = $context['widget'] ?? NULL;
@@ -391,17 +414,40 @@ function _ys_core_normalize_link_uri(array &$element, FormStateInterface $form_s
 }
 
 /**
- * Adds an "https://" scheme to a bare domain entered in a link field.
+ * Corrects a web address typed in a shape Drupal cannot resolve.
+ *
+ * Three shapes are rewritten to a valid absolute URL:
+ * - a bare host, "google.com" or "www.example.org/path?x=1";
+ * - a protocol-relative URL, "//example.com";
+ * - an http(s) URL missing its authority delimiter, "https:/example.com".
  *
  * Values that are empty, internal paths ("/", "#", "?"), route tokens
- * ("<front>", "<nolink>"), or already scheme-qualified ("https:", "mailto:",
- * "internal:", "entity:", …) are returned unchanged. Only bare hosts such as
- * "google.com" or "www.example.org/path?x=1" are rewritten.
+ * ("<front>", "<nolink>"), or already scheme-qualified ("https://", "mailto:",
+ * "internal:", "entity:", …) are returned unchanged.
  */
 function _ys_core_normalize_bare_domain_uri(string $uri): string {
   $trimmed = trim($uri);
   if ($trimmed === '') {
     return $uri;
+  }
+
+  // A protocol-relative URL is rewritten by the core link widget to
+  // "internal://example.com", which passes validation and saves, then renders
+  // as an anchor with an empty href — a dead link styled exactly like a working
+  // one. Supply the scheme the editor left off.
+  if (preg_match('~^//[^/]~', $trimmed)) {
+    return 'https:' . $trimmed;
+  }
+
+  // "https:/example.com" (and "https:example.com") already declare a scheme, so
+  // they are stored verbatim and rendered as a literal, broken href. Restore
+  // the authority delimiter that http and https always require. Other schemes
+  // are left alone: "mailto:" and "tel:" take no authority, and "internal:/"
+  // and "entity:" are correct with a single slash or none. The scheme is
+  // lowercased because core compares it against its allowed-protocol list with
+  // a case-sensitive in_array(), so "HTTPS://…" is rejected as invalid.
+  if (preg_match('~^(https?):/?([^/].*)$~i', $trimmed, $matches)) {
+    return strtolower($matches[1]) . '://' . $matches[2];
   }
 
   // Internal paths, fragments, query strings, and route tokens are valid as-is.


### PR DESCRIPTION
## [1497: RC: Quick Links: several malformed URLs save silently as broken or dead links](https://github.com/yalesites-org/YaleSites-Internal/issues/1497)

### Description of work

All three reported cases were reproduced on local Lando before anything was changed, and each was fixed.

- **`//example.com` (protocol-relative) saved as a dead link.** Confirmed mechanism: the core link widget rewrites it to the unresolvable `internal://example.com`, which *passes* validation, saves, and renders as `<a href="">`. Note the issue says "no `href` attribute is emitted" — measured, it emits an **empty** `href=""`. Dead either way.
- **`https:/example.com` (one slash) saved as a broken link.** It already declares a scheme, so it was stored verbatim and rendered as a literal `<a href="https:/example.com">`.
- Both are now **auto-corrected** to a valid absolute URL. **This is the AC's "pick one behavior" call:** auto-correct, not reject, applied identically to both shapes — consistent with the bare-domain case the same function already corrects silently (from yalesites-org/YaleSites-Internal#1158). Rejecting one shape while silently fixing its sibling would be the inconsistent option.
- **The AC's third development bullet asked whether the fix belongs in a constraint scoped to Quick Links or in a broader Linkit/core fix. It is neither.** There is already a platform-wide normaliser (`_ys_core_normalize_bare_domain_uri()`, hooked onto *every* core LinkWidget by `ys_core_field_widget_single_element_form_alter()`), so the correct place was to extend that one function: every link field on the platform gets the fix, no new constraint, plugin, or file. Quick Links needing no custom plugin is exactly why this works.
- The scheme is **lowercased** during correction. Verified empirically that this is required, not cosmetic: core compares `parse_url()`'s scheme against its allowed-protocol list with a case-sensitive `in_array()`, so `HTTPS://example.com` is rejected as invalid — without lowering, the "correction" would produce a value that still fails.
- **`htp://example.com` was rejected with no visible message.** The root cause is more specific than the ticket assumed, and worth flagging: **the submit is not an Ajax request at all.** Measured in the browser — `Drupal.ajax.instances` has 55 entries, none bound to the Update button; fetching the route with `_wrapper_format=drupal_dialog.off_canvas`, `drupal_ajax`, and none all return the submit as a plain `<input type="submit">` with no ajax settings entry and no `ajaxSubmit` anywhere. So core's own error-path message injection (`AjaxFormHelperTrait::ajaxSubmit()`) never runs. The editor is thrown out of the off-canvas dialog onto the standalone Configure block page, and Gin's `page--layout-builder.html.twig` prints only `pre_content` and `content` — never the `highlighted` region where `block.block.ys_admin_theme_messages` lives. So the message stayed queued and appeared later on an unrelated page.
- Fixed by adding a `status_messages` element to both Layout Builder configure-block forms, which renders the message wherever the form renders. It deliberately reuses the key core's Ajax error path assigns, so if that path ever does run it **overwrites** this element instead of rendering and announcing the error twice.
- Scoped to all Layout Builder block forms rather than just Quick Links: any block's configure form can reject any field, and the missing-message defect is not Quick Links-specific.
- Adds unit cases for the normaliser (it previously had **no** test coverage at all) and 3 kernel tests for the form alter.

### Update — a mistyped scheme is now auto-corrected too (per review)

Per @dblanken-yale's review comment, `htp://example.com` is now **auto-corrected** rather than merely rejected-with-a-visible-message. It is handled in the same platform-wide normaliser as the other three shapes, so it applies to every link field on the platform.

- The correction is bounded to a scheme within **one edit** (`levenshtein()`) of `http`/`https`, and can only ever emit `http` or `https`.
- **That bound is the safety property, not a heuristic.** Measured against this site's real `UrlHelper::getAllowedProtocols()` — `http, https, ftp, news, nntp, tel, telnet, mailto, irc, ssh, sftp, webcal, rtsp` — every one of them is **at least 2 edits** from both (`ftp` and `rtsp` are the closest, at 2). `javascript` is 9 and `data` is 3. So no scheme an editor deliberately typed can be rewritten, and no executable scheme can be manufactured. A dedicated test pins this, so widening the bound to 2 fails the suite rather than silently rewriting `ftp://`.
- Ties resolve to `https`, so a secure address is never downgraded.
- Two edits is treated as a different word, not a typo: `hxxp://example.com` (a defanged URL — the realistic case) is still rejected, now with the visible message this PR already added.

**This does NOT make PR #1444 redundant — recommend keeping it open.** #1444 patches gin_lb's `preprocessFieldMultipleValueForm`, which runs for **every multi-value field on the platform**; its own regression steps include an Accordion block submitted with empty required fields, which has nothing to do with URLs. This change removes exactly one input that can trigger a validation-error re-render on one field of one block type — every other trigger survives, including `hxxp://example.com` above. That matches @miketullo95's read in the approval above that the two are complementary.

**Known limits, stated plainly:**
- A bare domain carrying a **port** (`example.com:8080/a`) is still not normalised — the pre-existing "already declares a scheme" guard matches `example.com:`. That is a real pre-existing gap rather than intended behaviour; it is now pinned by a test asserting current behaviour so the change above provably does not make it worse. Out of scope here, worth a follow-up.
- **Links already saved in the database are not fixed** — only new saves are corrected. No backfill update hook is included. This matches #1158's own precedent (it shipped no backfill either), but existing broken links stay broken until an editor re-saves them. Worth a follow-up ticket.
- The editor being ejected from the off-canvas dialog is itself broken behaviour and is the *reason* the message was lost. Restoring the missing `#ajax` is core/gin_lb territory and would change the configure-block submit flow for every block type — **deliberately not attempted here.** The alternative deeper fix (overriding `page--layout-builder.html.twig` in `ys_admin_theme` to print `{{ page.highlighted }}`) would also close it generically, and would additionally cover `layout_builder.remove_block` / `remove_section` / `choose_*`, which have the same message-dropping defect and are **not** covered by this PR.
- Pre-existing and untouched: a well-formed but upper-cased `HTTPS://example.com` (double slash) is still rejected by core for the same case-sensitivity reason. Not in this ticket's scope, but it is a real defect, not a quirk.
- **Accessibility:** the rejection now meets WCAG 3.3.1 with visible text (not colour alone) — the box renders an `<h2>Error message</h2>` plus the error text, with `role="contentinfo"`/`aria-labelledby`, measured contrast 5.16:1 (AA for normal text), and `aria-invalid="true"` on the field. **Gap:** the field's `aria-describedby` points at its description, not the error text, so this is a form-level message rather than a per-field programmatic association. Closing that means enabling core's Inline Form Errors module platform-wide — out of scope here.

### Verification already done on local Lando

- Cases 1 and 2, end to end through the real contextual **Configure** dialog on node 36's Quick Links block: `//example.com` and `https:/example.com` both now store `https://example.com` and the published page renders `<a href="https://example.com">`. Controls `/about` (→ `internal:/about`) and `https://yale.edu` save unchanged, and the block's other 8 links render unaffected. Test fixture restored to its original value afterwards.
- Case 3: the rejection message is now visible on screen at the moment of failure, and appears **exactly once** (measured in the DOM, not assumed).
- Security: the message now renders editor-supplied input where it previously rendered nothing, so this was checked at runtime rather than reasoned about — entering `htp://x"><img src=x onerror=alert(1)><script>alert(1)</script>` renders as literal escaped text with no script execution (escaped at `FormattableMarkup::placeholderFormat()`'s `@` → `Html::escape()`). No protocol-filter bypass: both new branches can only emit `http`/`https`, `javascript:`/`data:` fall through untouched, and `https:/javascript:…` becomes *more* strictly rejected than before.
- `composer code-sniff` (the real CI gate): **exit 0**. `composer lint:php`: exit 0.
- ys_core **Unit**: `Tests: 158, Assertions: 211, Skipped: 1` — 0 failures (baseline before the change: 131 tests, 0 failures).
- ys_core **Kernel** (full): `OK (20 tests, 327 assertions)`, including the pre-existing `GrandHeroReusableBlockFormAlter` regression test for this same `ys_core_form_alter()` branch.
- The tests were written first and confirmed failing for the right reason; the kernel test was additionally mutation-checked (renaming the form key back makes 2 of 3 fail), so it cannot pass vacuously.
- Note this project's CI runs no PHPUnit, so these suites are local-only and do not gate the PR.

### Functional testing steps:

- [ ] Edit a page, open **Layout Builder**, and **Configure** an existing Quick Links block.
- [ ] Set one link's URL to `//example.com` and save the block, then **Save layout**. Confirm the link on the published page goes to `https://example.com` — not a link-styled element that does nothing when clicked.
- [ ] Repeat with `https:/example.com` (one slash). Confirm it also resolves to `https://example.com`.
- [ ] Repeat with `HTTPS:/example.com`. Confirm it saves and resolves to `https://example.com`.
- [ ] Repeat with `htp://example.com` (mistyped scheme). Confirm it now **saves** and the published page resolves it to `http://example.com` — it is no longer rejected.
- [ ] Configure the block again, set a link's URL to `hxxp://example.com` (a defanged URL: two characters wrong, so deliberately not guessed at), and click **Update**. Confirm a visible red error box reading `The path 'hxxp://example.com' is invalid.` appears immediately, and that it appears only once. Before this fix the field was outlined in red with no message, and the text turned up later on an unrelated page.
- [ ] Regression on the scheme correction: confirm `ftp://example.com`, `mailto:someone@yale.edu` and `tel:+12035551212` all save **exactly as typed** and are not rewritten to `http`.
- [ ] Regression: confirm normal links still work — an internal link picked from autocomplete, `/about`, `https://yale.edu`, `mailto:someone@yale.edu`, and a `tel:` link all save and render as before.
- [ ] Regression: confirm a validation error on a **different** block type's configure form (e.g. leave a required Grand Hero field empty) also now shows its message in the form.

References yalesites-org/YaleSites-Internal#1497

---

Created with AI

