### PR TITLE
1543: RC: Resource external source link renders the URL as its button label

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/ResourceMetaBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Block/ResourceMetaBlock.php
@@ -284,9 +284,13 @@ class ResourceMetaBlock extends BlockBase implements ContainerFactoryPluginInter
         $linkItem = $node->get('field_external_source')->first();
         $url = UrlHelper::filterBadProtocol($linkItem->getUrl()->toString());
         if ($url) {
+          // The link title sub-field is disabled for this field, so the label
+          // is always this fixed string -- matching the Download CTA below.
+          // Never fall back to the URL: a raw URL is not a meaningful link
+          // name (WCAG 2.4.4) and reads as broken with long URLs.
           $externalSource = [
             'url' => $url,
-            'title' => $linkItem->get('title')->getValue() ?: $url,
+            'title' => $this->t('Visit Source'),
           ];
         }
       }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/ResourceMetaBlockTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/ResourceMetaBlockTest.php
@@ -6,8 +6,12 @@ use Drupal\Core\Controller\TitleResolver;
 use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Url;
 use Drupal\Tests\UnitTestCase;
+use Drupal\link\LinkItemInterface;
+use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\ys_layouts\Plugin\Block\ResourceMetaBlock;
 use Drupal\ys_layouts\Service\MediaAltResolver;
