### PR TITLE
1514: RC: Emergency alert's expand/collapse chevron has no pointer cursor on hover - FOR MULTIDEV ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,5 @@ lando xdebug-off           # Disable Xdebug
 - **Semantic Release**: Automated versioning on master branch using conventional commits
 
 
+
+


### PR DESCRIPTION
## [1514: RC: Emergency alert's expand/collapse chevron has no pointer cursor on hover](https://github.com/yalesites-org/YaleSites-Internal/issues/1514)

### Description of work

- **For multidev only. Do not merge.** The only change in this repo is two blank lines appended to `README.md`, so a Pantheon multidev builds and picks up the matching `1514-alert-toggle-cursor` branch in component-library-twig.
- Other work completed in: yalesites-org/component-library-twig#680

### Functional testing steps:

- [x] In this multidev, activate an Emergency sitewide alert, hover the expand/collapse chevron, and confirm the cursor becomes a pointer
- [x] Click the chevron and confirm it still collapses and expands the alert details, and that the cursor stays a pointer while collapsed
- [x] With an Announcement alert active, hover the close "X" and confirm the cursor becomes a pointer and that dismissing still works
- [ ] Repeat for a Marketing alert
- [ ] Confirm nothing else about the alerts changed visually

References yalesites-org/YaleSites-Internal#1514

---

Created with AI
