### PR TITLE
1528: Bug: Alert toggle has no click handler when localStorage is blocked - FOR MULTIDEV ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,5 @@ lando xdebug-off           # Disable Xdebug
 - **Semantic Release**: Automated versioning on master branch using conventional commits
 
 
+
+


### PR DESCRIPTION
## [1528: Bug: Alert toggle has no click handler when localStorage is blocked](https://github.com/yalesites-org/YaleSites-Internal/issues/1528)

### Description of work

- **For multidev only. Do not merge.** The only change in this repo is two blank lines appended to `README.md`, so a Pantheon multidev builds and picks up the matching `1528-alert-toggle-localstorage` branch in component-library-twig.
- Other work completed in: yalesites-org/component-library-twig#681

### Functional testing steps:

- [ ] In this multidev, activate an **Emergency** sitewide alert, then open the site in a window with storage blocked (a private window set to block all cookies, or a cookie-blocking extension) and confirm the chevron expands and collapses the alert on click
- [ ] In that blocked window, focus the chevron and confirm **Enter** and **Space** each toggle it
- [ ] In a normal window, confirm the chevron still collapses and expands and that the choice still survives a reload
- [ ] With an **Announcement** alert active and storage blocked, confirm the dismiss "X" still dismisses the alert
- [ ] Repeat that dismiss check for a **Marketing** alert
- [ ] Confirm the browser console shows no `SecurityError` or `QuotaExceededError` from the alert behavior

References yalesites-org/YaleSites-Internal#1528

---
Created with AI
