### PR TITLE
1511: RC: Delete collection on content page turns sub pages to new collections

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookCollectionDeleteTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookCollectionDeleteTest.php
@@ -54,13 +54,6 @@ class BookCollectionDeleteTest extends KernelTestBase {
     _ys_book_add_book_title_column();
     $this->installConfig(['node', 'book', 'field']);
 
-    // ys_book keeps custom menu link titles in a column it adds to contrib
-    // book's table from ys_book_update_10001(). installSchema() only builds
-    // contrib book's own hook_schema(), so run the update hook to match a
-    // real site -- without it every book node save fails on a missing column.
-    $this->container->get('module_handler')->loadInclude('ys_book', 'install');
-    ys_book_update_10001();
-
     // The delete route is gated on 'administer book outlines'; build the router
     // so the confirm form's cancel link can resolve the collections overview.
     $this->container->get('router.builder')->rebuild();

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookCollectionDeleteTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookCollectionDeleteTest.php
@@ -6,6 +6,7 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
+use Drupal\node\NodeInterface;
 use Drupal\ys_book\Controller\YsBookController;
 use Drupal\ys_book\Form\BookCollectionDeleteForm;
 use Drupal\Core\Form\FormState;
@@ -97,6 +98,20 @@ class BookCollectionDeleteTest extends KernelTestBase {
     $grandchild->save();
 
     return [$root, $child, $grandchild];
+  }
+
+  /**
+   * Reloads a node so book_node_load() repopulates its $node->book data.
+   *
+   * Both the delete hooks and the delete confirmation read $node->book, which
+   * only exists because contrib book_node_load() attaches it on load. Deleting
+   * the in-memory node returned by createCollection() would skip that and stop
+   * exercising the real Manage Content path.
+   */
+  private function reload(NodeInterface $node): NodeInterface {
+    $storage = $this->container->get('entity_type.manager')->getStorage('node');
+    $storage->resetCache([$node->id()]);
+    return $storage->load($node->id());
   }
 
   /**
@@ -261,6 +276,161 @@ class BookCollectionDeleteTest extends KernelTestBase {
       $this->container->get('entity_type.manager')->getStorage('node')->load($root->id()),
       'The former collection root survives as a standalone page.'
     );
+  }
+
+  /**
+   * Deleting a collection's top-level page creates no new collections.
+   *
+   * This is the Manage Content path: the page is deleted as a piece of
+   * content, rather than the collection being taken apart from Manage Content
+   * Collections. Contrib BookManager::deleteFromBook() promotes the children
+   * of a book root into books of their own, which left the editor with one
+   * junk collection per sub-page and no bulk way to undo it.
+   *
+   * @see yalesites-org/YaleSites-Internal#1511
+   */
+  public function testDeletingCollectionRootLeavesSubPagesStandalone(): void {
+    [$root, $child, $grandchild] = $this->createCollection();
+
+    $this->reload($root)->delete();
+
+    $this->assertSame(
+      0,
+      $this->bookRowCount(),
+      'No outline rows survive, so no sub-page was promoted into a collection.'
+    );
+    $this->assertEmpty(
+      $this->container->get('book.manager')->getAllBooks(),
+      'No new collections were created from the sub-pages.'
+    );
+
+    // Only the deleted page is gone; the sub-pages stay as standalone content.
+    $storage = $this->container->get('entity_type.manager')->getStorage('node');
+    $storage->resetCache();
+    foreach ([$child, $grandchild] as $page) {
+      $this->assertNotNull($storage->load($page->id()), 'Sub-page survives the delete.');
+    }
+    $this->assertNull($storage->load($root->id()), 'The deleted top-level page is gone.');
+  }
+
+  /**
+   * Deleting a page mid-collection still moves its children up a level.
+   *
+   * Only the top-level page needed new behaviour. Contrib's handling of a page
+   * in the middle of a collection is already what we want and must not
+   * regress.
+   */
+  public function testDeletingMidCollectionPageKeepsCollectionIntact(): void {
+    [$root, $child, $grandchild] = $this->createCollection();
+    $bid = (int) $root->id();
+
+    $this->reload($child)->delete();
+
+    $this->assertCount(
+      2,
+      _ys_book_get_all_book_nids($bid),
+      'The collection keeps its remaining pages.'
+    );
+    $this->assertCount(
+      1,
+      $this->container->get('book.manager')->getAllBooks(),
+      'No extra collection was created.'
+    );
+
+    $link = $this->container->get('book.manager')->loadBookLink($grandchild->id(), FALSE);
+    $this->assertEquals($bid, $link['bid'], 'The orphaned page stays in the original collection.');
+    $this->assertEquals($bid, $link['pid'], 'The orphaned page moved up under the root.');
+  }
+
+  /**
+   * The Manage Content delete confirmation says the sub-pages survive.
+   *
+   * Left alone this is the generic content-delete confirmation, whose only
+   * description is "This action cannot be undone". That is a big part of why
+   * losing the collection here is a surprise; Manage Content Collections' own
+   * confirmation already spells the consequence out.
+   *
+   * @see \Drupal\ys_book\Form\BookCollectionDeleteForm::getDescription()
+   */
+  public function testDeleteConfirmFormExplainsSubPagesSurvive(): void {
+    [$root] = $this->createCollection();
+
+    $form = $this->container->get('entity.form_builder')
+      ->getForm($this->reload($root), 'delete');
+
+    $this->assertArrayHasKey('ys_book_collection_notice', $form);
+    $this->assertStringContainsString(
+      "won't be deleted",
+      (string) $form['ys_book_collection_notice']['#value'],
+      'The confirmation tells the editor the other pages are kept.'
+    );
+  }
+
+  /**
+   * Pages with no sub-pages to lose keep the plain delete confirmation.
+   */
+  public function testDeleteConfirmFormLeavesOtherPagesAlone(): void {
+    [, $child] = $this->createCollection();
+    $builder = $this->container->get('entity.form_builder');
+
+    $standalone = Node::create(['type' => 'page', 'title' => 'Standalone', 'status' => 1]);
+    $standalone->save();
+    $this->assertArrayNotHasKey(
+      'ys_book_collection_notice',
+      $builder->getForm($this->reload($standalone), 'delete'),
+      'A page in no collection gets the plain confirmation.'
+    );
+
+    $this->assertArrayNotHasKey(
+      'ys_book_collection_notice',
+      $builder->getForm($this->reload($child), 'delete'),
+      'A sub-page is not a collection root, so nothing extra is said.'
+    );
+
+    $solo = Node::create([
+      'type' => 'page',
+      'title' => 'Solo',
+      'status' => 1,
+      'book' => ['bid' => 'new'],
+    ]);
+    $solo->save();
+    $this->assertCount(
+      1,
+      _ys_book_get_all_book_nids((int) $solo->id()),
+      'Solo really is a one-page collection, so the page count is what suppresses the notice here.'
+    );
+    $this->assertArrayNotHasKey(
+      'ys_book_collection_notice',
+      $builder->getForm($this->reload($solo), 'delete'),
+      'A collection that is only its top-level page has no sub-pages to explain.'
+    );
+  }
+
+  /**
+   * Pages taken out of the outline are hidden from contrib book's predelete.
+   *
+   * Contrib book_node_predelete() only checks the in-memory copy of the book
+   * data, so once a page's outline row has gone that copy has to be cleared or
+   * contrib goes looking for a row that no longer exists. It applies to the
+   * top-level page itself, and to any sub-page swept up in the same bulk
+   * delete, which runs predelete for every selected node before removing any.
+   */
+  public function testPredeleteHidesDismantledPagesFromContribBook(): void {
+    [$root, $child] = $this->createCollection();
+    $root = $this->reload($root);
+    $child = $this->reload($child);
+
+    ys_book_node_predelete($root);
+
+    $this->assertSame(0, $this->bookRowCount(), 'The whole collection left the outline.');
+    $this->assertEmpty($root->book['bid'] ?? NULL, 'Contrib book skips the top-level page.');
+
+    // The sub-page still carries the collection data it was loaded with.
+    $this->assertNotEmpty($child->book['bid'], 'The sub-page copy is stale, not yet cleared.');
+
+    ys_book_node_predelete($child);
+
+    $this->assertEmpty($child->book['bid'] ?? NULL, 'Contrib book skips the sub-page too.');
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookLinkRepeatSaveTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookLinkRepeatSaveTest.php
@@ -71,14 +71,11 @@ class BookLinkRepeatSaveTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->installSchema('node', 'node_access');
     $this->installSchema('book', ['book']);
-    $this->installConfig(['node', 'book', 'field']);
-
-    // ys_book keeps custom menu link titles in a column it adds to contrib
-    // book's table from ys_book_update_10001(). installSchema() only builds
-    // contrib book's own hook_schema(), so run the update hook to match a
-    // real site -- without it every book node save fails on a missing column.
+    // Kernel tests never run hook_install(), so add the title column this
+    // module installs on a real site; see _ys_book_add_book_title_column().
     $this->container->get('module_handler')->loadInclude('ys_book', 'install');
-    ys_book_update_10001();
+    _ys_book_add_book_title_column();
+    $this->installConfig(['node', 'book', 'field']);
 
     // Needed so the clone route can be looked up by name.
     $this->container->get('router.builder')->rebuild();

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.module
@@ -8,6 +8,7 @@
  */
 
 use Drupal\node\NodeInterface;
+use Drupal\Core\Entity\ContentEntityDeleteForm;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Form\FormStateInterface;
@@ -48,6 +49,18 @@ function ys_book_module_implements_alter(&$implementations, $hook) {
   // - node_view: We handle navigation rendering via template instead.
   if (in_array($hook, ['help', 'node_view'])) {
     unset($implementations['book']);
+  }
+
+  // Run our node_predelete ahead of book's. Both modules are weight 0, so
+  // module_implements() would order them alphabetically and
+  // book_node_predelete() would promote a deleted collection's sub-pages into
+  // new collections before we ever got the chance to take the collection
+  // apart.
+  // @see ys_book_node_predelete()
+  if ($hook === 'node_predelete' && isset($implementations['ys_book'])) {
+    $ys_book = $implementations['ys_book'];
+    unset($implementations['ys_book']);
+    $implementations = ['ys_book' => $ys_book] + $implementations;
   }
 }
 
@@ -219,6 +232,50 @@ function ys_book_form_alter(&$form, FormStateInterface $form_state, $form_id) {
     // so appending here runs after them instead of replacing them.
     $form['actions']['submit']['#submit'][] = '_ys_book_outline_form_submit';
   }
+
+  // Warn the editor that deleting a collection's top-level page from Manage
+  // Content takes the collection with it.
+  if ($form_state->getFormObject() instanceof ContentEntityDeleteForm) {
+    _ys_book_add_collection_delete_notice($form, $form_state);
+  }
+}
+
+/**
+ * Explains that a deleted collection root's sub-pages are kept.
+ *
+ * The Manage Content delete route uses the generic content-delete
+ * confirmation, whose only description is "This action cannot be undone".
+ * Losing a whole collection to it is a surprise worth spelling out, the way
+ * the Manage Content Collections confirmation already does.
+ *
+ * @param array $form
+ *   The delete confirmation form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ *
+ * @see \Drupal\ys_book\Form\BookCollectionDeleteForm::getDescription()
+ */
+function _ys_book_add_collection_delete_notice(array &$form, FormStateInterface $form_state): void {
+  $node = $form_state->getFormObject()->getEntity();
+
+  // Only a collection's top-level page loses a collection when it is deleted.
+  if (!$node instanceof NodeInterface || empty($node->book['bid']) || $node->book['bid'] != $node->id()) {
+    return;
+  }
+
+  // A collection that is only its top-level page has no sub-pages to explain.
+  if (count(_ys_book_get_all_book_nids((int) $node->id())) < 2) {
+    return;
+  }
+
+  $form['ys_book_collection_notice'] = [
+    '#type' => 'html_tag',
+    '#tag' => 'p',
+    '#value' => t("This page is the top of a content collection. Deleting it removes the collection's shared navigation and grouping. The other pages in the collection won't be deleted; they'll stay published as standalone content."),
+    // Lead with the collection-specific consequence, ahead of the generic
+    // "This action cannot be undone" the confirm form adds at weight 0.
+    '#weight' => -10,
+  ];
 }
 
 /**
@@ -705,12 +762,52 @@ function _ys_book_keep_existing_collection_link(NodeInterface $node): void {
 /**
  * Implements hook_ENTITY_TYPE_predelete() for node entities.
  *
- * Invalidates collection nav cache when a book node is deleted.
+ * Invalidates the collection nav cache when a book node is deleted, and takes
+ * the collection apart first when the page being deleted is its top-level one.
+ *
+ * Deleting a collection's top-level page from Manage Content used to promote
+ * every sub-page into the top page of a brand-new collection, because contrib
+ * BookManager::deleteFromBook() re-points a book root's children at themselves
+ * as new book IDs. The pages were never lost, but the editor was left with a
+ * pile of junk collections cluttering the Collection dropdown and no bulk way
+ * to undo it.
+ *
+ * Taking the collection apart here, ahead of book_node_predelete(), removes
+ * every page from the outline deepest-first, so no page is ever a root with
+ * children left to promote and the sub-pages come out as ordinary standalone
+ * pages. That matches what "Delete collection" on Manage Content Collections
+ * already does. Deleting a page in the middle of a collection is deliberately
+ * untouched: contrib moves its children up under its parent and the collection
+ * survives, which is the behaviour we want there.
+ *
+ * @see ys_book_module_implements_alter()
+ * @see _ys_book_dismantle_collection()
+ * @see yalesites-org/YaleSites-Internal#1511
  */
 function ys_book_node_predelete($node) {
-  if (!empty($node->book['bid'])) {
-    _ys_book_invalidate_collection_nav_cache($node->book['bid']);
+  if (empty($node->book['bid'])) {
+    return;
   }
+
+  // A collection's top-level page is the one whose book ID is its own node ID.
+  if ($node->book['bid'] == $node->id()) {
+    _ys_book_dismantle_collection((int) $node->book['bid']);
+  }
+
+  // This page may no longer be in the outline at all: the dismantle above just
+  // took it out, or -- when a collection's top-level page and one of its
+  // sub-pages go in the same bulk delete, which runs this hook for every
+  // selected node before any of them is removed -- the top-level page's own
+  // predelete already did. Contrib book_node_predelete() trusts the in-memory
+  // copy and would go looking for a row that is gone, reading 'bid' and 'pid'
+  // off the empty array loadBookLink() returns. Drop the stale copy so it
+  // skips this node instead.
+  if (!\Drupal::service('book.manager')->loadBookLink($node->id(), FALSE)) {
+    $node->book = [];
+    return;
+  }
+
+  _ys_book_invalidate_collection_nav_cache($node->book['bid']);
 }
 
 /**


### PR DESCRIPTION
## [1511: RC: Delete collection on content page turns sub pages to new collections](https://github.com/yalesites-org/YaleSites-Internal/issues/1511)

### Description of work
- Deleting a content collection's top-level page from Manage Content promoted every sub-page into the top page of a brand-new collection. The pages were never lost, but editors were left with a pile of junk collections filling the Collection dropdown on every page edit form, and no bulk way to undo them.
- Root cause: contrib `BookManager::deleteFromBook()` re-points a book root's children at themselves as new book IDs. `book` and `ys_book` are both weight 0, so `module_implements()` ordered them alphabetically and `book_node_predelete()` ran first; our own predelete only invalidated caches and ran too late to matter.
- Fixed entirely inside `ys_book` — no patch to contrib `book`, per the ticket. `ys_book_module_implements_alter()` now moves `ys_book` to the front for `node_predelete`, and `ys_book_node_predelete()` takes the collection apart through the existing `_ys_book_dismantle_collection()` helper from yalesites-org/YaleSites-Internal#1350 rather than a second implementation of it. Dismantling deepest-first means no page is ever a root with children left to promote, so sub-pages come out as ordinary standalone content — the same outcome "Delete collection" on Manage Content Collections already produces.
- Deleting a page in the **middle** of a collection is deliberately unchanged: contrib moves its children up under its parent and the collection survives. There is a regression test pinning that.
- Contrib `book_node_predelete()` only checks the in-memory copy of the book data, so a page whose outline row we just removed has that copy cleared, otherwise contrib reads `bid`/`pid` off the empty array `loadBookLink()` returns. This also covers bulk delete, where selecting a collection's top page together with one of its sub-pages runs predelete for every selected node before any row is written.
- The Manage Content delete confirmation was the generic content-delete form, whose only description is "This action cannot be undone" — a large part of why losing a collection here was a surprise. It now leads with what happens to the sub-pages, matching the Manage Content Collections wording. Suppressed when the collection is only its top-level page, since then there are no sub-pages to describe.
- Second commit (`test(1505)`) repairs two `ys_book` kernel fixtures that were calling `ys_book_update_10001()`, a function yalesites-org/YaleSites-Internal#1505's fix renumbered away. All 7 `BookCollectionDeleteTest` tests and all 13 `BookLinkRepeatSaveTest` tests were erroring in `setUp()` on `develop` before reaching an assertion, so the fixture had to be repaired before the new tests could be added.

**UX decision taken:** the ticket left open whether sub-pages should become standalone pages or whether this delete path should be blocked and the editor pointed at Manage Content Collections. This implements the first option — the reporter's stated expectation, and what the rest of the ticket's acceptance criteria are written against. It also makes both delete paths behave identically, which the ticket says removes the need for a KB change.

### Please note before reviewing

- **Verified by kernel tests only — the new confirmation copy has never been rendered in a browser.** This checkout had no working local site (the local database held no `node` or `book` tables, and `lando pull` could not authenticate to Pantheon — terminus has no saved machine token in the appserver container). The end-to-end `/admin/content` click-through in the testing steps below was therefore not performed by me. The notice's presence, text, weight and conditional suppression are asserted against the real built form array, and the element is a plain `<p>` so it cannot disturb heading order, but it has not been looked at.
- **The notice does not appear on the bulk-delete confirmation.** `DeleteMultipleForm` extends `ConfirmFormBase`, not `ContentEntityDeleteForm`. The behaviour fix covers the bulk path correctly; only the explanation is single-path.
- **The fix is not retroactive.** Stray collections already created by this bug on existing sites still need manual cleanup. Worth deciding whether that cleanup needs its own ticket.

### Test evidence

- `ys_book` kernel suite: **30 tests / 237 assertions / 20 errors** on `develop` → **35 tests / 450 assertions / 0 errors** on this branch.
- `lando composer code-sniff` exits 0; `lando composer lint:php` exits 0.
- `npm run lint:styles` fails, but only on `web/themes/contrib/atomic/_yale-packages/tokens/build/scss/tokens.scss` — a generated build artifact in the local gyst'd atomic clone. `web/themes/contrib/` is gitignored, this PR contains no SCSS, and that path does not exist in CI.

### Functional testing steps:
- [ ] Create a content collection with a top-level page and at least three sub-pages, including one nested two levels deep.
- [ ] Go to Manage Content (`/admin/content`), open the edit dropdown for the collection's top-level page, and choose Delete.
- [ ] Confirm the delete message clearly states what will happen to the sub-pages before you confirm.
- [ ] Confirm the delete.
- [ ] Go to Manage Content Collections and confirm no new collections were created.
- [ ] Edit one of the former sub-pages and confirm the "Collection" dropdown shows no collection selected, and that the dropdown itself contains no junk entries.
- [ ] Confirm every former sub-page is still published and reachable at its own URL.
- [ ] Repeat with a page in the middle of a collection: delete it and confirm its children move up under its parent and the collection is otherwise intact.
- [ ] Confirm deleting a whole collection from Manage Content Collections still works as it did before.

References yalesites-org/YaleSites-Internal#1511
References yalesites-org/YaleSites-Internal#1505

---
Created with AI
