### PR TITLE
1502: RC: Clarify that Banner Full Width only looks different on very wide screens

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_style_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_style_width.yml
@@ -12,7 +12,7 @@ field_name: field_style_width
 entity_type: block_content
 bundle: cta_banner
 label: 'Banner Width'
-description: 'On the published page, Full Width only looks different from Contained in browser windows wider than 2400 pixels, such as a maximized window on a 2560-pixel-wide or 4K display. On narrower screens both options fill the same width, so seeing no difference is expected. The Layout Builder preview always shows a difference because of the editing frame.'
+description: 'Full Width only looks different from Contained on screens wider than 2400 pixels, such as a maximized window at 2560 pixels or 4K — on typical screens they look the same. Note: the Layout Builder preview always shows a difference, because of the editing frame.'
 required: true
 translatable: false
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_style_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.cta_banner.field_style_width.yml
@@ -12,7 +12,7 @@ field_name: field_style_width
 entity_type: block_content
 bundle: cta_banner
 label: 'Banner Width'
-description: ''
+description: 'On the published page, Full Width only looks different from Contained in browser windows wider than 2400 pixels, such as a maximized window on a 2560-pixel-wide or 4K display. On narrower screens both options fill the same width, so seeing no difference is expected. The Layout Builder preview always shows a difference because of the editing frame.'
 required: true
 translatable: false
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_style_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_style_width.yml
@@ -12,7 +12,7 @@ field_name: field_style_width
 entity_type: block_content
 bundle: grand_hero
 label: 'Banner Width'
-description: ''
+description: 'On the published page, Full Width only looks different from Contained in browser windows wider than 2400 pixels, such as a maximized window on a 2560-pixel-wide or 4K display. On narrower screens both options fill the same width, so seeing no difference is expected. The Layout Builder preview always shows a difference because of the editing frame.'
 required: true
 translatable: false
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_style_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_style_width.yml
@@ -12,7 +12,7 @@ field_name: field_style_width
 entity_type: block_content
 bundle: grand_hero
 label: 'Banner Width'
-description: 'On the published page, Full Width only looks different from Contained in browser windows wider than 2400 pixels, such as a maximized window on a 2560-pixel-wide or 4K display. On narrower screens both options fill the same width, so seeing no difference is expected. The Layout Builder preview always shows a difference because of the editing frame.'
+description: 'Full Width only looks different from Contained on screens wider than 2400 pixels, such as a maximized window at 2560 pixels or 4K — on typical screens they look the same. Note: the Layout Builder preview always shows a difference, because of the editing frame.'
 required: true
 translatable: false
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.image_banner.field_style_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.image_banner.field_style_width.yml
@@ -12,7 +12,7 @@ field_name: field_style_width
 entity_type: block_content
 bundle: image_banner
 label: 'Banner Width'
-description: ''
+description: 'On the published page, Full Width only looks different from Contained in browser windows wider than 2400 pixels, such as a maximized window on a 2560-pixel-wide or 4K display. On narrower screens both options fill the same width, so seeing no difference is expected. The Layout Builder preview always shows a difference because of the editing frame.'
 required: true
 translatable: false
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.image_banner.field_style_width.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.image_banner.field_style_width.yml
@@ -12,7 +12,7 @@ field_name: field_style_width
 entity_type: block_content
 bundle: image_banner
 label: 'Banner Width'
