### PR TITLE
1535: Beacon content feed API returns flattened plain text where the legacy feed returned HTML

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
@@ -331,7 +331,7 @@ Response shape:
       "changed": "2026-02-01T00:00:00+00:00",
       "ai_description": "…",
       "ai_tags": "…",
-      "content": "plain-text rendering of the default view (nodes only)"
+      "content": "<article>…</article>"
     }
   ],
   "pagination": {
@@ -345,7 +345,20 @@ Response shape:
 ```
 
 Node bodies are rendered as the anonymous user, so the feed never exposes
-content a logged-out visitor could not see.
+content a logged-out visitor could not see. Media items always have an empty
+`content`; their file lives at `url`.
+
+**`content` is HTML, not plain text.** It is the entity's default view mode
+rendered and then sanitized, so headings, lists, tables, links, and emphasis
+reach the consumer intact — the same contract the legacy `/api/ai/v1/content`
+endpoint published for its `documentContent` field. Sanitizing means
+`<script>` and `<style>` elements are removed with their contents, HTML
+comments are dropped, and the remainder is passed through
+`Xss::filterAdmin()`, which strips every tag that can execute or embed
+(`<iframe>`, `<object>`, form controls), all `on*` event-handler attributes,
+and `javascript:` URLs. A consumer can render the value directly; it is not
+escaped, so a consumer that wants text instead should strip the tags on its
+side.
 
 ## Citations
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/ContentFeedBuilder.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/ContentFeedBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\ys_beacon\Service;
 
+use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\Xss;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Render\RendererInterface;
@@ -152,7 +154,12 @@ class ContentFeedBuilder {
   }
 
   /**
-   * Renders an entity's default view, returning plain text.
+   * Renders an entity's default view as HTML a consumer can safely render.
+   *
+   * HTML - rather than plain text or Markdown - is the contract the legacy
+   * ai_engine_feed endpoint published for its documentContent field, so a
+   * consumer written against that feed keeps working. Headings, lists, tables,
+   * links, and emphasis therefore survive; see sanitize() for what does not.
    *
    * The caller (build()) switches to the anonymous user for the whole page, so
    * the feed body matches what the chatbot indexes and never leaks content only
@@ -164,12 +171,42 @@ class ContentFeedBuilder {
       $build = $this->entityTypeManager
         ->getViewBuilder($entity->getEntityTypeId())
         ->view($entity, 'default');
-      $html = (string) $this->renderer->renderInIsolation($build);
+      // Sanitizing inside the try keeps one unrenderable entity from failing
+      // the whole request: the item is fed with an empty body instead.
+      return $this->sanitize((string) $this->renderer->renderInIsolation($build));
     }
     catch (\Throwable $e) {
-      $html = '';
+      return '';
     }
-    return trim((string) preg_replace('/\s+/', ' ', strip_tags($html)));
+  }
+
+  /**
+   * Strips everything a consumer must not execute, keeping the structure.
+   *
+   * @param string $html
+   *   The rendered entity markup.
+   *
+   * @return string
+   *   HTML limited to non-executable body markup.
+   */
+  protected function sanitize(string $html): string {
+    if (trim($html) === '') {
+      return '';
+    }
+
+    // Remove script and style elements, and comments, with their contents:
+    // Xss below drops the tags but would leave the JavaScript, the CSS, and
+    // Twig's debug output behind as text in the middle of the content.
+    $document = Html::load($html);
+    $xpath = new \DOMXPath($document);
+    foreach (iterator_to_array($xpath->query('//script|//style|//comment()')) as $node) {
+      $node->parentNode->removeChild($node);
+    }
+
+    // filterAdmin() allows every body tag except script and style, so the
+    // structure survives, and strips the rest - iframes, objects, form
+    // controls - along with every event-handler attribute and javascript: URL.
+    return trim(Xss::filterAdmin(Html::serialize($document)));
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/ContentFeedBuilderTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/ContentFeedBuilderTest.php
@@ -2,7 +2,10 @@
 
 namespace Drupal\Tests\ys_beacon\Kernel;
 
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\filter\Entity\FilterFormat;
+use Drupal\media\MediaInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\ys_beacon\Service\AiMetadataManager;
@@ -33,7 +36,11 @@ class ContentFeedBuilderTest extends KernelTestBase {
     parent::setUp();
     $this->installEntitySchema('user');
     $this->installEntitySchema('node');
-    $this->installConfig(['node', 'filter']);
+    // System supplies the core.date_format.* config the node template's
+    // submitted line needs; without it rendering throws and the builder's
+    // catch turns every body into an empty string, so nothing about the
+    // content format can be asserted.
+    $this->installConfig(['system', 'node', 'filter']);
     NodeType::create(['type' => 'page', 'name' => 'Page'])->save();
   }
 
@@ -79,6 +86,80 @@ class ContentFeedBuilderTest extends KernelTestBase {
     $this->assertSame(2, $payload['pagination']['total_records']);
     $this->assertSame('node', $payload['pagination']['type']);
     $this->assertSame(1, $payload['pagination']['page']);
+  }
+
+  /**
+   * Node content keeps its structure and drops executable markup.
+   *
+   * The feed's contract is the same one the legacy ai_engine_feed endpoint
+   * published: the rendered default view, as HTML. A regression to the
+   * flattened plain text this replaced fails every structural assertion here.
+   *
+   * @covers ::buildItem
+   */
+  public function testNodeContentIsStructuredSafeHtml(): void {
+    // A format with no filters enabled passes the markup through verbatim, so
+    // the assertions below exercise the builder rather than the filter system.
+    FilterFormat::create(['format' => 'ys_beacon_raw', 'name' => 'Raw'])->save();
+    node_add_body_field(NodeType::load('page'));
+
+    $node = Node::create([
+      'type' => 'page',
+      'title' => 'Structured page',
+      'status' => 1,
+      'body' => [
+        'value' => '<h2>A heading</h2>'
+        . '<ul><li>First item</li><li>Second item</li></ul>'
+        . '<p>A <strong>bold</strong> word and a <a href="https://example.com">link</a>.</p>'
+        . '<script>alert("xss")</script>'
+        . '<style>.leaked { color: red; }</style>'
+        . '<p onclick="alert(1)">Handler</p>'
+        . '<iframe src="https://evil.example"></iframe>',
+        'format' => 'ys_beacon_raw',
+      ],
+    ]);
+    $node->save();
+
+    $content = $this->builder()->buildItem($node)['content'];
+
+    // Structure a consumer can render or parse survives.
+    $this->assertStringContainsString('<h2>A heading</h2>', $content);
+    $this->assertStringContainsString('<li>First item</li>', $content);
+    $this->assertStringContainsString('<strong>bold</strong>', $content);
+    $this->assertStringContainsString('href="https://example.com"', $content);
+
+    // Executable markup does not — tags AND their contents are gone.
+    $this->assertStringNotContainsString('<script', $content);
+    $this->assertStringNotContainsString('alert("xss")', $content);
+    $this->assertStringNotContainsString('<style', $content);
+    $this->assertStringNotContainsString('color: red', $content);
+    $this->assertStringNotContainsString('<iframe', $content);
+    $this->assertStringNotContainsString('onclick', $content);
+    // The text of the element carrying the stripped handler is kept.
+    $this->assertStringContainsString('Handler', $content);
+  }
+
+  /**
+   * Media items still return an empty content value.
+   *
+   * @covers ::buildItem
+   */
+  public function testMediaContentStaysEmpty(): void {
+    $language = $this->createMock(LanguageInterface::class);
+    $language->method('getId')->willReturn('en');
+    $media = $this->createMock(MediaInterface::class);
+    $media->method('getEntityTypeId')->willReturn('media');
+    $media->method('id')->willReturn('7');
+    $media->method('bundle')->willReturn('image');
+    $media->method('uuid')->willReturn('a-uuid');
+    $media->method('label')->willReturn('A file');
+    $media->method('language')->willReturn($language);
+    $media->method('hasField')->willReturn(FALSE);
+
+    $item = $this->builder()->buildItem($media);
+
+    $this->assertSame('', $item['content']);
+    $this->assertSame('media/7', $item['id']);
   }
 
   /**


### PR DESCRIPTION
## [1535: Beacon content feed API returns flattened plain text where the legacy feed returned HTML](https://github.com/yalesites-org/YaleSites-Internal/issues/1535)

### Decision needed — please confirm or overturn (the ticket's first acceptance criterion)

AC #1 is a contract decision, not code: `content` should be structured HTML, Markdown, or
deliberately-plain text. **I chose sanitized, structured HTML.** Reasoning, so it is easy to
overturn:

- **HTML is what the endpoint this replaced actually published.** `ai_engine_feed`'s
  `Sources::processContentBody()` returns `$this->renderer->render($renderArray)` with no
  `strip_tags`, and its `API_ENDPOINT_DOCUMENTATION.md` states `documentContent` "contains
  rendered HTML" / "Fully rendered content using the default display mode". Restoring HTML makes
  a consumer written against the old feed drop-in compatible, which is the regression the ticket
  describes.
- **Markdown would be a third format** — neither the old contract nor the current one — so every
  consumer would have to change again, and we would own a lossy conversion step permanently. No
  consumer is known to want Markdown.
- **The ticket's "reuse `MarkdownConverter`" note does not work here, and that is worth saying
  plainly.** `MarkdownConverter::ALLOWED_TAGS` is `['a','br','p','strong','em','sub','sup']` —
  deliberately no headings, lists, or tables, because that service exists to round-trip the
  *restricted_html* WYSIWYG for system instructions. Running feed markup through `toMarkdown()`
  would strip exactly the headings and bullet lists this ticket asks to preserve, recreating the
  bug in a different notation. The AC says reuse it *if conversion is needed*; with HTML chosen,
  no conversion is needed. I did not widen that service's tag set — it is the security boundary
  for the instructions editor.
- **"Document plain text as intended" was the third option and I rejected it.** The docblock did
  say "returning plain text", so the flattening was documented intent — but it silently broke a
  published API contract, and documenting that as a feature leaves the fidelity gap unfixed.

If you want Markdown or plain text instead, reverting this single commit restores the previous
behavior exactly.

### Description of work

- `ContentFeedBuilder::renderContent()` no longer runs `strip_tags()` and collapses all
  whitespace. It returns the entity's rendered default view as HTML.
- A new `sanitize()` step keeps the public endpoint safe to render: `<script>` and `<style>`
  elements are removed **with their contents** and HTML comments are dropped (via
  `Html::load()` + `DOMXPath`, the same idiom `MarkdownConverter` already uses in this module),
  then `Xss::filterAdmin()` strips every remaining tag that can execute or embed (`<iframe>`,
  `<object>`, `<form>`/`<input>`, `<svg>`, `<math>`), every `on*` event-handler attribute,
  `style`/`srcdoc`, and any `javascript:`/`data:` URL.
- Worth noting: the **old** plain-text output leaked `<script>` and `<style>` **bodies** into the
  feed as bare text, because `strip_tags()` removes tags but keeps their contents. That stops too.
- Sanitizing runs inside `renderContent()`'s `try`, so one unrenderable entity yields an empty
  body rather than failing the whole request.
- `renderContent()`'s docblock now describes what it actually returns (AC #6), and the README's
  Content feed API section documents the HTML contract (AC #9).
- Media items still return an empty `content`, and content is still rendered as the anonymous
  user — both pinned by tests.

**A pre-existing flaw I found and fixed rather than worked around:** the Kernel test could only
assert `assertIsString($item['content'])` because it was asserting that an *empty string* is a
string. The test installed `node` and `filter` config but not `system`, so
`core.date_format.medium` was missing, the node template's "Submitted" line threw
`Call to a member function getPattern() on null`, and `renderContent()`'s `catch (\Throwable)`
swallowed it and returned `''`. Installing `system` config makes the render work, which is what
lets the new test assert the format at all.

### Blast radius — smaller than the Hotfix label suggests

- **No in-repo consumer reads this endpoint.** Its only references are its service definition,
  its route, its controller, and tests.
- **This does not feed the vector index.** No change to the chat path or the Citations panel, and
  **no reindex is needed or was run.** (Issue 1534 / PR #1463 is the separate indexing-side fix;
  zero file overlap with this branch.)
- **But it is a wire-format change for anything outside this repo.** The flattened-text shape has
  been live since `1d12ba7fa` (2026-06-12), so an external consumer that integrated against plain
  text in the last two months will now receive HTML. That is the intended fix, but it is worth a
  heads-up to whoever owns external Beacon consumers.
- **Payloads grow**, as they must when structure is preserved: one local node went from 1.4 KB of
  flattened text to 9.0 KB of sanitized HTML (its raw render is 38 KB). `page_size` default 50 /
  max 200 are unchanged.

### Follow-ups (not done here, deliberately out of scope)

- `renderContent()`'s `catch (\Throwable) { return ''; }` still swallows render failures silently
  — it is what hid the test-environment bug above. Fixing it properly means injecting a logger,
  i.e. a new constructor argument and a service definition change.
- `core.entity_view_mode.node.search_index` exists in `config/sync` with `status: false` and no
  per-bundle displays. Feeding a purpose-built view mode instead of `default` would be cleaner
  than rendering everything and scrubbing it, but it changes *what* content is fed (a curation
  question), not just its format.

### Functional testing steps:

- [ ] On the multidev, authorize Beacon for the site (Platform Admin Settings) — the feed returns
      `403 {"error":"The content feed is not enabled."}` until `platform_authorized` is on.
- [ ] Request `GET /api/ys-beacon/v1/content?type=node&page=1&page_size=10` and confirm each
      item's `content` is now HTML: headings, `<ul>`/`<li>`, `<strong>`/`<em>` and `<a href>` are
      present rather than words run together.
- [ ] Confirm no `<script`, `<style`, `<iframe`, `<object`, `<form`, `on*=` handler, `srcdoc`, or
      `javascript:` appears in any item's `content`, and that no HTML comments leak through.
- [ ] Open one of the fed nodes in a browser and compare: the feed's `content` should carry the
      same structure the page shows.
- [ ] Request `?type=media` and confirm every media item's `content` is still `""` and its `url`
      points at the file.
- [ ] Confirm content still respects anonymity: a CAS-protected or unpublished node must not
      appear in the feed while logged in as an admin.
- [ ] Confirm the chat and its Citations panel are unchanged (this endpoint does not feed the
      index).

References yalesites-org/YaleSites-Internal#1535

---
Created with AI
