### PR TITLE
1534: Beacon citations: stop html_filter stripping structure from indexed content (requires full reindex)

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/search_api.index.ys_beacon.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/search_api.index.ys_beacon.yml
@@ -105,8 +105,7 @@ processor_settings:
       preprocess_index: -49
       preprocess_query: -48
     all_fields: false
-    fields:
-      - rendered_item
+    fields: {  }
     title: true
     alt: true
     tags:
@@ -121,6 +120,12 @@ processor_settings:
   ys_beacon_ai_metadata: {  }
   ys_beacon_citation_fields: {  }
   ys_beacon_exclude_ai_disabled: {  }
+  ys_beacon_invisible_html:
+    weights:
+      preprocess_index: -49
+    all_fields: false
+    fields:
+      - rendered_item
 tracker_settings:
   default:
     indexing_order: fifo

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/schema/ys_beacon.schema.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/schema/ys_beacon.schema.yml
@@ -77,3 +77,7 @@ ys_beacon.settings:
     guardrail_supplement:
       type: text
       label: 'Site-specific additions to the platform guardrail'
+
+plugin.plugin_configuration.search_api_processor.ys_beacon_invisible_html:
+  type: search_api.fields_processor_configuration
+  label: 'Beacon invisible HTML removal settings'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/search_api/processor/InvisibleHtml.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/search_api/processor/InvisibleHtml.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Drupal\ys_beacon\Plugin\search_api\processor;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\search_api\Attribute\SearchApiProcessor;
+use Drupal\search_api\Processor\FieldsProcessorPluginBase;
+
+/**
+ * Removes markup that is never page content, together with its text.
+ *
+ * Beacon's rendered_item field used to run through Search API's html_filter,
+ * which flattened every paragraph, heading, list and link into one run-on line
+ * before the AI indexer saw it, so the chat widget's Citations panel could only
+ * ever show unstructured text. Removing that processor from the field restores
+ * the structure - ai_search converts the HTML to Markdown - but it also gives
+ * up the one useful thing html_filter was doing here:
+ * removeInvisibleHtmlElements(), which deleted script, style, noscript, svg and
+ * friends before anything else ran.
+ *
+ * That deletion is load-bearing, because ai_search's converter has
+ * strip_tags enabled (EmbeddingStrategyPluginBase::__construct) and therefore
+ * flattens an element it cannot express in Markdown down to its *text*. A
+ * <script> body is dropped as a tag and kept as prose: measured on this repo,
+ * an analytics snippet is stored as
+ * "window.dataLayer=[];function gtag(){...}", and a <style> block as
+ * ".embed__inner{color:red;padding:16px}". Those strings then become part of
+ * the embedding vector and part of the excerpt quoted back to the visitor.
+ *
+ * So this processor does exactly the one job, and no more: the element list is
+ * html_filter's own, plus "object" and "template", which it omits. Wrapper
+ * markup and presentation attributes need no handling here - the converter's
+ * strip_tags already discards them - and nothing narrows the surviving tags,
+ * so ai_search's TableConverter still turns an editor's table into a Markdown
+ * table rather than a run of concatenated cells.
+ *
+ * Query preprocessing is deliberately not declared as a supported stage: a
+ * visitor's question is not HTML and has no business being parsed as a
+ * document.
+ *
+ * @see \Drupal\search_api\Plugin\search_api\processor\HtmlFilter::removeInvisibleHtmlElements()
+ * @see \Drupal\ai_search\Base\EmbeddingStrategyPluginBase::__construct()
+ */
+#[SearchApiProcessor(
+  id: 'ys_beacon_invisible_html',
+  label: new TranslatableMarkup('Beacon invisible HTML removal'),
+  description: new TranslatableMarkup('Removes script, style and other non-content elements, along with the text inside them, before content is embedded.'),
+  stages: [
+    'pre_index_save' => 0,
+    'preprocess_index' => -49,
+  ],
+)]
+class InvisibleHtml extends FieldsProcessorPluginBase {
+
+  /**
+   * Elements removed together with their contents.
+   *
+   * @see \Drupal\search_api\Plugin\search_api\processor\HtmlFilter::removeInvisibleHtmlElements()
+   */
+  protected const REMOVED_ELEMENTS = [
+    'applet', 'audio', 'canvas', 'command', 'embed', 'iframe', 'map', 'menu',
+    'noembed', 'noframes', 'noscript', 'object', 'script', 'style', 'svg',
+    'template', 'video',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function process(&$value) {
+    if (!is_string($value) || !preg_match($this->detectionPattern(), $value)) {
+      return;
+    }
+
+    // Parse rather than pattern-match the removal itself: an element's contents
+    // can hold anything, including markup that looks like its own closing tag.
+    $document = Html::load($value);
+    $xpath = new \DOMXPath($document);
+    foreach ($xpath->query('//' . implode('|//', static::REMOVED_ELEMENTS)) as $node) {
+      $node->parentNode?->removeChild($node);
+    }
+    $value = trim(Html::serialize($document));
+  }
+
+  /**
+   * Builds the "is any of these elements present?" pre-check pattern.
+   *
+   * The pattern only decides whether to parse, so it must never disagree with
+   * the parser about where a tag name ends - a stricter pre-check would skip
+   * parsing on markup the parser still turns into a live element, and the
+   * element's text would be indexed. HTML5 ends a tag name at anything outside
+   * ":_-", digits and letters (Tokenizer::tagName()), so the terminator here is
+   * the complement of that set rather than a list of the plausible characters:
+   * <script"x"> and <script=1> are both real script elements.
+   *
+   * @return string
+   *   A PCRE pattern.
+   */
+  protected function detectionPattern(): string {
+    return '#<(?:' . implode('|', static::REMOVED_ELEMENTS) . ')(?![:_\-0-9a-z])#i';
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/InvisibleHtmlProcessorTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/InvisibleHtmlProcessorTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\Plugin\search_api\processor\InvisibleHtml;
+
+/**
+ * Proves script and style bodies never become part of an indexed chunk.
+ *
+ * With html_filter no longer applied to Beacon's rendered_item, ai_search's
+ * converter is what turns the rendered HTML into the stored chunk - and its
+ * strip_tags option flattens an element it cannot express in Markdown down to
+ * the *text* inside it. So without this processor an analytics snippet or a CSS
+ * rule is stored as prose, embedded into the vector, and quoted back in the
+ * Citations panel (yalesites-org/YaleSites-Internal#1534). Structural markup is
+ * deliberately left alone here: restoring it is the point of that issue, and
+ * the converter handles wrappers and attributes on its own.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Plugin\search_api\processor\InvisibleHtml
+ */
+class InvisibleHtmlProcessorTest extends UnitTestCase {
+
+  /**
+   * Non-content elements go, and the text inside them goes with them.
+   *
+   * @dataProvider providerInvisibleElements
+   *
+   * @covers ::process
+   */
+  public function testInvisibleElementsAreRemovedWithTheirText(string $html, string $leak): void {
+    $cleaned = $this->process($html);
+
+    $this->assertStringNotContainsString($leak, $cleaned);
+    $this->assertStringContainsString('Visit us.', $cleaned, 'Real page content is untouched.');
+  }
+
+  /**
+   * Non-content elements and the text each one would otherwise leak.
+   */
+  public static function providerInvisibleElements(): array {
+    return [
+      'script body' => [
+        '<p>Visit us.</p><script>window.dataLayer=[];gtag("js");</script>',
+        'dataLayer',
+      ],
+      'style body' => [
+        '<p>Visit us.</p><style>.embed__inner{color:red}</style>',
+        'color:red',
+      ],
+      'noscript body' => [
+        '<p>Visit us.</p><noscript><p>Enable JavaScript.</p></noscript>',
+        'Enable JavaScript',
+      ],
+      'svg title' => [
+        '<p>Visit us.</p><svg><title>decorative chevron</title></svg>',
+        'decorative chevron',
+      ],
+      'template body' => [
+        '<p>Visit us.</p><template><p>hidden draft</p></template>',
+        'hidden draft',
+      ],
+      'iframe' => [
+        '<p>Visit us.</p><iframe src="https://www.instagram.com/embed"></iframe>',
+        'instagram',
+      ],
+      'object' => [
+        '<p>Visit us.</p><object data="movie.swf">fallback copy</object>',
+        'fallback copy',
+      ],
+      'unclosed script swallowing the page' => [
+        '<p>Visit us.</p><script>var s = "</script>";</script>',
+        'var s',
+      ],
+      // The HTML5 parser ends a tag name at any character outside ":_-",
+      // digits and letters, so each of these is a live element even though the
+      // character after the name is not whitespace, ">" or "/". A pre-check
+      // that only looked for those three would skip the removal entirely and
+      // index the body as prose.
+      'script with a quote after the name' => [
+        '<p>Visit us.</p><script"x">window.dataLayer=[];</script>',
+        'dataLayer',
+      ],
+      'script with an equals after the name' => [
+        '<p>Visit us.</p><script=1>window.dataLayer=[];</script>',
+        'dataLayer',
+      ],
+      'style with quotes after the name' => [
+        '<p>Visit us.</p><style"">.x{color:red}</style>',
+        'color:red',
+      ],
+    ];
+  }
+
+  /**
+   * An element name appearing in prose is not mistaken for a tag.
+   *
+   * @covers ::process
+   */
+  public function testElementNameInsideWordIsNotTreatedAsMarkup(): void {
+    $html = '<p>Read the scripture and the mapping guide.</p>';
+
+    $this->assertSame($html, $this->process($html));
+  }
+
+  /**
+   * Structural markup survives: restoring it is the point of the change.
+   *
+   * @covers ::process
+   */
+  public function testStructuralMarkupIsLeftAlone(): void {
+    $html = '<div class="layout"><h2>Deadlines</h2>'
+      . '<p>Read the <a href="/guide">guide</a> by <strong>March 1</strong>.</p>'
+      . '<ul><li>one</li></ul>'
+      . '<table><tr><th>Term</th><td>Fall</td></tr></table></div>';
+
+    // Verbatim, including the wrapper: ai_search's converter flattens wrappers
+    // and attributes, and its TableConverter needs the table markup intact.
+    $this->assertSame($html, $this->process($html));
+  }
+
+  /**
+   * A value with nothing to remove is returned untouched, not re-serialized.
+   *
+   * @covers ::process
+   */
+  public function testValueWithoutInvisibleElementsIsNotRewritten(): void {
+    $html = '  <p>Already clean, oddly indented.</p>  ';
+
+    $this->assertSame($html, $this->process($html));
+  }
+
+  /**
+   * Runs the processor's value seam over one string.
+   *
+   * Which field the seam is reached for is Search API's own concern
+   * (FieldsProcessorPluginBase::testField() against the configured "fields"
+   * list); this covers what the processor itself does to a value.
+   */
+  private function process(string $html): string {
+    $processor = new class([], 'ys_beacon_invisible_html', []) extends InvisibleHtml {
+
+      /**
+       * Exposes the protected value seam for testing.
+       */
+      public function processValue(string $value): string {
+        $this->process($value);
+        return $value;
+      }
+
+    };
+
+    return $processor->processValue($html);
+  }
+
+}


### PR DESCRIPTION
## [1534: Beacon citations: stop html_filter stripping structure from indexed content (requires full reindex)](https://github.com/yalesites-org/YaleSites-Internal/issues/1534)

> [!WARNING]
> **Do not merge until the full-platform reindex window is agreed with stakeholders.**
> The stored chunk text is also the string the embedding vectors are built from, so this
> changes every vector for every site. Sizing is in "Reindex impact" below.

### Description of work

- Removed `rendered_item` from the `html_filter` processor's `fields` list on the
  `ys_beacon` Search API index. `html_filter` can only ever emit plain text — the tags it
  keeps are consumed to assign keyword boosts and then dropped — which is why every
  paragraph, subheading, list and link arrived in the Citations panel as one run-on block.
  With it off, `ai_search` converts the real page structure to Markdown, and the panel
  already renders Markdown.
- The `fields` key is left **present but empty**, not deleted:
  `FieldsProcessorPluginBase::testField()` falls back to *all* text fields when `fields` is
  unset. `html_filter` also stays enabled — its `process()` override still strips HTML from
  query keywords, and that path is not gated on `fields`.
- Added a `ys_beacon_invisible_html` Search API processor. Turning `html_filter` off for the
  field also gives up the one other thing it did here — `removeInvisibleHtmlElements()`,
  which deleted `script`, `style`, `noscript`, `svg` and friends *with their contents*. That
  deletion is load-bearing: `ai_search`'s converter runs with `strip_tags` enabled
  (`EmbeddingStrategyPluginBase::__construct()`), so it flattens an element it cannot express
  in Markdown down to the **text inside it**. Measured on this repo, an inline analytics
  snippet is otherwise stored as `window.dataLayer=[];function gtag(){...}` and a style block
  as `.embed__inner{color:red;padding:16px}` — text invisible on the page, embedded into the
  vector, and quoted back to visitors as page content.
- The new processor does that one job and no more. It extends `FieldsProcessorPluginBase`
  (the same base `html_filter` uses) so field selection stays in config and Search API
  handles the value shapes; it declares `preprocess_index` and `pre_index_save` but
  **deliberately not `preprocess_query`**, because a visitor's question is not a document
  and should not be DOM-parsed.
- Surviving tags are **not** narrowed. An earlier draft added an `Xss::filter()` allowlist;
  it bought 28 and 72 characters on two real nodes and **destroyed editor tables** (ai_search
  registers a `TableConverter`, and `basic_html` permits table markup), so it was removed.
- The element-presence pre-check uses the *complement* of the HTML5 tag-name character set
  rather than a list of plausible terminators. This is a sanitiser-bypass fix found during
  security review of this branch: the parser ends a tag name at any character outside
  `:_-`, digits and letters, so `<script"x">` and `<script=1>` are live elements that a
  `[\s>/]` check misses and would have passed through unremoved.

### Reindex impact (please read before scheduling)

Measured across all 65 indexable nodes in the local corpus, before vs after:

| | before | after | change |
|---|---|---|---|
| total stored chunk text | 159,442 chars | 221,634 chars | **+39%** |
| estimated chunks at the 588-char budget | 311 | 415 | **+33%** |

`EmbeddingBase::getRawEmbeddings()` makes one blocking embedding call per chunk, so a full
reindex is roughly a third more embedding calls and stored vectors than the current index,
and every subsequent save of a large page costs proportionally more. Worth confirming
against a production-shaped corpus before the window is agreed — 65 starterkit nodes is a
small sample.

### Two acceptance criteria resolved differently than the ticket describes

**1. `decodeStoredValue()` on `content` was not implemented — the premise is falsified.**
The ticket asks for it so that "no literal backslashes (for example `annual\_report`) appear
in the rendered panel." Running the app's own installed `dompurify` +
`remark-parse`/`remark-gfm`/`remark-rehype`/`rehype-raw` (mirroring `Chat.tsx`) over the exact
strings `ai_search` stores shows the panel **already** renders them correctly, and that
decoding makes things worse:

| stored | panel today (no decode) | panel with the decode applied |
|---|---|---|
| `The annual\_report covers R&amp;D spending \[2024\].` | `The annual_report covers R&D spending [2024].` | same |
| `\* Required field. Use \*emphasis\* literally.` | `* Required field. Use *emphasis* literally.` | `Required field. Use emphasis literally.` rendered as a spurious `<ul><li>` + `<em>` |

`ReactMarkdown` already interprets `\_`, `\[` and `&amp;`. Stripping the escapes server-side
hands Markdown syntax to the renderer that the escapes existed to neutralise. **If you want
it anyway, say so** — the safe subset is entity-decoding only, which helps the LLM prompt and
the AI-tester export but does nothing for the panel.

**2. `MarkdownConverter` was not reused, despite the AC asking for it.** Its `toMarkdown()`
is hard-bound to the `restricted_html` seven-tag set and flattens headings and lists — exactly
what this ticket is trying to stop. No second HTML-to-Markdown implementation was added
either: conversion still happens once, in `ai_search`, where it does today.

### What was verified, and what was not

Verified locally against the real code path:
- Real nodes pushed through `Index::preprocessIndexItems()` and then through a faithful copy
  of the converter `ai_search` actually builds. nid 15: 3,606 chars run-on → 3,746 chars with
  a heading, a link and 15 paragraph breaks. nid 29 (embed-heavy): 521 → 1,321 chars with 8
  working links and blockquotes.
- No `<script>`, `<iframe>`, `<style>`, `<div>`, `class=` or `style=` in the stored chunk.
- Each removed element checked in isolation: without the processor, `script`, `style`,
  `noscript`, `svg` and `template` bodies are all stored as prose; with it, none are.
- The existing DOMPurify allowlist needs no widening — with `strip_tags` on, the stored chunk
  contains no raw HTML tags at all.
- Plugin discovery, field targeting and stage registration read back from the running site:
  `preprocess_index: html_filter, ys_beacon_invisible_html` / `preprocess_query: html_filter`.
- ys_beacon Unit suite **335 tests / 778 assertions / 0 failures** (baseline 321 / 0 failures).
  `composer code-sniff` and `composer lint:php` both exit 0. `npm run confex` reproduced the
  config byte-for-byte.

**Not verified — please treat as open:**
- **The rendered end-to-end result in a live Citations panel was never observed.** That needs
  Azure AI Search, which cannot be exercised from a local checkout, and it needs the reindex.
  The indexing half and the front-end render half were each verified against real code, but
  they were never joined through Azure. This is the claim I would most expect to need a
  second look.
- **The ticket's retrieval-quality spot-check was not done.** It needs a live index on both
  sides of the change, i.e. the reindex. Still outstanding.
- No reindex was run, triggered, or scheduled by this work.
- Scanning all 65 local nodes found **no** inline `script`/`style`/`noscript`/`template` text
  — the starterkit's embeds use `<script src>` with empty bodies. So the new processor is
  restoring a protection rather than fixing an observed leak on this corpus.

### Functional testing steps

- [ ] Agree and schedule the full-platform reindex window with the stakeholders currently
      testing Beacon **before merging**.
- [ ] On the multidev, confirm the Beacon index config imported: `html_filter` shows
      `fields: {  }` and `ys_beacon_invisible_html` shows `fields: [rendered_item]`.
- [ ] Reindex, then open the chat widget, ask a question that cites a content-rich page, and
      open the Citations panel. Confirm paragraph breaks, subheadings, bulleted lists and
      emphasis render instead of one run-on block.
- [ ] Confirm inline links inside the citation body are clickable and go to the right place.
- [ ] Confirm no literal backslashes (e.g. `annual\_report`) appear in the panel.
- [ ] Cite a page containing a table and confirm the table survives as a table rather than
      run-together cell text.
- [ ] Cite a page with a social embed (e.g. `/blocks-for-visreg/embed`) and confirm no
      JavaScript or CSS source text appears in the panel.
- [ ] Confirm the Metadata Tags, Source URL and Additional Metadata labels below the content
      chunk still render as they do today.
- [ ] Accessibility: confirm headings in the panel are real heading elements in correct
      document order, lists are real list markup, and links have discernible text.
- [ ] Capture the before/after retrieval-quality spot-check on a handful of known questions
      and record it on the issue.

References yalesites-org/YaleSites-Internal#1534

---
Created with AI
