### PR TITLE
1503: RC: Decide whether to clean up orphaned blocks left behind by Layout Builder

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/README.md
@@ -24,6 +24,55 @@ This module includes a service called `MetaFieldsManager` that was specifically 
 
 The `ics_url` is auto-calculated if there is an ICS URL provided from Localist, then use it. If not, calculate an ICS URL dynamically from the first date in the series.
 
+## Orphaned inline blocks
+
+When an editor removes a non-reusable ("inline") block from a page's layout, the block
+disappears from the page but its `block_content` record stays in the database. Nothing in the
+admin UI can reach it afterwards: non-reusable blocks have no canonical route, so
+`/block/{id}/edit` returns 404 for every one of them, orphaned or not.
+
+This is documented Drupal core behaviour, not a YaleSites defect, and core cannot clean it up
+for a node that still exists:
+
+- `layout_builder_cron()` collects only `inline_block_usage` rows whose `layout_entity_type`
+  and `layout_entity_id` are **both** NULL, which happens when the parent entity is deleted.
+- `InlineBlockEntityOperations::removeUnusedForEntityOnSave()` returns early for anything
+  implementing `RevisionableInterface`. Nodes always do, so it never runs for them. Core skips
+  it deliberately: an older revision of the node might still reference the block, and core
+  cannot prove otherwise cheaply from inside a single save.
+
+### Sweeping them up
+
+A deliberate sweep can afford the proof core cannot, so this module provides one **on demand**.
+It is **not** wired into cron, because automatically deleting editor content on a schedule is a
+much riskier default than leaving inert rows in place.
+
+```bash
+# Report only. Changes nothing.
+lando drush ys-layouts:orphaned-blocks
+
+# Delete the reported orphans.
+lando drush ys-layouts:orphaned-blocks --delete
+```
+
+Safety guarantees, in order of importance:
+
+1. **Report by default.** Deletion happens only with the explicit `--delete` flag.
+2. **A block counts as referenced if *any* revision of *any* layout-bearing entity points at
+   *any* of its revisions.** This is stricter than core's own intent and is what makes deletion
+   safe.
+3. **Layout Builder default layouts stored in config are checked too.** They belong to no node,
+   so a node-only sweep would report their blocks as orphans and delete live content.
+4. **Blocks referenced only by a non-default revision are never deleted.** They are listed
+   separately in the command output, because rolling a node back to such a revision would make
+   the block live again. Choosing to delete that category would be a separate, explicit
+   decision.
+5. **Deletion derives its own list** and accepts no IDs from the caller, so removing a block
+   that is still on a page is structurally impossible rather than merely guarded against.
+
+Reusable blocks from the Custom Block Library are never candidates; only `reusable = 0` blocks
+are considered.
+
 ## Running tests
 
 This module has PHPUnit tests under `tests/src/` (`Unit/` and `Kernel/`). Run them from the project root on the local Lando environment, passing the module's `tests` path so PHPUnit only discovers this module's tests (not Drupal core/contrib):

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/drush.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  ys_layouts.commands:
+    class: \Drupal\ys_layouts\Commands\YaleSitesLayoutsCommands
+    arguments: ['@entity_type.manager', '@ys_layouts.orphaned_inline_block_cleaner']
+    tags:
+      - { name: drush.command }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Commands/YaleSitesLayoutsCommands.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Commands/YaleSitesLayoutsCommands.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Drupal\ys_layouts\Commands;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\ys_layouts\Service\OrphanedInlineBlockCleanerInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Drush commands for YaleSites Layout Builder maintenance.
+ */
+class YaleSitesLayoutsCommands extends DrushCommands {
+
+  /**
+   * Constructs a YaleSitesLayoutsCommands object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\ys_layouts\Service\OrphanedInlineBlockCleanerInterface $cleaner
+   *   The orphaned inline block cleaner.
+   */
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected OrphanedInlineBlockCleanerInterface $cleaner,
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * Reports inline blocks that no Layout Builder layout references any more.
+   *
+   * Removing a non-reusable block from a page leaves its content record behind
+   * with no admin screen able to reach it. Drupal core cannot clean these up on
+   * a node that still exists, so this sweep does it deliberately. It reports by
+   * default and only deletes when asked.
+   *
+   * @command ys-layouts:orphaned-blocks
+   * @aliases ys-orphaned-blocks
+   * @option delete Delete the reported orphans instead of only listing them.
+   * @usage ys-layouts:orphaned-blocks
+   *   List orphaned inline blocks. Changes nothing.
+   * @usage ys-layouts:orphaned-blocks --delete
+   *   Delete the orphaned inline blocks.
+   */
+  public function orphanedBlocks(array $options = ['delete' => FALSE]): void {
+    // Deleting derives its own orphan list, so the two modes are kept separate
+    // to avoid sweeping every revision on the site twice in one run. The
+    // deleted IDs are written to the log by the service.
+    if (!empty($options['delete'])) {
+      $deleted = $this->cleaner->deleteOrphans();
+      $this->logger->success($deleted
+        ? sprintf('Deleted %d orphaned inline block(s).', $deleted)
+        : 'No orphaned inline blocks found.');
+      return;
+    }
+
+    $report = $this->cleaner->analyze();
+
+    if ($report['revision_only']) {
+      $this->logger->notice(sprintf(
+        '%d inline block(s) are referenced only by older revisions and are NOT collected: %s. Rolling a node back to such a revision makes the block live again.',
+        count($report['revision_only']),
+        implode(', ', $report['revision_only'])
+      ));
+    }
+
+    if (!$report['orphans']) {
+      $this->logger->success('No orphaned inline blocks found.');
+      return;
+    }
+
+    $this->io()->table(
+      ['Block ID', 'Type', 'Label'],
+      $this->describe($report['orphans'])
+    );
+    $this->logger->notice(sprintf(
+      '%d orphaned inline block(s) found. Nothing was changed. Re-run with --delete to remove them.',
+      count($report['orphans'])
+    ));
+  }
+
+  /**
+   * Builds table rows describing the given blocks.
+   *
+   * @param int[] $block_ids
+   *   The block content entity IDs.
+   *
+   * @return array[]
+   *   Rows of block ID, bundle and label.
+   */
+  protected function describe(array $block_ids): array {
+    $blocks = $this->entityTypeManager->getStorage('block_content')->loadMultiple($block_ids);
+    $rows = [];
+    foreach ($block_ids as $block_id) {
+      $block = $blocks[$block_id] ?? NULL;
+      $rows[] = [
+        $block_id,
+        $block ? $block->bundle() : 'missing',
+        $block ? (string) $block->label() : '',
+      ];
+    }
+    return $rows;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Service/OrphanedInlineBlockCleaner.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Service/OrphanedInlineBlockCleaner.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace Drupal\ys_layouts\Service;
+
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\RevisionableStorageInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\layout_builder\Entity\LayoutEntityDisplayInterface;
+use Drupal\layout_builder\InlineBlockUsageInterface;
+use Drupal\layout_builder\Section;
+
+/**
+ * Finds and deletes Layout Builder inline blocks no layout references.
+ *
+ * Removing a non-reusable block from a page's layout does not delete the
+ * underlying block_content entity, and no admin screen can reach it afterwards.
+ * Drupal core cannot clean these up for a node that still exists:
+ * InlineBlockEntityOperations::removeUnusedForEntityOnSave() early-returns for
+ * anything implementing RevisionableInterface, and layout_builder_cron() only
+ * collects inline_block_usage rows whose parent columns are both NULL, which
+ * happens only when the parent entity is deleted outright.
+ *
+ * Core skips the work because it cannot cheaply prove a block is unreferenced
+ * from inside a single entity save. A deliberate sweep can afford that proof,
+ * so this service does it properly: a block counts as referenced if ANY
+ * revision of ANY layout-bearing entity points at ANY of its revisions, or if
+ * a Layout Builder default layout in config points at it.
+ *
+ * See the module README for the operator-facing description and the full list
+ * of safety guarantees.
+ */
+class OrphanedInlineBlockCleaner implements OrphanedInlineBlockCleanerInterface {
+
+  /**
+   * How many entities to load, or blocks to delete, at a time.
+   */
+  private const BATCH_SIZE = 50;
+
+  /**
+   * The field type Layout Builder stores layouts in.
+   */
+  private const LAYOUT_FIELD_TYPE = 'layout_section';
+
+  /**
+   * Plugin ID prefix shared by every inline block derivative.
+   */
+  private const INLINE_BLOCK_PREFIX = 'inline_block:';
+
+  /**
+   * Constructs an OrphanedInlineBlockCleaner.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entityFieldManager
+   *   The entity field manager, used to discover layout fields.
+   * @param \Drupal\layout_builder\InlineBlockUsageInterface $inlineBlockUsage
+   *   Core's inline block usage tracker.
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   The ys_layouts logger channel.
+   */
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected EntityFieldManagerInterface $entityFieldManager,
+    protected InlineBlockUsageInterface $inlineBlockUsage,
+    protected LoggerChannelInterface $logger,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function analyze(): array {
+    [$referenced_anywhere, $referenced_currently] = $this->collectReferencedRevisionIds();
+
+    // One query yields the whole revision ID => block ID map, so narrowing to
+    // the live subset is a key lookup rather than a second query.
+    $map = $this->blockIdsByRevisionId($referenced_anywhere);
+    $any = array_unique($map);
+    $current = array_unique(array_intersect_key($map, array_flip($referenced_currently)));
+    $candidates = $this->inlineBlockIds();
+
+    $orphans = array_diff($candidates, $any);
+    // Referenced somewhere, but never by a layout that is currently live.
+    $revision_only = array_intersect($candidates, array_diff($any, $current));
+    // sort() reindexes, so no array_values() is needed.
+    sort($orphans);
+    sort($revision_only);
+
+    return [
+      'orphans' => $orphans,
+      'revision_only' => $revision_only,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function deleteOrphans(): int {
+    $orphans = $this->analyze()['orphans'];
+    if (!$orphans) {
+      return 0;
+    }
+
+    $storage = $this->entityTypeManager->getStorage('block_content');
+    $deleted = 0;
+    foreach (array_chunk($orphans, self::BATCH_SIZE) as $chunk) {
+      $blocks = $storage->loadMultiple($chunk);
+      if ($blocks) {
+        $storage->delete($blocks);
+        $deleted += count($blocks);
+      }
+    }
+
+    // Clear the tracking rows too, matching what core does when it is able to
+    // clean up itself. This also clears rows for blocks that were already gone.
+    $this->inlineBlockUsage->deleteUsage($orphans);
+
+    $this->logger->notice('Deleted @count orphaned inline block(s): @ids', [
+      '@count' => $deleted,
+      '@ids' => implode(', ', $orphans),
+    ]);
+
+    return $deleted;
+  }
+
+  /**
+   * Collects inline block revision IDs referenced by any layout on the site.
+   *
+   * @return array
+   *   A two-element list: the revision IDs referenced by any revision, and the
+   *   subset referenced by a currently live layout (a default revision or a
+   *   Layout Builder default in config).
+   */
+  protected function collectReferencedRevisionIds(): array {
+    $anywhere = [];
+    $currently = [];
+
+    $field_map = $this->entityFieldManager->getFieldMapByFieldType(self::LAYOUT_FIELD_TYPE);
+    foreach ($field_map as $entity_type_id => $fields) {
+      $definition = $this->entityTypeManager->getDefinition($entity_type_id, FALSE);
+      if (!$definition) {
+        continue;
+      }
+      $storage = $this->entityTypeManager->getStorage($entity_type_id);
+      $field_names = array_keys($fields);
+
+      // Test the entity type, not the storage class: SqlContentEntityStorage
+      // implements RevisionableStorageInterface even for entity types that are
+      // not revisionable, and calling allRevisions() on one of those throws
+      // "No revision table for <type>, invalid query". Section Library's
+      // section_library_template is a real example of a layout-bearing entity
+      // type with no revision table.
+      $revisionable = $definition->isRevisionable() && $storage instanceof RevisionableStorageInterface;
+
+      $query = $storage->getQuery()->accessCheck(FALSE);
+      if ($revisionable) {
+        $query->allRevisions();
+      }
+      $result = $query->execute();
+      // An allRevisions() query keys results by revision ID; a plain one keys
+      // by entity ID.
+      $keys = $revisionable ? array_keys($result) : array_values($result);
+
+      foreach (array_chunk($keys, self::BATCH_SIZE) as $chunk) {
+        $entities = $revisionable
+          ? $storage->loadMultipleRevisions($chunk)
+          : $storage->loadMultiple($chunk);
+        foreach ($entities as $entity) {
+          // A non-revisionable entity's only layout is by definition the live
+          // one, so it can never be a revision-only reference.
+          $is_live = !$revisionable || $entity->isDefaultRevision();
+          foreach ($this->inlineBlockRevisionIds($this->sections($entity, $field_names)) as $id) {
+            // Accumulate as keyed sets: array_merge inside this loop would copy
+            // the growing array on every revision.
+            $anywhere[$id] = TRUE;
+            if ($is_live) {
+              $currently[$id] = TRUE;
+            }
+          }
+        }
+      }
+    }
+
+    // Default layouts live in config rather than on any entity, so an
+    // entity-only sweep would report the blocks they use as orphans.
+    foreach ($this->entityTypeManager->getStorage('entity_view_display')->loadMultiple() as $display) {
+      if (!$display instanceof LayoutEntityDisplayInterface || !$display->isLayoutBuilderEnabled()) {
+        continue;
+      }
+      foreach ($this->inlineBlockRevisionIds($display->getSections()) as $id) {
+        $anywhere[$id] = TRUE;
+        $currently[$id] = TRUE;
+      }
+    }
+
+    return [array_keys($anywhere), array_keys($currently)];
+  }
+
+  /**
+   * Gets the layout sections stored on an entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity or entity revision to read.
+   * @param string[] $field_names
+   *   The layout field names to look at.
+   *
+   * @return \Drupal\layout_builder\Section[]
+   *   The sections found.
+   */
+  protected function sections(EntityInterface $entity, array $field_names): array {
+    $sections = [];
+    foreach ($field_names as $field_name) {
+      // The field map is per entity type rather than per bundle, so a bundle
+      // without the layout field can still reach here.
+      if (!$entity->hasField($field_name)) {
+        continue;
+      }
+      $sections = array_merge($sections, $entity->get($field_name)->getSections());
+    }
+    return $sections;
+  }
+
+  /**
+   * Extracts inline block revision IDs from sections.
+   *
+   * Reads the stored component configuration rather than instantiating each
+   * block plugin. SectionComponent::getPlugin() would throw
+   * PluginNotFoundException for a component whose block type has since been
+   * deleted, which would abort a whole-site sweep.
+   *
+   * @param \Drupal\layout_builder\Section[] $sections
+   *   The sections to inspect.
+   *
+   * @return int[]
+   *   The referenced block content revision IDs.
+   */
+  protected function inlineBlockRevisionIds(array $sections): array {
+    $revision_ids = [];
+    foreach ($sections as $section) {
+      // LayoutSectionItemList::getSections() returns each item's raw section
+      // property, which is NULL for an empty field item.
+      if (!$section instanceof Section) {
+        continue;
+      }
+      foreach ($section->getComponents() as $component) {
+        $configuration = $component->get('configuration');
+        if (!is_array($configuration)) {
+          continue;
+        }
+        $plugin_id = $configuration['id'] ?? '';
+        if (!is_string($plugin_id) || !str_starts_with($plugin_id, self::INLINE_BLOCK_PREFIX)) {
+          continue;
+        }
+        if (!empty($configuration['block_revision_id'])) {
+          $revision_ids[] = (int) $configuration['block_revision_id'];
+        }
+      }
+    }
+    return $revision_ids;
+  }
+
+  /**
+   * Maps block content revision IDs to their owning entity IDs.
+   *
+   * @param int[] $revision_ids
+   *   Block content revision IDs.
+   *
+   * @return int[]
+   *   Block content entity IDs, keyed by the revision ID that resolved them.
+   */
+  protected function blockIdsByRevisionId(array $revision_ids): array {
+    if (!$revision_ids) {
+      return [];
+    }
+    // allRevisions() is required: a layout can reference a superseded block
+    // revision, which a default-revision-only query would never match. It also
+    // makes the query return revision ID => entity ID rather than just IDs.
+    $result = $this->entityTypeManager->getStorage('block_content')->getQuery()
+      ->accessCheck(FALSE)
+      ->allRevisions()
+      ->condition('revision_id', $revision_ids, 'IN')
+      ->execute();
+
+    return array_map('intval', $result);
+  }
+
+  /**
+   * Gets every inline block candidate on the site.
+   *
+   * Layout Builder creates inline blocks with reusable set to FALSE, which is
+   * what separates them from the reusable Custom Block Library.
+   *
+   * @return int[]
+   *   The candidate block content entity IDs.
+   */
+  protected function inlineBlockIds(): array {
+    $result = $this->entityTypeManager->getStorage('block_content')->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('reusable', 0)
+      ->execute();
+
+    return array_values(array_map('intval', $result));
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Service/OrphanedInlineBlockCleanerInterface.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Service/OrphanedInlineBlockCleanerInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\ys_layouts\Service;
+
+/**
+ * Finds and deletes Layout Builder inline blocks no layout references.
+ */
+interface OrphanedInlineBlockCleanerInterface {
+
+  /**
+   * Analyses every layout on the site for unreferenced inline blocks.
+   *
+   * @return array
+   *   An associative array with two keys, each a sorted list of block_content
+   *   entity IDs:
+   *   - orphans: referenced by no layout at all. Safe to delete.
+   *   - revision_only: referenced only by a non-default entity revision, never
+   *     by a current layout. Reported for review but never deleted, because
+   *     rolling that revision back would make the block live again.
+   */
+  public function analyze(): array;
+
+  /**
+   * Deletes every orphan found by a fresh analysis.
+   *
+   * This deliberately takes no ID list. Deriving the orphans here is what makes
+   * deleting a block that is still on a page structurally impossible, rather
+   * than something a caller has to be trusted not to ask for.
+   *
+   * @return int
+   *   The number of blocks deleted.
+   */
+  public function deleteOrphans(): int;
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/OrphanedInlineBlockCleanerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Kernel/OrphanedInlineBlockCleanerTest.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace Drupal\Tests\ys_layouts\Kernel;
+
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\block_content\Entity\BlockContentType;
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\layout_builder\Entity\LayoutBuilderEntityViewDisplay;
+use Drupal\layout_builder\Section;
+use Drupal\layout_builder\SectionComponent;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\node\NodeInterface;
+use Drupal\ys_layouts\Service\OrphanedInlineBlockCleanerInterface;
+
+/**
+ * Tests detection and deletion of orphaned Layout Builder inline blocks.
+ *
+ * Removing a non-reusable block from a layout leaves its block_content behind,
+ * and core cannot collect it for a node that still exists. See
+ * OrphanedInlineBlockCleaner and the module README for why.
+ *
+ * These tests pin the safety bar: the cases the cleaner must REFUSE to collect
+ * are a block still in a current layout, a block referenced only by an older
+ * revision, and a block held by a non-revisionable entity. Getting any of them
+ * wrong deletes content an editor can still reach.
+ *
+ * @group ys_layouts
+ */
+class OrphanedInlineBlockCleanerTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'node',
+    'block_content',
+    // BlockContent::preDelete() deletes each placement via
+    // getInstances(), which loads the 'block' entity type, so deleting a
+    // block_content is impossible without the block module.
+    'block',
+    'layout_discovery',
+    'layout_builder',
+    // ys_layouts.services.yml injects quick_node_clone's form builder into
+    // ys_layouts.block_cloner, so the container cannot compile without it.
+    'quick_node_clone',
+    // Stands in for a non-revisionable layout-bearing entity type.
+    'entity_test',
+    'ys_layouts',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('block_content');
+    $this->installEntitySchema('entity_test');
+    $this->installSchema('node', ['node_access']);
+    $this->installSchema('layout_builder', ['inline_block_usage']);
+    $this->installConfig(['system', 'field', 'filter', 'node']);
+
+    NodeType::create(['type' => 'page', 'name' => 'Page'])->save();
+    BlockContentType::create(['id' => 'basic', 'label' => 'Basic'])->save();
+
+    // Enabling Layout Builder overrides is what puts the
+    // layout_builder__layout field on nodes of this bundle.
+    LayoutBuilderEntityViewDisplay::create([
+      'targetEntityType' => 'node',
+      'bundle' => 'page',
+      'mode' => 'default',
+      'status' => TRUE,
+    ])->enableLayoutBuilder()->setOverridable()->save();
+  }
+
+  /**
+   * Gets the service under test.
+   */
+  protected function cleaner(): OrphanedInlineBlockCleanerInterface {
+    return $this->container->get('ys_layouts.orphaned_inline_block_cleaner');
+  }
+
+  /**
+   * Creates a block_content entity.
+   *
+   * @param string $label
+   *   The block description.
+   * @param bool $reusable
+   *   Whether the block belongs to the reusable Custom Block Library.
+   *
+   * @return \Drupal\block_content\Entity\BlockContent
+   *   The saved block.
+   */
+  protected function createBlock(string $label, bool $reusable = FALSE): BlockContent {
+    $block = BlockContent::create([
+      'type' => 'basic',
+      'info' => $label,
+      'reusable' => $reusable,
+    ]);
+    $block->save();
+    return $block;
+  }
+
+  /**
+   * Builds a section whose components reference the given block revisions.
+   *
+   * Only block_revision_id is set (no block_serialized), so core's
+   * InlineBlock::saveBlockContent() leaves these components untouched on save.
+   *
+   * @param int[] $revision_ids
+   *   Block content revision IDs to reference.
+   *
+   * @return \Drupal\layout_builder\Section
+   *   The section.
+   */
+  protected function sectionReferencing(array $revision_ids): Section {
+    $components = [];
+    foreach ($revision_ids as $revision_id) {
+      $components[] = new SectionComponent(
+        $this->container->get('uuid')->generate(),
+        'content',
+        [
+          'id' => 'inline_block:basic',
+          'block_revision_id' => $revision_id,
+        ]
+      );
+    }
+    return new Section('layout_onecol', [], $components);
+  }
+
+  /**
+   * Creates a node whose current layout references the given block revisions.
+   *
+   * @param int[] $revision_ids
+   *   Block content revision IDs to reference.
+   *
+   * @return \Drupal\node\NodeInterface
+   *   The saved node.
+   */
+  protected function createNodeWithLayout(array $revision_ids): NodeInterface {
+    $node = Node::create(['type' => 'page', 'title' => 'Layout test']);
+    $node->set('layout_builder__layout', [['section' => $this->sectionReferencing($revision_ids)]]);
+    $node->save();
+    return $node;
+  }
+
+  /**
+   * Empties a node's layout, optionally keeping the prior revision.
+   */
+  protected function clearLayout(NodeInterface $node, bool $new_revision): void {
+    $node->setNewRevision($new_revision);
+    $node->set('layout_builder__layout', []);
+    $node->save();
+  }
+
+  /**
+   * Gets the orphan IDs the cleaner would collect.
+   */
+  protected function orphans(): array {
+    return $this->cleaner()->analyze()['orphans'];
+  }
+
+  /**
+   * A block in a node's current layout must never be collected.
+   *
+   * This is the case the #1503 ticket mis-classified: block_content 341/342 are
+   * referenced by node 95's current revision and render on a published page.
+   */
+  public function testBlockInCurrentLayoutIsNotAnOrphan(): void {
+    $block = $this->createBlock('Live block');
+    $this->createNodeWithLayout([$block->getRevisionId()]);
+
+    $this->assertNotContains((int) $block->id(), $this->orphans());
+  }
+
+  /**
+   * A block no revision references is an orphan.
+   *
+   * Saving without a new revision leaves nothing pointing at the block, which
+   * is the genuine orphan case core cannot clean up for a surviving node.
+   */
+  public function testBlockUnreferencedByAnyRevisionIsAnOrphan(): void {
+    $block = $this->createBlock('Removed block');
+    $node = $this->createNodeWithLayout([$block->getRevisionId()]);
+    $this->clearLayout($node, FALSE);
+
+    $this->assertContains((int) $block->id(), $this->orphans());
+  }
+
+  /**
+   * A block referenced only by an older revision must not be collected.
+   *
+   * It is reported separately instead, so the revision-history trade-off stays
+   * a visible decision rather than a silent deletion.
+   */
+  public function testBlockReferencedOnlyByOldRevisionIsReportedNotCollected(): void {
+    $block = $this->createBlock('Old revision only');
+    $node = $this->createNodeWithLayout([$block->getRevisionId()]);
+    $this->clearLayout($node, TRUE);
+
+    $report = $this->cleaner()->analyze();
+    $this->assertNotContains((int) $block->id(), $report['orphans']);
+    $this->assertContains((int) $block->id(), $report['revision_only']);
+  }
+
+  /**
+   * A block used by a Layout Builder default layout must not be collected.
+   *
+   * Defaults live in config, not on any node, so a node-only sweep would report
+   * these as orphans and delete live content.
+   */
+  public function testBlockInLayoutBuilderDefaultIsNotAnOrphan(): void {
+    $block = $this->createBlock('Default layout block');
+
+    $display = LayoutBuilderEntityViewDisplay::load('node.page.default');
+    $display->appendSection($this->sectionReferencing([$block->getRevisionId()]));
+    $display->save();
+
+    $this->assertNotContains((int) $block->id(), $this->orphans());
+  }
+
+  /**
+   * A block on a non-revisionable layout-bearing entity is not an orphan.
+   *
+   * Section Library's section_library_template holds layouts but has no
+   * revision table, so an allRevisions() query against it throws. entity_test
+   * stands in for that shape here.
+   */
+  public function testBlockOnNonRevisionableEntityIsNotAnOrphan(): void {
+    FieldStorageConfig::create([
+      'field_name' => 'layout_builder__layout',
+      'entity_type' => 'entity_test',
+      'type' => 'layout_section',
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'layout_builder__layout',
+      'entity_type' => 'entity_test',
+      'bundle' => 'entity_test',
+    ])->save();
+
+    $block = $this->createBlock('Held by a non-revisionable entity');
+    $entity = EntityTest::create(['name' => 'Layout holder']);
+    $entity->set('layout_builder__layout', [
+      ['section' => $this->sectionReferencing([$block->getRevisionId()])],
+    ]);
+    $entity->save();
+
+    $this->assertNotContains((int) $block->id(), $this->orphans());
+  }
+
+  /**
+   * Reusable library blocks are not inline blocks and are never collected.
+   */
+  public function testReusableBlockIsNeverAnOrphan(): void {
+    $block = $this->createBlock('Library block', TRUE);
+
+    $this->assertNotContains((int) $block->id(), $this->orphans());
+  }
+
+  /**
+   * Deleting collects orphans, clears their usage rows, and spares live blocks.
+   *
+   * Because deleteOrphans() takes no ID list, deleting something still on a
+   * page is structurally impossible; this pins both halves in one sweep.
+   */
+  public function testDeleteRemovesOnlyOrphans(): void {
+    $live = $this->createBlock('Live block');
+    $this->createNodeWithLayout([$live->getRevisionId()]);
+
+    $orphan = $this->createBlock('Doomed block');
+    $orphan_id = (int) $orphan->id();
+    $node = $this->createNodeWithLayout([$orphan->getRevisionId()]);
+    $this->container->get('inline_block.usage')->addUsage($orphan_id, $node);
+    $this->clearLayout($node, FALSE);
+
+    $this->assertSame(1, $this->cleaner()->deleteOrphans());
+
+    $storage = $this->container->get('entity_type.manager')->getStorage('block_content');
+    $this->assertNull($storage->load($orphan_id));
+    $this->assertNotNull($storage->load((int) $live->id()));
+    $this->assertEmpty($this->usageRows($orphan_id));
+  }
+
+  /**
+   * Gets inline_block_usage rows for a block.
+   */
+  protected function usageRows(int $block_id): array {
+    return $this->container->get('database')
+      ->select('inline_block_usage', 'u')
+      ->fields('u', ['block_content_id'])
+      ->condition('block_content_id', $block_id)
+      ->execute()
+      ->fetchCol();
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.services.yml
@@ -45,3 +45,13 @@ services:
   ys_layouts.block_cloner:
     class: Drupal\ys_layouts\Service\BlockCloner
     arguments: ['@quick_node_clone.entity.form_builder', '@uuid', '@entity_type.manager', '@logger.channel.ys_layouts']
+  # Finds inline blocks left behind when an editor removes a non-reusable block
+  # from a layout. Core cannot collect these for revisionable entities, so the
+  # sweep is on demand via drush ys-layouts:orphaned-blocks.
+  ys_layouts.orphaned_inline_block_cleaner:
+    class: Drupal\ys_layouts\Service\OrphanedInlineBlockCleaner
+    arguments: ['@entity_type.manager', '@entity_field.manager', '@inline_block.usage', '@logger.channel.ys_layouts']
+
+  # Alias to allow type-hinting against the interface.
+  Drupal\ys_layouts\Service\OrphanedInlineBlockCleanerInterface:
+    alias: ys_layouts.orphaned_inline_block_cleaner


### PR DESCRIPTION
## [1503: RC: Decide whether to clean up orphaned blocks left behind by Layout Builder](https://github.com/yalesites-org/YaleSites-Internal/issues/1503)

> **Read this first: the issue's central premise did not hold up, so this PR needs a product decision before it needs a code review.** The issue is a "decide whether to build this" ticket carrying both `forming` and `claude`. Details below.

### The issue's five "known orphans" are not orphans

The issue names `block_content` **341, 342, 344, 346, 347** as orphans left behind by a QA run and asks the mechanism to confirm it identifies them as deletion candidates. Traced through every node revision, none of them is:

| block | type | actually referenced by | verdict |
|---|---|---|---|
| **341** | image_banner | node 95 vid **389 = current revision** | **live content on a published page** |
| **342** | video_banner | node 95 vid **389 = current revision** | **live content on a published page** |
| 344 | cta_banner | node 77 vids 393, 397 (old revisions) | revision-only reference |
| 346 | grand_hero | node 77 vid 397 (old revision) | revision-only reference |
| 347 | image_banner | node 77 vid 397 (old revision) | revision-only reference |

Confirmed three independent ways: an entity-API walk of all 245 node revisions; SQL showing node 95's current `vid` is 389 with three component rows in `node__layout_builder__layout`; and `GET /qa1157-banner-width-test` returning HTTP 200 with `image-banner` and `video-banner` markup rendered.

The issue inferred orphanhood from `/block/341/edit` returning 404 — but that is true of **all 334** non-reusable blocks on the site, orphaned or not, because non-reusable blocks have no canonical route.

**Consequence: the issue's two Verification criteria contradict each other.** It asks the mechanism to flag 341/342 *and* to never flag a block referenced by a current layout. No mechanism can do both. **This PR implements the safety criterion and deliberately fails the other**, because satisfying it means shipping a command that deletes live page content.

### The underlying concern is real

The sweep found **21 genuine orphans** the issue never identified. **Update (post-review):** re-run against a fresh copy of the Pantheon `dev` database, the current count is **4**, not 21 — the same four listed below. The other 17 were parent-deleted cases that core's own `layout_builder_cron()` collects, and `dev` has since cleaned them. Blocks 341/342/344/346/347 do not exist on `dev` at all. See the verification comment on this PR. Four match its described scenario exactly — block removed from a layout, parent node still exists, so core's cron will never reach them:

| block | type | label | parent (still exists) |
|---|---|---|---|
| 10 | pull_quote | quote1 | node 7 |
| 13 | text | test_2 | node 7 |
| 23 | button_link | button link 1 | node 22 |
| 32 | grand_hero | Grand Hero 1 | node 31 |

The core-behaviour half of the issue is confirmed: `layout_builder_cron()` collects only rows whose `inline_block_usage` parent columns are both NULL, and `InlineBlockEntityOperations::removeUnusedForEntityOnSave()` early-returns for `RevisionableInterface`, which nodes always implement.

### Description of work
- Adds `OrphanedInlineBlockCleaner` (+ interface) and the `ys-layouts:orphaned-blocks` Drush command to **`ys_layouts`** — not `ys_core`, because it needs `layout_builder` and `block_content`, which `ys_layouts` already declares.
- **Reports by default; deletes only with `--delete`. Deliberately not wired into cron** — auto-deleting editor content on a schedule is a much riskier default than leaving inert rows in place. This is a decision to ratify, not an oversight.
- Answers the issue's open revision-history question with **full safety**: a block counts as referenced if ANY revision of ANY layout-bearing entity points at ANY of its revisions. Blocks referenced only by a non-default revision are reported separately and never deleted, because rolling a node back would make them live again.
- Also checks **Layout Builder default layouts stored in config**. They belong to no entity, so an entity-only sweep would report their blocks as orphans and delete live content.
- `deleteOrphans()` takes no ID list and derives its own, so deleting a block still on a page is structurally impossible rather than merely guarded against.
- Discovers layout-bearing entity types from the field map instead of hardcoding `node`, and tests revisionability on the **entity type definition**, not the storage class — `SqlContentEntityStorage` implements `RevisionableStorageInterface` even for non-revisionable types, and Section Library's `section_library_template` is a real layout-bearing type with no revision table (it crashed the first version).
- 7 kernel tests, documentation in the module README.

### Verification already done
- `composer code-sniff` (both standards, whole custom tree): **exit 0, zero findings**.
- `ys_layouts` kernel suite: **OK, 31 tests / 334 assertions**, zero failures.
- `ys_layouts` unit suite unchanged at 93 tests with 1 **pre-existing** failure (`BlockContextualLinks`), proven pre-existing by reverting this branch's only tracked change and re-running.
- Report run on a real database cross-checked against an independently written throwaway probe: **both agree on the same 21 IDs**, with 341/342 correctly excluded.
- **`--delete` HAS now been run against a real `dev` database copy**, at @miketullo95's request. 4 orphans deleted (10, 13, 23, 32); the revision-only block survived; a second run reports empty; all four affected pages render byte-identically before and after. Full results, including an independent cross-check of the orphan set, are in the verification comment on this PR.

### Functional testing steps:
- [ ] `lando drush ys-layouts:orphaned-blocks` — reports a table of orphans and changes nothing.
- [ ] Confirm no block listed is visible on any published page (spot-check a few IDs at `/node/{parent}`).
- [ ] Create a test page, add an inline block, save; remove that block, save again; re-run the report and confirm the block now appears.
- [ ] Add an inline block to a page and leave it in place; confirm it never appears in the report.
- [x] `lando drush ys-layouts:orphaned-blocks --delete` on a throwaway DB, then re-run the report and confirm it is empty and pages still render. **Done on a fresh `dev` copy — see the verification comment.**
- [ ] Decide whether report-only-plus-opt-in-delete is the wanted shape, or whether this should be cron-driven / not built at all.

**Re-verification steps added after review (@miketullo95's `--delete` request):**
- [ ] `dbget && confim` for a fresh `dev` copy, then `lando drush cr` (a brand-new service is not in the compiled container until caches rebuild).
- [ ] `lando drush ys-layouts:orphaned-blocks` — expect 4 orphans (10, 13, 23, 32) and 1 revision-only (21) on a current `dev` copy.
- [ ] Note the row counts first: `SELECT COUNT(*) FROM block_content;` / `... WHERE reusable = 0` / `SELECT COUNT(*) FROM inline_block_usage;` (305 / 303 / 303 on `dev` today).
- [ ] `lando drush ys-layouts:orphaned-blocks --delete` — expect exactly 4 deleted and every count down by 4.
- [ ] Confirm block 21 still exists with all its revisions: `SELECT COUNT(*) FROM block_content_revision WHERE id = 21;`
- [ ] `lando drush cr`, then load `/events/dinner-with-dad`, `/blocks-for-visreg`, `/blocks-for-visreg/button`, `/blocks-for-visreg/grand-hero` — all 200, all visually unchanged.
- [ ] Re-run the report — expect "No orphaned inline blocks found" with block 21 still withheld.

References yalesites-org/YaleSites-Internal#1503

---

Created with AI

