### PR TITLE
1505: RC: Content Collection delete tests error before they can test anything

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookCollectionDeleteTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookCollectionDeleteTest.php
@@ -48,6 +48,10 @@ class BookCollectionDeleteTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->installSchema('node', 'node_access');
     $this->installSchema('book', ['book']);
+    // Kernel tests never run hook_install(), so add the title column this
+    // module installs on a real site; see _ys_book_add_book_title_column().
+    $this->container->get('module_handler')->loadInclude('ys_book', 'install');
+    _ys_book_add_book_title_column();
     $this->installConfig(['node', 'book', 'field']);
 
     // The delete route is gated on 'administer book outlines'; build the router

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookTitleColumnTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookTitleColumnTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\Tests\ys_book\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests that ys_book adds its title column to the contrib book table.
+ *
+ * A fresh install never runs ys_book_update_10005(), so hook_install() is the
+ * only thing that adds the column; see _ys_book_add_book_title_column() for
+ * why. Without this test that path is uncovered, because the other kernel
+ * tests build the column into their fixtures directly.
+ *
+ * @group ys_book
+ * @group yalesites
+ */
+class BookTitleColumnTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'node',
+    'field',
+    'text',
+    'book',
+    'custom_book_block',
+    'ys_book',
+  ];
+
+  /**
+   * Installing ys_book adds the title column, and re-running it is harmless.
+   */
+  public function testInstallAddsTitleColumn(): void {
+    // installSchema() builds the table from contrib book's own hook_schema(),
+    // which is exactly the table a brand new site starts with.
+    $this->installSchema('book', ['book']);
+
+    $schema = $this->container->get('database')->schema();
+    $this->assertFalse(
+      $schema->fieldExists('book', 'title'),
+      "Contrib book's schema has no title column, so ys_book must add it."
+    );
+
+    $this->container->get('module_handler')->loadInclude('ys_book', 'install');
+    ys_book_install();
+
+    $this->assertTrue(
+      $schema->fieldExists('book', 'title'),
+      'hook_install() adds the title column on a fresh site.'
+    );
+
+    // The update hook shares the same guarded helper, so running it against a
+    // site that already has the column must not fail.
+    ys_book_update_10005();
+
+    $this->assertTrue(
+      $schema->fieldExists('book', 'title'),
+      'Re-running the column add is a no-op rather than an error.'
+    );
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/YsExpandBookManagerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/YsExpandBookManagerTest.php
@@ -49,6 +49,10 @@ class YsExpandBookManagerTest extends KernelTestBase {
     // Loading a node fires the book module's hook_node_load, which queries the
     // book table, so its schema must be installed.
     $this->installSchema('book', ['book']);
+    // Kernel tests never run hook_install(), so add the title column this
+    // module installs on a real site; see _ys_book_add_book_title_column().
+    $this->container->get('module_handler')->loadInclude('ys_book', 'install');
+    _ys_book_add_book_title_column();
 
     NodeType::create(['type' => 'page', 'name' => 'Page'])->save();
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.install
@@ -6,9 +6,43 @@
  */
 
 /**
- * Add title column to book table for custom menu link titles.
+ * Implements hook_install().
  */
-function ys_book_update_10001(): void {
+function ys_book_install(): void {
+  _ys_book_add_book_title_column();
+}
+
+/**
+ * Add title column to book table for custom menu link titles.
+ *
+ * Numbered 10005 rather than 10001 because 10001 through 10004 were previously
+ * taken by microsite-rename hooks that were later removed. An environment that
+ * deployed while those existed is stamped at 10004, so it would skip a re-used
+ * lower number and never get the column. Nothing below 10005 ever reached a
+ * release tag, and the add is guarded, so this is safe to run anywhere.
+ */
+function ys_book_update_10005(): void {
+  _ys_book_add_book_title_column();
+}
+
+/**
+ * Adds this module's title column to the book module's table.
+ *
+ * Both hook_install() and hook_update_N() need this. Nothing in Drupal adds the
+ * column on its own: hook_schema() only creates a module's own tables, and
+ * installing a module stamps its schema version at the highest update it
+ * provides, so ys_book_update_10005() is treated as already applied and skipped
+ * on every fresh install. Without the hook_install() path a new site ends up
+ * with the unmodified contrib book table, and the first page saved into a
+ * collection fails in _ys_book_save_menu_link_title() with "Unknown column
+ * 'title'".
+ *
+ * There is deliberately no matching hook_uninstall() dropping the column: it
+ * holds editor-authored menu link titles, so dropping it would silently destroy
+ * content on an uninstall/reinstall cycle. Leaving it behind is harmless, since
+ * it is nullable and contrib book inserts an explicit field list.
+ */
+function _ys_book_add_book_title_column(): void {
   $schema = \Drupal::database()->schema();
   $table_name = 'book';
 


### PR DESCRIPTION
## [1505: RC: Content Collection delete tests error before they can test anything](https://github.com/yalesites-org/YaleSites-Internal/issues/1505)

### Description of work

**Heads up: the ticket's premise turned out to be wrong, so this PR is bigger than "fix a test fixture."** The ticket says *"This is a test-fixture problem, not a live-site defect."* It isn't — the fixture was faithfully reproducing what a freshly installed site actually looks like. The tests were telling the truth; the install path was broken.

`ys_book` keeps per-collection menu link titles in a `title` column it adds to the **contrib** `book` module's table, but only an update hook ever added it. That leaves two classes of environment with no column, where the first page saved into a collection dies in `_ys_book_save_menu_link_title()` with `Unknown column 'title'`:

- **Fresh installs.** `ModuleInstaller::install()` stamps a new module's schema version at the highest update it provides (`web/core/lib/Drupal/Core/Extension/ModuleInstaller.php:277-281`), so the update hook is marked already-applied and never runs. `hook_schema()` can't help — it only creates a module's *own* tables — and `hook_schema_alter()` does not exist in Drupal 10 (zero hits across `web/core`). `hook_install()` is the only available point. And there *is* a real fresh-install path: `.ci/github/deploy_release_sites` runs `drush si yalesites_profile` for the `yalesites-platform` release environment — precisely where collections get QA'd before a release.
- **Environments stamped above the update's number.** `10001`–`10004` were previously used by microsite-rename hooks that were later removed, and the title-column hook then re-used `10001`. Anything that deployed while those existed sits at `10004` and skips the lower number forever. Renumbered to `10005`, which covers every stamped state (8000, 10001, 10004, and fresh installs). Nothing below `10005` ever reached a release tag, and the add is guarded, so it is safe to re-run anywhere.

Changes:

- `ys_book.install`: extracted the existing guarded column-add into `_ys_book_add_book_title_column()`, added `ys_book_install()`, and renumbered the update hook to `ys_book_update_10005()`. Both entry points delegate to the one helper. The guard body itself is unchanged.
- Both existing kernel fixtures (`BookCollectionDeleteTest`, `YsExpandBookManagerTest`) now call that same helper after `installSchema('book', ['book'])`, so they stop modelling a table shape that exists on no real site — and can't silently drift from the install code again.
- New `BookTitleColumnTest` covers the `hook_install()` path itself, which none of the other tests can catch.
- Deliberately **no** `hook_uninstall()` dropping the column: it holds editor-authored content, so dropping it would silently destroy menu link titles on a reinstall cycle. Rationale is recorded in the docblock so nobody "finishes" the lifecycle later.

Verification:

- `ys_book` kernel suite: **12 tests / 113 assertions / 7 errors → 13 tests / 144 assertions / 0 errors.** The assertion count is the point — those 7 tests previously died in `setUp()` before reaching a single assertion.
- `lando composer code-sniff` (Drupal + DrupalPractice, the real CI gate) and `lando composer lint:php`: both **exit 0**.
- Runtime-confirmed on local Lando: `drush updatedb-status` now lists `ys_book 10005` as pending on a DB stamped at `10001`, i.e. the renumber genuinely makes the hook eligible on the environments that would otherwise skip it.
- **Not verified by me:** whether any given remote environment currently lacks the column. I never touched a remote site. Worth checking before/after deploy with `terminus -n drush <site>.<env> -- sqlq "SHOW COLUMNS FROM book LIKE 'title'"`.

### Functional testing steps:

- [ ] On the multidev, add a page to a Content Collection and save it. It saves without a database error (this is the path that fatals when the column is missing).
- [ ] Edit that page's menu link title in the collection outline, save, and confirm the custom title shows in the collection navigation.
- [ ] Confirm `drush updatedb-status` lists `ys_book 10005` before deploy, and that `drush deploy` applies it cleanly.
- [ ] Confirm `drush sqlq "SHOW COLUMNS FROM book LIKE 'title'"` returns the `title varchar(255)` row after deploy.
- [ ] Run the kernel suite and confirm 13/13 pass: `lando ssh -c "env SIMPLETEST_DB=mysql://pantheon:pantheon@database/pantheon php /app/vendor/bin/phpunit -c /app/phpunit.xml /app/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests --testdox"`
- [ ] Delete an entire Content Collection and confirm the pages survive as standalone content (the behaviour the previously-erroring tests cover).

References yalesites-org/YaleSites-Internal#1505

---

Created with AI
