### PR TITLE
1541: Add color theme picker to Two Column (70/30) layout

### DIFF
--- a/docs/color-theme.md
+++ b/docs/color-theme.md
@@ -108,7 +108,8 @@ global-themes:
       slot-nine:
         value: "{color.gray.100.value}"
   ```
-  - `slot-nine` is reserved for the secondary background variant in our global theme palettes. In the current implementation, ONHA uses `soft-oceanic` and the other themes use a neutral gray background.
+  - `slot-nine` is reserved for the secondary background variant in our global theme palettes. In the current implementation, ONHA uses `soft-oceanic` and the other themes use a neutral gray background. It is always paired with `slot-seven` as the foreground/text color — that pairing is contrast-safe (AA) across all 7 global themes; see the Storybook contrast matrix story (`?path=/docs/tokens-colors-contrast-matrix--docs`) rather than a hardcoded table here, since it recomputes live from `tokens.json`.
+  - Layout Section's "Component theme" picker exposes this as option `'five'` (labeled "Five" in the admin UI), not a `'six'` option like block-level component pickers — Sections have their own slot mapping (see `ColorTokenResolver::getColorStylesForEntity()`'s `layout_section` case) that omits `slot-three` by design. Don't be misled by the option label: `'five'` resolves to `slot-nine`, not `slot-five`.
   - Add your new theme, following the same convention shown above. If there are `three` themes already entered, and yours would be number `four`, name it accordingly.
   - For example (say we wanted to use the new `brown` value we added above): 
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/two_column/layout--two-column.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/two_column/layout--two-column.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a one-column layout.
+ * Default theme implementation to display a two-column (70/30) layout.
  *
  * Available variables:
  * - in_preview: Whether the plugin is being rendered in preview mode.
@@ -11,24 +11,28 @@
  * @ingroup themeable
  */
 #}
-
-{% set layout__base_class = layout__base_class|default('yds-two-column') %}
-
-{% set classes = ['layout', 'yds-two-column'] %}
-
 {% if content %}
-	<div{{ attributes.addClass(classes).setAttribute('data-component-padding', settings['padding']|default('default')).setAttribute('data-component-width', layout__width|default('site')).setAttribute('data-embedded-components', 'true') }}>
-		<div {{ bem('inner', [], layout__base_class)}}>
-			{% if content.content %}
-				<div {{ region_attributes.content.addClass('yds-two-column__primary') }}>
-					{{ content.content }}
-				</div>
-			{% endif %}
-			{% if content.sidebar %}
-				<div {{ region_attributes.sidebar.addClass('yds-two-column__secondary') }}>
-					{{ content.sidebar }}
-				</div>
-			{% endif %}
-		</div>
-	</div>
+  {% if in_preview %}
+    <div {{ attributes}}>
+  {% endif %}
+  {% embed "@organisms/layout/layout/yds-layout.twig" with {
+    component__layout: 'seventy-thirty',
+    layout__padding: settings.padding|default('default'),
+    layout__divider: settings.divider ? 'true' : 'false',
+    component__theme: settings.theme|default('default'),
+  } %}
+    {% block layout__primary %}
+      <div {{ region_attributes.content }}>
+        {{ content.content }}
+      </div>
+    {% endblock %}
+    {% block layout__secondary %}
+      <div {{ region_attributes.sidebar }}>
+        {{ content.sidebar }}
+      </div>
+    {% endblock %}
+  {% endembed %}
+  {% if in_preview %}
+    </div>
+  {% endif %}
 {% endif %}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/YsLayoutsDefinitionsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/YsLayoutsDefinitionsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\Tests\ys_layouts\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_layouts\Plugin\Layout\YSLayoutOptions;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests which layout plugin definitions expose the color theme picker.
+ *
+ * @group yalesites
+ * @group ys_layouts
+ */
+class YsLayoutsDefinitionsTest extends UnitTestCase {
+
+  /**
+   * Parses the layout plugin definitions.
+   *
+   * @return array
+   *   The decoded ys_layouts.layouts.yml content.
+   */
+  protected function getLayoutDefinitions(): array {
+    $path = __DIR__ . '/../../../ys_layouts.layouts.yml';
+    return Yaml::parseFile($path);
+  }
+
+  /**
+   * Two Column (70/30) is wired to the same layout class as 50/50 and 33/33/33.
+   *
+   * Two Column (70/30) previously used core LayoutDefault with no color
+   * theme picker at all, unlike Two Column (50/50) and Three Column
+   * (33/33/33). This pins the plugin definition's `class` key to
+   * YSLayoutOptions for all three -- the actual form/picker behavior that
+   * class provides is covered separately by YSLayoutOptionsTest.
+   */
+  public function testTwoColumnUsesLayoutOptionsClass(): void {
+    $definitions = $this->getLayoutDefinitions();
+
+    // Also pin the layouts that already had it, so a future edit that
+    // removes the class from one of these is caught here too.
+    foreach ([
+      'ys_layout_two_column',
+      'ys_layout_two_column_50_50',
+      'ys_layout_three_column_33_33_33',
+    ] as $id) {
+      $this->assertSame('\\' . YSLayoutOptions::class, $definitions[$id]['class'] ?? NULL, $id);
+    }
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.layouts.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.layouts.yml
@@ -16,6 +16,7 @@ ys_layout_two_column:
   path: layouts/two_column
   template: layout--two-column
   library: ys_layouts/ys_layout_two_column
+  class: '\Drupal\ys_layouts\Plugin\Layout\YSLayoutOptions'
   category: 'Columns: 2'
   default_region: content
   icon_map:


### PR DESCRIPTION
## [1541: Add color theme picker to Two Column (70/30) layout](https://github.com/yalesites-org/YaleSites-Internal/issues/1541)

Investigating yalesites-org/YaleSites-Internal#1541 (which asked to add a slot-9 color
option to the Layout Section picker) found the ticket's premise was already resolved for
Two Column (50/50) and Three Column (33/33/33) since ticket #1153 — verified via the
compiled CSS the site actually loads, the token values, and git history tracing both
sections' and blocks' slot-9 wiring to the same commits. Posted evidence on the issue
recommending it be closed/retitled:
https://github.com/yalesites-org/YaleSites-Internal/issues/1541#issuecomment-5286073268

The actual gap, found while verifying "does every Section layout have this option":
Two Column (70/30) has no "Component theme" picker at all, unlike Two Column (50/50) and
Three Column (33/33/33).

### Description of work
- Wire `ys_layout_two_column` to the existing `YSLayoutOptions` layout class (already used
  by 50/50 and 33/33/33), giving it the same "Component theme" config form (divider
  checkbox + 6-option color picker, including the already-correct slot-9 option).
- Rewrite `layout--two-column.html.twig` to embed the shared `yds-layout.twig` organism
  (component-library-twig) with `component__layout: 'seventy-thirty'` instead of its own
  standalone `yds-two-column` markup — that organism already supports a seventy-thirty
  layout variant (added earlier for divider-width/flex-proportion purposes).
- New unit test (`YsLayoutsDefinitionsTest`) pinning the `class` key for all three layouts
  that now share it.
- Documented in `docs/color-theme.md` that Section option `'five'` resolves to slot-9 —
  the source of the original confusion behind #1541.
- Other work completed in: yalesites-org/component-library-twig#687,
  yalesites-org/atomic#501

### Reviewer flags — please read before merging
- **Existing published 70/30 sections lose the `<aside>` landmark tag** on the sidebar
  region (now a plain `<div>`, matching 50/50 and 33/33/33 — the shared organism has no
  landmark-tag variant). Accepted trade-off; fixing it means adding a parameterized tag to
  the shared organism, out of scope for this PR.
- **Existing published 70/30 sections newly pick up the shared organism's heading
  step-down** (h2→h3, h3→h4, h4→h5), since they never had a `data-component-layout`
  attribute before. This is the organism working exactly as designed, not a bug — but it
  retypesets already-published content across the site and deserves a human visual
  sign-off, not just this PR's automated checks.
- Verified no regression to already-published 70/30 sections' column proportions,
  divider border, or gutter: computed styles on an existing, unmodified 70/30 section
  (`border-left: 1px`, `margin-left: 96px`, `padding-left: 48px`) match pre-change values
  exactly, after restoring that treatment in the component-library-twig companion PR
  (it was originally unconditional in the old organism, opt-in-only in the shared one).

### Functional testing steps:
- [ ] Add a Two Column (70/30) section in Layout Builder, confirm the "Component theme"
  picker now appears with 6 color swatch options matching Two Column (50/50)
- [ ] Select a color option, save, confirm the section renders with the correct
  background color across a couple of global themes
- [ ] View an existing/pre-existing 70/30 section (e.g. the "Accordion" visual-regression
  page) and confirm column proportions, divider border, and gutter still look correct
- [ ] Place a Link Grid with 2+ links or an Accordion in the narrow sidebar column at
  desktop width (≥1400px) and confirm no clipping or broken multi-column wrapping

A follow-up issue, yalesites-org/YaleSites-Internal#1549, was originally filed for the
Banner layout, which has the same missing-picker gap. That approach was implemented in
yalesites-org/yalesites-project#1468, then abandoned and closed: Banner is locked out of
"Configure Section" for content editors (`layout_builder_lock`) and, even where reachable,
its blocks typically fill the section so a background color wouldn't show. #1549 was
retargeted to `layout_onecol` ("One column") — the generic, fully-editable main-content
section, which will be the only user-addable Section layout still missing the picker once
this PR merges. That work is in progress on a branch stacked on top of this one.

References yalesites-org/YaleSites-Internal#1541

