### PR TITLE
1549: Layout Section: add Component theme picker support to Banner (one column)

### DIFF
--- a/docs/color-theme.md
+++ b/docs/color-theme.md
@@ -179,6 +179,10 @@ Component themes are visualized here: https://yalesites-org.github.io/component-
 - Quick Links (`component-library-twig/components/02-molecules/quick-links/yds-quick-links.twig`)
 - Tabs (`component-library-twig/components/02-molecules/tabs/yds-tabs.twig`)
 
+**Layout Builder Sections** also expose a "Component theme" picker. Any layout in `ys_layouts.layouts.yml` whose `class` is (or extends) `\Drupal\ys_layouts\Plugin\Layout\YSLayoutOptions` gets it. Sections do not map options to slots 1:1 — `ColorTokenResolver::getColorStylesForEntity()` holds the mapping under the `layout_section`/`ys_layout_options` pair, and is the only place it should be read from. The one thing worth stating here because it surprises people: the option labeled "Five" resolves to slot-nine, not slot-five.
+
+Most of those layouts render through `@organisms/layout/layout` (`yds-layout.twig`), which carries the `data-component-theme` attribute the color rules in `_yds-layout.scss` key on. **Banner is the exception** — it adopts the `yds-layout` class and the attribute without embedding the organism, and drops the inherited divider checkbox because it has a single region. The reasoning is in the docblock of `ys_layouts/layouts/banner/layout--banner.html.twig`; read it before changing that template.
+
 The purpose in registering these component themes is to establish default values from which a global theme will be iterated over to apply color slots, changing color values depending on the active global theme.
 
 **Note:** 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/banner/layout--banner.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/banner/layout--banner.html.twig
@@ -7,6 +7,15 @@
  * - in_preview: Whether the plugin is being rendered in preview mode.
  * - content: The content for this layout.
  * - attributes: HTML attributes for the layout <div>.
+ * - settings: The section configuration, including the selected theme.
+ *
+ * The `yds-layout` class plus `data-component-theme` reuse the section color
+ * rules in component-library-twig's `_yds-layout.scss`. This deliberately does
+ * NOT embed `@organisms/layout/layout` the way the two- and three-column
+ * layouts do: that organism also carries the site-width clamp
+ * (`[class*='__inner']`) and the gutter padding it gets from
+ * `[data-component-width]` in `00-tokens/layout/_layout.scss`, both of which
+ * would break the full-bleed banner components.
  *
  * @ingroup themeable
  */
@@ -15,11 +24,12 @@
   set classes = [
     'layout',
     'layout--banner',
+    'yds-layout',
   ]
 %}
 
 {% if content['#show_region_content'] %}
-  <div{{ attributes.addClass(classes) }}>
+  <div{{ attributes.addClass(classes).setAttribute('data-component-theme', settings.theme|default('default')) }}>
     <div {{ region_attributes.content.addClass('layout__region', 'layout__region--content') }}>
       {{ content.content }}
     </div>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Layout/YSLayoutBanner.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Plugin/Layout/YSLayoutBanner.php
@@ -2,12 +2,27 @@
 
 namespace Drupal\ys_layouts\Plugin\Layout;
 
-use Drupal\Core\Layout\LayoutDefault;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Banner layout class.
+ *
+ * Extends YSLayoutOptions so Banner sections get the same "Component theme"
+ * picker as the other themed Section layouts. Banner has a single region, so
+ * the inherited divider checkbox is removed.
  */
