### PR TITLE
1522: Four ColorTokenResolverTest tests fail on develop, asserting a component-themes override no code path returns

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/tests/src/Unit/ColorTokenResolverTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/tests/src/Unit/ColorTokenResolverTest.php
@@ -398,47 +398,32 @@ class ColorTokenResolverTest extends UnitTestCase {
   }
 
   /**
-   * Tests build color info resolves component theme variable.
+   * Tests build color info does not resolve component theme variables.
    *
-   * BuildColorInfo() resolves a component-themes CSS variable directly from
-   * the component-themes section of the token JSON.
+   * BuildColorInfo() only resolves --global-themes-*-colors-slot-* variables.
+   * A component-themes variable is passed through with hex/name/ref left empty
+   * even though the fixture's component-themes section does define
+   * five.background. Ticket #1153 replaced the component-token bypass with
+   * global slot resolution, so no code path reads that section any more.
    *
    * @covers ::buildColorInfo
    */
-  public function testBuildColorInfoResolvesComponentThemeVariable(): void {
+  public function testBuildColorInfoDoesNotResolveComponentThemeVariable(): void {
     $resolver = $this->createResolver($this->fixturePath);
     $this->assertSame([
       'css_var' => 'var(--component-themes-five-background)',
-      'hex' => '#e3f7f5',
-      'token_name' => '',
-      'token_ref' => 'component-themes-five-background',
-    ], $resolver->buildColorInfo('five', 'var(--component-themes-five-background)'));
-  }
-
-  /**
-   * Tests build color info returns empty for missing component theme.
-   *
-   * BuildColorInfo() leaves hex/name/ref empty when the component-themes
-   * property doesn't exist.
-   *
-   * @covers ::buildColorInfo
-   */
-  public function testBuildColorInfoReturnsEmptyForMissingComponentThemeProperty(): void {
-    $resolver = $this->createResolver($this->fixturePath);
-    $this->assertSame([
-      'css_var' => 'var(--component-themes-five-nonexistent)',
       'hex' => '',
       'token_name' => '',
       'token_ref' => '',
-    ], $resolver->buildColorInfo('five', 'var(--component-themes-five-nonexistent)'));
+    ], $resolver->buildColorInfo('five', 'var(--component-themes-five-background)'));
   }
 
   /**
    * Tests build color info returns empty for unmatched var pattern.
    *
    * BuildColorInfo() keeps the raw css_var but leaves hex/name/ref empty when
-   * a var() value matches neither the global-themes nor component-themes
-   * variable name patterns.
+   * a var() value does not match the global-themes slot variable name pattern,
+   * which is the only pattern it resolves.
    *
    * @covers ::buildColorInfo
    */
