### PR TITLE
1526: Feature Request: CSV Import for Resources

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Batch/CsvImportBatch.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Batch/CsvImportBatch.php
@@ -26,34 +26,30 @@ class CsvImportBatch {
   const CHUNK_SIZE = 50;
 
   /**
-   * Builds a batch definition that imports $rows through $import_service_id.
+   * Builds a batch definition that imports $rows through $options.
    *
-   * @param string $import_service_id
-   *   Service id of an import service exposing
-   *   processImport(array $rows, bool $skip_duplicates): array, returning
-   *   'created', 'skipped', 'errors' and (optionally) 'needs_media' keys.
+   * @param array $options
+   *   Batch options: 'import_service_id' (service id of an import service
+   *   exposing processImport(array $rows, bool $skip_duplicates): array,
+   *   returning 'created', 'skipped', 'errors' and, optionally,
+   *   'needs_media' keys), 'skip_duplicates' (whether to skip duplicates),
+   *   and 'entity_label' (singular noun for the imported entity, e.g.
+   *   'profile' or 'resource').
    * @param array $rows
    *   The full set of already-parsed CSV rows.
-   * @param bool $skip_duplicates
-   *   Whether to skip duplicates.
    * @param int $file_id
    *   The uploaded file entity id, deleted once the batch finishes.
-   * @param string $entity_label
-   *   Singular noun for the imported entity, e.g. 'profile' or 'resource'.
    * @param string $title
    *   The batch progress title.
    *
    * @return array
    *   A batch definition suitable for batch_set().
    */
-  public static function build($import_service_id, array $rows, $skip_duplicates, $file_id, $entity_label, $title) {
+  public static function build(array $options, array $rows, $file_id, $title) {
     $operations = [];
 
     foreach (array_chunk($rows, self::CHUNK_SIZE) as $chunk) {
-      $operations[] = [
-        [static::class, 'processChunk'],
-        [$import_service_id, $chunk, $skip_duplicates, $entity_label],
-      ];
+      $operations[] = [[static::class, 'processChunk'], [$options, $chunk]];
     }
 
     // Runs last regardless of how many chunks preceded it, so the upload
@@ -71,21 +67,23 @@ class CsvImportBatch {
   /**
    * Batch operation: imports one chunk and folds its results into $context.
    *
-   * @param string $import_service_id
-   *   Service id of the import service to invoke.
+   * Each chunk's 'errors' and 'needs_media' are appended as their own
+   * sub-array rather than merged into a single running list, so this stays
+   * O(1) per chunk regardless of how many rows have failed or need media so
+   * far; finished() flattens the sub-arrays once, at the end.
+   *
+   * @param array $options
+   *   The 'import_service_id', 'skip_duplicates' and 'entity_label' options
+   *   described in build().
    * @param array $chunk
    *   The rows in this chunk.
-   * @param bool $skip_duplicates
-   *   Whether to skip duplicates.
-   * @param string $entity_label
-   *   Singular noun for the imported entity, carried through to finished().
    * @param array $context
    *   The batch context, passed by reference.
    */
-  public static function processChunk($import_service_id, array $chunk, $skip_duplicates, $entity_label, array &$context) {
+  public static function processChunk(array $options, array $chunk, array &$context) {
     if (!isset($context['results']['created'])) {
       $context['results'] = [
-        'entity_label' => $entity_label,
+        'entity_label' => $options['entity_label'],
         'created' => 0,
         'skipped' => 0,
         'errors' => [],
@@ -93,14 +91,14 @@ class CsvImportBatch {
       ];
     }
 
-    $chunk_result = \Drupal::service($import_service_id)->processImport($chunk, $skip_duplicates);
+    $chunk_result = \Drupal::service($options['import_service_id'])->processImport($chunk, $options['skip_duplicates']);
 
     $context['results']['created'] += $chunk_result['created'];
     $context['results']['skipped'] += $chunk_result['skipped'];
-    $context['results']['errors'] = array_merge($context['results']['errors'], $chunk_result['errors']);
+    $context['results']['errors'][] = $chunk_result['errors'];
 
     if (!empty($chunk_result['needs_media'])) {
-      $context['results']['needs_media'] = array_merge($context['results']['needs_media'], $chunk_result['needs_media']);
+      $context['results']['needs_media'][] = $chunk_result['needs_media'];
     }
   }
 
@@ -125,21 +123,63 @@ class CsvImportBatch {
    * @param bool $success
    *   Whether the batch completed without a fatal error.
    * @param array $results
-   *   The accumulated $context['results'] from the last operation.
+   *   The accumulated $context['results'] from the last operation that ran,
+   *   with 'errors' and 'needs_media' still shaped as one sub-array per
+   *   chunk. Empty if the batch failed before its first chunk completed.
    * @param array $operations
-   *   The operations that were not completed, if any.
+   *   The operations that were queued but never reached, if the batch
+   *   stopped early.
    */
   public static function finished($success, array $results, array $operations) {
     $messenger = \Drupal::messenger();
 
     if (!$success) {
-      $messenger->addError(new TranslatableMarkup('The import could not be completed. Please try again.'));
+      // Chunks that completed before the failure already saved their nodes,
+      // so their counts are reported rather than discarded -- otherwise an
+      // editor who sees no results assumes nothing happened and re-runs the
+      // whole file, creating duplicates of rows that did succeed.
+      if (isset($results['created'])) {
+        $results['errors'] = static::flatten($results['errors'] ?? []);
+        $results['needs_media'] = static::flatten($results['needs_media'] ?? []);
+        foreach (static::buildMessages($results) as [$method, $message]) {
+          $messenger->$method($message);
+        }
+      }
+
+      // deleteUploadedFile() is normally the batch's own trailing operation,
+      // so it never runs if an earlier chunk aborted the batch; run it here
+      // from its still-queued arguments instead of leaving the upload behind.
+      foreach ($operations as $operation) {
+        if ($operation[0] === [static::class, 'deleteUploadedFile']) {
+          $unused_context = [];
+          static::deleteUploadedFile($operation[1][0], $unused_context);
+          break;
+        }
+      }
+
+      $messenger->addError(new TranslatableMarkup('The import did not finish. Check the results above, then try again if needed.'));
       return;
     }
+
+    $results['errors'] = static::flatten($results['errors'] ?? []);
+    $results['needs_media'] = static::flatten($results['needs_media'] ?? []);
 
     foreach (static::buildMessages($results) as [$method, $message]) {
       $messenger->$method($message);
     }
+  }
+
+  /**
+   * Flattens a list of per-chunk sub-arrays into one array, once.
+   *
+   * @param array $chunks
+   *   A list of arrays, one per batch chunk.
+   *
+   * @return array
+   *   All chunk values combined into a single flat list.
+   */
+  protected static function flatten(array $chunks) {
+    return $chunks ? array_merge(...$chunks) : [];
   }
 
   /**
@@ -149,8 +189,8 @@ class CsvImportBatch {
    * unit tested without a messenger service.
    *
    * @param array $results
-   *   The accumulated results: 'entity_label', 'created', 'skipped',
-   *   'errors', 'needs_media'.
+   *   The accumulated results: 'entity_label', 'created', 'skipped', and
+   *   already-flat 'errors' and 'needs_media' lists.
    *
    * @return array
    *   A list of [messenger method name, message] pairs.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Batch/CsvImportBatch.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Batch/CsvImportBatch.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Drupal\ys_migrate\Batch;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Batch API glue shared by the profile and resource CSV importers.
+ *
+ * A CSV of any real size timed out in a single request before this existed.
+ * Drupal stores batch operations as serialized callback strings and may
+ * invoke each one in a separate request, so every method here is static and
+ * re-fetches services through \Drupal:: rather than relying on injected
+ * state that would not survive across requests.
+ */
+class CsvImportBatch {
+
+  /**
+   * Rows processed per batch operation (one HTTP request each).
+   *
+   * Large enough that a several-hundred-row import doesn't spend most of its
+   * wall-clock time on per-request overhead; small enough to keep even a
+   * slow chunk (taxonomy term creation, node saves) well under typical PHP
+   * execution time limits.
+   */
+  const CHUNK_SIZE = 50;
+
+  /**
+   * Builds a batch definition that imports $rows through $import_service_id.
+   *
+   * @param string $import_service_id
+   *   Service id of an import service exposing
+   *   processImport(array $rows, bool $skip_duplicates): array, returning
+   *   'created', 'skipped', 'errors' and (optionally) 'needs_media' keys.
+   * @param array $rows
+   *   The full set of already-parsed CSV rows.
+   * @param bool $skip_duplicates
+   *   Whether to skip duplicates.
+   * @param int $file_id
+   *   The uploaded file entity id, deleted once the batch finishes.
+   * @param string $entity_label
+   *   Singular noun for the imported entity, e.g. 'profile' or 'resource'.
+   * @param string $title
+   *   The batch progress title.
+   *
+   * @return array
+   *   A batch definition suitable for batch_set().
+   */
+  public static function build($import_service_id, array $rows, $skip_duplicates, $file_id, $entity_label, $title) {
+    $operations = [];
+
+    foreach (array_chunk($rows, self::CHUNK_SIZE) as $chunk) {
+      $operations[] = [
+        [static::class, 'processChunk'],
+        [$import_service_id, $chunk, $skip_duplicates, $entity_label],
+      ];
+    }
+
+    // Runs last regardless of how many chunks preceded it, so the upload
+    // is cleaned up exactly once the whole import (not just one chunk) has
+    // been processed.
+    $operations[] = [[static::class, 'deleteUploadedFile'], [$file_id]];
+
+    return [
+      'title' => $title,
+      'operations' => $operations,
+      'finished' => [static::class, 'finished'],
+    ];
+  }
+
+  /**
+   * Batch operation: imports one chunk and folds its results into $context.
+   *
+   * @param string $import_service_id
+   *   Service id of the import service to invoke.
+   * @param array $chunk
+   *   The rows in this chunk.
+   * @param bool $skip_duplicates
+   *   Whether to skip duplicates.
+   * @param string $entity_label
+   *   Singular noun for the imported entity, carried through to finished().
+   * @param array $context
+   *   The batch context, passed by reference.
+   */
+  public static function processChunk($import_service_id, array $chunk, $skip_duplicates, $entity_label, array &$context) {
+    if (!isset($context['results']['created'])) {
+      $context['results'] = [
+        'entity_label' => $entity_label,
+        'created' => 0,
+        'skipped' => 0,
+        'errors' => [],
+        'needs_media' => [],
+      ];
+    }
+
+    $chunk_result = \Drupal::service($import_service_id)->processImport($chunk, $skip_duplicates);
+
+    $context['results']['created'] += $chunk_result['created'];
+    $context['results']['skipped'] += $chunk_result['skipped'];
+    $context['results']['errors'] = array_merge($context['results']['errors'], $chunk_result['errors']);
+
+    if (!empty($chunk_result['needs_media'])) {
+      $context['results']['needs_media'] = array_merge($context['results']['needs_media'], $chunk_result['needs_media']);
+    }
+  }
+
+  /**
+   * Batch operation: deletes the uploaded CSV once the import has run.
+   *
+   * @param int $file_id
+   *   The file entity id.
+   * @param array $context
+   *   The batch context, passed by reference.
+   */
+  public static function deleteUploadedFile($file_id, array &$context) {
+    $file = \Drupal::entityTypeManager()->getStorage('file')->load($file_id);
+    if ($file) {
+      $file->delete();
+    }
+  }
+
+  /**
+   * Batch finished callback: reports the accumulated results to the user.
+   *
+   * @param bool $success
+   *   Whether the batch completed without a fatal error.
+   * @param array $results
+   *   The accumulated $context['results'] from the last operation.
+   * @param array $operations
+   *   The operations that were not completed, if any.
+   */
+  public static function finished($success, array $results, array $operations) {
+    $messenger = \Drupal::messenger();
+
+    if (!$success) {
+      $messenger->addError(new TranslatableMarkup('The import could not be completed. Please try again.'));
+      return;
+    }
+
+    foreach (static::buildMessages($results) as [$method, $message]) {
+      $messenger->$method($message);
+    }
+  }
+
+  /**
+   * Builds the [messenger method, message] pairs finished() will display.
+   *
+   * Kept free of any \Drupal:: calls so the message text and shape can be
+   * unit tested without a messenger service.
+   *
+   * @param array $results
+   *   The accumulated results: 'entity_label', 'created', 'skipped',
+   *   'errors', 'needs_media'.
+   *
+   * @return array
+   *   A list of [messenger method name, message] pairs.
+   */
+  public static function buildMessages(array $results) {
+    $label = $results['entity_label'] ?? 'item';
+    $messages = [];
+
+    if (!empty($results['created'])) {
+      $messages[] = [
+        'addStatus',
+        new TranslatableMarkup('Created @count @label(s).', ['@count' => $results['created'], '@label' => $label]),
+      ];
+    }
+
+    if (!empty($results['skipped'])) {
+      $messages[] = [
+        'addWarning',
+        new TranslatableMarkup(
+          'Skipped @count duplicate @label(s).',
+          ['@count' => $results['skipped'], '@label' => $label]
+        ),
+      ];
+    }
+
+    if (!empty($results['needs_media'])) {
+      $messages[] = [
+        'addWarning',
+        new TranslatableMarkup(
+          '@count imported resource(s) have no External Source and still need Resource Media attached: @titles', [
+            '@count' => count($results['needs_media']),
+            '@titles' => implode(', ', $results['needs_media']),
+          ]
+        ),
+      ];
+    }
+
+    foreach ($results['errors'] ?? [] as $error) {
+      $messages[] = ['addError', $error];
+    }
+
+    return $messages;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Controller/ResourceCsvSampleController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Controller/ResourceCsvSampleController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Drupal\ys_migrate\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\ys_migrate\Service\CsvValidatorService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Streams a downloadable skeleton CSV for the Resource bulk importer.
+ */
+class ResourceCsvSampleController extends ControllerBase {
+
+  /**
+   * The CSV validator service.
+   *
+   * @var \Drupal\ys_migrate\Service\CsvValidatorService
+   */
+  protected $csvValidator;
+
+  /**
+   * Constructs a ResourceCsvSampleController object.
+   *
+   * @param \Drupal\ys_migrate\Service\CsvValidatorService $csv_validator
+   *   The CSV validator service.
+   */
+  public function __construct(CsvValidatorService $csv_validator) {
+    $this->csvValidator = $csv_validator;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static($container->get('ys_migrate.csv_validator'));
+  }
+
+  /**
+   * Returns the sample CSV as a downloadable attachment.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   The CSV response.
+   */
+  public function download() {
+    $csv = static::buildCsv($this->csvValidator->getExpectedResourceColumns(), $this->exampleRow());
+
+    $response = new Response($csv);
+    $response->headers->set('Content-Type', 'text/csv');
+    $response->headers->set('Content-Disposition', 'attachment; filename="resource-import-sample.csv"');
+
+    return $response;
+  }
+
+  /**
+   * The single example row shown under the header, keyed like a CSV row.
+   *
+   * Values are illustrative only: a real http URL for External Source, a
+   * date accepted by ResourceImportService::DATE_INPUT_FORMATS, and a
+   * Date Format label accepted by ResourceImportService::parseDateFormat().
+   *
+   * @return array
+   *   Example cell values keyed by the same machine names as
+   *   CsvValidatorService::EXPECTED_RESOURCE_COLUMNS.
+   */
+  protected function exampleRow() {
+    return [
+      'title' => 'Yale Research Symposium Recap',
+      'description' => 'Summary of presentations from the annual research symposium.',
+      'resource category' => 'Event',
+      'audience' => 'Faculty, Staff',
+      'custom vocab' => 'Sustainability',
+      'resource publication date' => '2026-03-04',
+      'date format' => 'Month/Day/Year',
+      'tags' => 'Research, Symposium',
+      'teaser title' => 'Symposium Recap',
+      'teaser text' => 'Highlights from this year\'s research symposium.',
+      'external source' => 'https://example.edu/symposium-2026',
+      'cas login required' => 'No',
+      'pin to beginning of list' => 'No',
+    ];
+  }
+
+  /**
+   * Builds CSV text from a header row and one example row.
+   *
+   * @param array $columns
+   *   Expected columns, keyed by machine name with the header label as the
+   *   value (the same shape CsvValidatorService::getExpectedResourceColumns()
+   *   returns).
+   * @param array $example_row
+   *   Example values keyed by the same machine names as $columns. A column
+   *   with no matching key is written as an empty cell.
+   *
+   * @return string
+   *   The CSV file contents, including the header row.
+   */
+  public static function buildCsv(array $columns, array $example_row) {
+    $stream = fopen('php://temp', 'r+');
+
+    fputcsv($stream, array_values($columns));
+    fputcsv($stream, array_map(
+      static fn ($key) => $example_row[$key] ?? '',
+      array_keys($columns)
+    ));
+
+    rewind($stream);
+    $csv = stream_get_contents($stream);
+    fclose($stream);
+
+    return $csv;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Controller/ResourceCsvSampleController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Controller/ResourceCsvSampleController.php
@@ -67,6 +67,10 @@ class ResourceCsvSampleController extends ControllerBase {
     return [
       'title' => 'Yale Research Symposium Recap',
       'description' => 'Summary of presentations from the annual research symposium.',
+      'abstract' => 'A short abstract of the symposium proceedings.',
+      'citation' => 'Yale Research Review, 2026.',
+      'journal publication name' => 'Yale Research Review',
+      'journal publication issue' => 'Vol. 12, No. 2',
       'resource category' => 'Event',
       'audience' => 'Faculty, Staff',
       'custom vocab' => 'Sustainability',

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/BatchSubmitTrait.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/BatchSubmitTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\ys_migrate\Form;
+
+/**
+ * Shared batch_set() wrapper for the CSV import forms.
+ *
+ * Isolated so tests can verify the batch definition a form's submitForm()
+ * builds without going through the real batch_set(), which needs a full
+ * Drupal batch/session stack unavailable in a unit test.
+ */
+trait BatchSubmitTrait {
+
+  /**
+   * Hands the batch definition to Drupal's Batch API.
+   *
+   * @param array $batch
+   *   A batch definition suitable for batch_set().
+   */
+  protected function setBatch(array $batch) {
+    batch_set($batch);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ColumnReferenceTableTrait.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ColumnReferenceTableTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\ys_migrate\Form;
+
+/**
+ * Shared "Recognised columns" reference table for the CSV import forms.
+ *
+ * Keeps the two forms' column-guidance tables structurally identical, so a
+ * change to how one presents its columns doesn't quietly drift from the
+ * other.
+ */
+trait ColumnReferenceTableTrait {
+
+  /**
+   * Builds the recognised-columns reference table render array.
+   *
+   * @param array $columns
+   *   Expected columns keyed by machine name, valued by display label -- the
+   *   shape CsvValidatorService::getExpectedColumns()/
+   *   getExpectedResourceColumns() return.
+   * @param array $notes
+   *   Guidance text keyed by the same machine names as $columns. A column
+   *   with no matching key renders an empty notes cell.
+   *
+   * @return array
+   *   A #type => table render array.
+   */
+  protected function columnReferenceTable(array $columns, array $notes) {
+    $rows = [];
+
+    foreach ($columns as $key => $label) {
+      $rows[] = [$label, $notes[$key] ?? ''];
+    }
+
+    return [
+      '#type' => 'table',
+      '#caption' => $this->t('Recognised columns'),
+      '#header' => [$this->t('Column'), $this->t('Notes')],
+      '#rows' => $rows,
+    ];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ProfileCsvImportForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ProfileCsvImportForm.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class ProfileCsvImportForm extends FormBase {
 
   use BatchSubmitTrait;
+  use ColumnReferenceTableTrait;
 
   /**
    * The messenger service.
@@ -119,34 +120,29 @@ class ProfileCsvImportForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $form['description'] = [
-      '#type' => 'markup',
-      '#markup' => '<div class="profile-csv-import-description">
-        <h3>Bulk Import Profile Content</h3>
-        <p>Upload a CSV file to bulk import profile content. The CSV should contain one profile per row with the following columns:</p>
-        <ul>
-          <li><strong>Display Name</strong> (required) - The main title for the profile</li>
-          <li><strong>First Name</strong> - Person\'s first name</li>
-          <li><strong>Last Name</strong> - Person\'s last name</li>
-          <li><strong>Honorific Prefix</strong> - Title (e.g., Dr., Prof., Mr., Ms.)</li>
-          <li><strong>Pronouns</strong> - Preferred pronouns</li>
-          <li><strong>Position</strong> - Job title or role</li>
-          <li><strong>Subtitle</strong> - Secondary title or role</li>
-          <li><strong>Department</strong> - Department or unit</li>
-          <li><strong>Email</strong> - Email address</li>
-          <li><strong>Telephone</strong> - Phone number</li>
-          <li><strong>Address</strong> - Physical address</li>
-          <li><strong>Teaser Title</strong> - Short title for teaser displays</li>
-          <li><strong>Teaser Text</strong> - Brief description (max 150 characters)</li>
-          <li><strong>Affiliation</strong> - Comma-separated affiliation terms</li>
-          <li><strong>Audience</strong> - Comma-separated audience terms</li>
-          <li><strong>Tags</strong> - Comma-separated tag terms</li>
-          <li><strong>Custom Vocabulary</strong> - Comma-separated custom terms</li>
-        </ul>
-        <p><strong>Note:</strong> The first row should contain column headers. All fields except Display Name are optional.</p>
-        <p><a href="https://yalesites.yale.edu/resource/bulk-profile-importer-template" target="_blank">For more information and the CSV Template, visit the YaleSites Profile resource in our User Guide</a></p>
+    $form['heading'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'h3',
+      '#value' => $this->t('Bulk Import Profile Content'),
+    ];
 
-      </div>',
+    $form['intro'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('Upload a CSV file to bulk import profile content. The CSV should contain one profile per row with the following columns:'),
+    ];
+
+    $form['columns'] = $this->columnReferenceTable($this->csvValidator->getExpectedColumns(), $this->columnNotes());
+
+    $form['note'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('The first row should contain column headers. All fields except Display Name are optional.'),
+    ];
+
+    $form['template_link'] = [
+      '#type' => 'markup',
+      '#markup' => '<p><a href="https://yalesites.yale.edu/resource/bulk-profile-importer-template" target="_blank">For more information and the CSV Template, visit the YaleSites Profile resource in our User Guide</a></p>',
     ];
 
     $form['csv_file'] = [
@@ -267,6 +263,34 @@ class ProfileCsvImportForm extends FormBase {
       $fid,
       (string) $this->t('Importing profiles...')
     ));
+  }
+
+  /**
+   * Guidance text for the recognised-columns reference table.
+   *
+   * @return array
+   *   Notes keyed by column machine name.
+   */
+  protected function columnNotes() {
+    return [
+      'display name' => $this->t('Required. The main title for the profile.'),
+      'first name' => $this->t("Person's first name."),
+      'last name' => $this->t("Person's last name."),
+      'honorific prefix' => $this->t('Title, e.g. Dr., Prof., Mr., Ms.'),
+      'pronouns' => $this->t('Preferred pronouns.'),
+      'position' => $this->t('Job title or role.'),
+      'subtitle' => $this->t('Secondary title or role.'),
+      'department' => $this->t('Department or unit.'),
+      'email' => $this->t('Email address. Also used to detect duplicates.'),
+      'telephone' => $this->t('Phone number.'),
+      'address' => $this->t('Physical address.'),
+      'teaser title' => $this->t('Plain text.'),
+      'teaser text' => $this->t('Plain text, max 150 characters.'),
+      'affiliation' => $this->t('Comma-separated. Terms are created if missing.'),
+      'audience' => $this->t('Comma-separated. Terms are created if missing.'),
+      'tags' => $this->t('Comma-separated. Terms are created if missing.'),
+      'custom vocabulary' => $this->t('Comma-separated. Terms are created if missing.'),
+    ];
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ProfileCsvImportForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ProfileCsvImportForm.php
@@ -18,6 +18,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class ProfileCsvImportForm extends FormBase {
 
+  use BatchSubmitTrait;
+
   /**
    * The messenger service.
    *
@@ -238,7 +240,10 @@ class ProfileCsvImportForm extends FormBase {
       // Preview renders its own response and never touches the batch queue,
       // so the upload is cleaned up immediately rather than by a batch
       // operation.
-      $this->entityTypeManager->getStorage('file')->load($fid)->delete();
+      $file = $this->entityTypeManager->getStorage('file')->load($fid);
+      if ($file) {
+        $file->delete();
+      }
       return;
     }
 
@@ -246,28 +251,22 @@ class ProfileCsvImportForm extends FormBase {
     // large CSV cannot time out a single request. File cleanup becomes the
     // batch's own trailing operation instead of happening here, since
     // submitForm() returns before any row is processed.
+    $data = $validation_result['data'];
+    // Drupal's FormSubmitter attaches $form_state to the batch it persists,
+    // so the parsed CSV would otherwise be serialized twice: once chunked
+    // into the batch operations below, and again here.
+    $form_state->set('csv_validation', NULL);
+
     $this->setBatch(CsvImportBatch::build(
-      'ys_migrate.profile_import',
-      $validation_result['data'],
-      $skip_duplicates,
+      [
+        'import_service_id' => 'ys_migrate.profile_import',
+        'skip_duplicates' => $skip_duplicates,
+        'entity_label' => 'profile',
+      ],
+      $data,
       $fid,
-      'profile',
       (string) $this->t('Importing profiles...')
     ));
-  }
-
-  /**
-   * Hands the batch definition to Drupal's Batch API.
-   *
-   * Isolated in its own method so tests can verify the batch definition
-   * submitForm() builds without going through the real batch_set(), which
-   * needs a full Drupal batch/session stack unavailable in a unit test.
-   *
-   * @param array $batch
-   *   A batch definition suitable for batch_set().
-   */
-  protected function setBatch(array $batch) {
-    batch_set($batch);
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ProfileCsvImportForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ProfileCsvImportForm.php
@@ -8,6 +8,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\ys_migrate\Batch\CsvImportBatch;
 use Drupal\ys_migrate\Service\CsvValidatorService;
 use Drupal\ys_migrate\Service\ProfileImportService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -230,18 +231,43 @@ class ProfileCsvImportForm extends FormBase {
     $preview_only = $form_state->getValue('preview');
     $skip_duplicates = $form_state->getValue('skip_duplicates');
     $validation_result = $form_state->get('csv_validation');
-
-    $file = $this->entityTypeManager->getStorage('file')->load($csv_file[0]);
+    $fid = $csv_file[0];
 
     if ($preview_only) {
       $this->previewImport($validation_result['data'], $skip_duplicates);
-    }
-    else {
-      $this->processImport($validation_result['data'], $skip_duplicates);
+      // Preview renders its own response and never touches the batch queue,
+      // so the upload is cleaned up immediately rather than by a batch
+      // operation.
+      $this->entityTypeManager->getStorage('file')->load($fid)->delete();
+      return;
     }
 
-    // Clean up the uploaded file.
-    $file->delete();
+    // A real import runs through the Batch API, one request per chunk, so a
+    // large CSV cannot time out a single request. File cleanup becomes the
+    // batch's own trailing operation instead of happening here, since
+    // submitForm() returns before any row is processed.
+    $this->setBatch(CsvImportBatch::build(
+      'ys_migrate.profile_import',
+      $validation_result['data'],
+      $skip_duplicates,
+      $fid,
+      'profile',
+      (string) $this->t('Importing profiles...')
+    ));
+  }
+
+  /**
+   * Hands the batch definition to Drupal's Batch API.
+   *
+   * Isolated in its own method so tests can verify the batch definition
+   * submitForm() builds without going through the real batch_set(), which
+   * needs a full Drupal batch/session stack unavailable in a unit test.
+   *
+   * @param array $batch
+   *   A batch definition suitable for batch_set().
+   */
+  protected function setBatch(array $batch) {
+    batch_set($batch);
   }
 
   /**
@@ -264,33 +290,6 @@ class ProfileCsvImportForm extends FormBase {
 
     if (!empty($preview_result['valid_profiles'])) {
       $this->displayPreviewTable($preview_result['valid_profiles']);
-    }
-  }
-
-  /**
-   * Processes the import and creates profile nodes.
-   *
-   * @param array $data
-   *   The CSV data.
-   * @param bool $skip_duplicates
-   *   Whether to skip duplicates.
-   */
-  protected function processImport(array $data, $skip_duplicates) {
-    $import_result = $this->profileImport->processImport($data, $skip_duplicates);
-
-    // Display results.
-    if ($import_result['created'] > 0) {
-      $this->messenger->addStatus($this->t('Successfully created @count profile(s).', ['@count' => $import_result['created']]));
-    }
-
-    if ($import_result['skipped'] > 0) {
-      $this->messenger->addWarning($this->t('Skipped @count duplicate profile(s).', ['@count' => $import_result['skipped']]));
-    }
-
-    if (!empty($import_result['errors'])) {
-      foreach ($import_result['errors'] as $error) {
-        $this->messenger->addError($error);
-      }
     }
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ResourceCsvImportForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ResourceCsvImportForm.php
@@ -17,6 +17,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class ResourceCsvImportForm extends FormBase {
 
+  use BatchSubmitTrait;
+
   /**
    * Maximum upload size, in bytes.
    */
@@ -232,7 +234,10 @@ class ResourceCsvImportForm extends FormBase {
       // Preview renders its own response and never touches the batch queue,
       // so the upload is cleaned up immediately rather than by a batch
       // operation.
-      $this->entityTypeManager->getStorage('file')->load($fid)->delete();
+      $file = $this->entityTypeManager->getStorage('file')->load($fid);
+      if ($file) {
+        $file->delete();
+      }
       return;
     }
 
@@ -240,28 +245,22 @@ class ResourceCsvImportForm extends FormBase {
     // large CSV cannot time out a single request. File cleanup becomes the
     // batch's own trailing operation instead of happening here, since
     // submitForm() returns before any row is processed.
+    $data = $validation_result['data'];
+    // Drupal's FormSubmitter attaches $form_state to the batch it persists,
+    // so the parsed CSV would otherwise be serialized twice: once chunked
+    // into the batch operations below, and again here.
+    $form_state->set('csv_validation', NULL);
+
     $this->setBatch(CsvImportBatch::build(
-      'ys_migrate.resource_import',
-      $validation_result['data'],
-      $skip_duplicates,
+      [
+        'import_service_id' => 'ys_migrate.resource_import',
+        'skip_duplicates' => $skip_duplicates,
+        'entity_label' => 'resource',
+      ],
+      $data,
       $fid,
-      'resource',
       (string) $this->t('Importing resources...')
     ));
-  }
-
-  /**
-   * Hands the batch definition to Drupal's Batch API.
-   *
-   * Isolated in its own method so tests can verify the batch definition
-   * submitForm() builds without going through the real batch_set(), which
-   * needs a full Drupal batch/session stack unavailable in a unit test.
-   *
-   * @param array $batch
-   *   A batch definition suitable for batch_set().
-   */
-  protected function setBatch(array $batch) {
-    batch_set($batch);
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ResourceCsvImportForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ResourceCsvImportForm.php
@@ -276,6 +276,10 @@ class ResourceCsvImportForm extends FormBase {
     return [
       'title' => $this->t('Required. Also used to detect duplicates.'),
       'description' => $this->t('Plain text.'),
+      'abstract' => $this->t('Plain text.'),
+      'citation' => $this->t('Plain text.'),
+      'journal publication name' => $this->t('Plain text.'),
+      'journal publication issue' => $this->t('Plain text.'),
       'resource category' => $this->t('Comma-separated. Terms are created if missing.'),
       'audience' => $this->t('Comma-separated. Terms are created if missing.'),
       'custom vocab' => $this->t('Comma-separated. "Custom Vocabulary" also works as a header.'),

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ResourceCsvImportForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ResourceCsvImportForm.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class ResourceCsvImportForm extends FormBase {
 
   use BatchSubmitTrait;
+  use ColumnReferenceTableTrait;
 
   /**
    * Maximum upload size, in bytes.
@@ -129,18 +130,12 @@ class ResourceCsvImportForm extends FormBase {
       '#value' => $this->t('Resources are imported as drafts, so review and publish them once the import finishes. Resource Media cannot be set from a CSV file: rows with an External Source are ready to use straight away, and the import summary lists the rest, which you will need to open and attach media to.'),
     ];
 
+    $form['columns'] = $this->columnReferenceTable($this->csvValidator->getExpectedResourceColumns(), $this->columnNotes());
+
     $form['sample_download'] = [
       '#type' => 'link',
-      '#title' => $this->t('Download a sample CSV'),
+      '#title' => $this->t('Download a sample CSV to see the expected columns and an example row.'),
       '#url' => Url::fromRoute('ys_migrate.resource_csv_sample'),
-      '#attributes' => ['class' => ['button']],
-    ];
-
-    $form['columns'] = [
-      '#type' => 'table',
-      '#caption' => $this->t('Recognised columns'),
-      '#header' => [$this->t('Column'), $this->t('Notes')],
-      '#rows' => $this->columnReferenceRows(),
     ];
 
     $form['csv_file'] = [
@@ -272,33 +267,27 @@ class ResourceCsvImportForm extends FormBase {
   }
 
   /**
-   * Builds the rows of the recognised-columns reference table.
+   * Guidance text for the recognised-columns reference table.
    *
    * @return array
-   *   Table rows of column label and guidance.
+   *   Notes keyed by column machine name.
    */
-  protected function columnReferenceRows() {
-    // Columns absent from this list need no explanation beyond their name.
-    $notes = [
+  protected function columnNotes() {
+    return [
       'title' => $this->t('Required. Also used to detect duplicates.'),
+      'description' => $this->t('Plain text.'),
       'resource category' => $this->t('Comma-separated. Terms are created if missing.'),
       'audience' => $this->t('Comma-separated. Terms are created if missing.'),
       'custom vocab' => $this->t('Comma-separated. "Custom Vocabulary" also works as a header.'),
       'resource publication date' => $this->t('YYYY-MM-DD or MM/DD/YYYY.'),
       'date format' => $this->t('Year, Month/Year, or Month/Day/Year.'),
       'tags' => $this->t('Comma-separated. Terms are created if missing.'),
+      'teaser title' => $this->t('Plain text.'),
+      'teaser text' => $this->t("Plain text. Character count is capped by the Teaser Text field's own limit."),
       'external source' => $this->t('Full http:// or https:// URL.'),
       'cas login required' => $this->t('Yes or No.'),
       'pin to beginning of list' => $this->t('Yes or No.'),
     ];
-
-    $rows = [];
-
-    foreach ($this->csvValidator->getExpectedResourceColumns() as $key => $label) {
-      $rows[] = [$label, $notes[$key] ?? ''];
-    }
-
-    return $rows;
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ResourceCsvImportForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ResourceCsvImportForm.php
@@ -7,6 +7,7 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Url;
 use Drupal\ys_migrate\Batch\CsvImportBatch;
 use Drupal\ys_migrate\Service\CsvValidatorService;
 use Drupal\ys_migrate\Service\ResourceImportService;
@@ -126,6 +127,13 @@ class ResourceCsvImportForm extends FormBase {
       '#type' => 'html_tag',
       '#tag' => 'p',
       '#value' => $this->t('Resources are imported as drafts, so review and publish them once the import finishes. Resource Media cannot be set from a CSV file: rows with an External Source are ready to use straight away, and the import summary lists the rest, which you will need to open and attach media to.'),
+    ];
+
+    $form['sample_download'] = [
+      '#type' => 'link',
+      '#title' => $this->t('Download a sample CSV'),
+      '#url' => Url::fromRoute('ys_migrate.resource_csv_sample'),
+      '#attributes' => ['class' => ['button']],
     ];
 
     $form['columns'] = [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ResourceCsvImportForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ResourceCsvImportForm.php
@@ -7,6 +7,7 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\RendererInterface;
+use Drupal\ys_migrate\Batch\CsvImportBatch;
 use Drupal\ys_migrate\Service\CsvValidatorService;
 use Drupal\ys_migrate\Service\ResourceImportService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -224,18 +225,43 @@ class ResourceCsvImportForm extends FormBase {
     $preview_only = $form_state->getValue('preview');
     $skip_duplicates = $form_state->getValue('skip_duplicates');
     $validation_result = $form_state->get('csv_validation');
-
-    $file = $this->entityTypeManager->getStorage('file')->load($csv_file[0]);
+    $fid = $csv_file[0];
 
     if ($preview_only) {
       $this->previewImport($validation_result['data'], $skip_duplicates);
-    }
-    else {
-      $this->processImport($validation_result['data'], $skip_duplicates);
+      // Preview renders its own response and never touches the batch queue,
+      // so the upload is cleaned up immediately rather than by a batch
+      // operation.
+      $this->entityTypeManager->getStorage('file')->load($fid)->delete();
+      return;
     }
 
-    // Clean up the uploaded file.
-    $file->delete();
+    // A real import runs through the Batch API, one request per chunk, so a
+    // large CSV cannot time out a single request. File cleanup becomes the
+    // batch's own trailing operation instead of happening here, since
+    // submitForm() returns before any row is processed.
+    $this->setBatch(CsvImportBatch::build(
+      'ys_migrate.resource_import',
+      $validation_result['data'],
+      $skip_duplicates,
+      $fid,
+      'resource',
+      (string) $this->t('Importing resources...')
+    ));
+  }
+
+  /**
+   * Hands the batch definition to Drupal's Batch API.
+   *
+   * Isolated in its own method so tests can verify the batch definition
+   * submitForm() builds without going through the real batch_set(), which
+   * needs a full Drupal batch/session stack unavailable in a unit test.
+   *
+   * @param array $batch
+   *   A batch definition suitable for batch_set().
+   */
+  protected function setBatch(array $batch) {
+    batch_set($batch);
   }
 
   /**
@@ -302,38 +328,6 @@ class ResourceCsvImportForm extends FormBase {
     if (!empty($result['valid_resources'])) {
       $this->displayPreviewTable($result['valid_resources']);
     }
-  }
-
-  /**
-   * Processes the import and creates resource nodes.
-   *
-   * @param array $data
-   *   The CSV data.
-   * @param bool $skip_duplicates
-   *   Whether to skip duplicates.
-   */
-  protected function processImport(array $data, $skip_duplicates) {
-    $result = $this->resourceImport->processImport($data, $skip_duplicates);
-
-    if ($result['created'] > 0) {
-      $this->messenger->addStatus($this->t('Created @count resource(s).', ['@count' => $result['created']]));
-    }
-
-    if ($result['skipped'] > 0) {
-      $this->messenger->addWarning($this->t('Skipped @count duplicate resource(s).', ['@count' => $result['skipped']]));
-    }
-
-    if (!empty($result['needs_media'])) {
-      $this->messenger->addWarning($this->t(
-        '@count imported resource(s) have no External Source and still need Resource Media attached: @titles',
-        [
-          '@count' => count($result['needs_media']),
-          '@titles' => implode(', ', $result['needs_media']),
-        ]
-      ));
-    }
-
-    $this->reportErrors($result['errors']);
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ResourceCsvImportForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Form/ResourceCsvImportForm.php
@@ -1,0 +1,394 @@
+<?php
+
+namespace Drupal\ys_migrate\Form;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\ys_migrate\Service\CsvValidatorService;
+use Drupal\ys_migrate\Service\ResourceImportService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Form for bulk importing resource content from CSV files.
+ */
+class ResourceCsvImportForm extends FormBase {
+
+  /**
+   * Maximum upload size, in bytes.
+   */
+  const MAX_FILE_SIZE = 10485760;
+
+  /**
+   * How many preview rows to show before truncating.
+   */
+  const PREVIEW_LIMIT = 100;
+
+  /**
+   * The messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * The CSV validator service.
+   *
+   * @var \Drupal\ys_migrate\Service\CsvValidatorService
+   */
+  protected $csvValidator;
+
+  /**
+   * The resource import service.
+   *
+   * @var \Drupal\ys_migrate\Service\ResourceImportService
+   */
+  protected $resourceImport;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The renderer service.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected $renderer;
+
+  /**
+   * Constructs a ResourceCsvImportForm object.
+   *
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   * @param \Drupal\ys_migrate\Service\CsvValidatorService $csv_validator
+   *   The CSV validator service.
+   * @param \Drupal\ys_migrate\Service\ResourceImportService $resource_import
+   *   The resource import service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The renderer service.
+   */
+  public function __construct(
+    MessengerInterface $messenger,
+    CsvValidatorService $csv_validator,
+    ResourceImportService $resource_import,
+    EntityTypeManagerInterface $entity_type_manager,
+    RendererInterface $renderer,
+  ) {
+    $this->messenger = $messenger;
+    $this->csvValidator = $csv_validator;
+    $this->resourceImport = $resource_import;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->renderer = $renderer;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('messenger'),
+      $container->get('ys_migrate.csv_validator'),
+      $container->get('ys_migrate.resource_import'),
+      $container->get('entity_type.manager'),
+      $container->get('renderer')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'ys_migrate_resource_csv_import';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['intro'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('Upload a CSV file to create resources in bulk, one per row. The first row must contain column headers. Any column may be left out; only Title is required.'),
+    ];
+
+    $form['media_notice'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('Resources are imported as drafts, so review and publish them once the import finishes. Resource Media cannot be set from a CSV file: rows with an External Source are ready to use straight away, and the import summary lists the rest, which you will need to open and attach media to.'),
+    ];
+
+    $form['columns'] = [
+      '#type' => 'table',
+      '#caption' => $this->t('Recognised columns'),
+      '#header' => [$this->t('Column'), $this->t('Notes')],
+      '#rows' => $this->columnReferenceRows(),
+    ];
+
+    $form['csv_file'] = [
+      '#type' => 'managed_file',
+      '#title' => $this->t('CSV file'),
+      '#description' => $this->t('Maximum file size: 10MB.'),
+      '#upload_location' => 'private://csv_imports/',
+      '#upload_validators' => [
+        'FileExtension' => ['extensions' => 'csv'],
+        'FileSizeLimit' => ['fileLimit' => self::MAX_FILE_SIZE],
+      ],
+      '#required' => TRUE,
+    ];
+
+    $form['preview'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Preview only'),
+      '#description' => $this->t('Show what would be created without saving anything.'),
+      '#default_value' => TRUE,
+    ];
+
+    $form['skip_duplicates'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Skip duplicates'),
+      '#description' => $this->t('Skip rows whose title already belongs to an existing resource. Uncheck to import them anyway.'),
+      '#default_value' => TRUE,
+    ];
+
+    $form['actions'] = [
+      '#type' => 'actions',
+    ];
+
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Process CSV'),
+      '#button_type' => 'primary',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+
+    $csv_file = $form_state->getValue('csv_file');
+    if (empty($csv_file)) {
+      $form_state->setErrorByName('csv_file', $this->t('Please upload a CSV file.'));
+      return;
+    }
+
+    $file = $this->entityTypeManager->getStorage('file')->load($csv_file[0]);
+    if (!$file) {
+      $form_state->setErrorByName('csv_file', $this->t('Unable to load the uploaded file.'));
+      return;
+    }
+
+    $file_path = $file->getFileUri();
+    if (!file_exists($file_path)) {
+      $form_state->setErrorByName('csv_file', $this->t('The uploaded file could not be found.'));
+      return;
+    }
+
+    $validation_result = $this->csvValidator->validateResourceCsvStructure($file_path);
+    if (!$validation_result['valid']) {
+      $form_state->setErrorByName('csv_file', $validation_result['message']);
+      return;
+    }
+
+    // An unrecognised header is skipped in silence, so a mistyped column name
+    // would drop its data with nothing to show for it. Warn rather than fail:
+    // an extra column an editor keeps for their own notes is legitimate.
+    $unknown = $this->csvValidator->getUnknownResourceColumns($validation_result['headers']);
+    if (!empty($unknown)) {
+      $this->messenger->addWarning($this->t(
+        'These columns are not recognised and will be ignored: @columns',
+        ['@columns' => implode(', ', $unknown)]
+      ));
+    }
+
+    // Store validation results for use in submit.
+    $form_state->set('csv_validation', $validation_result);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $csv_file = $form_state->getValue('csv_file');
+    $preview_only = $form_state->getValue('preview');
+    $skip_duplicates = $form_state->getValue('skip_duplicates');
+    $validation_result = $form_state->get('csv_validation');
+
+    $file = $this->entityTypeManager->getStorage('file')->load($csv_file[0]);
+
+    if ($preview_only) {
+      $this->previewImport($validation_result['data'], $skip_duplicates);
+    }
+    else {
+      $this->processImport($validation_result['data'], $skip_duplicates);
+    }
+
+    // Clean up the uploaded file.
+    $file->delete();
+  }
+
+  /**
+   * Builds the rows of the recognised-columns reference table.
+   *
+   * @return array
+   *   Table rows of column label and guidance.
+   */
+  protected function columnReferenceRows() {
+    // Columns absent from this list need no explanation beyond their name.
+    $notes = [
+      'title' => $this->t('Required. Also used to detect duplicates.'),
+      'resource category' => $this->t('Comma-separated. Terms are created if missing.'),
+      'audience' => $this->t('Comma-separated. Terms are created if missing.'),
+      'custom vocab' => $this->t('Comma-separated. "Custom Vocabulary" also works as a header.'),
+      'resource publication date' => $this->t('YYYY-MM-DD or MM/DD/YYYY.'),
+      'date format' => $this->t('Year, Month/Year, or Month/Day/Year.'),
+      'tags' => $this->t('Comma-separated. Terms are created if missing.'),
+      'external source' => $this->t('Full http:// or https:// URL.'),
+      'cas login required' => $this->t('Yes or No.'),
+      'pin to beginning of list' => $this->t('Yes or No.'),
+    ];
+
+    $rows = [];
+
+    foreach ($this->csvValidator->getExpectedResourceColumns() as $key => $label) {
+      $rows[] = [$label, $notes[$key] ?? ''];
+    }
+
+    return $rows;
+  }
+
+  /**
+   * Previews the import without creating content.
+   *
+   * @param array $data
+   *   The CSV data.
+   * @param bool $skip_duplicates
+   *   Whether to skip duplicates.
+   */
+  protected function previewImport(array $data, $skip_duplicates) {
+    $result = $this->resourceImport->previewImport($data, $skip_duplicates);
+
+    $this->messenger->addStatus($this->t(
+      'Preview only, nothing was saved. @valid of @total row(s) would be imported.',
+      [
+        '@valid' => count($result['valid_resources']),
+        '@total' => $result['total'],
+      ]
+    ));
+
+    if (!empty($result['duplicates'])) {
+      $this->messenger->addWarning($this->t(
+        '@count row(s) would be skipped as duplicates: @titles',
+        [
+          '@count' => count($result['duplicates']),
+          '@titles' => implode(', ', $result['duplicates']),
+        ]
+      ));
+    }
+
+    $this->reportErrors($result['errors']);
+
+    if (!empty($result['valid_resources'])) {
+      $this->displayPreviewTable($result['valid_resources']);
+    }
+  }
+
+  /**
+   * Processes the import and creates resource nodes.
+   *
+   * @param array $data
+   *   The CSV data.
+   * @param bool $skip_duplicates
+   *   Whether to skip duplicates.
+   */
+  protected function processImport(array $data, $skip_duplicates) {
+    $result = $this->resourceImport->processImport($data, $skip_duplicates);
+
+    if ($result['created'] > 0) {
+      $this->messenger->addStatus($this->t('Created @count resource(s).', ['@count' => $result['created']]));
+    }
+
+    if ($result['skipped'] > 0) {
+      $this->messenger->addWarning($this->t('Skipped @count duplicate resource(s).', ['@count' => $result['skipped']]));
+    }
+
+    if (!empty($result['needs_media'])) {
+      $this->messenger->addWarning($this->t(
+        '@count imported resource(s) have no External Source and still need Resource Media attached: @titles',
+        [
+          '@count' => count($result['needs_media']),
+          '@titles' => implode(', ', $result['needs_media']),
+        ]
+      ));
+    }
+
+    $this->reportErrors($result['errors']);
+  }
+
+  /**
+   * Surfaces per-row errors, which never stop the rest of the run.
+   *
+   * @param array $errors
+   *   The row error messages.
+   */
+  protected function reportErrors(array $errors) {
+    foreach ($errors as $error) {
+      $this->messenger->addError($error);
+    }
+  }
+
+  /**
+   * Displays a preview table of the resources to be created.
+   *
+   * @param array $resources
+   *   Array of prepared resource data.
+   */
+  protected function displayPreviewTable(array $resources) {
+    $rows = [];
+
+    foreach (array_slice($resources, 0, self::PREVIEW_LIMIT) as $resource) {
+      $rows[] = [
+        $resource['title'],
+        $resource['category'] ? implode(', ', $resource['category']) : '-',
+        $resource['publish_date'] ?: '-',
+        $resource['external_source'] ?: '-',
+        $resource['external_source'] ? $this->t('No') : $this->t('Yes'),
+      ];
+    }
+
+    if (count($resources) > self::PREVIEW_LIMIT) {
+      $rows[] = [
+        $this->t('...and @count more', ['@count' => count($resources) - self::PREVIEW_LIMIT]),
+        '', '', '', '',
+      ];
+    }
+
+    $build = [
+      '#type' => 'table',
+      '#caption' => $this->t('Resources to be created'),
+      '#header' => [
+        $this->t('Title'),
+        $this->t('Resource Category'),
+        $this->t('Publication Date'),
+        $this->t('External Source'),
+        $this->t('Needs media'),
+      ],
+      '#rows' => $rows,
+      '#attributes' => ['class' => ['resource-preview-table']],
+    ];
+
+    $this->messenger->addStatus($this->renderer->render($build));
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Service/CsvValidatorService.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Service/CsvValidatorService.php
@@ -44,6 +44,10 @@ class CsvValidatorService {
   const EXPECTED_RESOURCE_COLUMNS = [
     'title' => 'Title',
     'description' => 'Description',
+    'abstract' => 'Abstract',
+    'citation' => 'Citation',
+    'journal publication name' => 'Journal Publication Name',
+    'journal publication issue' => 'Journal Publication Issue',
     'resource category' => 'Resource Category',
     'audience' => 'Audience',
     'custom vocab' => 'Custom Vocab',

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Service/CsvValidatorService.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Service/CsvValidatorService.php
@@ -35,7 +35,42 @@ class CsvValidatorService {
   ];
 
   /**
-   * Validates the CSV file structure and content.
+   * Expected CSV columns for resource import.
+   *
+   * Resource Media and Teaser Media are absent because a media reference
+   * cannot travel in a CSV cell; Affiliation is absent because the Resource
+   * content type has no such field.
+   */
+  const EXPECTED_RESOURCE_COLUMNS = [
+    'title' => 'Title',
+    'description' => 'Description',
+    'resource category' => 'Resource Category',
+    'audience' => 'Audience',
+    'custom vocab' => 'Custom Vocab',
+    'resource publication date' => 'Resource Publication Date',
+    'date format' => 'Date Format',
+    'tags' => 'Tags',
+    'teaser title' => 'Teaser Title',
+    'teaser text' => 'Teaser Text',
+    'external source' => 'External Source',
+    'cas login required' => 'CAS Login Required',
+    'pin to beginning of list' => 'Pin to beginning of list',
+  ];
+
+  /**
+   * Accepted alternative spellings for resource columns.
+   *
+   * Values are the canonical normalised header each alias maps to. "Custom
+   * Vocabulary" is the ticket's wording for "Custom Vocab"; "CAS Protected" is
+   * the header ys_content_export writes for "CAS Login Required".
+   */
+  const RESOURCE_COLUMN_ALIASES = [
+    'custom vocabulary' => 'custom vocab',
+    'cas protected' => 'cas login required',
+  ];
+
+  /**
+   * Validates the CSV file structure and content for a profile import.
    *
    * @param string $file_path
    *   The path to the CSV file.
@@ -44,6 +79,71 @@ class CsvValidatorService {
    *   Validation result with 'valid', 'message', 'data', and 'headers' keys.
    */
   public function validateCsvStructure($file_path) {
+    $result = $this->parseCsv(
+      $file_path,
+      'display name',
+      $this->t('The CSV file must contain a "Display Name" column.'),
+      [$this, 'validateRow']
+    );
+
+    if ($result['valid']) {
+      $result['message'] = $this->t('CSV file is valid. Found @count profiles.', ['@count' => count($result['data'])]);
+    }
+
+    return $result;
+  }
+
+  /**
+   * Validates the CSV file structure and content for a resource import.
+   *
+   * Only structure and the required Title are checked here. Cell-level
+   * problems (an unparseable date, a malformed URL) are reported per row by
+   * ResourceImportService, so one typo does not reject the whole file and the
+   * editor sees the problem in the preview.
+   *
+   * @param string $file_path
+   *   The path to the CSV file.
+   *
+   * @return array
+   *   Validation result with 'valid', 'message', 'data', and 'headers' keys.
+   */
+  public function validateResourceCsvStructure($file_path) {
+    $result = $this->parseCsv(
+      $file_path,
+      'title',
+      $this->t('The CSV file must contain a "Title" column.'),
+      [$this, 'validateResourceRow'],
+      self::RESOURCE_COLUMN_ALIASES
+    );
+
+    if ($result['valid']) {
+      $result['message'] = $this->t('CSV file is valid. Found @count resources.', ['@count' => count($result['data'])]);
+    }
+
+    return $result;
+  }
+
+  /**
+   * Reads a CSV file into normalised rows, applying per-row validation.
+   *
+   * @param string $file_path
+   *   The path to the CSV file.
+   * @param string $required_header
+   *   The normalised header the file must contain.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $missing_header_message
+   *   The message to return when that header is absent.
+   * @param callable $row_validator
+   *   Receives the normalised row and its line number, returns an array of
+   *   error messages.
+   * @param array $aliases
+   *   Optional alternative header spellings, mapping the alias to the
+   *   canonical header, so consumers only ever see canonical keys.
+   *
+   * @return array
+   *   Validation result with 'valid', 'message', 'data', and 'headers' keys.
+   *   On success 'message' is empty and the caller supplies its own.
+   */
+  protected function parseCsv($file_path, $required_header, $missing_header_message, callable $row_validator, array $aliases = []) {
     $handle = fopen($file_path, 'r');
     if (!$handle) {
       return [
@@ -66,15 +166,21 @@ class CsvValidatorService {
       ];
     }
 
-    // Normalize headers (remove whitespace, convert to lowercase).
-    $normalized_headers = $this->normalizeHeaders($headers);
+    // Normalize headers (remove whitespace, convert to lowercase) and fold any
+    // accepted alias onto its canonical name.
+    $normalized_headers = array_map(
+      function ($header) use ($aliases) {
+        return $aliases[$header] ?? $header;
+      },
+      $this->normalizeHeaders($headers)
+    );
 
     // Check for required header.
-    if (!in_array('display name', $normalized_headers)) {
+    if (!in_array($required_header, $normalized_headers)) {
       fclose($handle);
       return [
         'valid' => FALSE,
-        'message' => $this->t('The CSV file must contain a "Display Name" column.'),
+        'message' => $missing_header_message,
         'data' => [],
         'headers' => [],
       ];
@@ -109,7 +215,7 @@ class CsvValidatorService {
       $row_data = array_combine($normalized_headers, $row);
 
       // Validate the row data.
-      $row_errors = $this->validateRow($row_data, $row_number);
+      $row_errors = $row_validator($row_data, $row_number);
       if (!empty($row_errors)) {
         $errors = array_merge($errors, $row_errors);
         continue;
@@ -134,7 +240,7 @@ class CsvValidatorService {
 
     return [
       'valid' => TRUE,
-      'message' => $this->t('CSV file is valid. Found @count profiles.', ['@count' => count($data)]),
+      'message' => '',
       'data' => $data,
       'headers' => $header_mapping,
     ];
@@ -151,7 +257,9 @@ class CsvValidatorService {
    */
   protected function normalizeHeaders(array $headers) {
     return array_map(function ($header) {
-      return strtolower(trim($header));
+      // Excel's "CSV UTF-8" export writes a byte-order mark, which would
+      // otherwise make the first column's header unrecognisable.
+      return strtolower(trim(preg_replace('/^\xEF\xBB\xBF/', '', $header)));
     }, $headers);
   }
 
@@ -191,6 +299,27 @@ class CsvValidatorService {
   }
 
   /**
+   * Validates a single row of resource CSV data.
+   *
+   * @param array $row_data
+   *   The row data with normalized keys.
+   * @param int $row_number
+   *   The row number for error reporting.
+   *
+   * @return array
+   *   Array of validation errors.
+   */
+  protected function validateResourceRow(array $row_data, $row_number) {
+    $errors = [];
+
+    if (empty(trim($row_data['title'] ?? ''))) {
+      $errors[] = $this->t('Row @row: Title is required.', ['@row' => $row_number]);
+    }
+
+    return $errors;
+  }
+
+  /**
    * Gets the expected columns for profile import.
    *
    * @return array
@@ -198,6 +327,36 @@ class CsvValidatorService {
    */
   public function getExpectedColumns() {
     return self::EXPECTED_COLUMNS;
+  }
+
+  /**
+   * Gets the expected columns for resource import.
+   *
+   * @return array
+   *   Array of expected columns, keyed by normalised header.
+   */
+  public function getExpectedResourceColumns() {
+    return self::EXPECTED_RESOURCE_COLUMNS;
+  }
+
+  /**
+   * Lists resource CSV headers the importer does not understand.
+   *
+   * A header the importer does not recognise is skipped in silence, so a
+   * mistyped "Tags" would drop every tag with nothing to show for it. The
+   * caller warns about whatever this returns.
+   *
+   * @param array $headers
+   *   The header mapping returned by validateResourceCsvStructure(), keyed by
+   *   normalised header.
+   *
+   * @return array
+   *   The original spellings of the headers that will be ignored.
+   */
+  public function getUnknownResourceColumns(array $headers) {
+    // Aliases were already folded into their canonical header when the file
+    // was parsed, so only the canonical list needs comparing here.
+    return array_values(array_diff_key($headers, self::EXPECTED_RESOURCE_COLUMNS));
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Service/ResourceImportService.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Service/ResourceImportService.php
@@ -50,7 +50,7 @@ class ResourceImportService {
    *
    * Long-text fields need an explicit format, or Drupal falls back to the
    * plain-text fallback filter and escapes the editor's markup. The format
-   * must also be one the field itself allows: both of these fields restrict
+   * must also be one the field itself allows: each of these fields restricts
    * allowed_formats to a single format, and storing anything else leaves the
    * widget disabled on the node form ("you do not have sufficient permissions
    * to edit it"), because no YaleSites role holds "administer filters".
@@ -61,6 +61,8 @@ class ResourceImportService {
   const TEXT_FORMAT_FALLBACKS = [
     'field_content_description' => 'restricted_html',
     'field_teaser_text' => 'heading_html',
+    'field_abstract' => 'restricted_html',
+    'field_citation' => 'restricted_html',
   ];
 
   /**
@@ -175,6 +177,10 @@ class ResourceImportService {
     return [
       'title' => trim($row['title'] ?? ''),
       'description' => trim($row['description'] ?? ''),
+      'abstract' => trim($row['abstract'] ?? ''),
+      'citation' => trim($row['citation'] ?? ''),
+      'journal_publication_name' => trim($row['journal publication name'] ?? ''),
+      'journal_publication_issue' => trim($row['journal publication issue'] ?? ''),
       'category' => $this->taxonomyResolver->parseCommaSeparatedValues($row['resource category'] ?? ''),
       'audience' => $this->taxonomyResolver->parseCommaSeparatedValues($row['audience'] ?? ''),
       // Alternative header spellings are folded onto the canonical name by
@@ -256,6 +262,24 @@ class ResourceImportService {
         'value' => $data['description'],
         'format' => $this->textFormat('field_content_description'),
       ];
+    }
+    if ($data['abstract'] !== '') {
+      $values['field_abstract'] = [
+        'value' => $data['abstract'],
+        'format' => $this->textFormat('field_abstract'),
+      ];
+    }
+    if ($data['citation'] !== '') {
+      $values['field_citation'] = [
+        'value' => $data['citation'],
+        'format' => $this->textFormat('field_citation'),
+      ];
+    }
+    if ($data['journal_publication_name'] !== '') {
+      $values['field_journal_publication_name'] = $data['journal_publication_name'];
+    }
+    if ($data['journal_publication_issue'] !== '') {
+      $values['field_journal_publication_issue'] = $data['journal_publication_issue'];
     }
     if ($data['teaser_title'] !== '') {
       $values['field_teaser_title'] = $data['teaser_title'];

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Service/ResourceImportService.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Service/ResourceImportService.php
@@ -1,0 +1,660 @@
+<?php
+
+namespace Drupal\ys_migrate\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Service for importing resource content from CSV data.
+ *
+ * Resource Media cannot travel in a CSV cell, so imported resources never carry
+ * one. Rows with an External Source are usable immediately; the rest are listed
+ * in the import result so the editor knows which nodes still need a file.
+ */
+class ResourceImportService {
+
+  use StringTranslationTrait;
+
+  /**
+   * Date formats accepted in the Resource Publication Date column.
+   *
+   * Deliberately an explicit list rather than strtotime(): "03/04/2026" means
+   * different days to different readers, and a silently wrong publication date
+   * is worse than a rejected row.
+   */
+  const DATE_INPUT_FORMATS = ['Y-m-d', 'm/d/Y', 'n/j/Y', 'Y-n-j'];
+
+  /**
+   * The field storage holding the allowed Date Format values.
+   */
+  const DATE_FORMAT_STORAGE = 'node.field_date_format';
+
+  /**
+   * Fallback Date Format options, keyed by stored value.
+   *
+   * The live values are read from DATE_FORMAT_STORAGE so adding an option to
+   * that field does not silently start rejecting valid CSV cells. This copy is
+   * only used if the field is missing, as it is in a unit test.
+   */
+  const DATE_FORMAT_OPTIONS = [
+    'year_only' => 'Year',
+    'month_year' => 'Month/Year',
+    'date' => 'Month/Day/Year',
+  ];
+
+  /**
+   * Fallback text format per long-text field.
+   *
+   * Long-text fields need an explicit format, or Drupal falls back to the
+   * plain-text fallback filter and escapes the editor's markup. The format
+   * must also be one the field itself allows: both of these fields restrict
+   * allowed_formats to a single format, and storing anything else leaves the
+   * widget disabled on the node form ("you do not have sufficient permissions
+   * to edit it"), because no YaleSites role holds "administer filters".
+   *
+   * The live values are read from each field's own config; these are only the
+   * documented fallbacks, used when the field cannot be loaded.
+   */
+  const TEXT_FORMAT_FALLBACKS = [
+    'field_content_description' => 'restricted_html',
+    'field_teaser_text' => 'heading_html',
+  ];
+
+  /**
+   * Maximum Teaser Text length when the form display does not declare one.
+   */
+  const TEASER_TEXT_MAX_LENGTH = 150;
+
+  /**
+   * Moderation state imported resources are created in.
+   *
+   * Matches the editorial workflow's own default_moderation_state.
+   */
+  const MODERATION_STATE = 'draft';
+
+  /**
+   * Cell values accepted as TRUE in a boolean column.
+   */
+  const TRUE_VALUES = ['yes', 'true', '1', 'on'];
+
+  /**
+   * Cell values accepted as FALSE in a boolean column.
+   */
+  const FALSE_VALUES = ['no', 'false', '0', 'off', ''];
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * The taxonomy resolver service.
+   *
+   * @var \Drupal\ys_migrate\Service\TaxonomyResolverService
+   */
+  protected $taxonomyResolver;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The logger factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
+
+  /**
+   * Allowed Date Format values, resolved once per import run.
+   *
+   * @var array|null
+   */
+  protected $dateFormatOptions;
+
+  /**
+   * Text formats per long-text field, resolved once per import run.
+   *
+   * @var string[]
+   */
+  protected $textFormats = [];
+
+  /**
+   * The Teaser Text character limit, resolved once per import run.
+   *
+   * @var int|null
+   */
+  protected $teaserTextMaxLength;
+
+  /**
+   * Constructs a ResourceImportService object.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\ys_migrate\Service\TaxonomyResolverService $taxonomy_resolver
+   *   The taxonomy resolver service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   The logger factory.
+   */
+  public function __construct(
+    AccountInterface $current_user,
+    TaxonomyResolverService $taxonomy_resolver,
+    EntityTypeManagerInterface $entity_type_manager,
+    LoggerChannelFactoryInterface $logger_factory,
+  ) {
+    $this->currentUser = $current_user;
+    $this->taxonomyResolver = $taxonomy_resolver;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->loggerFactory = $logger_factory;
+  }
+
+  /**
+   * Prepares resource data from a CSV row.
+   *
+   * @param array $row
+   *   The CSV row data, keyed by lowercased column header.
+   *
+   * @return array
+   *   Prepared resource data.
+   *
+   * @throws \InvalidArgumentException
+   *   If a cell cannot be interpreted. Thrown per row so one bad cell fails
+   *   only its own row rather than the whole file.
+   */
+  public function prepareResourceData(array $row) {
+    return [
+      'title' => trim($row['title'] ?? ''),
+      'description' => trim($row['description'] ?? ''),
+      'category' => $this->taxonomyResolver->parseCommaSeparatedValues($row['resource category'] ?? ''),
+      'audience' => $this->taxonomyResolver->parseCommaSeparatedValues($row['audience'] ?? ''),
+      // Alternative header spellings are folded onto the canonical name by
+      // CsvValidatorService::RESOURCE_COLUMN_ALIASES before we see the row.
+      'custom_vocab' => $this->taxonomyResolver->parseCommaSeparatedValues($row['custom vocab'] ?? ''),
+      'tags' => $this->taxonomyResolver->parseCommaSeparatedValues($row['tags'] ?? ''),
+      'publish_date' => $this->parseDate($row['resource publication date'] ?? ''),
+      'date_format' => $this->parseDateFormat($row['date format'] ?? ''),
+      'teaser_title' => trim($row['teaser title'] ?? ''),
+      'teaser_text' => $this->parseTeaserText($row['teaser text'] ?? ''),
+      'external_source' => $this->parseExternalSource($row['external source'] ?? ''),
+      'login_required' => $this->parseBoolean($row['cas login required'] ?? '', 'CAS Login Required'),
+      'sticky' => $this->parseBoolean($row['pin to beginning of list'] ?? '', 'Pin to beginning of list'),
+    ];
+  }
+
+  /**
+   * Finds an existing resource by title.
+   *
+   * Resources have no natural unique key, so title is the duplicate key.
+   *
+   * @param string $title
+   *   The title to search for.
+   *
+   * @return \Drupal\node\NodeInterface|null
+   *   The existing resource node or NULL.
+   */
+  public function findExistingResource($title) {
+    $nids = $this->entityTypeManager->getStorage('node')->getQuery()
+      ->condition('type', 'resource')
+      ->condition('title', $title)
+      ->range(0, 1)
+      ->accessCheck(FALSE)
+      ->execute();
+
+    if (!empty($nids)) {
+      return $this->entityTypeManager->getStorage('node')->load(reset($nids));
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Creates a resource node from the prepared data.
+   *
+   * @param array $data
+   *   The resource data, as returned by prepareResourceData().
+   *
+   * @return \Drupal\node\NodeInterface
+   *   The created node.
+   *
+   * @throws \Exception
+   *   If the node cannot be saved. The reason is logged and re-thrown so the
+   *   caller can surface it instead of a generic failure message.
+   */
+  public function createResourceNode(array $data) {
+    $values = [
+      'type' => 'resource',
+      'title' => $data['title'],
+      'field_category' => $this->taxonomyResolver->resolveTerms($data['category'], 'resource_category'),
+      'field_audience' => $this->taxonomyResolver->resolveTerms($data['audience'], 'audience'),
+      'field_tags' => $this->taxonomyResolver->resolveTerms($data['tags'], 'tags'),
+      'field_custom_vocab' => $this->taxonomyResolver->resolveTerms($data['custom_vocab'], 'custom_vocab'),
+      'field_login_required' => (int) $data['login_required'],
+      'sticky' => (int) $data['sticky'],
+      'uid' => $this->currentUser->id(),
+      // The resource bundle runs under the editorial workflow, so publication
+      // is owned by moderation_state; a 'status' value set here is silently
+      // overridden. Imported resources land as drafts for an editor to review
+      // and publish, which is what that workflow's default_moderation_state
+      // asks for and the safer default for a bulk import.
+      'moderation_state' => self::MODERATION_STATE,
+    ];
+
+    // Optional values are omitted rather than written as empty, so an imported
+    // node looks the same as one an editor left blank in the node form.
+    if ($data['description'] !== '') {
+      $values['field_content_description'] = [
+        'value' => $data['description'],
+        'format' => $this->textFormat('field_content_description'),
+      ];
+    }
+    if ($data['teaser_title'] !== '') {
+      $values['field_teaser_title'] = $data['teaser_title'];
+    }
+    if ($data['teaser_text'] !== '') {
+      $values['field_teaser_text'] = [
+        'value' => $data['teaser_text'],
+        'format' => $this->textFormat('field_teaser_text'),
+      ];
+    }
+    if ($data['publish_date'] !== NULL) {
+      $values['field_publish_date'] = $data['publish_date'];
+    }
+    if ($data['date_format'] !== NULL) {
+      $values['field_date_format'] = $data['date_format'];
+    }
+    if ($data['external_source'] !== '') {
+      $values['field_external_source'] = ['uri' => $data['external_source']];
+    }
+
+    $node = $this->entityTypeManager->getStorage('node')->create($values);
+
+    try {
+      $node->save();
+      return $node;
+    }
+    catch (\Exception $e) {
+      $this->loggerFactory->get('ys_migrate')->error('Failed to create resource node: @error', ['@error' => $e->getMessage()]);
+      // Re-throw so processImport() can report the real reason to the user
+      // instead of a generic "could not create resource" message.
+      throw $e;
+    }
+  }
+
+  /**
+   * Processes the import and creates resource nodes.
+   *
+   * @param array $data
+   *   The CSV data.
+   * @param bool $skip_duplicates
+   *   Whether to skip rows whose title already exists.
+   *
+   * @return array
+   *   Import results with 'created', 'skipped', 'errors' and 'needs_media'
+   *   keys, the last being the titles created without an External Source,
+   *   which are the ones an editor must still attach Resource Media to.
+   */
+  public function processImport(array $data, $skip_duplicates) {
+    $created = 0;
+    $skipped = 0;
+    $errors = [];
+    $needs_media = [];
+
+    foreach ($data as $index => $row) {
+      try {
+        $resource_data = $this->prepareResourceData($row);
+
+        if ($skip_duplicates && $this->findExistingResource($resource_data['title'])) {
+          $skipped++;
+          continue;
+        }
+
+        $this->createResourceNode($resource_data);
+        $created++;
+
+        if ($resource_data['external_source'] === '') {
+          $needs_media[] = $resource_data['title'];
+        }
+      }
+      catch (\Exception $e) {
+        $errors[] = $this->rowError($row, $index, $e);
+      }
+    }
+
+    return [
+      'created' => $created,
+      'skipped' => $skipped,
+      'errors' => $errors,
+      'needs_media' => $needs_media,
+    ];
+  }
+
+  /**
+   * Previews the import without creating content.
+   *
+   * @param array $data
+   *   The CSV data.
+   * @param bool $skip_duplicates
+   *   Whether to skip rows whose title already exists.
+   *
+   * @return array
+   *   Preview results with 'valid_resources', 'duplicates', 'errors' and
+   *   'total' keys.
+   */
+  public function previewImport(array $data, $skip_duplicates) {
+    $duplicates = [];
+    $valid_resources = [];
+    $errors = [];
+    $seen_titles = [];
+
+    foreach ($data as $index => $row) {
+      try {
+        $resource_data = $this->prepareResourceData($row);
+
+        // A title repeated inside the file is a duplicate too: the import
+        // creates the first row, then skips the rest. Tracking it here keeps
+        // the preview's count honest, which is the whole point of previewing.
+        if ($skip_duplicates
+          && (isset($seen_titles[$resource_data['title']]) || $this->findExistingResource($resource_data['title']))) {
+          $duplicates[] = $resource_data['title'];
+          continue;
+        }
+
+        $seen_titles[$resource_data['title']] = TRUE;
+        $valid_resources[] = $resource_data;
+      }
+      catch (\Exception $e) {
+        $errors[] = $this->rowError($row, $index, $e);
+      }
+    }
+
+    return [
+      'valid_resources' => $valid_resources,
+      'duplicates' => $duplicates,
+      'errors' => $errors,
+      'total' => count($data),
+    ];
+  }
+
+  /**
+   * Formats a row-scoped error message.
+   *
+   * @param array $row
+   *   The CSV row, which may carry the true line number from the validator.
+   * @param int $index
+   *   The array offset, used when the row has no line number.
+   * @param \Exception $e
+   *   The exception raised while handling the row.
+   *
+   * @return \Drupal\Core\StringTranslation\TranslatableMarkup
+   *   The message to show the editor.
+   */
+  protected function rowError(array $row, $index, \Exception $e) {
+    return $this->t('Row @row: @error', [
+      // Prefer the true CSV line threaded through by the validator; blank rows
+      // it skipped mean the array offset is not the line the editor sees.
+      '@row' => $row['_row_number'] ?? ($index + 2),
+      '@error' => $e->getMessage(),
+    ]);
+  }
+
+  /**
+   * Parses a publication date cell into the field's storage format.
+   *
+   * @param string $value
+   *   The raw cell value.
+   *
+   * @return string|null
+   *   The date as Y-m-d, or NULL when the cell is empty.
+   *
+   * @throws \InvalidArgumentException
+   *   If the value is not one of the accepted formats or is not a real date.
+   */
+  protected function parseDate($value) {
+    $value = trim($value);
+    if ($value === '') {
+      return NULL;
+    }
+
+    foreach (self::DATE_INPUT_FORMATS as $format) {
+      $date = \DateTime::createFromFormat($format, $value);
+      // Re-formatting catches values PHP rolls over, such as 2026-02-31
+      // becoming 2026-03-03.
+      if ($date && $date->format($format) === $value) {
+        return $date->format('Y-m-d');
+      }
+    }
+
+    throw new \InvalidArgumentException(sprintf(
+      'Resource Publication Date "%s" is not a valid date. Use YYYY-MM-DD or MM/DD/YYYY.',
+      $value
+    ));
+  }
+
+  /**
+   * Parses a Date Format cell into the stored list value.
+   *
+   * @param string $value
+   *   The raw cell value: either the stored key or the human label.
+   *
+   * @return string|null
+   *   The stored value, or NULL when the cell is empty.
+   *
+   * @throws \InvalidArgumentException
+   *   If the value matches neither a key nor a label.
+   */
+  protected function parseDateFormat($value) {
+    $value = trim($value);
+    if ($value === '') {
+      return NULL;
+    }
+
+    $options = $this->dateFormatOptions();
+
+    foreach ($options as $key => $label) {
+      if (strcasecmp($value, $key) === 0 || strcasecmp($value, $label) === 0) {
+        return $key;
+      }
+    }
+
+    throw new \InvalidArgumentException(sprintf(
+      'Date Format "%s" is not recognised. Use one of: %s.',
+      $value,
+      implode(', ', $options)
+    ));
+  }
+
+  /**
+   * Resolves the text format to store for a long-text field.
+   *
+   * @param string $field_name
+   *   The field machine name.
+   *
+   * @return string
+   *   The first format the field allows, or the documented fallback.
+   */
+  protected function textFormat($field_name) {
+    if (isset($this->textFormats[$field_name])) {
+      return $this->textFormats[$field_name];
+    }
+
+    $allowed = [];
+
+    try {
+      $field = $this->entityTypeManager->getStorage('field_config')
+        ->load('node.resource.' . $field_name);
+      $allowed = $field ? (array) $field->getSetting('allowed_formats') : [];
+    }
+    catch (\Exception $e) {
+      // Fall through to the documented fallback below.
+    }
+
+    $this->textFormats[$field_name] = $allowed
+      ? reset($allowed)
+      : self::TEXT_FORMAT_FALLBACKS[$field_name];
+
+    return $this->textFormats[$field_name];
+  }
+
+  /**
+   * Reads the Teaser Text character limit from the resource form display.
+   *
+   * The limit is enforced only in JavaScript on the node form, so nothing
+   * stops an import writing past it unless it is checked here.
+   *
+   * @return int
+   *   The maximum length, or the documented fallback.
+   */
+  protected function teaserTextMaxLength() {
+    if ($this->teaserTextMaxLength !== NULL) {
+      return $this->teaserTextMaxLength;
+    }
+
+    $limit = 0;
+
+    try {
+      $display = $this->entityTypeManager->getStorage('entity_form_display')
+        ->load('node.resource.default');
+      $component = $display ? $display->getComponent('field_teaser_text') : [];
+      $limit = (int) ($component['third_party_settings']['maxlength']['maxlength_js'] ?? 0);
+    }
+    catch (\Exception $e) {
+      // Fall through to the documented fallback below.
+    }
+
+    $this->teaserTextMaxLength = $limit ?: self::TEASER_TEXT_MAX_LENGTH;
+
+    return $this->teaserTextMaxLength;
+  }
+
+  /**
+   * Reads the allowed Date Format values from the field's own storage config.
+   *
+   * @return array
+   *   Allowed values keyed by stored value, falling back to
+   *   DATE_FORMAT_OPTIONS when the field storage cannot be read.
+   */
+  protected function dateFormatOptions() {
+    if ($this->dateFormatOptions !== NULL) {
+      return $this->dateFormatOptions;
+    }
+
+    $options = [];
+
+    try {
+      $storage = $this->entityTypeManager->getStorage('field_storage_config')
+        ->load(self::DATE_FORMAT_STORAGE);
+      // A loaded field storage returns allowed_values already simplified to a
+      // value => label map, not the list of value/label pairs the config YAML
+      // is written as.
+      $options = $storage ? (array) $storage->getSetting('allowed_values') : [];
+    }
+    catch (\Exception $e) {
+      // Fall through to the documented defaults below.
+    }
+
+    $this->dateFormatOptions = $options ?: self::DATE_FORMAT_OPTIONS;
+
+    return $this->dateFormatOptions;
+  }
+
+  /**
+   * Checks a Teaser Text cell against the platform's own length limit.
+   *
+   * @param string $value
+   *   The raw cell value.
+   *
+   * @return string
+   *   The trimmed teaser text.
+   *
+   * @throws \InvalidArgumentException
+   *   If the text is longer than the node form allows.
+   */
+  protected function parseTeaserText($value) {
+    $value = trim($value);
+    $limit = $this->teaserTextMaxLength();
+
+    if (mb_strlen($value) > $limit) {
+      throw new \InvalidArgumentException(sprintf(
+        'Teaser Text is %d characters; the limit is %d.',
+        mb_strlen($value),
+        $limit
+      ));
+    }
+
+    return $value;
+  }
+
+  /**
+   * Parses an External Source cell into a link-field URI.
+   *
+   * @param string $value
+   *   The raw cell value.
+   *
+   * @return string
+   *   The validated URL, or an empty string when the cell is empty.
+   *
+   * @throws \InvalidArgumentException
+   *   If the value is not an absolute http or https URL.
+   */
+  protected function parseExternalSource($value) {
+    $value = trim($value);
+    if ($value === '') {
+      return '';
+    }
+
+    // The scheme check is what rejects javascript: and data: URLs; those pass
+    // FILTER_VALIDATE_URL, which only checks the general URL shape.
+    $scheme = strtolower((string) parse_url($value, PHP_URL_SCHEME));
+    if (!filter_var($value, FILTER_VALIDATE_URL) || !in_array($scheme, ['http', 'https'], TRUE)) {
+      throw new \InvalidArgumentException(sprintf(
+        'External Source "%s" is not a valid http or https URL.',
+        $value
+      ));
+    }
+
+    return $value;
+  }
+
+  /**
+   * Parses a yes/no cell into a boolean.
+   *
+   * @param string $value
+   *   The raw cell value. An empty cell is FALSE.
+   * @param string $column
+   *   The column label, for the error message.
+   *
+   * @return bool
+   *   The parsed value.
+   *
+   * @throws \InvalidArgumentException
+   *   If the value is not a recognised spelling. Unrecognised values are
+   *   rejected rather than quietly treated as FALSE.
+   */
+  protected function parseBoolean($value, $column) {
+    $value = strtolower(trim($value));
+
+    if (in_array($value, self::TRUE_VALUES, TRUE)) {
+      return TRUE;
+    }
+    if (in_array($value, self::FALSE_VALUES, TRUE)) {
+      return FALSE;
+    }
+
+    throw new \InvalidArgumentException(sprintf(
+      '%s "%s" is not a yes/no value. Use Yes or No.',
+      $column,
+      $value
+    ));
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Service/TaxonomyResolverService.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/src/Service/TaxonomyResolverService.php
@@ -25,6 +25,18 @@ class TaxonomyResolverService {
   protected $loggerFactory;
 
   /**
+   * Terms already resolved this request, keyed "vocabulary:name".
+   *
+   * A CSV import repeats the same category, audience and tag names across most
+   * of its rows, and each lookup is an uncached entity query. Remembering the
+   * terms resolved so far turns "one query per occurrence" into "one query per
+   * distinct name" for the life of the request.
+   *
+   * @var \Drupal\taxonomy\TermInterface[]
+   */
+  protected $resolvedTerms = [];
+
+  /**
    * Constructs a TaxonomyResolverService object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -76,6 +88,11 @@ class TaxonomyResolverService {
    *   The term or null on failure.
    */
   public function findOrCreateTerm($name, $vocabulary) {
+    $cache_key = $vocabulary . ':' . $name;
+    if (isset($this->resolvedTerms[$cache_key])) {
+      return $this->resolvedTerms[$cache_key];
+    }
+
     // First, try to find existing term.
     $query = $this->entityTypeManager->getStorage('taxonomy_term')->getQuery()
       ->condition('vid', $vocabulary)
@@ -86,7 +103,9 @@ class TaxonomyResolverService {
     $tids = $query->execute();
 
     if (!empty($tids)) {
-      return $this->entityTypeManager->getStorage('taxonomy_term')->load(reset($tids));
+      $term = $this->entityTypeManager->getStorage('taxonomy_term')->load(reset($tids));
+      $this->resolvedTerms[$cache_key] = $term;
+      return $term;
     }
 
     // Create new term if it doesn't exist.
@@ -96,9 +115,11 @@ class TaxonomyResolverService {
         'name' => $name,
       ]);
       $term->save();
+      $this->resolvedTerms[$cache_key] = $term;
       return $term;
     }
     catch (\Exception $e) {
+      // Deliberately not cached: a failure should be retried, not remembered.
       $this->loggerFactory->get('ys_migrate')->error('Failed to create taxonomy term @name in @vocabulary: @error', [
         '@name' => $name,
         '@vocabulary' => $vocabulary,
@@ -122,8 +143,11 @@ class TaxonomyResolverService {
       return [];
     }
 
-    $values = explode(',', $value);
-    return array_map('trim', array_filter($values));
+    // Trim before discarding empties: filtering first lets a whitespace-only
+    // segment through, which then trims to '' and has findOrCreateTerm()
+    // create a nameless term in the vocabulary. 'strlen' rather than the
+    // default callback so a term legitimately named "0" survives.
+    return array_values(array_filter(array_map('trim', explode(',', $value)), 'strlen'));
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ColumnReferenceTableTraitTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ColumnReferenceTableTraitTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\Tests\ys_migrate\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_migrate\Form\ColumnReferenceTableTrait;
+
+/**
+ * Unit tests for ColumnReferenceTableTrait.
+ *
+ * @coversDefaultClass \Drupal\ys_migrate\Form\ColumnReferenceTableTrait
+ * @group ys_migrate
+ * @group yalesites
+ */
+class ColumnReferenceTableTraitTest extends UnitTestCase {
+
+  /**
+   * Builds an object using the trait, with StringTranslationTrait stubbed.
+   */
+  protected function traitObject() {
+    return new class() {
+      use ColumnReferenceTableTrait;
+
+      /**
+       * Stubs translation with plain string substitution.
+       */
+      public function t($string, array $args = []) {
+        return strtr($string, $args);
+      }
+
+      /**
+       * Exposes the protected trait method for the test to call.
+       */
+      public function build(array $columns, array $notes) {
+        return $this->columnReferenceTable($columns, $notes);
+      }
+
+    };
+  }
+
+  /**
+   * ColumnReferenceTable() renders one row per column, label then note.
+   *
+   * @covers ::columnReferenceTable
+   */
+  public function testColumnReferenceTableBuildsRowsInColumnOrder() {
+    $columns = ['title' => 'Title', 'audience' => 'Audience'];
+    $notes = ['title' => 'Required.', 'audience' => 'Comma-separated.'];
+
+    $table = $this->traitObject()->build($columns, $notes);
+
+    $this->assertSame('table', $table['#type']);
+    $this->assertSame(['Title', 'Required.'], $table['#rows'][0]);
+    $this->assertSame(['Audience', 'Comma-separated.'], $table['#rows'][1]);
+  }
+
+  /**
+   * ColumnReferenceTable() renders an empty notes cell for an unlisted column.
+   *
+   * @covers ::columnReferenceTable
+   */
+  public function testColumnReferenceTableWithMissingNoteIsEmptyString() {
+    $columns = ['title' => 'Title'];
+
+    $table = $this->traitObject()->build($columns, []);
+
+    $this->assertSame(['Title', ''], $table['#rows'][0]);
+  }
+
+  /**
+   * ColumnReferenceTable() sets a "Column"/"Notes" header.
+   *
+   * @covers ::columnReferenceTable
+   */
+  public function testColumnReferenceTableSetsHeader() {
+    $table = $this->traitObject()->build(['title' => 'Title'], []);
+
+    $this->assertSame(['Column', 'Notes'], $table['#header']);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/CsvImportBatchTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/CsvImportBatchTest.php
@@ -1,0 +1,322 @@
+<?php
+
+namespace Drupal\Tests\ys_migrate\Unit;
+
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_migrate\Batch\CsvImportBatch;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Unit tests for CsvImportBatch.
+ *
+ * @coversDefaultClass \Drupal\ys_migrate\Batch\CsvImportBatch
+ * @group ys_migrate
+ * @group yalesites
+ */
+class CsvImportBatchTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Base container so any TranslatableMarkup built by the class under test
+    // can be cast to a string. Individual tests layer additional services
+    // (messenger, entity_type.manager, an import service id) onto this same
+    // container.
+    $container = new ContainerBuilder();
+    $container->set('string_translation', $this->getStringTranslationStub());
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Builds $count placeholder CSV rows.
+   */
+  protected function rows(int $count): array {
+    return array_fill(0, $count, ['title' => 'Row']);
+  }
+
+  /**
+   * Build() splits rows into CHUNK_SIZE-row operations plus a cleanup op.
+   *
+   * @covers ::build
+   */
+  public function testBuildChunksRowsAndAppendsCleanupOperation() {
+    $rows = $this->rows(125);
+
+    $batch = CsvImportBatch::build('ys_migrate.profile_import', $rows, TRUE, 42, 'profile', 'Importing profiles');
+
+    // 125 rows at CHUNK_SIZE (50) => 3 process operations + 1 cleanup.
+    $this->assertCount(4, $batch['operations']);
+
+    [$callback1, $args1] = $batch['operations'][0];
+    $this->assertSame([CsvImportBatch::class, 'processChunk'], $callback1);
+    $this->assertSame('ys_migrate.profile_import', $args1[0]);
+    $this->assertCount(50, $args1[1]);
+    $this->assertTrue($args1[2]);
+    $this->assertSame('profile', $args1[3]);
+
+    [, $args3] = $batch['operations'][2];
+    $this->assertCount(25, $args3[1], 'Last chunk carries the remainder.');
+
+    [$cleanupCallback, $cleanupArgs] = $batch['operations'][3];
+    $this->assertSame([CsvImportBatch::class, 'deleteUploadedFile'], $cleanupCallback);
+    $this->assertSame([42], $cleanupArgs);
+  }
+
+  /**
+   * Build() with fewer rows than CHUNK_SIZE produces a single chunk.
+   *
+   * @covers ::build
+   */
+  public function testBuildWithFewerRowsThanChunkSizeProducesSingleChunk() {
+    $batch = CsvImportBatch::build('ys_migrate.profile_import', $this->rows(10), TRUE, 1, 'profile', 'Importing profiles');
+
+    // 1 process operation + 1 cleanup.
+    $this->assertCount(2, $batch['operations']);
+  }
+
+  /**
+   * Build() with no rows still schedules the cleanup operation.
+   *
+   * @covers ::build
+   */
+  public function testBuildWithEmptyRowsStillCleansUpFile() {
+    $batch = CsvImportBatch::build('ys_migrate.profile_import', [], TRUE, 7, 'profile', 'Importing profiles');
+
+    $this->assertCount(1, $batch['operations']);
+    [$callback, $args] = $batch['operations'][0];
+    $this->assertSame([CsvImportBatch::class, 'deleteUploadedFile'], $callback);
+    $this->assertSame([7], $args);
+  }
+
+  /**
+   * Build() sets the batch title and static finished callback.
+   *
+   * @covers ::build
+   */
+  public function testBuildSetsTitleAndFinishedCallback() {
+    $batch = CsvImportBatch::build('ys_migrate.profile_import', $this->rows(1), TRUE, 1, 'profile', 'Importing profiles');
+
+    $this->assertSame('Importing profiles', $batch['title']);
+    $this->assertSame([CsvImportBatch::class, 'finished'], $batch['finished']);
+  }
+
+  /**
+   * ProcessChunk() resolves the import service from the container by id.
+   *
+   * @covers ::processChunk
+   */
+  public function testProcessChunkAccumulatesAcrossCalls() {
+    $importService = $this->getMockBuilder(\stdClass::class)->addMethods(['processImport'])->getMock();
+    $importService->method('processImport')->willReturnOnConsecutiveCalls(
+      ['created' => 2, 'skipped' => 1, 'errors' => ['Row 2: boom']],
+      ['created' => 3, 'skipped' => 0, 'errors' => []],
+    );
+
+    $container = \Drupal::getContainer();
+    $container->set('ys_migrate.profile_import', $importService);
+
+    $context = [];
+    CsvImportBatch::processChunk('ys_migrate.profile_import', ['row1'], TRUE, 'profile', $context);
+    CsvImportBatch::processChunk('ys_migrate.profile_import', ['row2'], TRUE, 'profile', $context);
+
+    $this->assertSame(5, $context['results']['created']);
+    $this->assertSame(1, $context['results']['skipped']);
+    $this->assertSame(['Row 2: boom'], $context['results']['errors']);
+    $this->assertSame('profile', $context['results']['entity_label']);
+    $this->assertSame([], $context['results']['needs_media']);
+  }
+
+  /**
+   * ProcessChunk() merges 'needs_media' when the underlying service returns it.
+   *
+   * @covers ::processChunk
+   */
+  public function testProcessChunkMergesNeedsMedia() {
+    $importService = $this->getMockBuilder(\stdClass::class)->addMethods(['processImport'])->getMock();
+    $importService->method('processImport')->willReturnOnConsecutiveCalls(
+      ['created' => 1, 'skipped' => 0, 'errors' => [], 'needs_media' => ['Resource A']],
+      ['created' => 1, 'skipped' => 0, 'errors' => [], 'needs_media' => ['Resource B']],
+    );
+
+    $container = \Drupal::getContainer();
+    $container->set('ys_migrate.resource_import', $importService);
+
+    $context = [];
+    CsvImportBatch::processChunk('ys_migrate.resource_import', ['row1'], TRUE, 'resource', $context);
+    CsvImportBatch::processChunk('ys_migrate.resource_import', ['row2'], TRUE, 'resource', $context);
+
+    $this->assertSame(['Resource A', 'Resource B'], $context['results']['needs_media']);
+  }
+
+  /**
+   * DeleteUploadedFile() deletes the file entity when it still exists.
+   *
+   * @covers ::deleteUploadedFile
+   */
+  public function testDeleteUploadedFileDeletesWhenFileExists() {
+    $file = $this->getMockBuilder(\stdClass::class)->addMethods(['delete'])->getMock();
+    $file->expects($this->once())->method('delete');
+
+    $storage = $this->getMockBuilder(\stdClass::class)->addMethods(['load'])->getMock();
+    $storage->method('load')->with(99)->willReturn($file);
+
+    $entityTypeManager = $this->getMockBuilder(\stdClass::class)->addMethods(['getStorage'])->getMock();
+    $entityTypeManager->method('getStorage')->with('file')->willReturn($storage);
+
+    $container = \Drupal::getContainer();
+    $container->set('entity_type.manager', $entityTypeManager);
+
+    $context = [];
+    CsvImportBatch::deleteUploadedFile(99, $context);
+  }
+
+  /**
+   * DeleteUploadedFile() does nothing if the file was already removed.
+   *
+   * @covers ::deleteUploadedFile
+   */
+  public function testDeleteUploadedFileSkipsMissingFile() {
+    $storage = $this->getMockBuilder(\stdClass::class)->addMethods(['load'])->getMock();
+    $storage->method('load')->with(99)->willReturn(NULL);
+
+    $entityTypeManager = $this->getMockBuilder(\stdClass::class)->addMethods(['getStorage'])->getMock();
+    $entityTypeManager->method('getStorage')->with('file')->willReturn($storage);
+
+    $container = \Drupal::getContainer();
+    $container->set('entity_type.manager', $entityTypeManager);
+
+    // No exception, nothing to assert beyond "this does not throw".
+    $context = [];
+    CsvImportBatch::deleteUploadedFile(99, $context);
+    $this->addToAssertionCount(1);
+  }
+
+  /**
+   * BuildMessages() reports created and skipped counts using the given label.
+   *
+   * @covers ::buildMessages
+   */
+  public function testBuildMessagesReportsCreatedAndSkipped() {
+    $messages = CsvImportBatch::buildMessages([
+      'entity_label' => 'profile',
+      'created' => 4,
+      'skipped' => 2,
+      'errors' => [],
+      'needs_media' => [],
+    ]);
+
+    $this->assertCount(2, $messages);
+    $this->assertSame('addStatus', $messages[0][0]);
+    $this->assertEquals(new TranslatableMarkup('Created @count @label(s).', ['@count' => 4, '@label' => 'profile']), $messages[0][1]);
+    $this->assertSame('addWarning', $messages[1][0]);
+    $this->assertEquals(
+      new TranslatableMarkup('Skipped @count duplicate @label(s).', ['@count' => 2, '@label' => 'profile']),
+      $messages[1][1]
+    );
+  }
+
+  /**
+   * BuildMessages() omits created/skipped lines when both counts are zero.
+   *
+   * @covers ::buildMessages
+   */
+  public function testBuildMessagesOmitsZeroCounts() {
+    $messages = CsvImportBatch::buildMessages([
+      'entity_label' => 'profile',
+      'created' => 0,
+      'skipped' => 0,
+      'errors' => [],
+      'needs_media' => [],
+    ]);
+
+    $this->assertSame([], $messages);
+  }
+
+  /**
+   * BuildMessages() surfaces the needs_media titles as a warning.
+   *
+   * @covers ::buildMessages
+   */
+  public function testBuildMessagesReportsNeedsMedia() {
+    $messages = CsvImportBatch::buildMessages([
+      'entity_label' => 'resource',
+      'created' => 1,
+      'skipped' => 0,
+      'errors' => [],
+      'needs_media' => ['Resource A', 'Resource B'],
+    ]);
+
+    $needsMediaMessages = array_values(array_filter($messages, fn($m) => str_contains((string) $m[1], 'Resource Media')));
+    $this->assertCount(1, $needsMediaMessages);
+    $this->assertSame('addWarning', $needsMediaMessages[0][0]);
+    $this->assertStringContainsString('Resource A, Resource B', (string) $needsMediaMessages[0][1]);
+  }
+
+  /**
+   * BuildMessages() forwards each error as its own addError entry, verbatim.
+   *
+   * @covers ::buildMessages
+   */
+  public function testBuildMessagesForwardsErrorsVerbatim() {
+    $messages = CsvImportBatch::buildMessages([
+      'entity_label' => 'profile',
+      'created' => 0,
+      'skipped' => 0,
+      'errors' => ['Row 2: Something went wrong.', 'Row 5: Also wrong.'],
+      'needs_media' => [],
+    ]);
+
+    $this->assertSame('addError', $messages[0][0]);
+    $this->assertSame('Row 2: Something went wrong.', $messages[0][1]);
+    $this->assertSame('addError', $messages[1][0]);
+    $this->assertSame('Row 5: Also wrong.', $messages[1][1]);
+  }
+
+  /**
+   * Finished() dispatches buildMessages() output through the messenger.
+   *
+   * @covers ::finished
+   */
+  public function testFinishedDispatchesMessagesThroughMessenger() {
+    $messenger = $this->createMock(MessengerInterface::class);
+    $messenger->expects($this->once())->method('addStatus');
+    $messenger->expects($this->once())->method('addWarning');
+    $messenger->expects($this->never())->method('addError');
+
+    $container = \Drupal::getContainer();
+    $container->set('messenger', $messenger);
+
+    CsvImportBatch::finished(TRUE, [
+      'entity_label' => 'profile',
+      'created' => 3,
+      'skipped' => 1,
+      'errors' => [],
+      'needs_media' => [],
+    ], []);
+  }
+
+  /**
+   * Finished() reports a single error and does not attempt to build messages.
+   *
+   * $success is FALSE when the batch itself did not complete (e.g. a PHP
+   * fatal partway through), and $results may not have the expected shape.
+   *
+   * @covers ::finished
+   */
+  public function testFinishedReportsBatchFailure() {
+    $messenger = $this->createMock(MessengerInterface::class);
+    $messenger->expects($this->once())->method('addError');
+    $messenger->expects($this->never())->method('addStatus');
+
+    $container = \Drupal::getContainer();
+    $container->set('messenger', $messenger);
+
+    CsvImportBatch::finished(FALSE, [], []);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/CsvImportBatchTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/CsvImportBatchTest.php
@@ -40,6 +40,17 @@ class CsvImportBatchTest extends UnitTestCase {
   }
 
   /**
+   * Builds the standard $options array build()/processChunk() expect.
+   */
+  protected function options(string $serviceId = 'ys_migrate.profile_import', string $label = 'profile', bool $skipDuplicates = TRUE): array {
+    return [
+      'import_service_id' => $serviceId,
+      'skip_duplicates' => $skipDuplicates,
+      'entity_label' => $label,
+    ];
+  }
+
+  /**
    * Build() splits rows into CHUNK_SIZE-row operations plus a cleanup op.
    *
    * @covers ::build
@@ -47,17 +58,15 @@ class CsvImportBatchTest extends UnitTestCase {
   public function testBuildChunksRowsAndAppendsCleanupOperation() {
     $rows = $this->rows(125);
 
-    $batch = CsvImportBatch::build('ys_migrate.profile_import', $rows, TRUE, 42, 'profile', 'Importing profiles');
+    $batch = CsvImportBatch::build($this->options(), $rows, 42, 'Importing profiles');
 
     // 125 rows at CHUNK_SIZE (50) => 3 process operations + 1 cleanup.
     $this->assertCount(4, $batch['operations']);
 
     [$callback1, $args1] = $batch['operations'][0];
     $this->assertSame([CsvImportBatch::class, 'processChunk'], $callback1);
-    $this->assertSame('ys_migrate.profile_import', $args1[0]);
+    $this->assertSame($this->options(), $args1[0]);
     $this->assertCount(50, $args1[1]);
-    $this->assertTrue($args1[2]);
-    $this->assertSame('profile', $args1[3]);
 
     [, $args3] = $batch['operations'][2];
     $this->assertCount(25, $args3[1], 'Last chunk carries the remainder.');
@@ -73,7 +82,7 @@ class CsvImportBatchTest extends UnitTestCase {
    * @covers ::build
    */
   public function testBuildWithFewerRowsThanChunkSizeProducesSingleChunk() {
-    $batch = CsvImportBatch::build('ys_migrate.profile_import', $this->rows(10), TRUE, 1, 'profile', 'Importing profiles');
+    $batch = CsvImportBatch::build($this->options(), $this->rows(10), 1, 'Importing profiles');
 
     // 1 process operation + 1 cleanup.
     $this->assertCount(2, $batch['operations']);
@@ -85,7 +94,7 @@ class CsvImportBatchTest extends UnitTestCase {
    * @covers ::build
    */
   public function testBuildWithEmptyRowsStillCleansUpFile() {
-    $batch = CsvImportBatch::build('ys_migrate.profile_import', [], TRUE, 7, 'profile', 'Importing profiles');
+    $batch = CsvImportBatch::build($this->options(), [], 7, 'Importing profiles');
 
     $this->assertCount(1, $batch['operations']);
     [$callback, $args] = $batch['operations'][0];
@@ -99,7 +108,7 @@ class CsvImportBatchTest extends UnitTestCase {
    * @covers ::build
    */
   public function testBuildSetsTitleAndFinishedCallback() {
-    $batch = CsvImportBatch::build('ys_migrate.profile_import', $this->rows(1), TRUE, 1, 'profile', 'Importing profiles');
+    $batch = CsvImportBatch::build($this->options(), $this->rows(1), 1, 'Importing profiles');
 
     $this->assertSame('Importing profiles', $batch['title']);
     $this->assertSame([CsvImportBatch::class, 'finished'], $batch['finished']);
@@ -121,22 +130,25 @@ class CsvImportBatchTest extends UnitTestCase {
     $container->set('ys_migrate.profile_import', $importService);
 
     $context = [];
-    CsvImportBatch::processChunk('ys_migrate.profile_import', ['row1'], TRUE, 'profile', $context);
-    CsvImportBatch::processChunk('ys_migrate.profile_import', ['row2'], TRUE, 'profile', $context);
+    CsvImportBatch::processChunk($this->options(), ['row1'], $context);
+    CsvImportBatch::processChunk($this->options(), ['row2'], $context);
 
     $this->assertSame(5, $context['results']['created']);
     $this->assertSame(1, $context['results']['skipped']);
-    $this->assertSame(['Row 2: boom'], $context['results']['errors']);
+    // Each chunk's errors are kept as their own sub-array (not flattened
+    // eagerly) so accumulation stays O(1) per chunk; finished() flattens
+    // once, at the end.
+    $this->assertSame([['Row 2: boom'], []], $context['results']['errors']);
     $this->assertSame('profile', $context['results']['entity_label']);
     $this->assertSame([], $context['results']['needs_media']);
   }
 
   /**
-   * ProcessChunk() merges 'needs_media' when the underlying service returns it.
+   * ProcessChunk() collects 'needs_media' when the service returns it.
    *
    * @covers ::processChunk
    */
-  public function testProcessChunkMergesNeedsMedia() {
+  public function testProcessChunkCollectsNeedsMedia() {
     $importService = $this->getMockBuilder(\stdClass::class)->addMethods(['processImport'])->getMock();
     $importService->method('processImport')->willReturnOnConsecutiveCalls(
       ['created' => 1, 'skipped' => 0, 'errors' => [], 'needs_media' => ['Resource A']],
@@ -147,10 +159,10 @@ class CsvImportBatchTest extends UnitTestCase {
     $container->set('ys_migrate.resource_import', $importService);
 
     $context = [];
-    CsvImportBatch::processChunk('ys_migrate.resource_import', ['row1'], TRUE, 'resource', $context);
-    CsvImportBatch::processChunk('ys_migrate.resource_import', ['row2'], TRUE, 'resource', $context);
+    CsvImportBatch::processChunk($this->options('ys_migrate.resource_import', 'resource'), ['row1'], $context);
+    CsvImportBatch::processChunk($this->options('ys_migrate.resource_import', 'resource'), ['row2'], $context);
 
-    $this->assertSame(['Resource A', 'Resource B'], $context['results']['needs_media']);
+    $this->assertSame([['Resource A'], ['Resource B']], $context['results']['needs_media']);
   }
 
   /**
@@ -161,15 +173,7 @@ class CsvImportBatchTest extends UnitTestCase {
   public function testDeleteUploadedFileDeletesWhenFileExists() {
     $file = $this->getMockBuilder(\stdClass::class)->addMethods(['delete'])->getMock();
     $file->expects($this->once())->method('delete');
-
-    $storage = $this->getMockBuilder(\stdClass::class)->addMethods(['load'])->getMock();
-    $storage->method('load')->with(99)->willReturn($file);
-
-    $entityTypeManager = $this->getMockBuilder(\stdClass::class)->addMethods(['getStorage'])->getMock();
-    $entityTypeManager->method('getStorage')->with('file')->willReturn($storage);
-
-    $container = \Drupal::getContainer();
-    $container->set('entity_type.manager', $entityTypeManager);
+    $this->mockFileStorage($file);
 
     $context = [];
     CsvImportBatch::deleteUploadedFile(99, $context);
@@ -181,19 +185,25 @@ class CsvImportBatchTest extends UnitTestCase {
    * @covers ::deleteUploadedFile
    */
   public function testDeleteUploadedFileSkipsMissingFile() {
-    $storage = $this->getMockBuilder(\stdClass::class)->addMethods(['load'])->getMock();
-    $storage->method('load')->with(99)->willReturn(NULL);
-
-    $entityTypeManager = $this->getMockBuilder(\stdClass::class)->addMethods(['getStorage'])->getMock();
-    $entityTypeManager->method('getStorage')->with('file')->willReturn($storage);
-
-    $container = \Drupal::getContainer();
-    $container->set('entity_type.manager', $entityTypeManager);
+    $this->mockFileStorage(NULL);
 
     // No exception, nothing to assert beyond "this does not throw".
     $context = [];
     CsvImportBatch::deleteUploadedFile(99, $context);
     $this->addToAssertionCount(1);
+  }
+
+  /**
+   * Registers an entity_type.manager mock whose file storage load(99) => $file.
+   */
+  protected function mockFileStorage($file): void {
+    $storage = $this->getMockBuilder(\stdClass::class)->addMethods(['load'])->getMock();
+    $storage->method('load')->with(99)->willReturn($file);
+
+    $entityTypeManager = $this->getMockBuilder(\stdClass::class)->addMethods(['getStorage'])->getMock();
+    $entityTypeManager->method('getStorage')->with('file')->willReturn($storage);
+
+    \Drupal::getContainer()->set('entity_type.manager', $entityTypeManager);
   }
 
   /**
@@ -301,6 +311,58 @@ class CsvImportBatchTest extends UnitTestCase {
   }
 
   /**
+   * Finished() flattens the per-chunk 'errors' sub-arrays before reporting.
+   *
+   * @covers ::finished
+   */
+  public function testFinishedFlattensChunkedErrors() {
+    $reported = [];
+    $messenger = $this->createMock(MessengerInterface::class);
+    $messenger->method('addError')->willReturnCallback(function ($message) use (&$reported) {
+      $reported[] = $message;
+    });
+
+    $container = \Drupal::getContainer();
+    $container->set('messenger', $messenger);
+
+    CsvImportBatch::finished(TRUE, [
+      'entity_label' => 'profile',
+      'created' => 0,
+      'skipped' => 0,
+      'errors' => [['Row 2: boom'], [], ['Row 9: also boom']],
+      'needs_media' => [],
+    ], []);
+
+    $this->assertSame(['Row 2: boom', 'Row 9: also boom'], $reported);
+  }
+
+  /**
+   * Finished() flattens the per-chunk 'needs_media' sub-arrays too.
+   *
+   * @covers ::finished
+   */
+  public function testFinishedFlattensChunkedNeedsMedia() {
+    $reported = [];
+    $messenger = $this->createMock(MessengerInterface::class);
+    $messenger->method('addWarning')->willReturnCallback(function ($message) use (&$reported) {
+      $reported[] = (string) $message;
+    });
+
+    $container = \Drupal::getContainer();
+    $container->set('messenger', $messenger);
+
+    CsvImportBatch::finished(TRUE, [
+      'entity_label' => 'resource',
+      'created' => 2,
+      'skipped' => 0,
+      'errors' => [],
+      'needs_media' => [['Resource A'], ['Resource B']],
+    ], []);
+
+    $this->assertStringContainsString('Resource A, Resource B', implode(' ', $reported));
+  }
+
+  /**
    * Finished() reports a single error and does not attempt to build messages.
    *
    * $success is FALSE when the batch itself did not complete (e.g. a PHP
@@ -317,6 +379,64 @@ class CsvImportBatchTest extends UnitTestCase {
     $container->set('messenger', $messenger);
 
     CsvImportBatch::finished(FALSE, [], []);
+  }
+
+  /**
+   * Finished() still reports chunks that completed before a later failure.
+   *
+   * A batch failure (e.g. a PHP fatal in a later chunk) must not discard the
+   * created/skipped/error counts from chunks that already ran -- those rows
+   * are already saved in the database, so hiding them risks a re-run
+   * duplicating work the editor believes never happened.
+   *
+   * @covers ::finished
+   */
+  public function testFinishedReportsPartialResultsOnBatchFailure() {
+    $statusMessages = [];
+    $messenger = $this->createMock(MessengerInterface::class);
+    $messenger->method('addStatus')->willReturnCallback(function ($m) use (&$statusMessages) {
+      $statusMessages[] = (string) $m;
+    });
+    $messenger->expects($this->once())->method('addError');
+
+    $container = \Drupal::getContainer();
+    $container->set('messenger', $messenger);
+
+    CsvImportBatch::finished(FALSE, [
+      'entity_label' => 'profile',
+      'created' => 40,
+      'skipped' => 0,
+      'errors' => [],
+      'needs_media' => [],
+    ], []);
+
+    $this->assertNotEmpty($statusMessages);
+    $this->assertStringContainsString('40', $statusMessages[0]);
+  }
+
+  /**
+   * Finished() deletes the uploaded file even when the batch failed early.
+   *
+   * DeleteUploadedFile() is normally the batch's own trailing operation, so
+   * it never runs if an earlier chunk aborts the batch; finished() has to
+   * find it among the operations that were queued but not reached and run
+   * it itself, or the upload is left behind.
+   *
+   * @covers ::finished
+   */
+  public function testFinishedCleansUpFileOnBatchFailure() {
+    $file = $this->getMockBuilder(\stdClass::class)->addMethods(['delete'])->getMock();
+    $file->expects($this->once())->method('delete');
+    $this->mockFileStorage($file);
+
+    $messenger = $this->createMock(MessengerInterface::class);
+    \Drupal::getContainer()->set('messenger', $messenger);
+
+    $remaining_operations = [
+      [[CsvImportBatch::class, 'deleteUploadedFile'], [99]],
+    ];
+
+    CsvImportBatch::finished(FALSE, [], $remaining_operations);
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/CsvValidatorServiceTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/CsvValidatorServiceTest.php
@@ -294,4 +294,157 @@ class CsvValidatorServiceTest extends UnitTestCase {
     $this->assertCount(17, $columns);
   }
 
+  /**
+   * A well-formed resource CSV validates and reports the resource count.
+   *
+   * @covers ::validateResourceCsvStructure
+   */
+  public function testValidateResourceCsvStructureWithValidCsv() {
+    $path = $this->createCsvFile(
+      "Title,Description,External Source\n" .
+      "Annual Report,A yearly summary.,https://example.com/a.pdf\n" .
+      "Style Guide,How we write.,\n"
+    );
+
+    $result = $this->csvValidator->validateResourceCsvStructure($path);
+
+    $this->assertTrue($result['valid']);
+    $this->assertEquals('CSV file is valid. Found 2 resources.', (string) $result['message']);
+    $this->assertCount(2, $result['data']);
+    $this->assertEquals('Annual Report', $result['data'][0]['title']);
+  }
+
+  /**
+   * A resource CSV without a Title column is rejected.
+   *
+   * @covers ::validateResourceCsvStructure
+   */
+  public function testValidateResourceCsvStructureRequiresTitleColumn() {
+    $path = $this->createCsvFile("Description,Tags\nSomething,tag1\n");
+
+    $result = $this->csvValidator->validateResourceCsvStructure($path);
+
+    $this->assertFalse($result['valid']);
+    $this->assertStringContainsString('must contain a "Title" column', (string) $result['message']);
+  }
+
+  /**
+   * A resource row with an empty Title is reported by line number.
+   *
+   * @covers ::validateResourceCsvStructure
+   */
+  public function testValidateResourceCsvStructureRequiresTitleValue() {
+    $path = $this->createCsvFile("Title,Description\nGood,fine\n   ,also fine\n");
+
+    $result = $this->csvValidator->validateResourceCsvStructure($path);
+
+    $this->assertFalse($result['valid']);
+    $this->assertStringContainsString('Row 3: Title is required.', (string) $result['message']);
+  }
+
+  /**
+   * Cell-level problems are left to the import service, not the validator.
+   *
+   * A bad date or URL must not reject the whole file; it surfaces as a row
+   * error in the preview so the editor can see and fix just that row.
+   *
+   * @covers ::validateResourceCsvStructure
+   */
+  public function testValidateResourceCsvStructureIgnoresCellSemantics() {
+    $path = $this->createCsvFile(
+      "Title,Resource Publication Date,External Source\n" .
+      "Odd One,whenever,not a url\n"
+    );
+
+    $result = $this->csvValidator->validateResourceCsvStructure($path);
+
+    $this->assertTrue($result['valid']);
+    $this->assertCount(1, $result['data']);
+  }
+
+  /**
+   * The true CSV line number is threaded onto each resource row.
+   *
+   * @covers ::validateResourceCsvStructure
+   */
+  public function testValidateResourceCsvStructureThreadsRowNumbers() {
+    $path = $this->createCsvFile("Title\nFirst\n\nSecond\n");
+
+    $result = $this->csvValidator->validateResourceCsvStructure($path);
+
+    $this->assertTrue($result['valid']);
+    $this->assertSame(2, $result['data'][0]['_row_number']);
+    // The blank line is skipped, so the second resource is really line 4.
+    $this->assertSame(4, $result['data'][1]['_row_number']);
+  }
+
+  /**
+   * Alternative header spellings are folded onto their canonical column.
+   *
+   * "Custom Vocabulary" is the ticket's wording; "CAS Protected" is the header
+   * ys_content_export writes, so an export can be edited and imported back.
+   *
+   * @covers ::validateResourceCsvStructure
+   */
+  public function testValidateResourceCsvStructureFoldsHeaderAliases() {
+    $path = $this->createCsvFile("Title,Custom Vocabulary,CAS Protected\nAliased,Vocab A,Yes\n");
+
+    $result = $this->csvValidator->validateResourceCsvStructure($path);
+
+    $this->assertTrue($result['valid']);
+    $this->assertSame('Vocab A', $result['data'][0]['custom vocab']);
+    $this->assertSame('Yes', $result['data'][0]['cas login required']);
+    $this->assertSame([], $this->csvValidator->getUnknownResourceColumns($result['headers']));
+  }
+
+  /**
+   * An Excel UTF-8 byte-order mark does not hide the first column's header.
+   *
+   * @covers ::validateResourceCsvStructure
+   */
+  public function testValidateResourceCsvStructureToleratesUtf8Bom() {
+    $path = $this->createCsvFile("\xEF\xBB\xBFTitle,Description\nBom Survivor,fine\n");
+
+    $result = $this->csvValidator->validateResourceCsvStructure($path);
+
+    $this->assertTrue($result['valid']);
+    $this->assertSame('Bom Survivor', $result['data'][0]['title']);
+  }
+
+  /**
+   * Headers the importer will silently ignore are reported to the caller.
+   *
+   * @covers ::getUnknownResourceColumns
+   */
+  public function testGetUnknownResourceColumnsNamesIgnoredHeaders() {
+    $path = $this->createCsvFile("Title,Tag,Editor Notes\nTypo'd,tag1,internal\n");
+
+    $result = $this->csvValidator->validateResourceCsvStructure($path);
+    $unknown = $this->csvValidator->getUnknownResourceColumns($result['headers']);
+
+    $this->assertTrue($result['valid']);
+    // "Tag" is a typo for "Tags"; without this warning it would be dropped.
+    $this->assertContains('Tag', $unknown);
+    $this->assertContains('Editor Notes', $unknown);
+    $this->assertNotContains('Title', $unknown);
+  }
+
+  /**
+   * GetExpectedResourceColumns() omits the fields a CSV cannot carry.
+   *
+   * @covers ::getExpectedResourceColumns
+   */
+  public function testGetExpectedResourceColumns() {
+    $columns = $this->csvValidator->getExpectedResourceColumns();
+
+    $this->assertEquals('Title', $columns['title']);
+    $this->assertEquals('Resource Category', $columns['resource category']);
+    $this->assertEquals('Pin to beginning of list', $columns['pin to beginning of list']);
+    // Media cannot travel in a CSV cell, and Resource has no Affiliation field.
+    $this->assertArrayNotHasKey('resource media', $columns);
+    $this->assertArrayNotHasKey('teaser media', $columns);
+    $this->assertArrayNotHasKey('affiliation', $columns);
+    $this->assertCount(13, $columns);
+  }
+
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/CsvValidatorServiceTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/CsvValidatorServiceTest.php
@@ -440,11 +440,15 @@ class CsvValidatorServiceTest extends UnitTestCase {
     $this->assertEquals('Title', $columns['title']);
     $this->assertEquals('Resource Category', $columns['resource category']);
     $this->assertEquals('Pin to beginning of list', $columns['pin to beginning of list']);
+    $this->assertEquals('Abstract', $columns['abstract']);
+    $this->assertEquals('Citation', $columns['citation']);
+    $this->assertEquals('Journal Publication Name', $columns['journal publication name']);
+    $this->assertEquals('Journal Publication Issue', $columns['journal publication issue']);
     // Media cannot travel in a CSV cell, and Resource has no Affiliation field.
     $this->assertArrayNotHasKey('resource media', $columns);
     $this->assertArrayNotHasKey('teaser media', $columns);
     $this->assertArrayNotHasKey('affiliation', $columns);
-    $this->assertCount(13, $columns);
+    $this->assertCount(17, $columns);
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ProfileCsvImportFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ProfileCsvImportFormTest.php
@@ -10,6 +10,7 @@ use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\file\FileInterface;
+use Drupal\ys_migrate\Batch\CsvImportBatch;
 use Drupal\ys_migrate\Form\ProfileCsvImportForm;
 use Drupal\ys_migrate\Service\CsvValidatorService;
 use Drupal\ys_migrate\Service\ProfileImportService;
@@ -59,6 +60,20 @@ class ProfileCsvImportFormTest extends UnitTestCase {
   protected $renderer;
 
   /**
+   * The current user mock.
+   *
+   * @var \Drupal\Core\Session\AccountInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $currentUser;
+
+  /**
+   * The entity type manager mock.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $entityTypeManager;
+
+  /**
    * The form under test.
    *
    * @var \Drupal\ys_migrate\Form\ProfileCsvImportForm
@@ -79,25 +94,48 @@ class ProfileCsvImportFormTest extends UnitTestCase {
     parent::setUp();
 
     $this->messenger = $this->createMock(MessengerInterface::class);
-    $current_user = $this->createMock(AccountInterface::class);
+    $this->currentUser = $this->createMock(AccountInterface::class);
     $this->csvValidator = $this->createMock(CsvValidatorService::class);
     $this->profileImport = $this->createMock(ProfileImportService::class);
 
     $this->fileStorage = $this->createMock(EntityStorageInterface::class);
-    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
-    $entity_type_manager->method('getStorage')->with('file')->willReturn($this->fileStorage);
+    $this->entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $this->entityTypeManager->method('getStorage')->with('file')->willReturn($this->fileStorage);
 
     $this->renderer = $this->createMock(RendererInterface::class);
 
     $this->form = new ProfileCsvImportForm(
       $this->messenger,
-      $current_user,
+      $this->currentUser,
       $this->csvValidator,
       $this->profileImport,
-      $entity_type_manager,
+      $this->entityTypeManager,
       $this->renderer
     );
     $this->form->setStringTranslation($this->getStringTranslationStub());
+  }
+
+  /**
+   * Builds a partial mock isolating submitForm() from the real batch_set().
+   *
+   * Setting a real batch requires a full Drupal batch API, unavailable in a
+   * unit test, so setBatch() is mocked out here to capture what it was
+   * called with.
+   */
+  protected function partialForm(array $onlyMethods): ProfileCsvImportForm {
+    $form = $this->getMockBuilder(ProfileCsvImportForm::class)
+      ->setConstructorArgs([
+        $this->messenger,
+        $this->currentUser,
+        $this->csvValidator,
+        $this->profileImport,
+        $this->entityTypeManager,
+        $this->renderer,
+      ])
+      ->onlyMethods($onlyMethods)
+      ->getMock();
+    $form->setStringTranslation($this->getStringTranslationStub());
+    return $form;
   }
 
   /**
@@ -291,39 +329,60 @@ class ProfileCsvImportFormTest extends UnitTestCase {
   }
 
   /**
-   * SubmitForm() processes the import and reports created/skipped/errors.
+   * SubmitForm() schedules a batch instead of processing synchronously.
+   *
+   * A real import runs through the Batch API so a large CSV cannot time out
+   * a single request; created/skipped/error reporting and file cleanup move
+   * to CsvImportBatch's operations and finished callback (covered by
+   * CsvImportBatchTest), so submitForm() itself no longer calls
+   * processImport(), the messenger, or delete() directly.
    *
    * @covers ::submitForm
    */
-  public function testSubmitFormProcessImport() {
+  public function testSubmitFormProcessImportSchedulesBatch() {
     $file = $this->createMock(FileInterface::class);
-    $file->expects($this->once())->method('delete');
+    $file->expects($this->never())->method('delete');
     $this->fileStorage->method('load')->with(123)->willReturn($file);
 
-    $this->profileImport->method('processImport')->willReturn([
-      'created' => 2,
-      'skipped' => 1,
-      'errors' => ['Row 4: Something went wrong.'],
-    ]);
+    $this->profileImport->expects($this->never())->method('processImport');
+    $this->messenger->expects($this->never())->method('addStatus');
 
-    $this->messenger->expects($this->once())->method('addStatus');
-    $this->messenger->expects($this->once())->method('addWarning');
-    $this->messenger->expects($this->once())->method('addError')->with('Row 4: Something went wrong.');
+    $captured = NULL;
+    $form = $this->partialForm(['setBatch']);
+    $form->expects($this->once())->method('setBatch')->with($this->callback(function ($batch) use (&$captured) {
+      $captured = $batch;
+      return TRUE;
+    }));
 
-    $form = [];
+    $data = [
+      ['display name' => 'Jane Doe'],
+      ['display name' => 'John Smith'],
+      ['display name' => 'Extra'],
+    ];
+
+    $form_array = [];
     $form_state = new FormState();
     $form_state->setValue('csv_file', [123]);
     $form_state->setValue('preview', FALSE);
     $form_state->setValue('skip_duplicates', TRUE);
-    $form_state->set('csv_validation', [
-      'data' => [
-        ['display name' => 'Jane Doe'],
-        ['display name' => 'John Smith'],
-        ['display name' => 'Extra'],
-      ],
-    ]);
+    $form_state->set('csv_validation', ['data' => $data]);
 
-    $this->form->submitForm($form, $form_state);
+    $form->submitForm($form_array, $form_state);
+
+    $this->assertSame([CsvImportBatch::class, 'finished'], $captured['finished']);
+    // 3 rows is a single chunk, plus the trailing file-cleanup operation.
+    $this->assertCount(2, $captured['operations']);
+
+    [$chunk_callback, $chunk_args] = $captured['operations'][0];
+    $this->assertSame([CsvImportBatch::class, 'processChunk'], $chunk_callback);
+    $this->assertSame('ys_migrate.profile_import', $chunk_args[0]);
+    $this->assertSame($data, $chunk_args[1]);
+    $this->assertTrue($chunk_args[2]);
+    $this->assertSame('profile', $chunk_args[3]);
+
+    [$cleanup_callback, $cleanup_args] = $captured['operations'][1];
+    $this->assertSame([CsvImportBatch::class, 'deleteUploadedFile'], $cleanup_callback);
+    $this->assertSame([123], $cleanup_args);
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ProfileCsvImportFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ProfileCsvImportFormTest.php
@@ -174,13 +174,33 @@ class ProfileCsvImportFormTest extends UnitTestCase {
    * @covers ::buildForm
    */
   public function testBuildForm() {
+    $this->csvValidator->method('getExpectedColumns')->willReturn(['display name' => 'Display Name']);
+
     $form = $this->form->buildForm([], new FormState());
 
+    $this->assertEquals('table', $form['columns']['#type']);
+    $this->assertEquals(['Column', 'Notes'], $form['columns']['#header']);
     $this->assertEquals('managed_file', $form['csv_file']['#type']);
     $this->assertTrue($form['csv_file']['#required']);
     $this->assertTrue($form['preview']['#default_value']);
     $this->assertTrue($form['skip_duplicates']['#default_value']);
     $this->assertEquals('submit', $form['actions']['submit']['#type']);
+  }
+
+  /**
+   * BuildForm() gives every recognised column a note, none left blank.
+   *
+   * @covers ::buildForm
+   * @covers ::columnNotes
+   */
+  public function testBuildFormAddsNoteForEveryColumn() {
+    $this->csvValidator->method('getExpectedColumns')->willReturn(CsvValidatorService::EXPECTED_COLUMNS);
+
+    $form = $this->form->buildForm([], new FormState());
+
+    foreach ($form['columns']['#rows'] as $row) {
+      $this->assertNotSame('', $row[1], "{$row[0]} should not have a blank notes cell.");
+    }
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ProfileCsvImportFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ProfileCsvImportFormTest.php
@@ -329,6 +329,32 @@ class ProfileCsvImportFormTest extends UnitTestCase {
   }
 
   /**
+   * SubmitForm() preview cleanup tolerates a file entity that is already gone.
+   *
+   * @covers ::submitForm
+   */
+  public function testSubmitFormPreviewOnlyToleratesMissingFile() {
+    $this->fileStorage->method('load')->with(123)->willReturn(NULL);
+
+    $this->profileImport->method('previewImport')->willReturn([
+      'valid_profiles' => [],
+      'duplicates' => [],
+      'total' => 0,
+    ]);
+
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValue('csv_file', [123]);
+    $form_state->setValue('preview', TRUE);
+    $form_state->setValue('skip_duplicates', TRUE);
+    $form_state->set('csv_validation', ['data' => []]);
+
+    // No exception, nothing to assert beyond "this does not throw".
+    $this->form->submitForm($form, $form_state);
+    $this->addToAssertionCount(1);
+  }
+
+  /**
    * SubmitForm() schedules a batch instead of processing synchronously.
    *
    * A real import runs through the Batch API so a large CSV cannot time out
@@ -375,10 +401,12 @@ class ProfileCsvImportFormTest extends UnitTestCase {
 
     [$chunk_callback, $chunk_args] = $captured['operations'][0];
     $this->assertSame([CsvImportBatch::class, 'processChunk'], $chunk_callback);
-    $this->assertSame('ys_migrate.profile_import', $chunk_args[0]);
+    $this->assertSame([
+      'import_service_id' => 'ys_migrate.profile_import',
+      'skip_duplicates' => TRUE,
+      'entity_label' => 'profile',
+    ], $chunk_args[0]);
     $this->assertSame($data, $chunk_args[1]);
-    $this->assertTrue($chunk_args[2]);
-    $this->assertSame('profile', $chunk_args[3]);
 
     [$cleanup_callback, $cleanup_args] = $captured['operations'][1];
     $this->assertSame([CsvImportBatch::class, 'deleteUploadedFile'], $cleanup_callback);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceCsvImportFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceCsvImportFormTest.php
@@ -148,6 +148,29 @@ class ResourceCsvImportFormTest extends UnitTestCase {
   }
 
   /**
+   * BuildForm() gives every column a note, including free-text fields.
+   *
+   * Description, Teaser Title and Teaser Text previously fell through to an
+   * empty notes cell with nothing to tell an editor what belongs there.
+   *
+   * @covers ::buildForm
+   * @covers ::columnNotes
+   */
+  public function testBuildFormNotesFreeTextColumnsRatherThanLeavingThemBlank() {
+    $this->csvValidator->method('getExpectedResourceColumns')->willReturn([
+      'description' => 'Description',
+      'teaser title' => 'Teaser Title',
+      'teaser text' => 'Teaser Text',
+    ]);
+
+    $form = $this->form->buildForm([], new FormState());
+
+    foreach ($form['columns']['#rows'] as $row) {
+      $this->assertNotSame('', $row[1], "{$row[0]} should not have a blank notes cell.");
+    }
+  }
+
+  /**
    * SubmitForm() previews the import and cleans up the uploaded file.
    *
    * Preview renders its own response synchronously and never touches the

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceCsvImportFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceCsvImportFormTest.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Drupal\Tests\ys_migrate\Unit;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\file\FileInterface;
+use Drupal\ys_migrate\Batch\CsvImportBatch;
+use Drupal\ys_migrate\Form\ResourceCsvImportForm;
+use Drupal\ys_migrate\Service\CsvValidatorService;
+use Drupal\ys_migrate\Service\ResourceImportService;
+
+/**
+ * Unit tests for ResourceCsvImportForm.
+ *
+ * Focused on submitForm()'s batching behavior, since that's the piece this
+ * change touches; buildForm() and validateForm() are unchanged from their
+ * shipped, manually-verified state.
+ *
+ * @coversDefaultClass \Drupal\ys_migrate\Form\ResourceCsvImportForm
+ * @group ys_migrate
+ * @group yalesites
+ */
+class ResourceCsvImportFormTest extends UnitTestCase {
+
+  /**
+   * The messenger mock.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $messenger;
+
+  /**
+   * The CSV validator mock.
+   *
+   * @var \Drupal\ys_migrate\Service\CsvValidatorService|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $csvValidator;
+
+  /**
+   * The resource import service mock.
+   *
+   * @var \Drupal\ys_migrate\Service\ResourceImportService|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $resourceImport;
+
+  /**
+   * The file storage mock.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $fileStorage;
+
+  /**
+   * The entity type manager mock.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The renderer mock.
+   *
+   * @var \Drupal\Core\Render\RendererInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $renderer;
+
+  /**
+   * The form under test.
+   *
+   * @var \Drupal\ys_migrate\Form\ResourceCsvImportForm
+   */
+  protected $form;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->messenger = $this->createMock(MessengerInterface::class);
+    $this->csvValidator = $this->createMock(CsvValidatorService::class);
+    $this->resourceImport = $this->createMock(ResourceImportService::class);
+
+    $this->fileStorage = $this->createMock(EntityStorageInterface::class);
+    $this->entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $this->entityTypeManager->method('getStorage')->with('file')->willReturn($this->fileStorage);
+
+    $this->renderer = $this->createMock(RendererInterface::class);
+
+    $this->form = new ResourceCsvImportForm(
+      $this->messenger,
+      $this->csvValidator,
+      $this->resourceImport,
+      $this->entityTypeManager,
+      $this->renderer
+    );
+    $this->form->setStringTranslation($this->getStringTranslationStub());
+  }
+
+  /**
+   * Builds a partial mock isolating submitForm() from the real batch_set().
+   *
+   * Setting a real batch requires a full Drupal batch API, unavailable in a
+   * unit test, so setBatch() is mocked out here to capture what it was
+   * called with.
+   */
+  protected function partialForm(array $onlyMethods): ResourceCsvImportForm {
+    $form = $this->getMockBuilder(ResourceCsvImportForm::class)
+      ->setConstructorArgs([
+        $this->messenger,
+        $this->csvValidator,
+        $this->resourceImport,
+        $this->entityTypeManager,
+        $this->renderer,
+      ])
+      ->onlyMethods($onlyMethods)
+      ->getMock();
+    $form->setStringTranslation($this->getStringTranslationStub());
+    return $form;
+  }
+
+  /**
+   * GetFormId() returns the expected form machine name.
+   *
+   * @covers ::getFormId
+   */
+  public function testGetFormId() {
+    $this->assertEquals('ys_migrate_resource_csv_import', $this->form->getFormId());
+  }
+
+  /**
+   * SubmitForm() previews the import and cleans up the uploaded file.
+   *
+   * Preview renders its own response synchronously and never touches the
+   * batch queue, so this path is unchanged by the batch work.
+   *
+   * @covers ::submitForm
+   */
+  public function testSubmitFormPreviewOnlyDoesNotBatch() {
+    $file = $this->createMock(FileInterface::class);
+    $file->expects($this->once())->method('delete');
+    $this->fileStorage->method('load')->with(123)->willReturn($file);
+
+    $this->resourceImport->method('previewImport')->willReturn([
+      'valid_resources' => [],
+      'duplicates' => [],
+      'errors' => [],
+      'total' => 0,
+    ]);
+    $this->resourceImport->expects($this->never())->method('processImport');
+
+    $form_array = [];
+    $form_state = new FormState();
+    $form_state->setValue('csv_file', [123]);
+    $form_state->setValue('preview', TRUE);
+    $form_state->setValue('skip_duplicates', TRUE);
+    $form_state->set('csv_validation', ['data' => [['title' => 'Resource A']]]);
+
+    $this->form->submitForm($form_array, $form_state);
+  }
+
+  /**
+   * SubmitForm() schedules a batch instead of processing synchronously.
+   *
+   * Mirrors ProfileCsvImportForm's batching: created/skipped/needs_media/
+   * error reporting and file cleanup move to CsvImportBatch (covered by
+   * CsvImportBatchTest), so submitForm() no longer calls processImport(),
+   * the messenger, or delete() directly.
+   *
+   * @covers ::submitForm
+   */
+  public function testSubmitFormProcessImportSchedulesBatch() {
+    $file = $this->createMock(FileInterface::class);
+    $file->expects($this->never())->method('delete');
+    $this->fileStorage->method('load')->with(123)->willReturn($file);
+
+    $this->resourceImport->expects($this->never())->method('processImport');
+    $this->messenger->expects($this->never())->method('addStatus');
+
+    $captured = NULL;
+    $form = $this->partialForm(['setBatch']);
+    $form->expects($this->once())->method('setBatch')->with($this->callback(function ($batch) use (&$captured) {
+      $captured = $batch;
+      return TRUE;
+    }));
+
+    $data = [
+      ['title' => 'Resource A'],
+      ['title' => 'Resource B'],
+    ];
+
+    $form_array = [];
+    $form_state = new FormState();
+    $form_state->setValue('csv_file', [123]);
+    $form_state->setValue('preview', FALSE);
+    $form_state->setValue('skip_duplicates', TRUE);
+    $form_state->set('csv_validation', ['data' => $data]);
+
+    $form->submitForm($form_array, $form_state);
+
+    $this->assertSame([CsvImportBatch::class, 'finished'], $captured['finished']);
+    $this->assertCount(2, $captured['operations']);
+
+    [$chunk_callback, $chunk_args] = $captured['operations'][0];
+    $this->assertSame([CsvImportBatch::class, 'processChunk'], $chunk_callback);
+    $this->assertSame('ys_migrate.resource_import', $chunk_args[0]);
+    $this->assertSame($data, $chunk_args[1]);
+    $this->assertTrue($chunk_args[2]);
+    $this->assertSame('resource', $chunk_args[3]);
+
+    [$cleanup_callback, $cleanup_args] = $captured['operations'][1];
+    $this->assertSame([CsvImportBatch::class, 'deleteUploadedFile'], $cleanup_callback);
+    $this->assertSame([123], $cleanup_args);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceCsvImportFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceCsvImportFormTest.php
@@ -148,25 +148,32 @@ class ResourceCsvImportFormTest extends UnitTestCase {
   }
 
   /**
-   * BuildForm() gives every column a note, including free-text fields.
+   * BuildForm() gives every expected column a note, free-text ones included.
    *
    * Description, Teaser Title and Teaser Text previously fell through to an
-   * empty notes cell with nothing to tell an editor what belongs there.
+   * empty notes cell with nothing to tell an editor what belongs there. The
+   * form is built against the real CsvValidatorService rather than a mock
+   * with a hand-listed column set, so a column added to
+   * EXPECTED_RESOURCE_COLUMNS without a matching columnNotes() entry fails
+   * here instead of shipping blank.
    *
    * @covers ::buildForm
    * @covers ::columnNotes
    */
-  public function testBuildFormNotesFreeTextColumnsRatherThanLeavingThemBlank() {
-    $this->csvValidator->method('getExpectedResourceColumns')->willReturn([
-      'description' => 'Description',
-      'teaser title' => 'Teaser Title',
-      'teaser text' => 'Teaser Text',
-    ]);
+  public function testBuildFormNotesEveryExpectedResourceColumn() {
+    $form = new ResourceCsvImportForm(
+      $this->messenger,
+      new CsvValidatorService(),
+      $this->resourceImport,
+      $this->entityTypeManager,
+      $this->renderer
+    );
+    $form->setStringTranslation($this->getStringTranslationStub());
 
-    $form = $this->form->buildForm([], new FormState());
+    $built = $form->buildForm([], new FormState());
 
-    foreach ($form['columns']['#rows'] as $row) {
-      $this->assertNotSame('', $row[1], "{$row[0]} should not have a blank notes cell.");
+    foreach ($built['columns']['#rows'] as $row) {
+      $this->assertNotSame('', (string) $row[1], "{$row[0]} should not have a blank notes cell.");
     }
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceCsvImportFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceCsvImportFormTest.php
@@ -134,6 +134,20 @@ class ResourceCsvImportFormTest extends UnitTestCase {
   }
 
   /**
+   * BuildForm() includes a link to download a sample CSV.
+   *
+   * @covers ::buildForm
+   */
+  public function testBuildFormIncludesSampleDownloadLink() {
+    $this->csvValidator->method('getExpectedResourceColumns')->willReturn(['title' => 'Title']);
+
+    $form = $this->form->buildForm([], new FormState());
+
+    $this->assertEquals('link', $form['sample_download']['#type']);
+    $this->assertEquals('ys_migrate.resource_csv_sample', $form['sample_download']['#url']->getRouteName());
+  }
+
+  /**
    * SubmitForm() previews the import and cleans up the uploaded file.
    *
    * Preview renders its own response synchronously and never touches the

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceCsvImportFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceCsvImportFormTest.php
@@ -165,6 +165,33 @@ class ResourceCsvImportFormTest extends UnitTestCase {
   }
 
   /**
+   * SubmitForm() preview cleanup tolerates a file entity that is already gone.
+   *
+   * @covers ::submitForm
+   */
+  public function testSubmitFormPreviewOnlyToleratesMissingFile() {
+    $this->fileStorage->method('load')->with(123)->willReturn(NULL);
+
+    $this->resourceImport->method('previewImport')->willReturn([
+      'valid_resources' => [],
+      'duplicates' => [],
+      'errors' => [],
+      'total' => 0,
+    ]);
+
+    $form_array = [];
+    $form_state = new FormState();
+    $form_state->setValue('csv_file', [123]);
+    $form_state->setValue('preview', TRUE);
+    $form_state->setValue('skip_duplicates', TRUE);
+    $form_state->set('csv_validation', ['data' => []]);
+
+    // No exception, nothing to assert beyond "this does not throw".
+    $this->form->submitForm($form_array, $form_state);
+    $this->addToAssertionCount(1);
+  }
+
+  /**
    * SubmitForm() schedules a batch instead of processing synchronously.
    *
    * Mirrors ProfileCsvImportForm's batching: created/skipped/needs_media/
@@ -208,10 +235,12 @@ class ResourceCsvImportFormTest extends UnitTestCase {
 
     [$chunk_callback, $chunk_args] = $captured['operations'][0];
     $this->assertSame([CsvImportBatch::class, 'processChunk'], $chunk_callback);
-    $this->assertSame('ys_migrate.resource_import', $chunk_args[0]);
+    $this->assertSame([
+      'import_service_id' => 'ys_migrate.resource_import',
+      'skip_duplicates' => TRUE,
+      'entity_label' => 'resource',
+    ], $chunk_args[0]);
     $this->assertSame($data, $chunk_args[1]);
-    $this->assertTrue($chunk_args[2]);
-    $this->assertSame('resource', $chunk_args[3]);
 
     [$cleanup_callback, $cleanup_args] = $captured['operations'][1];
     $this->assertSame([CsvImportBatch::class, 'deleteUploadedFile'], $cleanup_callback);

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceCsvSampleControllerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceCsvSampleControllerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Drupal\Tests\ys_migrate\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_migrate\Controller\ResourceCsvSampleController;
+use Drupal\ys_migrate\Service\CsvValidatorService;
+
+/**
+ * Unit tests for ResourceCsvSampleController.
+ *
+ * @coversDefaultClass \Drupal\ys_migrate\Controller\ResourceCsvSampleController
+ * @group ys_migrate
+ * @group yalesites
+ */
+class ResourceCsvSampleControllerTest extends UnitTestCase {
+
+  /**
+   * BuildCsv() writes the column labels as the header row, in order.
+   *
+   * @covers ::buildCsv
+   */
+  public function testBuildCsvWritesHeaderRowInColumnOrder() {
+    $columns = ['title' => 'Title', 'audience' => 'Audience', 'tags' => 'Tags'];
+    $example = ['title' => 'Example', 'audience' => 'Faculty', 'tags' => 'Research'];
+
+    $csv = ResourceCsvSampleController::buildCsv($columns, $example);
+    $rows = array_map('str_getcsv', explode("\n", trim($csv)));
+
+    $this->assertSame(['Title', 'Audience', 'Tags'], $rows[0]);
+  }
+
+  /**
+   * BuildCsv() writes the example row values in the same column order.
+   *
+   * @covers ::buildCsv
+   */
+  public function testBuildCsvWritesExampleRowInColumnOrder() {
+    $columns = ['title' => 'Title', 'audience' => 'Audience', 'tags' => 'Tags'];
+    $example = ['title' => 'Example Resource', 'audience' => 'Faculty', 'tags' => 'Research'];
+
+    $csv = ResourceCsvSampleController::buildCsv($columns, $example);
+    $rows = array_map('str_getcsv', explode("\n", trim($csv)));
+
+    $this->assertSame(['Example Resource', 'Faculty', 'Research'], $rows[1]);
+  }
+
+  /**
+   * BuildCsv() correctly quotes an example value containing a comma.
+   *
+   * @covers ::buildCsv
+   */
+  public function testBuildCsvQuotesValuesContainingCommas() {
+    $columns = ['title' => 'Title', 'audience' => 'Audience'];
+    $example = ['title' => 'Example Resource', 'audience' => 'Faculty, Staff'];
+
+    $csv = ResourceCsvSampleController::buildCsv($columns, $example);
+    $rows = array_map('str_getcsv', explode("\n", trim($csv)));
+
+    // A naive implementation might just implode(',', ...) and split the
+    // multi-value cell into two columns; str_getcsv() only recovers the
+    // intended single value if the writer actually quoted it.
+    $this->assertSame(['Example Resource', 'Faculty, Staff'], $rows[1]);
+  }
+
+  /**
+   * BuildCsv() writes an empty cell for a column missing from the example.
+   *
+   * @covers ::buildCsv
+   */
+  public function testBuildCsvWritesEmptyCellForMissingExampleValue() {
+    $columns = ['title' => 'Title', 'description' => 'Description'];
+    $example = ['title' => 'Example Resource'];
+
+    $csv = ResourceCsvSampleController::buildCsv($columns, $example);
+    $rows = array_map('str_getcsv', explode("\n", trim($csv)));
+
+    $this->assertSame(['Example Resource', ''], $rows[1]);
+  }
+
+  /**
+   * Download() streams a CSV response with an attachment filename.
+   *
+   * @covers ::download
+   */
+  public function testDownloadReturnsCsvAttachmentResponse() {
+    $csvValidator = $this->createMock(CsvValidatorService::class);
+    $csvValidator->method('getExpectedResourceColumns')->willReturn([
+      'title' => 'Title',
+      'audience' => 'Audience',
+    ]);
+
+    $controller = new ResourceCsvSampleController($csvValidator);
+    $response = $controller->download();
+
+    $this->assertStringContainsString('text/csv', $response->headers->get('Content-Type'));
+    $this->assertStringContainsString('attachment', $response->headers->get('Content-Disposition'));
+    $this->assertStringContainsString('resource-import-sample.csv', $response->headers->get('Content-Disposition'));
+
+    $rows = array_map('str_getcsv', explode("\n", trim($response->getContent())));
+    $this->assertSame(['Title', 'Audience'], $rows[0]);
+  }
+
+  /**
+   * Download() only ever writes columns CsvValidatorService actually expects.
+   *
+   * Guards against the controller's own hardcoded example row silently
+   * drifting out of sync with CsvValidatorService::EXPECTED_RESOURCE_COLUMNS
+   * (e.g. after a column is renamed or removed there).
+   *
+   * @covers ::download
+   */
+  public function testDownloadExampleRowHasNoColumnsOutsideExpected() {
+    $csvValidator = new CsvValidatorService();
+    $controller = new ResourceCsvSampleController($csvValidator);
+
+    $response = $controller->download();
+    $rows = array_map('str_getcsv', explode("\n", trim($response->getContent())));
+
+    $expected = array_values($csvValidator->getExpectedResourceColumns());
+    $this->assertSame($expected, $rows[0]);
+    $this->assertCount(count($expected), $rows[1], 'Example row has one cell per expected column.');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceCsvSampleControllerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceCsvSampleControllerTest.php
@@ -102,11 +102,13 @@ class ResourceCsvSampleControllerTest extends UnitTestCase {
   }
 
   /**
-   * Download() only ever writes columns CsvValidatorService actually expects.
+   * Download() writes exactly the columns CsvValidatorService expects, filled.
    *
    * Guards against the controller's own hardcoded example row silently
-   * drifting out of sync with CsvValidatorService::EXPECTED_RESOURCE_COLUMNS
-   * (e.g. after a column is renamed or removed there).
+   * drifting out of sync with CsvValidatorService::EXPECTED_RESOURCE_COLUMNS:
+   * a column renamed or removed there, or a column added there with no
+   * matching exampleRow() entry, which ships as a blank cell that tells the
+   * editor nothing about what belongs in it.
    *
    * @covers ::download
    */
@@ -120,6 +122,10 @@ class ResourceCsvSampleControllerTest extends UnitTestCase {
     $expected = array_values($csvValidator->getExpectedResourceColumns());
     $this->assertSame($expected, $rows[0]);
     $this->assertCount(count($expected), $rows[1], 'Example row has one cell per expected column.');
+
+    foreach ($rows[0] as $index => $label) {
+      $this->assertNotSame('', $rows[1][$index], "{$label} should have an example value.");
+    }
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceImportServiceTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceImportServiceTest.php
@@ -12,6 +12,7 @@ use Drupal\Tests\UnitTestCase;
 use Drupal\field\FieldConfigInterface;
 use Drupal\field\FieldStorageConfigInterface;
 use Drupal\node\NodeInterface;
+use Drupal\ys_migrate\Service\CsvValidatorService;
 use Drupal\ys_migrate\Service\ResourceImportService;
 use Drupal\ys_migrate\Service\TaxonomyResolverService;
 
@@ -145,6 +146,10 @@ class ResourceImportServiceTest extends UnitTestCase {
     $row = [
       'title' => '  Annual Report  ',
       'description' => ' A yearly summary. ',
+      'abstract' => ' What the report covers. ',
+      'citation' => ' Yale Research Review, 2026. ',
+      'journal publication name' => ' Yale Research Review ',
+      'journal publication issue' => ' Vol. 12, No. 2 ',
       'resource category' => 'Reports, Finance',
       'audience' => 'Alumni',
       'custom vocab' => 'Custom A',
@@ -162,6 +167,10 @@ class ResourceImportServiceTest extends UnitTestCase {
 
     $this->assertSame('Annual Report', $result['title']);
     $this->assertSame('A yearly summary.', $result['description']);
+    $this->assertSame('What the report covers.', $result['abstract']);
+    $this->assertSame('Yale Research Review, 2026.', $result['citation']);
+    $this->assertSame('Yale Research Review', $result['journal_publication_name']);
+    $this->assertSame('Vol. 12, No. 2', $result['journal_publication_issue']);
     $this->assertSame(['Reports', 'Finance'], $result['category']);
     $this->assertSame(['Alumni'], $result['audience']);
     $this->assertSame(['Custom A'], $result['custom_vocab']);
@@ -173,6 +182,53 @@ class ResourceImportServiceTest extends UnitTestCase {
     $this->assertSame('https://example.com/report.pdf', $result['external_source']);
     $this->assertTrue($result['login_required']);
     $this->assertFalse($result['sticky']);
+  }
+
+  /**
+   * Every recognised CSV column is actually read into the prepared data.
+   *
+   * A column added to CsvValidatorService but never read here is validated,
+   * listed as recognised, and given an example in the sample CSV -- and then
+   * silently dropped. Nothing else catches that: getUnknownResourceColumns()
+   * diffs incoming headers against the declared list, which is the very list
+   * the column was just added to.
+   *
+   * @covers ::prepareResourceData
+   */
+  public function testEveryExpectedColumnIsReadIntoPreparedData() {
+    $this->passThroughTaxonomyParsing();
+
+    // Each recognised column and the prepared-data key it lands in.
+    $lands_in = [
+      'title' => 'title',
+      'description' => 'description',
+      'abstract' => 'abstract',
+      'citation' => 'citation',
+      'journal publication name' => 'journal_publication_name',
+      'journal publication issue' => 'journal_publication_issue',
+      'resource category' => 'category',
+      'audience' => 'audience',
+      'custom vocab' => 'custom_vocab',
+      'resource publication date' => 'publish_date',
+      'date format' => 'date_format',
+      'tags' => 'tags',
+      'teaser title' => 'teaser_title',
+      'teaser text' => 'teaser_text',
+      'external source' => 'external_source',
+      'cas login required' => 'login_required',
+      'pin to beginning of list' => 'sticky',
+    ];
+
+    $this->assertEqualsCanonicalizing(
+      array_keys(CsvValidatorService::EXPECTED_RESOURCE_COLUMNS),
+      array_keys($lands_in),
+      'Every recognised column must name the prepared-data key it lands in.'
+    );
+    $this->assertEqualsCanonicalizing(
+      array_values($lands_in),
+      array_keys($this->resourceImport->prepareResourceData([])),
+      'Every mapped key must be produced by prepareResourceData().'
+    );
   }
 
   /**
@@ -214,6 +270,10 @@ class ResourceImportServiceTest extends UnitTestCase {
 
     $this->assertSame('Bare Resource', $result['title']);
     $this->assertSame('', $result['description']);
+    $this->assertSame('', $result['abstract']);
+    $this->assertSame('', $result['citation']);
+    $this->assertSame('', $result['journal_publication_name']);
+    $this->assertSame('', $result['journal_publication_issue']);
     $this->assertSame([], $result['tags']);
     $this->assertNull($result['publish_date']);
     $this->assertNull($result['date_format']);
@@ -477,6 +537,10 @@ class ResourceImportServiceTest extends UnitTestCase {
     $this->resourceImport->createResourceNode([
       'title' => 'Annual Report',
       'description' => 'A yearly summary.',
+      'abstract' => 'What the report covers.',
+      'citation' => 'Yale Research Review, 2026.',
+      'journal_publication_name' => 'Yale Research Review',
+      'journal_publication_issue' => 'Vol. 12, No. 2',
       'category' => ['Reports'],
       'audience' => ['Alumni'],
       'custom_vocab' => ['Custom A'],
@@ -521,6 +585,19 @@ class ResourceImportServiceTest extends UnitTestCase {
       ['value' => 'Short teaser.', 'format' => 'heading_html'],
       $captured['field_teaser_text']
     );
+    $this->assertSame(
+      ['value' => 'What the report covers.', 'format' => 'restricted_html'],
+      $captured['field_abstract']
+    );
+    $this->assertSame(
+      ['value' => 'Yale Research Review, 2026.', 'format' => 'restricted_html'],
+      $captured['field_citation']
+    );
+
+    // Journal Publication Name and Issue are plain string fields, so they
+    // store a bare value the way Teaser Title does.
+    $this->assertSame('Yale Research Review', $captured['field_journal_publication_name']);
+    $this->assertSame('Vol. 12, No. 2', $captured['field_journal_publication_issue']);
 
     // A link field stores a URI, not a bare string.
     $this->assertSame(
@@ -545,27 +622,17 @@ class ResourceImportServiceTest extends UnitTestCase {
         return $node;
       });
 
-    $this->resourceImport->createResourceNode([
-      'title' => 'Bare Resource',
-      'description' => '',
-      'category' => [],
-      'audience' => [],
-      'custom_vocab' => [],
-      'tags' => [],
-      'publish_date' => NULL,
-      'date_format' => NULL,
-      'teaser_title' => '',
-      'teaser_text' => '',
-      'external_source' => '',
-      'login_required' => FALSE,
-      'sticky' => FALSE,
-    ]);
+    $this->resourceImport->createResourceNode(['title' => 'Bare Resource'] + $this->emptyData());
 
     $this->assertArrayNotHasKey('field_publish_date', $captured);
     $this->assertArrayNotHasKey('field_date_format', $captured);
     $this->assertArrayNotHasKey('field_external_source', $captured);
     $this->assertArrayNotHasKey('field_content_description', $captured);
     $this->assertArrayNotHasKey('field_teaser_text', $captured);
+    $this->assertArrayNotHasKey('field_abstract', $captured);
+    $this->assertArrayNotHasKey('field_citation', $captured);
+    $this->assertArrayNotHasKey('field_journal_publication_name', $captured);
+    $this->assertArrayNotHasKey('field_journal_publication_issue', $captured);
     $this->assertSame('Bare Resource', $captured['title']);
   }
 
@@ -711,6 +778,10 @@ class ResourceImportServiceTest extends UnitTestCase {
   protected function emptyData(): array {
     return [
       'description' => '',
+      'abstract' => '',
+      'citation' => '',
+      'journal_publication_name' => '',
+      'journal_publication_issue' => '',
       'category' => [],
       'audience' => [],
       'custom_vocab' => [],

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceImportServiceTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/ResourceImportServiceTest.php
@@ -1,0 +1,728 @@
+<?php
+
+namespace Drupal\Tests\ys_migrate\Unit;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\field\FieldConfigInterface;
+use Drupal\field\FieldStorageConfigInterface;
+use Drupal\node\NodeInterface;
+use Drupal\ys_migrate\Service\ResourceImportService;
+use Drupal\ys_migrate\Service\TaxonomyResolverService;
+
+/**
+ * Unit tests for ResourceImportService.
+ *
+ * @coversDefaultClass \Drupal\ys_migrate\Service\ResourceImportService
+ * @group ys_migrate
+ * @group yalesites
+ */
+class ResourceImportServiceTest extends UnitTestCase {
+
+  /**
+   * The taxonomy resolver mock.
+   *
+   * @var \Drupal\ys_migrate\Service\TaxonomyResolverService|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $taxonomyResolver;
+
+  /**
+   * The node storage mock.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $nodeStorage;
+
+  /**
+   * The field storage config storage mock.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $fieldStorage;
+
+  /**
+   * The entity type manager mock.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The logger channel mock.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $loggerChannel;
+
+  /**
+   * The logger factory mock.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $loggerFactory;
+
+  /**
+   * The current user mock.
+   *
+   * @var \Drupal\Core\Session\AccountInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $currentUser;
+
+  /**
+   * The service under test.
+   *
+   * @var \Drupal\ys_migrate\Service\ResourceImportService
+   */
+  protected $resourceImport;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->currentUser = $this->createMock(AccountInterface::class);
+    $this->currentUser->method('id')->willReturn(42);
+
+    $this->taxonomyResolver = $this->createMock(TaxonomyResolverService::class);
+
+    $this->nodeStorage = $this->createMock(EntityStorageInterface::class);
+    $this->fieldStorage = $this->createMock(EntityStorageInterface::class);
+    $this->entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $this->entityTypeManager->method('getStorage')
+      ->willReturnCallback(function ($entity_type) {
+        return $entity_type === 'node' ? $this->nodeStorage : $this->fieldStorage;
+      });
+
+    $this->loggerChannel = $this->createMock(LoggerChannelInterface::class);
+    $this->loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $this->loggerFactory->method('get')->with('ys_migrate')->willReturn($this->loggerChannel);
+
+    $this->resourceImport = new ResourceImportService(
+      $this->currentUser,
+      $this->taxonomyResolver,
+      $this->entityTypeManager,
+      $this->loggerFactory
+    );
+    $this->resourceImport->setStringTranslation($this->getStringTranslationStub());
+  }
+
+  /**
+   * Builds a query mock that returns the given nids from execute().
+   */
+  protected function mockQuery(array $nids): QueryInterface {
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('condition')->willReturnSelf();
+    $query->method('range')->willReturnSelf();
+    $query->method('accessCheck')->willReturnSelf();
+    $query->method('execute')->willReturn($nids);
+    return $query;
+  }
+
+  /**
+   * Makes the taxonomy resolver behave like the real comma splitter.
+   */
+  protected function passThroughTaxonomyParsing(): void {
+    $this->taxonomyResolver->method('parseCommaSeparatedValues')
+      ->willReturnCallback(function ($value) {
+        return $value === '' ? [] : array_map('trim', array_filter(explode(',', $value)));
+      });
+  }
+
+  /**
+   * A full CSV row is trimmed and reshaped into the expected resource data.
+   *
+   * @covers ::prepareResourceData
+   */
+  public function testPrepareResourceDataWithFullRow() {
+    $this->passThroughTaxonomyParsing();
+
+    $row = [
+      'title' => '  Annual Report  ',
+      'description' => ' A yearly summary. ',
+      'resource category' => 'Reports, Finance',
+      'audience' => 'Alumni',
+      'custom vocab' => 'Custom A',
+      'resource publication date' => '2026-03-04',
+      'date format' => 'Month/Year',
+      'tags' => 'tag1, tag2',
+      'teaser title' => ' Report ',
+      'teaser text' => ' Short teaser. ',
+      'external source' => ' https://example.com/report.pdf ',
+      'cas login required' => 'Yes',
+      'pin to beginning of list' => 'No',
+    ];
+
+    $result = $this->resourceImport->prepareResourceData($row);
+
+    $this->assertSame('Annual Report', $result['title']);
+    $this->assertSame('A yearly summary.', $result['description']);
+    $this->assertSame(['Reports', 'Finance'], $result['category']);
+    $this->assertSame(['Alumni'], $result['audience']);
+    $this->assertSame(['Custom A'], $result['custom_vocab']);
+    $this->assertSame(['tag1', 'tag2'], $result['tags']);
+    $this->assertSame('2026-03-04', $result['publish_date']);
+    $this->assertSame('month_year', $result['date_format']);
+    $this->assertSame('Report', $result['teaser_title']);
+    $this->assertSame('Short teaser.', $result['teaser_text']);
+    $this->assertSame('https://example.com/report.pdf', $result['external_source']);
+    $this->assertTrue($result['login_required']);
+    $this->assertFalse($result['sticky']);
+  }
+
+  /**
+   * The stored text format is read from each field's own allowed_formats.
+   *
+   * @covers ::createResourceNode
+   */
+  public function testCreateResourceNodeReadsTextFormatFromFieldConfig() {
+    $this->taxonomyResolver->method('resolveTerms')->willReturn([]);
+
+    $field = $this->createMock(FieldConfigInterface::class);
+    $field->method('getSetting')->with('allowed_formats')->willReturn(['some_other_html']);
+    $this->fieldStorage->method('load')->willReturn($field);
+
+    $captured = NULL;
+    $node = $this->createMock(NodeInterface::class);
+    $this->nodeStorage->method('create')
+      ->willReturnCallback(function ($values) use (&$captured, $node) {
+        $captured = $values;
+        return $node;
+      });
+
+    $this->resourceImport->createResourceNode(
+      ['title' => 'Configured', 'description' => 'Body.'] + $this->emptyData()
+    );
+
+    $this->assertSame('some_other_html', $captured['field_content_description']['format']);
+  }
+
+  /**
+   * A row with only a title yields empty values for everything else.
+   *
+   * @covers ::prepareResourceData
+   */
+  public function testPrepareResourceDataWithTitleOnly() {
+    $this->passThroughTaxonomyParsing();
+
+    $result = $this->resourceImport->prepareResourceData(['title' => 'Bare Resource']);
+
+    $this->assertSame('Bare Resource', $result['title']);
+    $this->assertSame('', $result['description']);
+    $this->assertSame([], $result['tags']);
+    $this->assertNull($result['publish_date']);
+    $this->assertNull($result['date_format']);
+    $this->assertSame('', $result['external_source']);
+    $this->assertFalse($result['login_required']);
+    $this->assertFalse($result['sticky']);
+  }
+
+  /**
+   * A repeated title inside one file counts as a duplicate in the preview.
+   *
+   * The preview is the feature's safety net, so it must not promise two
+   * creations where the import would make one and skip the other.
+   *
+   * @covers ::previewImport
+   */
+  public function testPreviewImportCountsRepeatedTitlesWithinTheFile() {
+    $this->passThroughTaxonomyParsing();
+    $this->nodeStorage->method('getQuery')->willReturn($this->mockQuery([]));
+
+    $result = $this->resourceImport->previewImport([
+      ['title' => 'Same Name'],
+      ['title' => 'Same Name'],
+    ], TRUE);
+
+    $this->assertCount(1, $result['valid_resources']);
+    $this->assertSame(['Same Name'], $result['duplicates']);
+  }
+
+  /**
+   * An unparseable date is rejected rather than silently guessed at.
+   *
+   * @covers ::prepareResourceData
+   */
+  public function testPrepareResourceDataRejectsUnparseableDate() {
+    $this->passThroughTaxonomyParsing();
+
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('Resource Publication Date');
+
+    $this->resourceImport->prepareResourceData([
+      'title' => 'Bad Date',
+      'resource publication date' => 'sometime last spring',
+    ]);
+  }
+
+  /**
+   * A date that looks valid but is not a real day is rejected.
+   *
+   * @covers ::prepareResourceData
+   */
+  public function testPrepareResourceDataRejectsImpossibleDate() {
+    $this->passThroughTaxonomyParsing();
+
+    $this->expectException(\InvalidArgumentException::class);
+
+    $this->resourceImport->prepareResourceData([
+      'title' => 'Impossible Date',
+      'resource publication date' => '2026-02-31',
+    ]);
+  }
+
+  /**
+   * Date Format accepts the stored key as well as the human label.
+   *
+   * @covers ::prepareResourceData
+   */
+  public function testPrepareResourceDataAcceptsDateFormatKeyOrLabel() {
+    $this->passThroughTaxonomyParsing();
+
+    $byKey = $this->resourceImport->prepareResourceData([
+      'title' => 'Key',
+      'date format' => 'year_only',
+    ]);
+    $byLabel = $this->resourceImport->prepareResourceData([
+      'title' => 'Label',
+      'date format' => 'month/day/year',
+    ]);
+
+    $this->assertSame('year_only', $byKey['date_format']);
+    $this->assertSame('date', $byLabel['date_format']);
+  }
+
+  /**
+   * Date Format options come from the field's own storage config.
+   *
+   * A value added to field.storage.node.field_date_format must be accepted
+   * without editing this service.
+   *
+   * @covers ::prepareResourceData
+   */
+  public function testPrepareResourceDataReadsDateFormatOptionsFromFieldConfig() {
+    $this->passThroughTaxonomyParsing();
+
+    $field_storage = $this->createMock(FieldStorageConfigInterface::class);
+    // A loaded field storage hands back a simplified value => label map, not
+    // the value/label pairs the config YAML is written as.
+    $field_storage->method('getSetting')->with('allowed_values')->willReturn([
+      'year_only' => 'Year',
+      'decade' => 'Decade',
+    ]);
+    $this->fieldStorage->method('load')->with('node.field_date_format')->willReturn($field_storage);
+
+    $result = $this->resourceImport->prepareResourceData([
+      'title' => 'Config Driven',
+      'date format' => 'Decade',
+    ]);
+
+    $this->assertSame('decade', $result['date_format']);
+  }
+
+  /**
+   * An unknown Date Format value is rejected.
+   *
+   * @covers ::prepareResourceData
+   */
+  public function testPrepareResourceDataRejectsUnknownDateFormat() {
+    $this->passThroughTaxonomyParsing();
+
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('Date Format');
+
+    $this->resourceImport->prepareResourceData([
+      'title' => 'Bad Format',
+      'date format' => 'fortnightly',
+    ]);
+  }
+
+  /**
+   * A non-http External Source is rejected before it reaches the link field.
+   *
+   * @covers ::prepareResourceData
+   */
+  public function testPrepareResourceDataRejectsNonHttpExternalSource() {
+    $this->passThroughTaxonomyParsing();
+
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('External Source');
+
+    $this->resourceImport->prepareResourceData([
+      'title' => 'Bad Link',
+      'external source' => 'javascript:alert(1)',
+    ]);
+  }
+
+  /**
+   * A bare hostname with no scheme is rejected.
+   *
+   * @covers ::prepareResourceData
+   */
+  public function testPrepareResourceDataRejectsSchemelessExternalSource() {
+    $this->passThroughTaxonomyParsing();
+
+    $this->expectException(\InvalidArgumentException::class);
+
+    $this->resourceImport->prepareResourceData([
+      'title' => 'Bare Host',
+      'external source' => 'example.com/report.pdf',
+    ]);
+  }
+
+  /**
+   * Boolean columns accept the spellings editors actually type.
+   *
+   * @covers ::prepareResourceData
+   *
+   * @dataProvider booleanValueProvider
+   */
+  public function testPrepareResourceDataCoercesBooleans($value, $expected) {
+    $this->passThroughTaxonomyParsing();
+
+    $result = $this->resourceImport->prepareResourceData([
+      'title' => 'Boolish',
+      'cas login required' => $value,
+    ]);
+
+    $this->assertSame($expected, $result['login_required']);
+  }
+
+  /**
+   * Accepted boolean spellings and the value each maps to.
+   */
+  public static function booleanValueProvider(): array {
+    return [
+      ['Yes', TRUE],
+      ['yes', TRUE],
+      ['TRUE', TRUE],
+      ['1', TRUE],
+      ['On', TRUE],
+      ['No', FALSE],
+      ['false', FALSE],
+      ['0', FALSE],
+      ['Off', FALSE],
+      ['', FALSE],
+    ];
+  }
+
+  /**
+   * An unrecognised boolean value is rejected rather than treated as FALSE.
+   *
+   * @covers ::prepareResourceData
+   */
+  public function testPrepareResourceDataRejectsUnknownBoolean() {
+    $this->passThroughTaxonomyParsing();
+
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('CAS Login Required');
+
+    $this->resourceImport->prepareResourceData([
+      'title' => 'Maybe',
+      'cas login required' => 'maybe',
+    ]);
+  }
+
+  /**
+   * An existing resource is matched by exact title within the bundle.
+   *
+   * @covers ::findExistingResource
+   */
+  public function testFindExistingResourceReturnsMatch() {
+    $node = $this->createMock(NodeInterface::class);
+    $this->nodeStorage->method('getQuery')->willReturn($this->mockQuery([7]));
+    $this->nodeStorage->method('load')->with(7)->willReturn($node);
+
+    $this->assertSame($node, $this->resourceImport->findExistingResource('Annual Report'));
+  }
+
+  /**
+   * No match returns NULL rather than loading anything.
+   *
+   * @covers ::findExistingResource
+   */
+  public function testFindExistingResourceReturnsNullWhenAbsent() {
+    $this->nodeStorage->method('getQuery')->willReturn($this->mockQuery([]));
+    $this->nodeStorage->expects($this->never())->method('load');
+
+    $this->assertNull($this->resourceImport->findExistingResource('Nothing'));
+  }
+
+  /**
+   * Prepared data is mapped onto the resource bundle's real field names.
+   *
+   * @covers ::createResourceNode
+   */
+  public function testCreateResourceNodeMapsFields() {
+    $this->taxonomyResolver->method('resolveTerms')->willReturnMap([
+      [['Reports'], 'resource_category', [11]],
+      [['Alumni'], 'audience', [12]],
+      [['tag1'], 'tags', [13]],
+      [['Custom A'], 'custom_vocab', [14]],
+    ]);
+
+    $captured = NULL;
+    $node = $this->createMock(NodeInterface::class);
+    $this->nodeStorage->method('create')
+      ->willReturnCallback(function ($values) use (&$captured, $node) {
+        $captured = $values;
+        return $node;
+      });
+
+    $this->resourceImport->createResourceNode([
+      'title' => 'Annual Report',
+      'description' => 'A yearly summary.',
+      'category' => ['Reports'],
+      'audience' => ['Alumni'],
+      'custom_vocab' => ['Custom A'],
+      'tags' => ['tag1'],
+      'publish_date' => '2026-03-04',
+      'date_format' => 'month_year',
+      'teaser_title' => 'Report',
+      'teaser_text' => 'Short teaser.',
+      'external_source' => 'https://example.com/report.pdf',
+      'login_required' => TRUE,
+      'sticky' => TRUE,
+    ]);
+
+    $this->assertSame('resource', $captured['type']);
+    $this->assertSame('Annual Report', $captured['title']);
+    $this->assertSame([11], $captured['field_category']);
+    $this->assertSame([12], $captured['field_audience']);
+    $this->assertSame([13], $captured['field_tags']);
+    $this->assertSame([14], $captured['field_custom_vocab']);
+    $this->assertSame('2026-03-04', $captured['field_publish_date']);
+    $this->assertSame('month_year', $captured['field_date_format']);
+    $this->assertSame('Report', $captured['field_teaser_title']);
+    $this->assertSame(1, $captured['field_login_required']);
+    $this->assertSame(1, $captured['sticky']);
+    $this->assertSame(42, $captured['uid']);
+
+    // The resource bundle is under the editorial workflow, so publication is
+    // owned by moderation_state. Setting 'status' instead is silently
+    // overridden, which is why it must not be used here.
+    $this->assertSame('draft', $captured['moderation_state']);
+    $this->assertArrayNotHasKey('status', $captured);
+
+    // Long-text fields must carry an explicit format, or Drupal falls back to
+    // the plain-text fallback filter and escapes the editor's markup. The
+    // format also has to be one the field allows, or the widget renders
+    // disabled on the node form.
+    $this->assertSame(
+      ['value' => 'A yearly summary.', 'format' => 'restricted_html'],
+      $captured['field_content_description']
+    );
+    $this->assertSame(
+      ['value' => 'Short teaser.', 'format' => 'heading_html'],
+      $captured['field_teaser_text']
+    );
+
+    // A link field stores a URI, not a bare string.
+    $this->assertSame(
+      ['uri' => 'https://example.com/report.pdf'],
+      $captured['field_external_source']
+    );
+  }
+
+  /**
+   * Empty optional values are omitted rather than written as empty fields.
+   *
+   * @covers ::createResourceNode
+   */
+  public function testCreateResourceNodeOmitsEmptyOptionalFields() {
+    $this->taxonomyResolver->method('resolveTerms')->willReturn([]);
+
+    $captured = NULL;
+    $node = $this->createMock(NodeInterface::class);
+    $this->nodeStorage->method('create')
+      ->willReturnCallback(function ($values) use (&$captured, $node) {
+        $captured = $values;
+        return $node;
+      });
+
+    $this->resourceImport->createResourceNode([
+      'title' => 'Bare Resource',
+      'description' => '',
+      'category' => [],
+      'audience' => [],
+      'custom_vocab' => [],
+      'tags' => [],
+      'publish_date' => NULL,
+      'date_format' => NULL,
+      'teaser_title' => '',
+      'teaser_text' => '',
+      'external_source' => '',
+      'login_required' => FALSE,
+      'sticky' => FALSE,
+    ]);
+
+    $this->assertArrayNotHasKey('field_publish_date', $captured);
+    $this->assertArrayNotHasKey('field_date_format', $captured);
+    $this->assertArrayNotHasKey('field_external_source', $captured);
+    $this->assertArrayNotHasKey('field_content_description', $captured);
+    $this->assertArrayNotHasKey('field_teaser_text', $captured);
+    $this->assertSame('Bare Resource', $captured['title']);
+  }
+
+  /**
+   * A failed save is logged and rethrown so the row error is reportable.
+   *
+   * @covers ::createResourceNode
+   */
+  public function testCreateResourceNodeRethrowsSaveFailure() {
+    $this->taxonomyResolver->method('resolveTerms')->willReturn([]);
+
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('save')->willThrowException(new \Exception('Database went away'));
+    $this->nodeStorage->method('create')->willReturn($node);
+
+    $this->loggerChannel->expects($this->once())->method('error');
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('Database went away');
+
+    $this->resourceImport->createResourceNode(['title' => 'Doomed'] + $this->emptyData());
+  }
+
+  /**
+   * Import counts creations and flags rows that still need Resource Media.
+   *
+   * @covers ::processImport
+   */
+  public function testProcessImportFlagsRowsNeedingMedia() {
+    $this->passThroughTaxonomyParsing();
+    $this->taxonomyResolver->method('resolveTerms')->willReturn([]);
+
+    $node = $this->createMock(NodeInterface::class);
+    $this->nodeStorage->method('create')->willReturn($node);
+    $this->nodeStorage->method('getQuery')->willReturn($this->mockQuery([]));
+
+    $result = $this->resourceImport->processImport([
+      ['title' => 'Has Source', 'external source' => 'https://example.com/a.pdf'],
+      ['title' => 'Needs Media'],
+    ], FALSE);
+
+    $this->assertSame(2, $result['created']);
+    $this->assertSame(0, $result['skipped']);
+    $this->assertSame([], $result['errors']);
+    $this->assertSame(['Needs Media'], $result['needs_media']);
+  }
+
+  /**
+   * Duplicate titles are skipped when the option is on.
+   *
+   * @covers ::processImport
+   */
+  public function testProcessImportSkipsDuplicateTitles() {
+    $this->passThroughTaxonomyParsing();
+    $this->taxonomyResolver->method('resolveTerms')->willReturn([]);
+
+    $existing = $this->createMock(NodeInterface::class);
+    $this->nodeStorage->method('getQuery')->willReturn($this->mockQuery([9]));
+    $this->nodeStorage->method('load')->willReturn($existing);
+    $this->nodeStorage->expects($this->never())->method('create');
+
+    $result = $this->resourceImport->processImport([
+      ['title' => 'Already Here'],
+    ], TRUE);
+
+    $this->assertSame(0, $result['created']);
+    $this->assertSame(1, $result['skipped']);
+  }
+
+  /**
+   * A bad cell fails only its own row and reports the real CSV line number.
+   *
+   * @covers ::processImport
+   */
+  public function testProcessImportReportsRowErrorsWithoutStoppingTheRun() {
+    $this->passThroughTaxonomyParsing();
+    $this->taxonomyResolver->method('resolveTerms')->willReturn([]);
+
+    $node = $this->createMock(NodeInterface::class);
+    $this->nodeStorage->method('create')->willReturn($node);
+    $this->nodeStorage->method('getQuery')->willReturn($this->mockQuery([]));
+
+    $result = $this->resourceImport->processImport([
+      ['title' => 'Good', '_row_number' => 2],
+      ['title' => 'Bad', 'resource publication date' => 'whenever', '_row_number' => 7],
+      ['title' => 'Also Good', '_row_number' => 8],
+    ], FALSE);
+
+    $this->assertSame(2, $result['created']);
+    $this->assertCount(1, $result['errors']);
+    $this->assertStringContainsString('Row 7', (string) $result['errors'][0]);
+  }
+
+  /**
+   * Preview creates nothing and separates duplicates from importable rows.
+   *
+   * @covers ::previewImport
+   */
+  public function testPreviewImportCreatesNothing() {
+    $this->passThroughTaxonomyParsing();
+
+    $existing = $this->createMock(NodeInterface::class);
+    $this->nodeStorage->method('getQuery')->willReturnOnConsecutiveCalls(
+      $this->mockQuery([]),
+      $this->mockQuery([9])
+    );
+    $this->nodeStorage->method('load')->willReturn($existing);
+    $this->nodeStorage->expects($this->never())->method('create');
+
+    $result = $this->resourceImport->previewImport([
+      ['title' => 'New One'],
+      ['title' => 'Already Here'],
+    ], TRUE);
+
+    $this->assertCount(1, $result['valid_resources']);
+    $this->assertSame('New One', $result['valid_resources'][0]['title']);
+    $this->assertSame(['Already Here'], $result['duplicates']);
+    $this->assertSame(2, $result['total']);
+  }
+
+  /**
+   * Preview surfaces bad cells before anything is saved.
+   *
+   * @covers ::previewImport
+   */
+  public function testPreviewImportReportsRowErrors() {
+    $this->passThroughTaxonomyParsing();
+    $this->nodeStorage->method('getQuery')->willReturn($this->mockQuery([]));
+
+    $result = $this->resourceImport->previewImport([
+      ['title' => 'Fine'],
+      ['title' => 'Broken', 'external source' => 'not a url', '_row_number' => 3],
+    ], FALSE);
+
+    $this->assertCount(1, $result['valid_resources']);
+    $this->assertCount(1, $result['errors']);
+    $this->assertStringContainsString('Row 3', (string) $result['errors'][0]);
+  }
+
+  /**
+   * Empty prepared values, for tests that only care about one key.
+   */
+  protected function emptyData(): array {
+    return [
+      'description' => '',
+      'category' => [],
+      'audience' => [],
+      'custom_vocab' => [],
+      'tags' => [],
+      'publish_date' => NULL,
+      'date_format' => NULL,
+      'teaser_title' => '',
+      'teaser_text' => '',
+      'external_source' => '',
+      'login_required' => FALSE,
+      'sticky' => FALSE,
+    ];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/TaxonomyResolverServiceTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/tests/src/Unit/TaxonomyResolverServiceTest.php
@@ -96,6 +96,40 @@ class TaxonomyResolverServiceTest extends UnitTestCase {
   }
 
   /**
+   * A term name repeated across CSV rows is only queried once.
+   *
+   * @covers ::findOrCreateTerm
+   */
+  public function testFindOrCreateTermCachesResolvedTermsForTheRequest() {
+    $term = $this->createMock(TermInterface::class);
+    $this->termStorage->expects($this->once())->method('getQuery')->willReturn($this->mockQuery([5 => '5']));
+    $this->termStorage->expects($this->once())->method('load')->with('5')->willReturn($term);
+
+    $first = $this->taxonomyResolver->findOrCreateTerm('Repeated Term', 'tags');
+    $second = $this->taxonomyResolver->findOrCreateTerm('Repeated Term', 'tags');
+
+    $this->assertSame($term, $first);
+    $this->assertSame($term, $second);
+  }
+
+  /**
+   * The same term name in a different vocabulary is resolved separately.
+   *
+   * @covers ::findOrCreateTerm
+   */
+  public function testFindOrCreateTermKeepsVocabulariesSeparate() {
+    $tag = $this->createMock(TermInterface::class);
+    $audience = $this->createMock(TermInterface::class);
+
+    $this->termStorage->expects($this->exactly(2))->method('getQuery')
+      ->willReturnOnConsecutiveCalls($this->mockQuery([5 => '5']), $this->mockQuery([6 => '6']));
+    $this->termStorage->method('load')->willReturnMap([['5', $tag], ['6', $audience]]);
+
+    $this->assertSame($tag, $this->taxonomyResolver->findOrCreateTerm('Alumni', 'tags'));
+    $this->assertSame($audience, $this->taxonomyResolver->findOrCreateTerm('Alumni', 'audience'));
+  }
+
+  /**
    * FindOrCreateTerm() creates and saves a new term when none matches.
    *
    * @covers ::findOrCreateTerm
@@ -206,34 +240,43 @@ class TaxonomyResolverServiceTest extends UnitTestCase {
   /**
    * ParseCommaSeparatedValues() drops genuinely empty segments.
    *
-   * Leading, trailing, and doubled-up commas produce empty ('') segments
-   * that are filtered out entirely -- but array_filter() preserves the
-   * original explode() indices, so the surviving values keep their original
-   * (non-sequential) keys rather than being renumbered from 0.
+   * Leading, trailing, and doubled-up commas produce empty segments, which are
+   * filtered out. The survivors are renumbered from 0 so callers can index the
+   * result; array_filter() alone would leave the original explode() indices.
    *
    * @covers ::parseCommaSeparatedValues
    */
   public function testParseCommaSeparatedValuesDropsEmptySegments() {
     $result = $this->taxonomyResolver->parseCommaSeparatedValues(',Alpha,,Beta,');
 
-    $this->assertSame([1 => 'Alpha', 3 => 'Beta'], $result);
+    $this->assertSame(['Alpha', 'Beta'], $result);
   }
 
   /**
-   * A whitespace-only segment survives filtering and becomes an empty string.
+   * A whitespace-only segment is dropped rather than becoming an empty name.
    *
-   * Array_filter() runs before array_map('trim', ...) in the implementation,
-   * so a segment of only spaces (truthy before trimming) is not dropped the
-   * way a literally empty segment is -- it instead comes out as ''. This
-   * characterizes that exact, easy-to-miss ordering rather than the more
-   * intuitive "no empty strings in the result" behavior.
+   * Trimming has to happen before the empty values are filtered out. The other
+   * order lets a segment of only spaces through, and findOrCreateTerm() then
+   * creates a nameless term in the vocabulary, which shows up unlabelled in
+   * every autocomplete and listing filter with nothing to explain it.
    *
    * @covers ::parseCommaSeparatedValues
    */
-  public function testParseCommaSeparatedValuesWhitespaceOnlySegmentBecomesEmptyString() {
+  public function testParseCommaSeparatedValuesDropsWhitespaceOnlySegments() {
     $result = $this->taxonomyResolver->parseCommaSeparatedValues('Alpha, ,Beta');
 
-    $this->assertSame(['Alpha', '', 'Beta'], $result);
+    $this->assertSame(['Alpha', 'Beta'], $result);
+  }
+
+  /**
+   * A term legitimately named "0" is not mistaken for an empty value.
+   *
+   * @covers ::parseCommaSeparatedValues
+   */
+  public function testParseCommaSeparatedValuesKeepsZeroAsTermName() {
+    $result = $this->taxonomyResolver->parseCommaSeparatedValues('0, Alpha');
+
+    $this->assertSame(['0', 'Alpha'], $result);
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/ys_migrate.links.action.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/ys_migrate.links.action.yml
@@ -4,3 +4,10 @@ ys_migrate.csv_import_profiles:
   title: 'CSV Import'
   appears_on:
     - view.manage_profiles.page_1
+
+# Adds an action link to the manage resources interface.
+ys_migrate.csv_import_resources:
+  route_name: ys_migrate.resource_csv_import
+  title: 'CSV Import'
+  appears_on:
+    - view.manage_resources.page_1

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/ys_migrate.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/ys_migrate.routing.yml
@@ -13,3 +13,10 @@ ys_migrate.resource_csv_import:
     _title: 'Resource CSV Import'
   requirements:
     _permission: 'create resource content'
+
+ys_migrate.resource_csv_sample:
+  path: '/admin/content/manage-resources/csv-import/sample.csv'
+  defaults:
+    _controller: '\Drupal\ys_migrate\Controller\ResourceCsvSampleController::download'
+  requirements:
+    _permission: 'create resource content'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/ys_migrate.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/ys_migrate.routing.yml
@@ -5,3 +5,11 @@ ys_migrate.profile_csv_import:
     _title: 'Profile CSV Import'
   requirements:
     _permission: 'create profile content'
+
+ys_migrate.resource_csv_import:
+  path: '/admin/content/manage-resources/csv-import'
+  defaults:
+    _form: '\Drupal\ys_migrate\Form\ResourceCsvImportForm'
+    _title: 'Resource CSV Import'
+  requirements:
+    _permission: 'create resource content'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/ys_migrate.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_migrate/ys_migrate.services.yml
@@ -8,4 +8,8 @@ services:
     
   ys_migrate.profile_import:
     class: Drupal\ys_migrate\Service\ProfileImportService
-    arguments: ['@current_user', '@ys_migrate.taxonomy_resolver', '@entity_type.manager', '@logger.factory'] 
+    arguments: ['@current_user', '@ys_migrate.taxonomy_resolver', '@entity_type.manager', '@logger.factory']
+
+  ys_migrate.resource_import:
+    class: Drupal\ys_migrate\Service\ResourceImportService
+    arguments: ['@current_user', '@ys_migrate.taxonomy_resolver', '@entity_type.manager', '@logger.factory']


### PR DESCRIPTION
## [1526: Feature Request: CSV Import for Resources](https://github.com/yalesites-org/YaleSites-Internal/issues/1526)

### Description of work

- Adds a CSV bulk importer for the Resource content type at `/admin/content/manage-resources/csv-import`, gated on `create resource content`, with a **CSV Import** action link on Manage Resources beside the existing **Export to CSV**.
- Mirrors the existing Profiles importer rather than starting a second import framework. `TaxonomyResolverService` is reused as-is, and `CsvValidatorService` grows a shared `parseCsv()` that both importers call instead of being copy-pasted. **The Profiles path is unchanged.**
- Preview-only mode is on by default and saves nothing; the import summary reports created / skipped / errored and **lists which resources still need Resource Media attached**.
- Columns: Title (required), Description, Abstract, Citation, Journal Publication Name, Journal Publication Issue, Resource Category, Audience, Custom Vocab, Resource Publication Date, Date Format, Tags, Teaser Title, Teaser Text, External Source, CAS Login Required, Pin to beginning of list.

### Three places the ticket and the data model disagreed

Worth a look, since two change what the ticket asked for:

1. **Resource Media is not a required field.** `field.field.node.resource.field_media.yml` is `required: false`, and a programmatic save runs no form-level validation anyway. The AC asking for "field validation adjusted for the import path so nodes can save without it" needed **no code** — imported nodes pass `$node->validate()` with **zero violations**. The AC's intent is met instead: nodes import without media, and the summary flags them.
2. **Affiliation does not exist on Resource.** Only `node.profile` has `field_affiliation`. The nearest Resource field is `field_authors` ("Affiliated Authors"), an entity reference to *profile nodes* — a different thing needing a node-title resolver. **Dropped from the column set.**
3. **Teaser Media can't come from a CSV cell either.** It is a `media:image` reference — the exact limitation the ticket already accepted for Resource Media, but it was still listed in the mapping AC. **Dropped, for the same stated reason.**

### Decisions made

- **Duplicates key on Title** (the AC asked for this decision) — the only required, human-meaningful field. "Skip duplicates" defaults on; unchecking it *is* the allow-duplicates option, so a second toggle would be redundant. Titles repeated **within one file** count too, so the preview can't promise more than the import delivers.
- **Dates** accept `YYYY-MM-DD` and `MM/DD/YYYY`, padded or not (Excel writes `3/4/2026`), and are round-trip checked so `2026-02-31` is rejected rather than rolled to March. `strtotime()` was deliberately avoided — a silently wrong publication date is worse than a rejected row.
- **A bad cell fails only its own row**, reported by real CSV line number, instead of rejecting the whole file for one typo.
- **Values are read from their owning config**, not hardcoded: allowed Date Format options, the Teaser Text length cap, and the text format per long-text field.
- **Resources import as drafts** — the editorial workflow's own `default_moderation_state`. Setting `status` instead is silently overridden.
- **`Custom Vocabulary` and `CAS Protected` are accepted header aliases** so a `ys_content_export` CSV can be edited and imported back. Unrecognised headers are **warned about** rather than dropped in silence.

### Two pre-existing bugs fixed in shared code

Both are in services the new importer routes through, so the Profiles importer benefits too:

- `parseCommaSeparatedValues()` filtered before trimming, so a whitespace-only segment survived and **created a nameless taxonomy term**.
- `findOrCreateTerm()` re-queried every occurrence of a repeated term name. It now resolves each distinct name once per request — a 500-row import was issuing thousands of uncached term queries.

Two existing tests *characterised* these as intended behaviour; both were rewritten to assert the corrected behaviour.

### Known follow-ups (not in scope here)

- `ProfileImportService::createProfileNode()` sets `'status' => 1` on a bundle under the editorial workflow, so it is silently overridden and imported profiles land as drafts anyway — same class of bug as the one fixed here for resources, but in shipped, tested, out-of-scope code.
- No Batch API: a very large import runs in one request, matching the existing Profiles importer.
- `mockQuery()` is now duplicated in three test classes, and `submitForm()` is identical between the two import forms — both are extraction candidates once a third importer appears.
- The importer creates terms in `field_audience` / `field_custom_vocab`, whose node-form widgets do not allow term creation. Consistent with the Profiles importer, so flagging it as a product call rather than changing it silently.
- The user-guide documentation AC is not covered here — that content lives on yalesites.yale.edu, outside this repo.

### Verification

- **Unit tests: 125 tests / 408 assertions, 0 failures.** The 88 / 247 figure above predated the batch commits; the pre-change baseline for the most recent round was **123 / 353**, and the four added columns brought two new drift-guard tests with them. Existing Profiles and TaxonomyResolver tests stayed green throughout, which matters because this edits shared services.
- **Runtime on Lando**, not just green tests: real imports created nodes whose fields were read back and checked (both date shapes normalised, terms in the right vocabularies, link stored as a URI, teaser fields omitted when blank, `field_media` empty); `$node->validate()` returned 0 violations; the browser flow was driven end to end for preview, import, and duplicate re-import.
- **Text-format check, red/green as a real editor** (not user 1, who bypasses every permission check): both long-text fields render **editable**; forcing the previously-chosen `basic_html` back onto the same node reproduces a **disabled** widget and a "sufficient permissions" notice. Both fields restrict `allowed_formats` to a single format and no role holds `administer filters`, so the format now comes from each field's own config.
- **Accessibility (light gate): PASS** — contrast, images/media, form labels, interactive names, scoped to our own markup.
- **Security review: no high-confidence findings.** Checked route permission, `sticky`/`field_login_required` (not escalation — both are ordinary widgets on the node form for these roles), XSS via `@` placeholders and the rendered preview table (both escape), the External Source scheme allow-list (rejects `javascript:`, `data:`, protocol-relative), entity-query injection, mass assignment, and the private-filesystem upload.
- **`lando composer code-sniff` exit 0**, `lando composer lint:php` exit 0.

### Functional testing steps:

- [ ] As an editor, go to **Content → Manage Resources** and confirm a **CSV Import** action link appears next to **Export to CSV**.
- [ ] Open the form and confirm the **Recognised columns** table lists all 17 columns, and that **Preview only** and **Skip duplicates** are both checked by default.
- [ ] Upload a CSV with a header row and a few resources. With **Preview only** checked, submit and confirm a preview table appears, the **Needs media** column reads Yes for rows without an External Source, and **no resources were actually created**.
- [ ] Uncheck **Preview only** and submit. Confirm the resources are created, and that the warning lists exactly the ones with no External Source as still needing Resource Media.
- [ ] Confirm the imported resources are **Drafts**, and that opening one shows Description and Teaser Text as **editable** (not greyed out with a permissions notice).
- [ ] Include Abstract, Citation, Journal Publication Name and Journal Publication Issue values in a row, import it, and confirm all four land on the node -- and that **Abstract and Citation are editable** on the node form (not greyed out with a permissions notice), the same check as Description and Teaser Text above.
- [ ] Submit the same file again with **Skip duplicates** checked and confirm it reports them as skipped rather than creating a second copy.
- [ ] Include one row with a bad date (e.g. `not a date`) and one with a bad link (e.g. `example.com`) and confirm each is reported against **its own row number** while the other rows still import.
- [ ] Rename a column to something unrecognised (e.g. `Tag` instead of `Tags`) and confirm the form warns that it will be ignored.
- [ ] Confirm the Profiles CSV import at **Manage Profiles → CSV Import** still works unchanged.

References yalesites-org/YaleSites-Internal#1526

