### PR TITLE
1517: RC: og:image can still comma-split if an uploaded image's filename contains a comma

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/MediaImageTokenTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/MediaImageTokenTest.php
@@ -23,6 +23,10 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
  * core's default image formatter and the token resolves to a whole <img> tag
  * with the alt text inside it.
  *
+ * The separator can also arrive from the uploaded file's own name, which
+ * nothing sanitizes, so this also carries the chain through metatag's og:image
+ * plugin and asserts on the tags it actually emits.
+ *
  * @group ys_core
  * @group yalesites
  */
@@ -42,6 +46,14 @@ class MediaImageTokenTest extends KernelTestBase {
   private const FILE_NAME = 'sculpture-in-snow.jpg';
 
   /**
+   * A file name containing metatag's separator, which nothing sanitizes away.
+   *
+   * Every option under file.settings:filename_sanitization is off, so an editor
+   * can upload this name verbatim.
+   */
+  private const SEPARATOR_FILE_NAME = 'sunset, beach.jpg';
+
+  /**
    * {@inheritdoc}
    */
   protected static $modules = [
@@ -52,6 +64,8 @@ class MediaImageTokenTest extends KernelTestBase {
     'image',
     'media',
     'token',
+    'metatag',
+    'metatag_open_graph',
   ];
 
   /**
@@ -65,6 +79,16 @@ class MediaImageTokenTest extends KernelTestBase {
     $this->installEntitySchema('media');
     $this->installSchema('file', 'file_usage');
     $this->installConfig(['system', 'field', 'file', 'media']);
+
+    // Metatag ships a blank separator that falls back to a comma. Pin the value
+    // the platform actually exports, so separator() below and metatag's own
+    // plugin both read production's value rather than contrib's default. Its
+    // remaining settings stay unset and so read as NULL, which makes
+    // MetaNameBase::trimValue() short-circuit -- as it also does in production,
+    // where no trim maxlength is configured for og:image.
+    $this->config('metatag.settings')
+      ->set('separator', $this->readConfig('metatag.settings')['separator'])
+      ->save();
 
     $this->createMediaType('image', ['id' => 'image']);
 
@@ -107,10 +131,10 @@ class MediaImageTokenTest extends KernelTestBase {
   /**
    * Creates an image media whose alt text contains commas.
    */
-  private function createImageMedia(): MediaInterface {
+  private function createImageMedia(string $file_name = self::FILE_NAME): MediaInterface {
     $file = File::create([
-      'uri' => 'public://' . self::FILE_NAME,
-      'filename' => self::FILE_NAME,
+      'uri' => 'public://' . $file_name,
+      'filename' => $file_name,
     ]);
     $file->save();
 
@@ -118,7 +142,7 @@ class MediaImageTokenTest extends KernelTestBase {
       ->getStorage('media')
       ->create([
         'bundle' => 'image',
-        'name' => self::FILE_NAME,
+        'name' => $file_name,
         'field_media_image' => [
           'target_id' => $file->id(),
           'alt' => self::ALT_TEXT,
@@ -127,6 +151,38 @@ class MediaImageTokenTest extends KernelTestBase {
     $media->save();
 
     return $media;
+  }
+
+  /**
+   * Returns the separator metatag splits multi-valued tags like og:image on.
+   *
+   * Read from active config, which setUp() pinned to the platform's own export.
+   * Metatag's own getSeparator() substitutes a comma when that value is blank,
+   * so the pin is what keeps this helper and metatag in agreement.
+   */
+  private function separator(): string {
+    return $this->config('metatag.settings')->get('separator');
+  }
+
+  /**
+   * Renders the given value through metatag's real og:image plugin.
+   *
+   * Asserting on the token value alone would not be enough: og:image's value
+   * also passes through parseImageUrl(), whitespace tidying, absolute-URL
+   * handling and trimming, any of which could mangle an encoded URL. This goes
+   * through the plugin manager rather than instantiating the class so the
+   * plugin's own annotation, which is what marks og:image multi-valued, is the
+   * thing under test.
+   *
+   * @return array
+   *   The render array elements metatag would emit for this value.
+   */
+  private function ogImageOutput(string $value): array {
+    $tag = $this->container->get('plugin.manager.metatag.tag')
+      ->createInstance('og_image');
+    $tag->setValue($value);
+
+    return $tag->output();
   }
 
   /**
@@ -144,7 +200,7 @@ class MediaImageTokenTest extends KernelTestBase {
    * split on it, so a value containing one becomes several malformed tags.
    */
   public function testImageTokenResolvesToBareUrl(): void {
-    $separator = $this->readConfig('metatag.settings')['separator'];
+    $separator = $this->separator();
     $this->assertNotEmpty($separator, 'Metatag should define a multi-value separator.');
     $this->assertStringContainsString($separator, self::ALT_TEXT, 'The fixture alt text should contain the separator.');
 
@@ -168,6 +224,47 @@ class MediaImageTokenTest extends KernelTestBase {
       self::ALT_TEXT,
       trim($this->replaceImageToken($this->createImageMedia(), '[media:field_media_image:alt]')),
     );
+  }
+
+  /**
+   * A separator in the uploaded file's own name still yields one og:image tag.
+   *
+   * The token resolving to a bare URL is only half the guarantee: the URL
+   * itself has to be free of metatag's separator, or metatag's multi-value
+   * splitting would shatter it the same way the alt text did. Core
+   * percent-encodes the file path when it builds the URL, which is what keeps
+   * that true, so this asserts the whole chain rather than the encoding alone:
+   * it would fail if a future formatter, image style, or stream wrapper emitted
+   * the raw name.
+   */
+  public function testSeparatorInFileNameYieldsOneOgImageTag(): void {
+    $this->assertStringContainsString($this->separator(), self::SEPARATOR_FILE_NAME, 'The fixture file name should contain the separator.');
+
+    $media = $this->createImageMedia(self::SEPARATOR_FILE_NAME);
+    $url = trim($this->replaceImageToken($media, '[media:field_media_image]'));
+    $this->assertNotEmpty($url, 'The token should resolve to the image URL.');
+
+    $elements = $this->ogImageOutput($url);
+
+    // Each assertion catches a different way this has failed or could fail: the
+    // reported symptom was several tags; a naive fix could leave one truncated
+    // tag; and og:image is useless to a crawler if it is not absolute.
+    $this->assertCount(1, $elements, 'A separator in the file name must not split og:image into several tags.');
+    $content = $elements[0]['#attributes']['content'];
+    $this->assertStringEndsWith(rawurlencode(self::SEPARATOR_FILE_NAME), $content, 'The emitted URL should end in the whole encoded file name.');
+    $this->assertStringStartsWith('http', $content, 'og:image must be an absolute URL.');
+  }
+
+  /**
+   * Control for the test above: an unencoded separator really does split.
+   *
+   * Without this, the one-tag assertion could pass vacuously. Should metatag
+   * stop splitting values this way, this fails and that guard can be relaxed.
+   */
+  public function testMetatagSplitsAnUnencodedSeparator(): void {
+    $elements = $this->ogImageOutput('http://localhost/files/' . self::SEPARATOR_FILE_NAME);
+
+    $this->assertGreaterThan(1, count($elements), sprintf("Metatag is expected to split og:image on '%s'.", $this->separator()));
   }
 
 }


### PR DESCRIPTION
## [1517: RC: og:image can still comma-split if an uploaded image's filename contains a comma](https://github.com/yalesites-org/YaleSites-Internal/issues/1517)

### Description of work

**The reported bug does not reproduce, so no production code changed here.** The
ticket's first acceptance criterion was to confirm it before fixing, and confirming it
showed there is nothing to fix on our side. What ships is the ticket's third
acceptance criterion turned into a regression test, so the invariant is enforced
rather than remembered.

Why a comma in an uploaded filename cannot split `og:image`:

- The media image `token` view display renders `field_media_image` with the
  `image_url` formatter and no image style, so `ImageUrlFormatter` calls
  `FileUrlGenerator::generateString()`.
- That reaches `PublicStream::getExternalUrl()`, which passes the path through
  `UrlHelper::encodePath()`, i.e. `str_replace('%2F', '/', rawurlencode($path))`.
  `rawurlencode` percent-encodes a comma, so `sunset, beach.jpg` arrives as
  `sunset%2C%20beach.jpg`.
- `MetaNameBase::output()` then splits on `metatag.settings:separator` (a comma) and
  finds nothing to split.

The encoding is structural, not incidental: an image style would route through
`ImageStyle::buildUrl()`, which also ends at
`FileUrlGenerator::generateAbsoluteString()` and the same `encodePath`. Editors cannot
bypass it either, since `metatag.settings:entity_type_groups` exposes only the `basic`
and `ys_beacon` groups per node bundle, not `open_graph`, so `og:image` is never typed
by hand.

**No metatag patch was added.** The upstream defect the ticket cites is real: the
embedded-image check in `parseImageUrl()` is `strpos($value, '<img src="/')`, which
requires `src` to be the first attribute, and core emits
`<img loading="lazy" src="...">`. That is the mechanism that garbled #1495. But it is
unreachable here now that yalesites-org/yalesites-project#1445 routes the token
through `image_url`, and a `patches/contrib/metatag/` entry would be a permanent cost
on every metatag bump for no reachable code path. A bug report is drafted for filing
upstream separately.

Two cases are added to the existing #1495 test class, since they share its media,
file and token-display fixtures:

- A file named `sunset, beach.jpg` resolves through the real shipped view display and
  metatag's own `og_image` plugin to exactly one absolute tag ending in the fully
  encoded name. Asserting through the plugin rather than on the token string matters,
  because `output()` also runs `parseImageUrl()`, `tidy()`'s whitespace collapse,
  absolute-URL handling and `trimValue()`, any of which could mangle an encoded URL.
- A control case feeding `og:image` a raw, unencoded comma, which metatag does split
  into several tags. Without it the one-tag assertion could pass for the wrong reason
  and nobody could tell.

Also pins `metatag.settings:separator` to the platform's exported value so the tests
read production's separator instead of contrib's blank default, and folds three
repeated reads of it into a `separator()` helper.

### Testing limitation, please read before reviewing

**No browser or visual verification was performed on this branch.** The local Drupal
database was empty (no `node` table) and Terminus had no machine token, so no site
could be brought up to render a real page. All evidence here is from kernel tests
against their own isolated test database, plus reading core and contrib source. That
is a good fit for this particular change, since the whole question is PHP value
handling with no theme or browser involvement, but it does mean nobody has looked at a
rendered `<meta property="og:image">` tag in this run.

Recommendation once the multidev is up: confirm the behaviour once in a browser using
the steps below, then **verify and close**
yalesites-org/YaleSites-Internal#1517 rather than treating it as a code fix.

### Functional testing steps:

- [ ] `lando composer code-sniff` exits 0 (it does locally, along with `lint:php`).
- [ ] Run the test file and see 4 passing tests:
      `lando ssh -c "env SIMPLETEST_DB=mysql://pantheon:pantheon@database/pantheon?module=mysql SIMPLETEST_BASE_URL=http://appserver vendor/bin/phpunit -c /app/phpunit.xml web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/MediaImageTokenTest.php --testdox"`
- [ ] On the multidev, upload an image whose filename contains a comma, e.g.
      `sunset, beach.jpg`, into the media library.
- [ ] Set it as the teaser image on a Post and view the published Post.
- [ ] View source and confirm there is exactly **one** `<meta property="og:image">`
      tag, that its URL is absolute, and that the filename appears encoded as
      `sunset%2C%20beach.jpg`.
- [ ] Optionally paste the Post URL into Slack or the Facebook sharing debugger and
      confirm the preview image resolves.

References yalesites-org/YaleSites-Internal#1517

---

Created with AI