@@ -15,6 +19,7 @@ use Drupal\ys_layouts\Service\ResourceAuthorBuilder;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Route;
 
 /**
  * Tests the resource meta block.
@@ -164,6 +169,82 @@ class ResourceMetaBlockTest extends UnitTestCase {
     $build = $this->block->build();
 
     $this->assertSame([], $build);
+  }
+
+  /**
+   * The external source CTA is labelled, never the raw URL.
+   *
+   * The link field's title sub-field is disabled in config
+   * (field.field.node.resource.field_external_source: settings.title = 0), so
+   * the label always comes from here.
+   *
+   * @covers ::build
+   */
+  public function testExternalSourceUsesFixedLabelNotTheUrl(): void {
+    $url = 'https://example.com/a/very/long/path/that/should/not/be/a/button/label';
+    $build = $this->buildForResourceNodeWithExternalSource($url);
+
+    $this->assertSame($url, $build['#resource_meta__external_source']['url']);
+    $this->assertSame('Visit Source', (string) $build['#resource_meta__external_source']['title']);
+  }
+
+  /**
+   * The sibling Download CTA keeps its own fixed label.
+   *
+   * @covers ::build
+   */
+  public function testDownloadLabelIsUnchanged(): void {
+    $build = $this->buildForResourceNodeWithExternalSource('https://example.com/');
+
+    $this->assertSame('Download', (string) $build['#resource_meta__download_label']);
+  }
+
+  /**
+   * Builds the block for a resource node carrying an external source link.
+   *
+   * @param string $url
+   *   The external source URL.
+   *
+   * @return array
+   *   The block's render array.
+   */
+  protected function buildForResourceNodeWithExternalSource(string $url): array {
+    $this->block->setStringTranslation($this->getStringTranslationStub());
+
+    $urlObject = $this->createMock(Url::class);
+    $urlObject->method('toString')->willReturn($url);
+
+    $linkItem = $this->createMock(LinkItemInterface::class);
+    $linkItem->method('getUrl')->willReturn($urlObject);
+
+    $externalSourceField = $this->createMock(FieldItemListInterface::class);
+    $externalSourceField->method('isEmpty')->willReturn(FALSE);
+    $externalSourceField->method('first')->willReturn($linkItem);
+
+    // Every other field build() reads is left empty.
+    $emptyField = $this->createMock(FieldItemListInterface::class);
+    $emptyField->method('getValue')->willReturn([]);
+    $emptyField->method('first')->willReturn(NULL);
+
+    // Node is mocked as the concrete class so build()'s magic property reads
+    // (e.g. $node?->field_publish_date) resolve through a stubbed __get.
+    $node = $this->createMock(Node::class);
+    $node->method('bundle')->willReturn('resource');
+    $node->method('getTitle')->willReturn('A resource');
+    $node->method('__get')->willReturn($emptyField);
+    $node->method('hasField')->willReturnCallback(
+      fn (string $name): bool => $name === 'field_external_source'
+    );
+    $node->method('get')->with('field_external_source')->willReturn($externalSourceField);
+
+    $this->resourceAuthorBuilder->method('build')->willReturn([]);
+    $this->routeMatch->method('getRouteObject')->willReturn(new Route('/node/1'));
+
+    $request = new Request();
+    $request->attributes->set('node', $node);
+    $this->requestStack->method('getCurrentRequest')->willReturn($request);
+
+    return $this->block->build();
   }
 
   /**


### PR DESCRIPTION
## [1543: RC: Resource external source link renders the URL as its button label](https://github.com/yalesites-org/YaleSites-Internal/issues/1543)

### Description of work
- Fixed the Resource **External Source** CTA rendering the raw URL as its visible button label. It looked broken with long URLs, and a bare URL is not a meaningful link name (WCAG 2.4.4 Link Purpose) — Editoria11y flagged the CTA on the page before this change and no longer does after it.
- Root cause: `ResourceMetaBlock::build()` fell back to the URL whenever the link's title sub-field was empty (`'title' => $linkItem->get('title')->getValue() ?: $url`). That fallback fired every time, because `field_external_source` intentionally has `settings: title: 0` (confirmed in `field.field.node.resource.field_external_source.yml`) — editors cannot enter a label, so the value was always empty. It also meant the component's own `|default('Visit Source')` never got a chance to run.
- The fix hardcodes a fixed, translatable label — `'title' => $this->t('Visit Source')` — matching the pattern the sibling **Download** CTA on the same block already uses (`$this->t('Download')`).
- **Label wording is a deliberate deviation from the issue's acceptance criteria.** The AC gives `$this->t('External Source')` as its example, but the component renders a `<dt>External Source</dt>` immediately above this CTA, so that label would have read "External Source / External Source". `Visit Source` is the string the component itself already nominates as its default, and it still satisfies every binding part of the AC (no URL fallback; a fixed readable label; a PHP `t()` matching the Download pattern). Happy to change the wording — it is a one-word edit.
- Display-layer only: no config change, no stored data change, no migration needed. `component-library-twig` is untouched — this block's template is the only consumer of `publication_detail__external_source`.
- Test coverage: added `testExternalSourceUsesFixedLabelNotTheUrl` (red before the fix with the URL as the label, green after) and `testDownloadLabelIsUnchanged` (the AC's Download regression check) to `ResourceMetaBlockTest`. These also close a gap the test file itself documented — `build()`'s full success path previously had no coverage at all.
- Verification: `ys_layouts` unit suite 93 tests / 154 assertions before → 95 / 157 after, with the same single pre-existing unrelated failure (`BlockContextualLinksTest::testRemoveStaysLastAndLabelsDropTheWordBlock`) in both runs; `ys_layouts` kernel suite OK (30 tests, 321 assertions); `composer code-sniff` exit 0; checked in a browser on local Lando against a real Resource node before and after, plus the Download CTA on a second Resource; light accessibility check on the rendered page (contrast, alt text, form labels, accessible names) PASS — the link's accessible name is now "Visit Source (Link is external)" and its contrast is roughly 12:1.

### Functional testing steps:
- [ ] Edit (or create) a Resource node and fill in the **External Source** field with a long URL, e.g. `https://students.yale.edu/orientation`.
- [ ] View the Resource page. Under the **External Source** heading, the CTA button reads **Visit Source** — not the URL.
- [ ] Inspect or follow the link: the URL is still the link target (`href`) and still goes where it should.
- [ ] Regression: on a Resource with a document attached, the **Download** CTA still reads "Download" and still downloads the file.
- [ ] Regression: an existing Resource that already had an External Source filled in picks this up with no content edit — the change is display-layer only, so no migration is needed.

References yalesites-org/YaleSites-Internal#1543
