### PR TITLE
1532: Bug: Audio player total duration shows 0:00 when localStorage is unavailable - FOR MULTIDEV ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,5 @@ lando xdebug-off           # Disable Xdebug
 - **Semantic Release**: Automated versioning on master branch using conventional commits
 
 
+
+


### PR DESCRIPTION
## [1532: Bug: Audio player total duration shows 0:00 when localStorage is unavailable](https://github.com/yalesites-org/YaleSites-Internal/issues/1532)

### Description of work

- **For multidev only. Do not merge.** The only change in this repo is two blank lines appended to `README.md`, so a Pantheon multidev builds and picks up the matching `1532-audio-duration-localstorage` branch in component-library-twig.
- Other work completed in: yalesites-org/component-library-twig#685

### Functional testing steps:

- [ ] Add an Audio block with a file attached; in a normal window confirm the total duration shows the real length (not `0:00`)
- [ ] Open the same page in a browser session where storage is blocked — a Chrome window with "Block all cookies" set for the site, or a storage-blocking extension — and confirm the total duration still shows the real length
- [ ] In that blocked session, confirm play, pause, seeking, volume and the elapsed-time display all still work
- [ ] Confirm the browser console shows no unhandled promise rejection from the audio player in either session
- [ ] In a normal window, reload and confirm the duration still appears immediately (the cache is still being written and reused)

References yalesites-org/YaleSites-Internal#1532

---
Created with AI