-description: 'On the published page, Full Width only looks different from Contained in browser windows wider than 2400 pixels, such as a maximized window on a 2560-pixel-wide or 4K display. On narrower screens both options fill the same width, so seeing no difference is expected. The Layout Builder preview always shows a difference because of the editing frame.'
+description: 'Full Width only looks different from Contained on screens wider than 2400 pixels, such as a maximized window at 2560 pixels or 4K — on typical screens they look the same. Note: the Layout Builder preview always shows a difference, because of the editing frame.'
 required: true
 translatable: false
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/tests/src/Unit/BannerWidthFieldDescriptionTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/tests/src/Unit/BannerWidthFieldDescriptionTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\Tests\ys_themes\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * The Banner Width dial tells editors when Full Width actually looks different.
+ *
+ * "Contained" caps the banner at --break-max-width (2400px) while "Full Width"
+ * goes to 100vw, so on a narrower viewport the two render identically. Measured
+ * on the rendered page: at 1440px and 1920px both are 1440/1920 wide at left 0,
+ * while at 2560px Full Width is 2560 and Contained is 2400 centred at left 80.
+ * Without a field description an editor on an ordinary monitor changes the
+ * dial, sees nothing happen, and concludes the setting is broken (#1502).
+ *
+ * Asserted against the exported YAML rather than a loaded FieldConfig, for the
+ * reason InlineMessageIconFieldTest gives in
+ * testExportedFieldConfigDefaultsToLegacyIcon(): config/sync is what a deploy
+ * imports, so a re-export taken from a database that never imported this change
+ * would silently drop the copy again. The path idiom is ys_mail
+ * MailchimpConfigKeysTest::configSyncDir(); that Kernel test resolves the same
+ * directory through extension.list.profile instead.
+ *
+ * Deliberately scoped to the three banners that share the 2400px threshold.
+ * video_banner also offers Contained/Full Width, but its "Contained" resolves
+ * to --size-component-layout-width-max (100rem/1600px, see
+ * components/02-molecules/banner/video/yds-video-banner.scss), so it diverges
+ * on an ordinary 1920px monitor and this copy would be wrong there.
+ *
+ * @group ys_themes
+ * @group yalesites
+ */
+class BannerWidthFieldDescriptionTest extends UnitTestCase {
+
+  /**
+   * Block types whose Banner Width dial caps "Contained" at 2400px.
+   */
+  const BANNER_BUNDLES = ['cta_banner', 'grand_hero', 'image_banner'];
+
+  /**
+   * Absolute path to the profile's exported config/sync directory.
+   */
+  protected function configSyncDir(): string {
+    return dirname(__DIR__, 6) . '/config/sync';
+  }
+
+  /**
+   * Every banner width dial carries the same explanation of its two options.
+   *
+   * Asserted together rather than as separate cases because a per-bundle check
+   * alone passes while all three are empty, and a consistency check alone
+   * passes while all three are identically empty.
+   */
+  public function testBannerWidthFieldsExplainBothOptionsConsistently(): void {
+    $descriptions = [];
+
+    foreach (self::BANNER_BUNDLES as $bundle) {
+      $file = $this->configSyncDir()
+        . "/field.field.block_content.$bundle.field_style_width.yml";
+      $this->assertFileExists($file);
+
+      $description = Yaml::parseFile($file)['description'] ?? '';
+      $this->assertNotSame(
+        '',
+        $description,
+        "The $bundle Banner Width dial has no description, so an editor who " .
+        'sees no visual change has nothing telling them that is expected.'
+      );
+      $this->assertStringContainsString('Full Width', $description);
+      $this->assertStringContainsString('Contained', $description);
+
+      $descriptions[$bundle] = $description;
+    }
+
+    // One threshold and one pair of option labels, so letting the copy drift
+    // apart would teach editors three stories about the same control.
+    $this->assertCount(
+      1,
+      array_unique($descriptions),
+      'Every banner width dial should carry the same explanation: '
+      . print_r($descriptions, TRUE)
+    );
+  }
+
+}


### PR DESCRIPTION
## [1502: RC: Clarify that Banner Full Width only looks different on very wide screens](https://github.com/yalesites-org/YaleSites-Internal/issues/1502)

### Description of work

- Adds a description to the **Banner Width** field on the three block types whose "Contained" option is capped by the `--break-max-width` (2400px) token: `cta_banner`, `grand_hero`, `image_banner`. Until now the field had `description: ''`, so an editor who switched Contained → Full Width on an ordinary screen saw nothing happen and had no way to know that was correct.
- Adds a Unit test guarding that the copy stays present and consistent across all three block types. It asserts against the exported `config/sync` YAML, following `ys_core` `InlineMessageIconFieldTest::testExportedFieldConfigDefaultsToLegacyIcon()` — `config/sync` is what a deploy imports, so a re-export taken from a database that never imported this change would silently drop the copy again.
- Updates step 4 of #1157's Release Testing Steps to state the actual threshold, so a future tester does not file a false bug report. The original wording is preserved verbatim; the clarification is additive.

**Two corrections to the ticket's own framing, based on measurements rather than the report:**

1. The ticket (and #1157's steps) frame this as "4K only". Measured on the rendered page, a maximized window on a common **2560px-wide QHD/1440p monitor already shows the difference**, so the copy says "wider than 2400 pixels, such as a maximized window on a 2560-pixel-wide or 4K display" instead of implying 4K is required.

   | viewport | Full Width | Contained | same? |
   |---|---|---|---|
   | 1440px | 1440 @ left 0 | 1440 @ left 0 | yes |
   | 1920px | 1920 @ left 0 | 1920 @ left 0 | yes |
   | 2560px | 2560 @ left 0 | 2400 @ left 80 | **no** |
   | 2700px | 2700 @ left 0 | 2400 @ left 150 | **no** |

2. The **Layout Builder preview always shows a difference at any width**, because the editing frame insets each section by 2rem per side (measured at a 1440px viewport: Full Width 1440px vs Contained 1376px). Without a line about that, the new help text would flatly contradict what the editor sees while placing the block — so the copy scopes its claim to the published page and names the preview explicitly. This was caught in code review, not by me, and confirmed at runtime.

**`video_banner` is deliberately excluded.** It offers the same two labels, but its "Contained" resolves to `--size-component-layout-width-max` (100rem/1600px) rather than 2400px, so it diverges on an ordinary 1920px monitor and this copy would be wrong there. Recorded in the test's docblock so nobody pastes the copy onto it.

### Functional testing steps:

- [ ] Edit a page, add or configure an **Image Banner**, **Grand Hero**, or **CTA/Action Banner** block, and confirm the **Banner Width** field now shows help text under the select explaining that Full Width only differs above 2400px.
- [ ] Confirm the same text appears on all three of those block types, and that the block's behaviour is otherwise unchanged (this PR changes no rendering code — only the field description and a test).
- [ ] Save a banner as **Contained** and another as **Full Width**, view the **published page** at a normal window width, and confirm they look the same — that is the expected result the new copy describes.
- [ ] Resize the browser window past 2400px wide (devtools device toolbar, or a 2560px/4K display at native resolution) and confirm Full Width now stays edge-to-edge while Contained caps at 2400px and centres.
- [ ] Confirm the help text is announced with the field by a screen reader (it is wired through `aria-describedby` on the select).

### Verification performed

- `lando composer code-sniff` — **exit 0**, no findings (Drupal + DrupalPractice over the whole custom tree).
- `composer lint:php` — exit 0.
- `ys_themes` Unit suite — baseline **70 tests / 140 assertions / 4 failures** → after **71 / 153 / 4 failures**. The same four pre-existing `ColorTokenResolverTest` failures (`testBuildColorInfoResolvesComponentThemeVariable`, `testGetColorStylesForEntityCalloutBundleMapping`, `testGetColorStylesForEntityFactsBundleUsesFourOptionOverride`, `testGetColorStylesForEntityQuoteCalloutBundleMapping`) fail before and after this branch — they concern colour-slot variable resolution and are unrelated to this change. Flagged below, not fixed here.
- Applied to the local Lando site with a scoped `drush config:import --partial` and confirmed the description renders on the real Layout Builder block form for all three block types (`cta_banner` and `grand_hero` on node 95, `image_banner` on node 60), with a screenshot.
- Accessibility (light gate): the `<select>` carries `aria-describedby` pointing at the description element, so the copy is announced with the field. The surrounding markup is Drupal core's form-element template plus Gin, which we do not patch, so no further finding there is actionable.

### Notes for the reviewer

- The config YAML was hand-edited and then applied to the local database with a scoped `drush config:import --partial`, deliberately **not** `npm run confex` — `confex` exports *from* the database and would have reverted the hand edits. Round-tripping all three files through Drupal's own YAML encoder produces byte-identical output, so a later `confex` will not churn them.
- **Possible pre-existing bug, not investigated here:** `Full Width` uses `width: 100vw`, and `overflow-x: hidden` is only applied at ≤992px. On platforms with classic (non-overlay) scrollbars, `100vw` includes the scrollbar gutter, which could make Full Width render slightly wider than the viewport. It did not reproduce in headless Chrome on macOS (overlay scrollbars), so it is unconfirmed rather than ruled out. Raised in code review; may deserve its own ticket.
- **Left alone deliberately:** step 1 of #1157's Release Testing Steps describes the options as "Default and Full width", but the actual labels are "Contained" and "Full Width". Same class of stale-instruction problem as this ticket, but outside what #1502 asked for, so I did not edit someone else's step 1.

References yalesites-org/YaleSites-Internal#1502

---

Created with AI

<img width="1258" height="176" alt="Screenshot 2026-08-11 at 5 39 34 AM" src="https://github.com/user-attachments/assets/0adc0017-4a82-4dba-ada0-f7c7c8a304a5" />
