### PR TITLE
1518: RC: Layout Section color picker: add a 6th color option (slot-three) for parity with block pickers

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Layout/YSLayoutOptions.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Layout/YSLayoutOptions.php
@@ -80,9 +80,11 @@ class YSLayoutOptions extends LayoutDefault implements ContainerFactoryPluginInt
 
     // Use the saved theme value directly from configuration.
     $saved_theme = $this->configuration['theme'] ?? 'default';
-    // Sections offer five color options by design, where block components
-    // offer six. See ColorTokenResolver::getColorStylesForEntity() for which
-    // palette slot each option resolves to and why slot-three is excluded.
+    // Sections offer six color options, matching the block component pickers
+    // (#1518). See ColorTokenResolver::getColorStylesForEntity() for which
+    // palette slot each option resolves to. Labels are deliberately ordinals
+    // rather than color names: the underlying color differs per global theme,
+    // so 'six' is light blue on Old Blues but red on It's Your Yale.
     $form['theme'] = [
       '#type' => 'select',
       '#title' => $this->t('Component theme'),
@@ -94,6 +96,7 @@ class YSLayoutOptions extends LayoutDefault implements ContainerFactoryPluginInt
         'three' => $this->t('Three'),
         'four' => $this->t('Four'),
         'five' => $this->t('Five'),
+        'six' => $this->t('Six'),
       ],
       '#weight' => 10,
       '#after_build' => [
@@ -139,15 +142,18 @@ class YSLayoutOptions extends LayoutDefault implements ContainerFactoryPluginInt
     $complete_form = $form_state->getCompleteForm();
 
     // The resolver applies the section layout mapping: one→slot-one,
-    // two→slot-four, three→slot-five, four→slot-two, five→slot-nine. The
-    // rendered colors come from the same slots via _yds-layout.scss, so the
-    // swatch shown here matches the page.
+    // two→slot-four, three→slot-five, four→slot-two, five→slot-nine,
+    // six→slot-three. The rendered colors come from the same slots via
+    // _yds-layout.scss, so the swatch shown here matches the page.
     //
     // No mapping is passed from this plugin: getColorStylesForEntity() is the
     // single source of truth for which slot each option resolves to. The
-    // option list itself is not — it is declared three times and the copies
-    // must be kept in sync: the '#options' array above, that same mapping's
-    // keys, and $desired_order in ColorTokenResolver::processColorPicker().
+    // option list itself is not -- it is declared three times in PHP and the
+    // copies must be kept in sync: the '#options' array above, that same
+    // mapping's keys, and $palette_order in
+    // ColorTokenResolver::processColorPicker(). A fourth copy lives in the
+    // component library's _yds-layout.scss, which is what actually paints the
+    // section; a new option added here but not there renders no background.
     return $this->colorTokenResolver->processColorPicker(
       $element,
       $form_state,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/YSLayoutOptionsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/YSLayoutOptionsTest.php
@@ -70,12 +70,12 @@ class YSLayoutOptionsTest extends UnitTestCase {
     $this->assertSame('select', $form['theme']['#type']);
     $this->assertSame('two', $form['theme']['#default_value']);
 
-    // Sections offer five colors plus "Default - no color", where block
-    // components offer six colors. This is deliberate (see #1506), so pin the
-    // list an editor actually sees rather than letting a sixth option appear
-    // silently.
+    // Sections offer six colors plus "Default - no color", matching the block
+    // component pickers (#1518). Pin the list an editor actually sees, since
+    // it is declared here, in ColorTokenResolver's section slot mapping and
+    // ordering arrays, and again in the component library SCSS.
     $this->assertSame(
-      ['default', 'one', 'two', 'three', 'four', 'five'],
+      ['default', 'one', 'two', 'three', 'four', 'five', 'six'],
       array_keys($form['theme']['#options']),
     );
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ColorTokenResolver.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/src/ColorTokenResolver.php
@@ -385,15 +385,17 @@ class ColorTokenResolver {
     ];
 
     // Section layout mapping: one→slot-one, two→slot-four, three→slot-five,
-    // four→slot-two, five→slot-nine.
+    // four→slot-two, five→slot-nine, six→slot-three.
     //
-    // Unlike every other mapping in this method, sections deliberately expose
-    // five options rather than six: slot-three is the one palette slot they do
-    // not offer. Ticket #897 (commit 1a06ebc6f) reworked this mapping and
-    // dropped slot-three, and it has not been offered to sections since;
-    // #1153 later added the 'five' => slot-nine entry. Keep this list at five
-    // unless that product decision is revisited (see #1506); the corresponding
-    // form options live in YSLayoutOptions.
+    // Sections offered only five options for a long time -- slot-three was the
+    // single palette slot they never exposed, dropped by #897 (commit
+    // 1a06ebc6f) and left out when #1153 added the 'five' => slot-nine entry.
+    // #1518 restored it as 'six', so sections now match the block pickers at
+    // six options. This list is mirrored in three other places that must move
+    // together: the form options in YSLayoutOptions, the ordering arrays in
+    // processColorPicker() below, and the per-theme blocks in the component
+    // library's _yds-layout.scss (which is what actually paints the page --
+    // this resolver only drives the admin swatches).
     if ($entity_type === 'layout_section' && $bundle === 'ys_layout_options') {
       return $this->buildColorStyles([
         'one' => 'one',
@@ -401,6 +403,7 @@ class ColorTokenResolver {
         'three' => 'five',
         'four' => 'two',
         'five' => 'nine',
+        'six' => 'three',
       ], $global_themes, $theme_four_slot_swap);
     }
 
@@ -626,10 +629,12 @@ class ColorTokenResolver {
     $color_styles = $all_color_styles[$global_theme] ?? $all_color_styles['one'] ?? [];
 
     $is_section_layout = ($entity_type === 'layout_section' && $bundle === 'ys_layout_options');
+    // Match YSLayoutOptions theme select: default + one–six. Used both to
+    // reorder the select options and as the swatch order below, so it is
+    // declared once here rather than repeated.
+    $palette_order = $is_section_layout ? ['default', 'one', 'two', 'three', 'four', 'five', 'six'] : NULL;
     if ($is_section_layout) {
-      // Match YSLayoutOptions theme select: default + one–five.
-      $desired_order = ['default', 'one', 'two', 'three', 'four', 'five'];
-      $palette_options = $this->reorderPaletteOptions($palette_options, $desired_order);
+      $palette_options = $this->reorderPaletteOptions($palette_options, $palette_order);
       $element['#options'] = $palette_options;
     }
 
@@ -643,9 +648,6 @@ class ColorTokenResolver {
       $background_color_var = $color_styles[$option_key][0] ?? NULL;
       $color_info[$option_key] = $this->buildColorInfo($option_key, $background_color_var);
     }
-
-    // Set palette order for section layouts.
-    $palette_order = $is_section_layout ? ['default', 'one', 'two', 'three', 'four', 'five'] : NULL;
 
     $palette_render = [
       '#theme' => 'component_color_picker',

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/tests/src/Unit/ColorTokenResolverTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/tests/src/Unit/ColorTokenResolverTest.php
@@ -518,36 +518,34 @@ class ColorTokenResolverTest extends UnitTestCase {
   }
 
   /**
-   * Tests that layout sections expose five color options, not six.
+   * Tests that layout sections expose six color options, including slot-three.
    *
-   * Every block-content mapping in getColorStylesForEntity() offers six
-   * options covering slots one, two, three, four, five and nine. Sections
-   * deliberately offer five and never expose slot-three: an option for it was
-   * added and then removed again within ticket #897, and #1153 reused the
-   * freed 'five' key for slot-nine. This test pins that decision so the
-   * difference reads as intentional rather than as a missed slot (#1506), and
-   * so adding a sixth option is a deliberate change with a test to update.
+   * Sections offered five options for a long time while every block-content
+   * mapping offered six: slot-three was the one palette slot sections never
+   * exposed. #1518 closed that gap, so sections now match the block pickers at
+   * six options and 'six' is the key that resolves to slot-three.
    *
    * @covers ::getColorStylesForEntity
    */
-  public function testGetColorStylesForEntitySectionExposesFiveOptions(): void {
+  public function testGetColorStylesForEntitySectionExposesSixOptions(): void {
     $resolver = $this->createResolver($this->fixturePath);
     $styles = $resolver->getColorStylesForEntity('layout_section', 'ys_layout_options');
 
     $this->assertSame(
-      ['one', 'two', 'three', 'four', 'five'],
+      ['one', 'two', 'three', 'four', 'five', 'six'],
       array_keys($styles['one']),
     );
 
-    // No option resolves to slot-three under any global theme.
-    foreach ($styles as $global_theme => $options) {
-      foreach ($options as $option_key => $declarations) {
-        $this->assertNotContains(
-          "var(--global-themes-{$global_theme}-colors-slot-three)",
-          $declarations,
-          "Section option '{$option_key}' unexpectedly resolves to slot-three.",
-        );
-      }
+    // Option 'six' resolves to slot-three under every global theme. Theme
+    // 'four' (Onha) is included deliberately: its slot swap exchanges slot-two
+    // and slot-five only, so slot-three must pass through untouched there --
+    // mirroring the SCSS, which likewise leaves slot-three out of that swap.
+    foreach (array_keys($styles) as $global_theme) {
+      $this->assertSame(
+        ["var(--global-themes-{$global_theme}-colors-slot-three)"],
+        $styles[$global_theme]['six'],
+        "Section option 'six' should resolve to slot-three under global theme '{$global_theme}'.",
+      );
     }
   }
 


### PR DESCRIPTION
## [1518: RC: Layout Section color picker: add a 6th color option (slot-three) for parity with block pickers](https://github.com/yalesites-org/YaleSites-Internal/issues/1518)

### Description of work

Every block-level color picker on the platform offers six background colors; the Layout Section "Component theme" picker offered five. The missing one was slot-three, dropped by #897 and left out again when #1153 added slot-nine on the `five` key. yalesites-org/YaleSites-Internal#1506 chose to document the gap (Option A, merged as #1449) and split the real fix out as this ticket (Option B).

- `ColorTokenResolver::getColorStylesForEntity()` gains `'six' => 'three'` in the `layout_section` mapping, so the admin swatch resolves the new option under all seven global themes.
- `YSLayoutOptions::buildConfigurationForm()` exposes the matching `#options` entry.
- The label is the ordinal **"Six"**, not a color name. Section labels are deliberately ordinals because the underlying color differs per global theme: slot-three is light blue on Old Blues but red on It's Your Yale, so any single color name would be wrong on most themes. **Easy to change if a color name is preferred.**
- `processColorPicker()` previously declared the section option order twice, as `$desired_order` and again as `$palette_order` a few lines later. Since this change has to touch both copies, they are collapsed into one `$palette_order` declared before the branch. Behavior is unchanged; the non-section path still yields `NULL`.
- The two tests that pinned the five-option contract are updated: `ColorTokenResolverTest::testGetColorStylesForEntitySectionExposesFiveOptions` becomes `...ExposesSixOptions` and now asserts that option `six` resolves to slot-three under **each** of the seven global themes, and `YSLayoutOptionsTest::testBuildConfigurationFormExposesDividerAndTheme` asserts seven `#options` keys.

Global theme four (Onha) swaps slot-two and slot-five only, so slot-three passes through untouched there and the admin swatch matches the page.

- Other work completed in: yalesites-org/component-library-twig#679

**This PR does nothing on its own.** `ColorTokenResolver` only drives the admin color-picker swatches; the rendered page color comes from `_yds-layout.scss` in the companion PR. Merging this alone would add a picker option that paints no background.

### Functional testing steps:

- [ ] Edit a page, add or open a **50/50** or **33/33/33** section, and open its settings. Confirm the Component theme picker now shows **six** color swatches plus "Default - no color", matching a block-level picker such as Callout.
- [ ] Select the sixth option, save, and view the published page. Confirm the section background is the global theme's slot-three color and the text is dark and legible.
- [ ] Confirm the swatch shown in the editor matches the color that actually renders on the page.
- [ ] Repeat under several global themes, **including Onha (theme four)** -- that is the theme with the slot-two/slot-five swap, so it is the one most likely to disagree between swatch and page.
- [ ] Confirm the existing five options and "Default - no color" are unchanged.
- [ ] Confirm yalesites-org/YaleSites-Internal#1153's release-testing Step 1 (which already says sections should show 6 slots) now needs no correction.

### Verification performed

- `lando composer code-sniff` -- exit 0.
- `composer lint:php` -- no syntax errors.
- `ys_themes` and `ys_layouts` unit suites run before and after. Both new assertions pass. Pre-existing failures are unchanged in count **and name** (see below), so there are no regressions from this change.
- Compiled-CSS verification of the companion branch: built the component library and confirmed `dist/css/style.css` emits `.yds-layout[data-component-theme=six]` with `background-color: var(--color-layout-theme)` resolving to `--color-slot-three`, and that `--color-slot-three` resolves per global theme -- including theme four, where the swap re-declares only slot-two and slot-five, leaving slot-three untouched.

### Not verified -- needs a human

**There is no browser verification in this PR.** The local Drupal database had no content (no `node` table) and could not be restored, so the Layout Builder UI and the published page were never actually loaded. The functional testing steps above are all still owed. The claim most worth checking first is that the editor swatch and the rendered page agree under Onha.

### Pre-existing issues found, not fixed here

- Four unit tests in `ColorTokenResolverTest` **already fail on `develop`** and still fail: `testBuildColorInfoResolvesComponentThemeVariable`, `testGetColorStylesForEntityCalloutBundleMapping`, `testGetColorStylesForEntityFactsBundleUsesFourOptionOverride`, `testGetColorStylesForEntityQuoteCalloutBundleMapping`. They expect `getColorStylesForEntity()` to emit a `var(--component-themes-*-background)` direct override for the callout/facts/quote-callout `five` option, but `buildColorStyles()` only ever emits `var(--global-themes-*-colors-slot-*)` -- no code path produces that value. These assert behavior the code does not have. They are untouched by this PR (different bundles), but they are genuinely broken and worth their own ticket. CI runs no PHPUnit (`composer unit-test` is an echo stub), which is why this went unnoticed.
- `Drupal\Tests\ys_layouts\Unit\BlockContextualLinksTest::testRemoveStaysLastAndLabelsDropTheWordBlock` also already fails on `develop` (it does not expect `ys_layouts_block_detach`). Unrelated to this change.
- `theme` is missing from `YSLayoutOptions::defaultConfiguration()` while `divider` is present. Both the form and the Twig templates compensate with their own fallbacks, so nothing is broken today, but any third consumer would need its own fallback. Left alone as out of scope.

References yalesites-org/YaleSites-Internal#1518

---

Created with AI
