### PR TITLE
1529: Bug: Alert toggle mobile tap target is below WCAG 2.2 24px minimum - FOR MULTIDEV ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,5 @@ lando xdebug-off           # Disable Xdebug
 - **Semantic Release**: Automated versioning on master branch using conventional commits
 
 
+
+


### PR DESCRIPTION
## [1529: Bug: Alert toggle mobile tap target is below WCAG 2.2 24px minimum](https://github.com/yalesites-org/YaleSites-Internal/issues/1529)

### Description of work

- **For multidev only. Do not merge.** The only change in this repo is two blank lines appended to `README.md`, so a Pantheon multidev builds and picks up the matching `1529-alert-toggle-tap-target` branch in component-library-twig.
- Other work completed in: yalesites-org/component-library-twig#682

### Functional testing steps:

- [ ] In this multidev, activate an **Emergency** sitewide alert, then view the page at a phone width (or 390px-wide window) and confirm the chevron is easier to hit and still expands and collapses the alert
- [ ] Confirm the alert looks unchanged at that width — same height, same text wrapping, chevron in the same place
- [ ] With an **Announcement** alert active at mobile width, confirm the dismiss "X" still dismisses and has the larger target
- [ ] Repeat that check for a **Marketing** alert
- [ ] At 768px and 991px (both below the 992px breakpoint) confirm the target is enlarged and the toggle works
- [ ] At 992px and above, confirm nothing changed — the toggle should still be 41x41 with the same spacing
- [ ] Accessibility: validate against WCAG 2.2 SC 2.5.8, and confirm 24px is the agreed figure rather than the platform's 44px `--size-click-target-minimum` token (see the discussion on the component-library-twig PR)

References yalesites-org/YaleSites-Internal#1529

---
Created with AI