@@ -554,9 +539,11 @@ class ColorTokenResolverTest extends UnitTestCase {
   /**
    * Tests get color styles for entity callout bundle mapping.
    *
-   * GetColorStylesForEntity() applies the callout-family mapping, the
-   * slot-five->slot-two swap (one direction only) for theme 'four', and the
-   * component-themes-five-background direct override for option 'five'.
+   * GetColorStylesForEntity() applies the callout-family mapping plus the
+   * bidirectional slot-two <-> slot-five swap for global theme 'four' (Onha).
+   * The swap is keyed by the resolved slot identifier rather than the option
+   * key, so option 'three' (slot-five) and option 'five' (slot-two) trade
+   * places while option 'two' (slot-four) passes through unchanged.
    *
    * @covers ::getColorStylesForEntity
    */
@@ -568,7 +555,7 @@ class ColorTokenResolverTest extends UnitTestCase {
     $this->assertSame(['var(--global-themes-four-colors-slot-four)'], $styles['four']['two']);
     $this->assertSame(['var(--global-themes-four-colors-slot-two)'], $styles['four']['three']);
     $this->assertSame(['var(--global-themes-four-colors-slot-three)'], $styles['four']['four']);
-    $this->assertSame(['var(--component-themes-five-background)'], $styles['four']['five']);
+    $this->assertSame(['var(--global-themes-four-colors-slot-five)'], $styles['four']['five']);
 
     // Other callout-family bundles share the same mapping.
     $spotlight_styles = $resolver->getColorStylesForEntity('block_content', 'content_spotlight');
@@ -576,18 +563,20 @@ class ColorTokenResolverTest extends UnitTestCase {
   }
 
   /**
-   * Tests get color styles for entity facts bundle uses four option override.
+   * Tests get color styles for entity facts bundle swaps on the four option.
    *
-   * GetColorStylesForEntity() applies the facts-specific override, which
-   * targets option 'four' (not 'five') for the component-theme override.
+   * The facts mapping differs from the callout family in which option lands on
+   * slot-two: for facts it is option 'four', so that is the option the theme
+   * 'four' slot-two <-> slot-five swap moves. Option 'five' maps to slot-three
+   * and is unaffected by the swap.
    *
    * @covers ::getColorStylesForEntity
    */
-  public function testGetColorStylesForEntityFactsBundleUsesFourOptionOverride(): void {
+  public function testGetColorStylesForEntityFactsBundleSwapsOnFourOption(): void {
     $resolver = $this->createResolver($this->fixturePath);
     $styles = $resolver->getColorStylesForEntity('block_content', 'facts');
 
-    $this->assertSame(['var(--component-themes-five-background)'], $styles['four']['four']);
+    $this->assertSame(['var(--global-themes-four-colors-slot-five)'], $styles['four']['four']);
     $this->assertSame(['var(--global-themes-four-colors-slot-three)'], $styles['four']['five']);
   }
 
@@ -602,10 +591,50 @@ class ColorTokenResolverTest extends UnitTestCase {
 
     $this->assertSame(['var(--global-themes-four-colors-slot-three)'], $styles['four']['two']);
     $this->assertSame(['var(--global-themes-four-colors-slot-four)'], $styles['four']['four']);
-    $this->assertSame(['var(--component-themes-five-background)'], $styles['four']['five']);
+    $this->assertSame(['var(--global-themes-four-colors-slot-five)'], $styles['four']['five']);
 
     $link_grid_styles = $resolver->getColorStylesForEntity('block_content', 'link_grid');
     $this->assertSame($styles['four'], $link_grid_styles['four']);
+  }
+
+  /**
+   * Tests no entity mapping returns a component-themes variable.
+   *
+   * Regression pin for #1153, which replaced the per-component token bypass
+   * with global slot resolution. Four assertions in this class went stale
+   * asserting the bypass value one bundle at a time (#1522); this sweeps every
+   * mapping getColorStylesForEntity() knows about instead, so reintroducing
+   * the bypass in any of them fails here rather than going unnoticed.
+   *
+   * @covers ::getColorStylesForEntity
+   */
+  public function testGetColorStylesForEntityNeverReturnsComponentThemes(): void {
+    $resolver = $this->createResolver($this->fixturePath);
+    $targets = [
+      [NULL, NULL],
+      ['layout_section', 'ys_layout_options'],
+      ['block_content', 'callout'],
+      ['block_content', 'content_spotlight'],
+      ['block_content', 'content_spotlight_portrait'],
+      ['block_content', 'cta_banner'],
+      ['block_content', 'grand_hero'],
+      ['block_content', 'facts'],
+      ['block_content', 'quote_callout'],
+      ['block_content', 'link_grid'],
+      ['block_content', 'inline_message'],
+      ['block_content', 'accordion'],
+    ];
+
+    foreach ($targets as [$entity_type, $bundle]) {
+      $label = sprintf('%s/%s', $entity_type ?? 'null', $bundle ?? 'null');
+      $styles = $resolver->getColorStylesForEntity($entity_type, $bundle);
+      $this->assertNotEmpty($styles, "Mapping {$label} returned no styles.");
+      $this->assertStringNotContainsString(
+        '--component-themes-',
+        (string) json_encode($styles),
+        "Mapping {$label} returned a component-themes variable.",
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## [1522: Four ColorTokenResolverTest tests fail on develop, asserting a component-themes override no code path returns](https://github.com/yalesites-org/YaleSites-Internal/issues/1522)

### Description of work

Test-only change. No production code is touched, so nothing changes for sites.

- Corrected four `ColorTokenResolverTest` assertions that expected
  `var(--component-themes-five-background)`, a value no code path can return.
  They now assert the global slot values the resolver actually produces.
- Corrected four docblocks that described the removed override mechanism,
  including one on an already-passing test that claimed a `component-themes`
  pattern still exists in the resolver.
- Renamed two tests whose names referred to the removed override.
- Replaced one test that the removal made redundant with a sweep over every
  mapping `getColorStylesForEntity()` knows about, asserting none returns a
  `component-themes` variable. Net test count is unchanged at 41.

**The tests were the stale side, not the resolver.** Commit `8ae3f13be`
(2026-04-10, ticket yalesites-org/YaleSites-Internal#1153) removed the `$direct_overrides` mechanism from
`ColorTokenResolver::buildColorStyles()` in favour of global slot resolution. The
test file landed later, in `984ccd6ac` (2026-07-12), from a branch whose
merge-base with that removal is `33d706933` (2026-04-02). So the assertions were
correct against their own base and went stale on merge, with no textual conflict
for git to flag because the test file was new and that branch never touched the
resolver. Full reasoning and evidence is in a comment on
yalesites-org/YaleSites-Internal#1522.

The resolver is confirmed correct against the component library, not just against
itself: `components/02-molecules/callout/_yds-callout.scss` contains the same
bidirectional slot-two/slot-five swap for global theme four, and
`component-themes-five-background` has zero occurrences left in that repo.

### Two things a reviewer should know

**A pre-existing flaw was found and deliberately left alone.**
`getColorStylesForEntity()` maps the 6th option to
`var(--global-themes-{theme}-colors-slot-nine)`, but no token defines
`slot-nine`. The token file the resolver reads defines `slot-one` through
`slot-eight` for all seven global themes. Every 6th-slot swatch therefore
resolves to an undefined CSS custom property. This is yalesites-org/YaleSites-Internal#1153's outstanding
"add slot-nine to color.yml" item, needs a `tokens` repo change plus yalesites-org/YaleSites-Internal#1153's
visual regression pass, and is recorded on the issue rather than fixed here.

**A second failing suite was found outside this module.** Sweeping all 28 custom
Unit suites turned up `ys_layouts`
`BlockContextualLinksTest::testRemoveStaysLastAndLabelsDropTheWordBlock`
(93 tests, 1 failure), the same failure mode as this ticket. Not fixed here since
it is a different module, but it is captured in #1525 because it blocks enabling
the CI gate.

Acceptance criterion 6 asked to either wire `composer unit-test` into CI or file
a follow-up. Filed **yalesites-org/YaleSites-Internal#1525**, because
`phpunit.xml` hardcodes a Lando-only `/app` bootstrap path that cannot resolve on
the GitHub runner, PHPUnit 9 here silently runs only the first path argument, and
the `ys_layouts` failure would turn `develop` red on the first PR after the
change. None of that can be verified from a local checkout, so it belongs in its
own PR that demonstrates a failing test actually failing the job.

The commit is typed `test:` rather than `fix:` on purpose: no production code
changed, and `fix:` would trigger a semantic-release patch bump advertising a
user-facing fix that did not ship.

### Functional testing steps:

- [ ] No functional testing is required. There is no production code change, so
      no page, block, or color picker behaviour differs. The checks below are the
      real verification.
- [ ] `ColorTokenResolverTest` passes with no failures:
      `lando ssh -c "php /app/vendor/bin/phpunit -c /app/phpunit.xml /app/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/tests/src/Unit/ColorTokenResolverTest.php"`
      expects `OK (41 tests, 142 assertions)`.
- [ ] The full `ys_themes` Unit suite passes:
      `lando ssh -c "php /app/vendor/bin/phpunit -c /app/phpunit.xml /app/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/tests/src/Unit"`
      expects `OK (71 tests, 202 assertions)`, against a recorded baseline on
      clean develop of `Tests: 71, Assertions: 176, Failures: 4`.
- [ ] `lando composer code-sniff` exits 0.
- [ ] Optional sanity check that the resolver still behaves as before: open the
      color picker for a Callout block on a site using the ONHA theme (global
      theme four) and confirm the swatches are unchanged from develop. Slots one
      through five should look identical; the sixth swatch is expected to be
      blank both before and after, which is the pre-existing `slot-nine` gap
      described above and not caused by this PR.

References yalesites-org/YaleSites-Internal#1522

---

Created with AI
