### PR TITLE
1545: RC: Site Alert Link URL field – autocomplete suggestions can't be selected

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/LinkitUriSelectorTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/LinkitUriSelectorTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\Core\Form\FormInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the drupal selector applied to standalone linkit form elements.
+ *
+ * Linkit's autocomplete JavaScript refuses to act on any input whose
+ * data-drupal-selector does not end in "-uri", so a "#type => linkit" element
+ * outside a link field widget can never have a suggestion selected.
+ *
+ * The test doubles as its own form, following the core convention for kernel
+ * tests that need the form builder.
+ *
+ * @see \Drupal\KernelTests\Core\Form\ExternalFormUrlTest
+ *
+ * @group yalesites
+ * @group ys_core
+ */
+class LinkitUriSelectorTest extends KernelTestBase implements FormInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'linkit',
+    'ys_core',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'ys_core_linkit_uri_selector_test_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['link_url'] = [
+      '#type' => 'linkit',
+      '#title' => 'URL',
+    ];
+    $form['uri'] = [
+      '#type' => 'linkit',
+      '#title' => 'URI',
+    ];
+    $form['plain_text'] = [
+      '#type' => 'textfield',
+      '#title' => 'Plain text',
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+  }
+
+  /**
+   * Builds the test form through the form builder.
+   *
+   * The form builder is what sets data-drupal-selector, so the element cannot
+   * be inspected by calling buildForm() directly.
+   *
+   * @return array
+   *   The built form render array.
+   */
+  protected function buildTestForm(): array {
+    return $this->container->get('form_builder')->getForm($this);
+  }
+
+  /**
+   * Tests that a linkit element's selector is suffixed so linkit's JS acts.
+   */
+  public function testLinkitSelectorEndsInUri() {
+    $form = $this->buildTestForm();
+
+    $this->assertStringEndsWith('-uri', $form['link_url']['#attributes']['data-drupal-selector']);
+  }
+
+  /**
+   * Tests that a selector already ending in "-uri" is left alone.
+   */
+  public function testSelectorAlreadyEndingInUriIsNotSuffixedTwice() {
+    $form = $this->buildTestForm();
+
+    $this->assertSame('edit-uri', $form['uri']['#attributes']['data-drupal-selector']);
+  }
+
+  /**
+   * Tests that elements other than linkit keep their generated selector.
+   */
+  public function testNonLinkitElementSelectorIsUnchanged() {
+    $form = $this->buildTestForm();
+
+    $this->assertSame('edit-plain-text', $form['plain_text']['#attributes']['data-drupal-selector']);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -90,6 +90,42 @@ function ys_core_theme($existing, $type, $theme, $path): array {
 }
 
 /**
+ * Implements hook_element_info_alter().
+ */
+function ys_core_element_info_alter(array &$info) {
+  if (isset($info['linkit'])) {
+    $info['linkit']['#process'][] = 'ys_core_linkit_uri_selector';
+  }
+}
+
+/**
+ * Process callback: suffixes a linkit element's drupal selector with "-uri".
+ *
+ * Linkit's autocomplete JavaScript is written for the link field widget, whose
+ * URI sub-element always gets a data-drupal-selector ending in "-uri"; it
+ * derives the sibling metadata inputs from that suffix and throws outright when
+ * it is missing. A standalone "#type => linkit" element - which our settings
+ * forms use - is named for its own config key instead, so selecting a
+ * suggestion threw before the JavaScript ever wrote the chosen path into the
+ * field. Suffixing the selector satisfies that check; the sibling inputs it
+ * then looks for simply do not exist outside a link widget, which the
+ * JavaScript handles without complaint.
+ *
+ * @param array $element
+ *   The linkit element being processed.
+ *
+ * @return array
+ *   The processed element.
+ */
+function ys_core_linkit_uri_selector(array $element) {
+  $selector = $element['#attributes']['data-drupal-selector'] ?? '';
+  if ($selector && !str_ends_with($selector, '-uri')) {
+    $element['#attributes']['data-drupal-selector'] = $selector . '-uri';
+  }
+  return $element;
+}
+
+/**
  * Implements hook_form_alter().
  */
 function ys_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {


### PR DESCRIPTION
## [1545: RC: Site Alert Link URL field – autocomplete suggestions can't be selected](https://github.com/yalesites-org/YaleSites-Internal/issues/1545)

### Description of work
- Fixes the Link URL autocomplete on Alert Settings: clicking (or keyboard-selecting) a suggestion now fills the field with the selected page's internal path instead of silently closing the dropdown and leaving the raw typed text.
- Root cause is in Linkit's autocomplete JavaScript, not in the alert form. `$getWidgetSelector()` in `linkit/js/linkit.autocomplete.js` throws unless the input's `data-drupal-selector` ends in `-uri`, and that throw happens inside `selectHandler()` *before* the line that writes the chosen path into the field. Linkit is written for the link field widget, whose URI sub-element is literally keyed `uri`; a standalone `#type => linkit` element is keyed for its own config key (`link_url`), so it never matched.
- Fixed centrally rather than at the one reported call site: `ys_core_element_info_alter()` adds a `#process` callback to the `linkit` element type that suffixes the already-computed selector with `-uri`. `#process` runs after `FormBuilder` assigns the selector, and the selector is derived per element from `#parents`, so every element keeps its own distinct value (confirmed on the repeating footer rows).
- **This fixes more than the alert form.** All six standalone `#type => linkit` elements on the platform had this bug: `ys_alert` Alert Settings (`link_url`), `ys_core` Header Settings (`cta_url`), and four in `ys_core` Footer Settings (logo and column link URLs). Alert and Header are verified end to end in a browser, including keyboard selection and save.
- **On Footer Settings the symptom was worse than the ticket describes.** The throw also fires at the end of each iteration of linkit's `attach` behavior loop, which aborts the loop — so on a form with several linkit inputs, only the *first* ever had autocomplete attached at all. Measured before and after by temporarily reverting this change and reading the `ui-autocomplete-input` class off each input: **1 of 11 footer inputs initialized before, 11 of 11 after.** So ten of the footer's URL fields had no autocomplete whatsoever, not merely an unselectable one.
- Adds `ys_core/tests/src/Kernel/LinkitUriSelectorTest.php`. It builds a form through the form builder, which is the only thing that sets `data-drupal-selector`, and asserts the suffix is applied to a linkit element, is not applied twice to one whose selector already ends in `-uri`, and is not applied to other element types.
- Deliberately not done here: the underlying bug is Linkit's own — `$getWidgetSelector()` should degrade rather than throw for a standalone element, and that is worth filing upstream. A contrib patch was not used as the fix, since it would live in gitignored contrib with nothing in our own tree covering it, and it would force a profile `composer update` cycle for a one-line Drupal-side attribute change.

### Functional testing steps:
- [ ] Go to Settings > Alert Settings, open the Link section, clear the URL field, and type the title of an existing page.
- [ ] Click a suggestion in the dropdown. The URL field fills in with that page's internal path (e.g. `/hello-world`), and the browser console shows no error.
- [ ] Clear the field, type again, and this time select with the keyboard (Down arrow, then Enter). The field fills in the same way.
- [ ] Save configuration (confirming the modal if the alert type is Emergency), then reload the page. The selected path is still there.
- [ ] Type a raw external URL that matches no suggestion (e.g. `https://www.yale.edu/`) and save. It saves unchanged.
- [ ] Repeat the same check on Settings > Header Settings (the Call to action URL).
- [ ] On Settings > Footer Settings, check *every* link URL field, not just the first. Note that these fields render disabled under some footer configurations — where that is the case, verify by confirming suggestions appear as you type (before this change, only the first field on the form offered any at all) rather than by selecting one.
- [ ] Regression: confirm Alert Settings still saves headline, message, and type as before, and that the alert renders on the front end with its linked text.

References yalesites-org/YaleSites-Internal#1545
