### PR TITLE
1530: Bug: Audit other button-reset callers for missing cursor: pointer - FOR MULTIDEV ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,5 @@ lando xdebug-off           # Disable Xdebug
 - **Semantic Release**: Automated versioning on master branch using conventional commits
 
 
+
+


### PR DESCRIPTION
## [1530: Bug: Audit other button-reset callers for missing cursor: pointer](https://github.com/yalesites-org/YaleSites-Internal/issues/1530)

### Description of work

- **For multidev only. Do not merge.** The only change in this repo is two blank lines appended to `README.md`, so a Pantheon multidev builds and picks up the matching `1530-button-reset-cursor` branch in component-library-twig.
- Other work completed in: yalesites-org/component-library-twig#684

### Functional testing steps:

- [ ] Hover the mobile menu (hamburger) toggle and confirm the cursor becomes a pointer
- [ ] Hover a primary nav dropdown toggle, and a secondary nav / content-collection toggle, and confirm both show a pointer
- [ ] On a page with a long breadcrumb trail at mobile width, hover the overflow button and the left/right scroll controls and confirm each shows a pointer
- [ ] On a page with an "In this section" menu, hover its scroll control and its mobile toggle and confirm both show a pointer
- [ ] On a page with **more tabs than fit**, hover the visible scroll arrow and confirm a pointer; then on a page with **few tabs** (no overflow) confirm hovering the blank space either side of the tabs shows the normal cursor, not a pointer
- [ ] Open a Gallery (interactive media grid) modal and confirm the pager items and the prev/next controls show a pointer; at a phone width confirm the item-count indicator ("3 / 12") does **not** show a pointer
- [ ] On a **basic** media grid (not interactive), confirm hovering an image shows the normal cursor, not a pointer
- [ ] Confirm nothing else changed visually — this should only affect the hover cursor

References yalesites-org/YaleSites-Internal#1530

---
Created with AI
