### PR TITLE
1520: Beacon: raise default "Sources per answer" (top_k) from 5 to 10

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/install/ys_beacon.settings.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/install/ys_beacon.settings.yml
@@ -14,7 +14,7 @@ azure_search_url_key: ''
 read_only: false
 query_entire_index: false
 pdf_extraction_max_bytes: 20971520
-top_k: 5
+top_k: 10
 score_threshold: 0.0
 streaming: true
 # Context window (in tokens) of the model Portkey currently routes to. Used to

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/Controller/AiTesterController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/Controller/AiTesterController.php
@@ -1127,7 +1127,7 @@ class AiTesterController extends ControllerBase {
    * CitationFormatter::format() stores both 'content' — the entire retrieved
    * chunk — and 'excerpt', that same text's first 300 characters. Exporting
    * both made the file grow with however long the indexed pages happened to be,
-   * multiplied by up to top_k (default 5) sources per question per side, while
+   * multiplied by up to top_k (default 10) sources per question per side, while
    * adding no category of information the excerpt does not already carry. That
    * is what put the download beyond what an LLM will accept in one go.
    *

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconAdminSettings.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconAdminSettings.php
@@ -114,7 +114,7 @@ class YsBeaconAdminSettings extends ConfigFormBase {
       '#type' => 'number',
       '#title' => $this->t('Sources per answer'),
       '#description' => $this->t('How many content chunks are retrieved as sources for each answer.'),
-      '#default_value' => $config->get('top_k') ?: 5,
+      '#default_value' => $config->get('top_k') ?: 10,
       '#min' => 1,
       '#max' => 20,
       '#required' => TRUE,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/RagRetriever.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/RagRetriever.php
@@ -59,7 +59,7 @@ class RagRetriever {
 
     try {
       $query = $index->query([
-        'limit' => (int) ($settings->get('top_k') ?: 5),
+        'limit' => (int) ($settings->get('top_k') ?: 10),
       ]);
       $query->setOption('search_api_ai_get_chunks_result', TRUE);
       // Reading beyond this site's own documents - a read-only borrow or a

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconConfigDefaultsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconConfigDefaultsTest.php
@@ -61,6 +61,18 @@ class BeaconConfigDefaultsTest extends UnitTestCase {
   }
 
   /**
+   * Ten content chunks are retrieved as sources per answer by default.
+   *
+   * This is the platform default a newly provisioned site comes up with, and
+   * the value both runtime fallbacks degrade to when the key is absent
+   * (RagRetriever::retrieve() and the Beacon administration form). It stays
+   * inside the form's 1-20 range.
+   */
+  public function testSourcesPerAnswerDefaultsToTen(): void {
+    $this->assertSame(10, $this->installSettings()['top_k']);
+  }
+
+  /**
    * The fallback prompt ships with the full YaleSites system instruction.
    */
   public function testFallbackPromptShipsYaleSitesInstruction(): void {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconDeployProvisionTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconDeployProvisionTest.php
@@ -204,7 +204,7 @@ class BeaconDeployProvisionTest extends UnitTestCase {
     $this->assertTrue($healed->get('platform_authorized'), 'Authorization survives.');
     // ... and the keys that were reading NULL are back.
     $this->assertTrue($healed->get('streaming'), 'Streaming comes back on.');
-    $this->assertSame(5, $healed->get('top_k'), 'top_k comes back.');
+    $this->assertSame(10, $healed->get('top_k'), 'top_k comes back.');
     $this->assertCount(
       count($this->shippedDefaults()),
       $healed->getRawData(),
@@ -256,7 +256,7 @@ class BeaconDeployProvisionTest extends UnitTestCase {
     // them: hoisting the getEditable() above the seed would wipe every key the
     // legacy chat does not carry, and only these assertions would catch it.
     $this->assertTrue($restored->get('streaming'), 'Streaming still ships on.');
-    $this->assertSame(5, $restored->get('top_k'), 'Untouched defaults survive.');
+    $this->assertSame(10, $restored->get('top_k'), 'Untouched defaults survive.');
 
     // Guards the premise: these differ from the shipped defaults, so the
     // assertions above cannot pass by accident.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconSettingsSeedTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconSettingsSeedTest.php
@@ -165,12 +165,50 @@ class BeaconSettingsSeedTest extends UnitTestCase {
 
     // Everything the partial write never set is restored.
     $this->assertTrue($captured['streaming'], 'Streaming comes back on.');
-    $this->assertSame(5, $captured['top_k'], 'top_k comes back.');
+    $this->assertSame(10, $captured['top_k'], 'top_k comes back.');
     $shipped_keys = array_keys($this->shippedDefaults());
     $captured_keys = array_keys($captured);
     sort($shipped_keys);
     sort($captured_keys);
     $this->assertSame($shipped_keys, $captured_keys, 'The full shipped key set is present.');
+  }
+
+  /**
+   * A site's own tuned value survives a seed that raises the shipped default.
+   *
+   * Raising a shipped default must not retune a site that already made its own
+   * choice. testDoesNotClobberExistingSettings() cannot catch that: it stubs
+   * the existing data with the shipped defaults themselves, so every value
+   * already equals what the seed would write and "preserved" is
+   * indistinguishable from "overwritten with the same number". This holds the
+   * value the site stores deliberately BELOW the shipped default, so a merge
+   * the wrong way round changes it and fails here.
+   */
+  public function testExistingSourcesPerAnswerSurvivesRaisedDefault(): void {
+    $shipped = $this->shippedDefaults();
+    $tuned = $shipped;
+    $tuned['top_k'] = 3;
+    // Guards the premise: an equal value would make the assertion vacuous.
+    $this->assertNotSame(3, $shipped['top_k']);
+    // One shipped key is dropped so there is a gap and the seed does write.
+    unset($tuned['streaming']);
+
+    $captured = NULL;
+    $config = $this->createMock(Config::class);
+    $config->method('getRawData')->willReturn($tuned);
+    $config->expects($this->once())
+      ->method('setData')
+      ->with($this->callback(function (array $data) use (&$captured): bool {
+        $captured = $data;
+        return TRUE;
+      }))
+      ->willReturnSelf();
+    $config->expects($this->once())->method('save')->willReturnSelf();
+    $this->setContainer($config);
+
+    $this->assertTrue(_ys_beacon_seed_settings(), 'A gap was filled.');
+    $this->assertSame(3, $captured['top_k'], "The site's own value is kept.");
+    $this->assertTrue($captured['streaming'], 'The genuine gap was filled.');
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/RagRetrieverTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/RagRetrieverTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\ys_beacon\Unit;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -14,6 +15,7 @@ use Drupal\Tests\UnitTestCase;
 use Drupal\ys_beacon\Service\EntityCitationResolver;
 use Drupal\ys_beacon\Service\RagRetriever;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Tests Beacon RAG retrieval: failure logging, guards, and citation building.
@@ -95,7 +97,7 @@ class RagRetrieverTest extends UnitTestCase {
     $configFactory = $this->getConfigFactoryStub([
       'ys_beacon.settings' => [
         'search_index_id' => 'internal_corpus',
-        'top_k' => 5,
+        'top_k' => 10,
         'score_threshold' => 0.0,
       ],
     ]);
@@ -123,11 +125,122 @@ class RagRetrieverTest extends UnitTestCase {
     $entityTypeManager->method('getStorage')->with('search_api_index')->willReturn($storage);
 
     $configFactory = $this->getConfigFactoryStub([
-      'ys_beacon.settings' => ['top_k' => 5, 'score_threshold' => 0.0],
+      'ys_beacon.settings' => ['top_k' => 10, 'score_threshold' => 0.0],
     ]);
 
     $retriever = new RagRetriever($entityTypeManager, $configFactory, $this->createMock(LoggerInterface::class), $this->createMock(EntityCitationResolver::class));
     $this->assertSame([], $retriever->retrieve('hello'));
+  }
+
+  /**
+   * A stored sources-per-answer value becomes the retrieval query limit.
+   *
+   * @covers ::retrieve
+   */
+  public function testStoredSourcesPerAnswerBecomesTheQueryLimit(): void {
+    $index = $this->indexExpectingLimit(3);
+
+    $configFactory = $this->getConfigFactoryStub([
+      'ys_beacon.settings' => ['top_k' => 3, 'score_threshold' => 0.0],
+    ]);
+
+    $this->assertSame([], $this->retrieverForIndex($index, $configFactory)->retrieve('hello'));
+  }
+
+  /**
+   * With no stored value the query limit falls back to the shipped default.
+   *
+   * The settings are config-ignored and absent from config/sync, so a site can
+   * legitimately reach retrieval with this key unset - the fallback is the
+   * value such a site actually searches with, not dead code.
+   *
+   * The expectation is read from the shipped file rather than written out, so
+   * the hardcoded fallback and the shipped default cannot drift apart silently.
+   * BeaconConfigDefaultsTest is what pins that shipped value to a number.
+   *
+   * @covers ::retrieve
+   */
+  public function testMissingSourcesPerAnswerFallsBackToShippedDefault(): void {
+    $index = $this->indexExpectingLimit($this->shippedSourcesPerAnswer());
+
+    $configFactory = $this->getConfigFactoryStub([
+      'ys_beacon.settings' => ['score_threshold' => 0.0],
+    ]);
+
+    $this->assertSame([], $this->retrieverForIndex($index, $configFactory)->retrieve('hello'));
+  }
+
+  /**
+   * The shipped top_k default, read from the module's install config.
+   *
+   * @return int
+   *   The number of sources a site searches with when it stores no value.
+   */
+  private function shippedSourcesPerAnswer(): int {
+    $path = dirname(__DIR__, 3) . '/config/install/ys_beacon.settings.yml';
+    $this->assertFileExists($path);
+    return Yaml::parseFile($path)['top_k'];
+  }
+
+  /**
+   * Builds an enabled index that requires the given retrieval query limit.
+   *
+   * @param int $limit
+   *   The limit the query must be built with.
+   *
+   * @return \Drupal\search_api\IndexInterface|\PHPUnit\Framework\MockObject\MockObject
+   *   The index mock.
+   */
+  private function indexExpectingLimit(int $limit): IndexInterface {
+    $results = $this->createMock(ResultSetInterface::class);
+    $results->method('getResultItems')->willReturn([]);
+
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('setOption')->willReturnSelf();
+    $query->method('keys')->willReturnSelf();
+    $query->method('execute')->willReturn($results);
+
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('status')->willReturn(TRUE);
+    $index->method('isReadOnly')->willReturn(FALSE);
+    $index->expects($this->once())
+      ->method('query')
+      ->with(['limit' => $limit])
+      ->willReturn($query);
+
+    return $index;
+  }
+
+  /**
+   * Builds a RagRetriever wired to the given index and config factory.
+   *
+   * @param \Drupal\search_api\IndexInterface $index
+   *   The index the retriever loads.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory holding the Beacon settings.
+   *
+   * @return \Drupal\ys_beacon\Service\RagRetriever
+   *   The retriever under test.
+   */
+  private function retrieverForIndex(IndexInterface $index, ConfigFactoryInterface $configFactory): RagRetriever {
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $storage->method('load')->willReturn($index);
+
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $entityTypeManager->method('getStorage')->with('search_api_index')->willReturn($storage);
+
+    // retrieve() catches every Throwable around the query, so without this a
+    // limit these tests got right could still be followed by an unrelated
+    // failure and the test would stay green on its empty-array assertion.
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->never())->method('error');
+
+    return new RagRetriever(
+      $entityTypeManager,
+      $configFactory,
+      $logger,
+      $this->createMock(EntityCitationResolver::class),
+    );
   }
 
   /**
@@ -499,7 +612,7 @@ class RagRetrieverTest extends UnitTestCase {
 
     $configFactory = $this->getConfigFactoryStub([
       'ys_beacon.settings' => [
-        'top_k' => 5,
+        'top_k' => 10,
         'score_threshold' => 0.0,
         'query_entire_index' => $query_entire_index,
       ],


### PR DESCRIPTION
## [1520: Beacon: raise default "Sources per answer" (top_k) from 5 to 10](https://github.com/yalesites-org/YaleSites-Internal/issues/1520)

### Description of work

- Raises the shipped Beacon platform default for "Sources per answer" (`top_k`) from 5 to 10, so answers are grounded in more retrieved content chunks.
- Updates all four places the old number lived:
  - `ys_beacon/config/install/ys_beacon.settings.yml` -- the shipped default
  - `YsBeaconAdminSettings::buildForm()` -- the admin form fallback
  - `RagRetriever::retrieve()` -- the runtime fallback that becomes the `limit` on the vector search query
  - an `AiTesterController` doc comment that cited the old number
- The form already allows 1-20, so no validation change was needed. The 1-20 range is untouched.

**Scope is the default only. No migration and no deploy hook**, matching the ticket. `ys_beacon.settings` is config-ignored and deliberately absent from `config/sync`, and `_ys_beacon_seed_settings()` fills it by union (`$current + $shipped`), so a key the site already holds is never overwritten.

**Worth being explicit about for review:** this means the platform default is 10, but the existing fleet is not retuned. Sites provisioned before this ships keep whatever `top_k` they already store (5 for most) until an admin edits the form. The new default reaches newly provisioned sites and any site missing the key. That is the intended no-migration outcome, not an oversight.

**Cost tradeoff, stated so it can be weighed:** doubling `top_k` doubles the chunks retrieved and cited per answer, which increases the tokens and the latency of every Beacon response. That is the ticket's stated intent, so it is implemented as asked. It is not a request-failure risk: citations enter the system prompt and are subtracted from the input budget *before* the transcript is windowed, so a larger citation payload shrinks the retained conversation rather than overflowing the model. Budget is 193,856 tokens against a 200k window.

#### Tests

Two pre-existing coverage gaps were found and closed, because two of the acceptance criteria rested on untested behaviour:

- **Nothing asserted the retrieval query limit at all**, so the runtime fallback was entirely untested. Added tests that a stored value becomes the query limit, and that a missing value falls back to the shipped default. The fallback test reads its expectation from the shipped YAML rather than repeating the number, so the shipped default and the hardcoded fallback cannot drift apart silently.
- **No test proved a site's own differing value survives the seed.** The existing non-clobber test stubbed the stored data with the shipped defaults themselves, so its `top_k` already equalled what the seed would write and it could not tell "preserved" from "overwritten with the same number". Added a test that holds a stored value deliberately *below* the shipped default, so a union written the wrong way round fails.

Also updated the three existing assertions the ticket names (`BeaconDeployProvisionTest`, `BeaconSettingsSeedTest`, `RagRetrieverTest`).

```
ys_beacon Unit: OK (325 tests, 767 assertions)   baseline was (321 tests, 753 assertions), 0 failing both
composer code-sniff: exit 0 (full run, Drupal + DrupalPractice)
composer lint:php:   exit 0
BeaconConfigIgnoreCreateScopeTest (Kernel): OK (5 tests, 50 assertions)
```

One contract worth noting was checked: the citation marker goes from single- to double-digit. `[doc10]` parses correctly on both sides (`CitationFormatter.php` uses `/\[doc(\d+)\]/`, `AnswerParser.tsx` uses a 1-3 digit pattern), so sources 10+ render as citations rather than literal text.

**Not verified by me, and the reason:** the local Drupal database in this environment is empty and no Pantheon credentials were available, so **there was no browser verification of the rendered admin form or of a real answer returning 10 sources.** The last acceptance criterion is owed by a human on this multidev. That is the claim I would most expect to need a second look.

### Functional testing steps:

- [ ] On a fresh multidev, go to the Beacon administration form and confirm "Sources per answer" under "Retrieval and response" shows **10**.
- [ ] Confirm the field still enforces its 1-20 range (values of 0 or 21 are rejected).
- [ ] With Beacon enabled and content indexed, ask a question and confirm the answer can return up to 10 sources, and that citations numbered `[doc10]` and above render as real citation links rather than literal bracket text.
- [ ] On a site that already stores its own "Sources per answer" value, run a deploy and confirm the stored value is unchanged.

References yalesites-org/YaleSites-Internal#1520

---
Created with AI

<img width="481" height="196" alt="Screenshot 2026-08-12 at 8 50 27 AM" src="https://github.com/user-attachments/assets/bf8c4079-e474-4d9d-b4cf-cc74f1e6cc3e" />
