### PR TITLE
1530: Bug: Audit other button-reset callers for missing cursor: pointer - For multidev only

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,8 @@ lando xdebug-off           # Disable Xdebug
 - **Branch Strategy**: `develop` (primary), `master` (releases), `YALB-XXX-description` (features)
 - **Semantic Release**: Automated versioning on master branch using conventional commits
 
+<!-- Branch placeholder so a Pantheon multidev builds for the component-library-twig
+     work in yalesites-org/YaleSites-Internal#1530. Not intended for merge. -->
+
+
 


### PR DESCRIPTION
## [1530: Bug: Audit other button-reset callers for missing cursor: pointer](https://github.com/yalesites-org/YaleSites-Internal/issues/1530)

### Description of work

- Branch placeholder only, so a Pantheon multidev is built for the component-library-twig change and reviewers have a rendered Drupal site to check the hover behavior on.
- The only change is a comment appended to `README.md`. No platform code, config or dependency changes.
- **Do not merge.** This branch exists solely to produce the multidev.
- Other work completed in: yalesites-org/component-library-twig#683

### Functional testing steps:

- [ ] Confirm the multidev builds
- [ ] Run the functional testing steps from yalesites-org/component-library-twig#683 against this multidev
- [ ] Confirm this PR is closed rather than merged once review is complete

References yalesites-org/YaleSites-Internal#1530

---
Created with AI