-class YSLayoutBanner extends LayoutDefault {
+class YSLayoutBanner extends YSLayoutOptions {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildConfigurationForm($form, $form_state);
+
+    unset($form['divider']);
+
+    return $form;
+  }
 
   /**
    * {@inheritdoc}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/YSLayoutBannerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/YSLayoutBannerTest.php
@@ -3,10 +3,12 @@
 namespace Drupal\Tests\ys_layouts\Unit;
 
 use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Form\FormState;
 use Drupal\Core\Layout\LayoutDefinition;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\ys_layouts\Plugin\Layout\YSLayoutBanner;
+use Drupal\ys_themes\ColorTokenResolver;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -25,7 +27,32 @@ class YSLayoutBannerTest extends UnitTestCase {
     $definition = new LayoutDefinition([
       'regions' => ['content' => ['label' => 'Content']],
     ]);
-    return new YSLayoutBanner([], 'ys_layout_banner', $definition);
+    return new YSLayoutBanner(
+      [],
+      'ys_layout_banner',
+      $definition,
+      $this->createMock(ColorTokenResolver::class),
+    );
+  }
+
+  /**
+   * Banner exposes the Component theme picker, but not the divider checkbox.
+   *
+   * Banner is a single-region layout, so the inherited divider checkbox has
+   * nothing to divide and is removed.
+   *
+   * @covers ::buildConfigurationForm
+   */
+  public function testBuildConfigurationFormExposesThemeWithoutDivider(): void {
+    $layout = $this->buildLayout();
+    $layout->setStringTranslation($this->getStringTranslationStub());
+
+    $form = $layout->buildConfigurationForm([], new FormState());
+
+    // Only Banner's delta from YSLayoutOptions is asserted here. The theme
+    // element's own shape and option list stay pinned in YSLayoutOptionsTest.
+    $this->assertArrayNotHasKey('divider', $form);
+    $this->assertArrayHasKey('theme', $form);
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.info.yml
@@ -10,3 +10,4 @@ dependencies:
   - drupal:layout_builder
   - quick_node_clone
   - ys_localist
+  - ys_themes


### PR DESCRIPTION
## [1549: Layout Section: add Component theme picker support to Banner (one column)](https://github.com/yalesites-org/YaleSites-Internal/issues/1549)

### Description of work

- `YSLayoutBanner` now extends `YSLayoutOptions` instead of core `LayoutDefault`, so Banner sections get the same **Component theme** picker (with its color palette UI) as Two Column (50/50) and Three Column (33/33/33). Its existing `build()` override — the moderation-control visibility logic — is untouched.
- The inherited **Divider** checkbox is removed for Banner, which has a single region and therefore no columns to divide.
- `layout--banner.html.twig` adopts the `yds-layout` class and sets `data-component-theme`, which is what the section color rules in `_yds-layout.scss` key on — the same attribute the two- and three-column layouts pass through the organism.
- `ys_layouts.info.yml` now declares its `ys_themes` dependency. `YSLayoutOptions::create()` pulls `ys_themes.color_token_resolver` out of the container, and this makes Banner — which is in four exported `core.entity_view_display.*` files, i.e. effectively every page — the first render-path consumer. The gap was pre-existing (50/50 and 33/33/33 already need the service) but the blast radius of an uninstall changes, and declaring it is what makes Drupal refuse that uninstall.
- `docs/color-theme.md` documents which Section layouts expose the picker, points at `ColorTokenResolver::getColorStylesForEntity()` as the source of truth for the slot mapping (with the one surprise called out: "Five" resolves to slot-nine), and notes the Banner exception below.
- No config change: `ys_layouts.layouts.yml` already pointed `ys_layout_banner` at `YSLayoutBanner`.
- No `ColorTokenResolver` change: the inherited `processColorPicker()` passes the same `'layout_section'` / `'ys_layout_options'` pair, so Banner picks up the existing section slot mapping and its existing test coverage unchanged.

### Deliberate deviation from the issue's technical plan — please read

The issue prescribes a cross-repo implementation: add a `one-column` variant to `@organisms/layout/layout` in `component-library-twig`, release it, bump `atomic`, then have `layout--banner.html.twig` embed `yds-layout.twig`. **This PR does not do that**, on evidence the issue did not account for.

Embedding `yds-layout.twig` does not only bring the theme CSS — it brings the organism's *containment*:

- `component-library-twig/components/00-tokens/layout/_layout.scss` — `[class*='__inner'] { max-width: var(--component-width) }` clamps any `*__inner` wrapper to the site width, and `[data-component-width]` adds `--size-spacing-site-gutter` inline padding.
- `_yds-layout.scss` — `.yds-layout__inner` adds `padding-block: var(--size-spacing-10)`.

Banner sections are full-bleed today (measured locally: `.layout--banner` and its region are 1280px at a 1280px viewport, no gutter, no vertical padding), and the banner components are built to be full-bleed — `_yds-grand-hero.scss` uses `width: 100vw; max-width: 100vw` for its `full` width option, and `yds-video-banner.twig` carries `data-full-width-component`. Embedding the organism would clamp and pad every existing site's hero/image/video banner. Making it not do that would mean adding a variant to a shared, Percy-tested organism whose job is to undo that organism's own containment.

So Banner keeps its own markup and reuses the organism's *theme* rules only — no `__inner`, no `data-component-width`, therefore no clamp, no gutter, no padding. An unthemed Banner is unchanged, verified by pixel diff below.

**Consequence:** the issue's AC 1 (CLT `one-column` variant + Percy) and AC 2 (release CLT, bump atomic) are not done and are not needed for this implementation. This is a single-repo change with no cross-repo release blocker. Happy to build the organism variant instead if you'd rather have it.

The trade being accepted: a Drupal template now hand-adopts a component-library class, so no Storybook story or Percy snapshot covers a themed Banner, and a future refactor of `.yds-layout` in CLT could drift from it silently. The alternative deeper fix — extracting the theme-slot `@each` blocks from `_yds-layout.scss` into a shared CLT mixin, which already has three hand-rolled callers — is worth doing on its own merits but is a separate CLT branch, not this PR.

### Verification already done locally

- **Unthemed Banner is pixel-identical.** Screenshotted `/node/1` with and without the change (`git stash` + `drush cr` between): 939 of 921,600 pixels differ, confined to a 728x18 strip at the very bottom of the viewport, which on inspection is the WebProfiler toolbar's counters (query count, timings, memory). The page content is identical. Computed styles agree: `background rgba(0,0,0,0)`, margin 0, padding 0, same box, still full-bleed.
- **Contrast: 35/35 combinations pass WCAG 2.1 AA** — all 7 global themes x all 5 section color options, computing the ratio of the resolved section `background-color` against the resolved `color`. Minimum 4.61, maximum 16.10. The slot-nine option ("Five") ranges 11.41–15.33.
- **Round-trips through the real editor**, not just drush: set the theme in the section form, clicked Save layout, and read the persisted section back as `"theme":"three"`. Layout Builder preview keeps all its affordances (Configure / Move / Clone / Remove, contextual links).
- `ys_layouts` Unit suite: 94 tests, 1 failure, which is the pre-existing `BlockContextualLinksTest` failure — confirmed identical on clean `develop`.
- `lando composer code-sniff` exits 0 with zero errors or warnings; `composer lint:php` clean.

### Known follow-up / open question

On a Banner section whose block fills the section, the new color is not visible — measured with theme `three`, the section background resolves correctly but the image-banner block covers 100% of the section height. That is inherent to what the issue asked for rather than a defect here, but it may be worth deciding whether Banner should expose all five options or whether the intent was to theme the banner *component* rather than the *section*.

Two implementation notes for review, both raised by the review pass and both deliberately left alone:

1. `YSLayoutOptions::submitConfigurationForm()` still reads the divider element this subclass removes, so Banner stores `divider: null`. Verified harmless — `ys_layouts` ships no `config/schema`, nothing declares `divider`, `defaultConfiguration()` sets a falsy `''`, and the banner template never reads it. The one-line fix would be `$form_state->getValue('divider', '')` in the shared class.
2. A cleaner altitude for the divider removal would be to gate it in `YSLayoutOptions::buildConfigurationForm()` on region count (`count($this->getPluginDefinition()->getRegions()) > 1`) rather than `unset()`-ing it in the subclass. That is behavior-neutral for the two other layouts (2 and 3 regions), fixes the `divider: null` above at the same time, and would let `YSLayoutBanner` drop the override entirely — but it edits the shared class every themed section renders through, and it needs `YSLayoutOptionsTest::setUp()`'s single-region fixture corrected. Say the word and I'll do it.

`docs/color-theme.md` is also edited by the open PR #1465, so expect a small conflict there; both notes should be kept.

### Functional testing steps:

- [ ] On any page, choose **Edit Layout And Content**, then **Configure Banner Section**. Confirm a **Component theme** picker is present with the color swatches, and that there is **no** Divider checkbox.
- [ ] Pick a color, save the section, then **Save layout**. Confirm the Banner section renders with that background color and readable text.
- [ ] Re-open the section, set the theme back to **Default - no color**, and save. Confirm the banner returns to exactly its previous appearance — no added padding, no added margin, still full-bleed edge to edge.
- [ ] Repeat with a few different global themes (Appearance / Theme Settings) and confirm the section color changes with the global theme and text stays readable.
- [ ] Confirm the Two Column (50/50) and Three Column (33/33/33) sections still behave exactly as before, divider checkbox included.
- [ ] On a page whose banner holds a moderation control only, confirm the banner region is still hidden when the page is published (the existing behavior this layout's `build()` provides).

References yalesites-org/YaleSites-Internal#1549
