### PR TITLE
1506: RC: Layout Section color picker offers 5 colors, not 6 like every other picker

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Layout/YSLayoutOptions.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Layout/YSLayoutOptions.php
@@ -80,6 +80,9 @@ class YSLayoutOptions extends LayoutDefault implements ContainerFactoryPluginInt
 
     // Use the saved theme value directly from configuration.
     $saved_theme = $this->configuration['theme'] ?? 'default';
+    // Sections offer five color options by design, where block components
+    // offer six. See ColorTokenResolver::getColorStylesForEntity() for which
+    // palette slot each option resolves to and why slot-three is excluded.
     $form['theme'] = [
       '#type' => 'select',
       '#title' => $this->t('Component theme'),
@@ -116,9 +119,9 @@ class YSLayoutOptions extends LayoutDefault implements ContainerFactoryPluginInt
   /**
    * After build callback to add the color picker palette UI.
    *
-   * Wraps the ColorTokenResolver processColorPicker method with the section
-   * layout mapping: one=Blue Yale, two=Gray 100, three=Gray 800,
-   * four=Blue Medium, five=Blue Light.
+   * Wraps the ColorTokenResolver processColorPicker method, which owns the
+   * section layout mapping for the 'layout_section'/'ys_layout_options'
+   * entity/bundle pair.
    *
    * @param array $element
    *   The form element.
@@ -135,10 +138,16 @@ class YSLayoutOptions extends LayoutDefault implements ContainerFactoryPluginInt
     // Get the complete form from form state (required for after_build).
     $complete_form = $form_state->getCompleteForm();
 
-    // Use section layout mapping: one→slot-one, two→slot-three,
-    // three→slot-two, four→slot-five, five→slot-four.
-    // This gives: one=Blue Yale, two=Gray 100, three=Gray 800,
-    // four=Blue Medium, five=Blue Light.
+    // The resolver applies the section layout mapping: one→slot-one,
+    // two→slot-four, three→slot-five, four→slot-two, five→slot-nine. The
+    // rendered colors come from the same slots via _yds-layout.scss, so the
+    // swatch shown here matches the page.
+    //
+    // No mapping is passed from this plugin: getColorStylesForEntity() is the
+    // single source of truth for which slot each option resolves to. The
+    // option list itself is not — it is declared three times and the copies
+    // must be kept in sync: the '#options' array above, that same mapping's
+    // keys, and $desired_order in ColorTokenResolver::processColorPicker().
     return $this->colorTokenResolver->processColorPicker(
       $element,
       $form_state,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/YSLayoutOptionsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/YSLayoutOptionsTest.php
@@ -69,6 +69,15 @@ class YSLayoutOptionsTest extends UnitTestCase {
     $this->assertTrue($form['divider']['#default_value']);
     $this->assertSame('select', $form['theme']['#type']);
     $this->assertSame('two', $form['theme']['#default_value']);
+
+    // Sections offer five colors plus "Default - no color", where block
+    // components offer six colors. This is deliberate (see #1506), so pin the
+    // list an editor actually sees rather than letting a sixth option appear
+    // silently.
+    $this->assertSame(
+      ['default', 'one', 'two', 'three', 'four', 'five'],
+      array_keys($form['theme']['#options']),
+    );
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ColorTokenResolver.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ColorTokenResolver.php
@@ -386,8 +386,14 @@ class ColorTokenResolver {
 
     // Section layout mapping: one→slot-one, two→slot-four, three→slot-five,
     // four→slot-two, five→slot-nine.
-    // Widget options: one=Blue Yale, two=Gray 100, three=Gray 800,
-    // four=Blue Medium, five=Soft Oceanic (ONHA) / Gray 100 (others).
+    //
+    // Unlike every other mapping in this method, sections deliberately expose
+    // five options rather than six: slot-three is the one palette slot they do
+    // not offer. Ticket #897 (commit 1a06ebc6f) reworked this mapping and
+    // dropped slot-three, and it has not been offered to sections since;
+    // #1153 later added the 'five' => slot-nine entry. Keep this list at five
+    // unless that product decision is revisited (see #1506); the corresponding
+    // form options live in YSLayoutOptions.
     if ($entity_type === 'layout_section' && $bundle === 'ys_layout_options') {
       return $this->buildColorStyles([
         'one' => 'one',

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/tests/src/Unit/ColorTokenResolverTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/tests/src/Unit/ColorTokenResolverTest.php
@@ -518,6 +518,40 @@ class ColorTokenResolverTest extends UnitTestCase {
   }
 
   /**
+   * Tests that layout sections expose five color options, not six.
+   *
+   * Every block-content mapping in getColorStylesForEntity() offers six
+   * options covering slots one, two, three, four, five and nine. Sections
+   * deliberately offer five and never expose slot-three: an option for it was
+   * added and then removed again within ticket #897, and #1153 reused the
+   * freed 'five' key for slot-nine. This test pins that decision so the
+   * difference reads as intentional rather than as a missed slot (#1506), and
+   * so adding a sixth option is a deliberate change with a test to update.
+   *
+   * @covers ::getColorStylesForEntity
+   */
+  public function testGetColorStylesForEntitySectionExposesFiveOptions(): void {
+    $resolver = $this->createResolver($this->fixturePath);
+    $styles = $resolver->getColorStylesForEntity('layout_section', 'ys_layout_options');
+
+    $this->assertSame(
+      ['one', 'two', 'three', 'four', 'five'],
+      array_keys($styles['one']),
+    );
+
+    // No option resolves to slot-three under any global theme.
+    foreach ($styles as $global_theme => $options) {
+      foreach ($options as $option_key => $declarations) {
+        $this->assertNotContains(
+          "var(--global-themes-{$global_theme}-colors-slot-three)",
+          $declarations,
+          "Section option '{$option_key}' unexpectedly resolves to slot-three.",
+        );
+      }
+    }
+  }
+
+  /**
    * Tests get color styles for entity callout bundle mapping.
    *
    * GetColorStylesForEntity() applies the callout-family mapping, the


### PR DESCRIPTION
## [1506: RC: Layout Section color picker offers 5 colors, not 6 like every other picker](https://github.com/yalesites-org/YaleSites-Internal/issues/1506)

Takes **Option A** from the ticket: the 5 options are intentional, so this corrects the documentation rather than adding a 6th color. **No behavior change — every changed line in both production files is a comment.**

### Description of work

- Corrected the comments in `YSLayoutOptions::processColorPicker()`, which described the section mapping as `two→slot-three, three→slot-two, four→slot-five, five→slot-four`. The resolver and the SCSS both use `two→slot-four, three→slot-five, four→slot-two, five→slot-nine`, so **four of the five were wrong** — a developer trusting that comment would have got the mapping backwards.
- Removed the two `five=Blue Light` comments. Option five resolves to slot-nine; "Blue Light" is slot-three, which sections do not offer at all.
- Corrected `ColorTokenResolver`, which labelled slot-nine "Gray 100". It is **Gray 200** in the default theme and varies per global theme (soft-oceanic on Onha).
- Replaced the removed text with an explanation of *why* sections stop at five, so the next reader does not re-open this question.
- Added two tests pinning the contract so a 6th option cannot appear silently:
  - `ColorTokenResolverTest::testGetColorStylesForEntitySectionExposesFiveOptions()` — asserts the section mapping exposes exactly `one`–`five` and that no option resolves to slot-three under any of the 7 global themes.
  - Extended the existing `YSLayoutOptionsTest::testBuildConfigurationFormExposesDividerAndTheme()` to assert the form's own `#options` list — which is what the ticket was actually reported against.

### Why 5 is intentional (this refines the ticket)

- Every other mapping in `getColorStylesForEntity()` — base, callout family, facts, quote_callout, link_grid, inline_message — exposes the **same six slots** `{one, two, three, four, five, nine}`, just in different display order. Sections expose `{one, two, four, five, nine}`. The single gap is **slot-three**.
- The ticket framed Option B's open question as "choosing which slot it should map to and what it should be called." That is **not open** — slot-three is the unique gap, and it is Blue Light in the default theme.
- `git show 1a06ebc6f` (#897) shows the section mapping being reworked from slots `{1,3,2,5,4}` down to `{1,4,5,2}`, dropping slot-three. It has not been offered to sections since. #1153 later added `five => slot-nine`. **The omission was a deliberate act, not an oversight.**
- Verified on a live Lando site that the picker swatch matches what actually renders for all five values, including the global-theme-four (Onha) slot-two↔slot-five swap. There is no user-facing defect.

### Worth knowing: why this looked like a bug

Both pickers render **6 circles**. The section picker's first circle is "Default - no color" (white), so it shows Default + 5 colors; a block picker shows 6 colors with no Default entry. A tester counting circles gets 6 in both places and honestly reports "6 slots visible." That — not a simple miscount — is the mechanism behind #1153's misleading test step.

### Functional testing steps:

- [ ] On any page, edit the layout and add or configure a **Two column (50/50)** or **Three column (33/33/33)** section. Open the "Component theme" picker and confirm it shows **Default - no color, Blue Yale, Gray 100, Gray 800, Blue Medium, Gray 200** — 5 colors plus Default.
- [ ] Open the theme picker on any **block** (Callout, Grand Hero, Quote Callout) and confirm it shows **6 colors**, including **Blue Light**, which the section picker does not offer.
- [ ] Pick each of the 5 section colors, save, and confirm the rendered section background matches the swatch that was selected.
- [ ] On an ONHA site (global theme four), confirm section options three and four still render swapped correctly (slot-five↔slot-two) and match their swatches.
- [ ] Confirm no visual change anywhere — this PR changes only comments and tests.

### Two things for the reviewer to decide

1. **Product call (Mike):** should Layout Sections get a 6th option mapped to **slot-three (Blue Light)** for parity with blocks? This PR assumes **no**, on the evidence above. If the answer is yes, that is Option B and it is now a one-line decision rather than a design exercise — but it changes what every editor sees, so it should not be decided in an unattended run.
2. **#1153's Release Testing Steps still need correcting.** I deliberately did **not** edit that ticket — it is a separate open issue and the wording encodes the product decision above. The exact ready-to-paste replacement text is in the run log at `~/Documents/Claude/not_dave/1506-layout-section-color-picker-20260811.md`.

### Verification

| Check | Baseline (`develop`) | This branch |
|---|---|---|
| `lando composer code-sniff` | — | **exit 0** |
| `lando composer lint:php` | — | no syntax errors |
| `ys_themes` Unit | 70 tests, 4 failures | 71 tests, **same 4 failures** |
| `ys_layouts` Unit | 93 tests / 153 assertions, 1 failure | 93 tests / 154 assertions, **same 1 failure** |

Baselines were measured on a clean tree at `origin/develop`. The new resolver test was mutation-checked: adding `'six' => 'three'` to the section mapping makes it fail, so it is not vacuous.

> **Pre-existing, not from this PR:** 5 custom unit tests are already red on `develop` (4 in `ys_themes`, 1 in `ys_layouts` `BlockContextualLinksTest`). CI runs no PHPUnit, so nothing catches them. Out of scope here, but they probably deserve their own ticket.

References yalesites-org/YaleSites-Internal#1506

---

Created with AI
