### PR TITLE
1550: Bug: Beacon system instructions treat the recommended 4,000-character length as a hard maximum

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/schema/ys_beacon.schema.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/schema/ys_beacon.schema.yml
@@ -67,7 +67,7 @@ ys_beacon.settings:
       label: 'Context window in tokens of the model Portkey routes to'
     instructions_max_length:
       type: integer
-      label: 'Maximum system instructions length in characters'
+      label: 'Recommended system instructions length in characters'
     instructions_warning_threshold:
       type: integer
       label: 'Character count at which the instructions editor shows a warning'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/js/system-instructions.js
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/js/system-instructions.js
@@ -9,8 +9,9 @@
    *
    * Instructions are stored as Markdown, but the editor holds HTML. There is no
    * Markdown length available client-side, so the counter reports the editor's
-   * plain-text length as a close, intuitive equivalent; the server-side
-   * validation on the converted Markdown remains authoritative.
+   * plain-text length as a close, intuitive equivalent. This is a
+   * recommendation only; the server does not enforce it, so going over does
+   * not block saving.
    */
   Drupal.behaviors.systemInstructionsCharacterCount = {
     attach(context) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/SystemInstructionsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/SystemInstructionsForm.php
@@ -65,12 +65,15 @@ class SystemInstructionsForm extends FormBase {
   }
 
   /**
-   * Get the maximum instructions length from configuration.
+   * Get the recommended instructions length from configuration.
+   *
+   * This is a soft cap: editors are warned when they go over it, but saving
+   * longer instructions is not blocked.
    *
    * @return int
-   *   The maximum instructions length.
+   *   The recommended instructions length.
    */
-  protected function getMaxInstructionsLength(): int {
+  protected function getRecommendedInstructionsLength(): int {
     return $this->config('ys_beacon.settings')->get('instructions_max_length') ?: 4000;
   }
 
@@ -106,7 +109,7 @@ class SystemInstructionsForm extends FormBase {
       ]),
     ];
 
-    $max_length = $this->getMaxInstructionsLength();
+    $max_length = $this->getRecommendedInstructionsLength();
     $form['instructions'] = [
       '#type' => 'text_format',
       '#title' => $this->t('System Instructions'),
@@ -176,13 +179,9 @@ class SystemInstructionsForm extends FormBase {
       $form_state->setErrorByName('instructions', $this->t('System instructions cannot be empty.'));
     }
 
-    $max_length = $this->getMaxInstructionsLength();
-    if (mb_strlen($instructions) > $max_length) {
-      $form_state->setErrorByName('instructions', $this->t('Instructions are @count characters, which exceeds the maximum of @max characters.', [
-        '@count' => mb_strlen($instructions),
-        '@max' => number_format($max_length),
-      ]));
-    }
+    // The configured length is a recommendation, not a hard requirement: the
+    // character counter (js/system-instructions.js) already warns editors
+    // when they go over it, but saving must not be blocked.
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/SystemInstructionsFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/SystemInstructionsFormTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Core\Form\FormState;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\Form\SystemInstructionsForm;
+use Drupal\ys_beacon\Service\MarkdownConverter;
+use Drupal\ys_beacon\Service\SystemInstructionsStorage;
+
+/**
+ * Tests validation behavior of the Beacon system instructions form.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Form\SystemInstructionsForm
+ */
+class SystemInstructionsFormTest extends UnitTestCase {
+
+  /**
+   * Builds a form instance with a mocked Markdown converter.
+   *
+   * @param string $convertedMarkdown
+   *   The value the Markdown converter should return for any HTML input.
+   */
+  private function createForm(string $convertedMarkdown): SystemInstructionsForm {
+    $markdownConverter = $this->createMock(MarkdownConverter::class);
+    $markdownConverter->method('toMarkdown')->willReturn($convertedMarkdown);
+
+    $storage = $this->createMock(SystemInstructionsStorage::class);
+
+    $form = new SystemInstructionsForm($storage, $markdownConverter);
+    $form->setStringTranslation($this->getStringTranslationStub());
+
+    return $form;
+  }
+
+  /**
+   * Instructions longer than the recommended length still validate cleanly.
+   *
+   * The 4,000-character length is a recommendation, not a hard requirement:
+   * editors must be able to save instructions that run over it.
+   *
+   * @covers ::validateForm
+   */
+  public function testValidateFormAllowsInstructionsOverRecommendedLength(): void {
+    $longInstructions = str_repeat('a', 4780);
+    $form = $this->createForm($longInstructions);
+
+    $formArray = [];
+    $formState = new FormState();
+    $formState->setValue('instructions', [
+      'value' => '<p>anything</p>',
+      'format' => 'restricted_html',
+    ]);
+
+    $form->validateForm($formArray, $formState);
+
+    $this->assertSame([], $formState->getErrors());
+  }
+
+  /**
+   * Whitespace/markup-only input is still rejected as empty.
+   *
+   * @covers ::validateForm
+   */
+  public function testValidateFormRejectsMarkupOnlyInput(): void {
+    $form = $this->createForm('');
+
+    $formArray = [];
+    $formState = new FormState();
+    $formState->setValue('instructions', [
+      'value' => '<p></p>',
+      'format' => 'restricted_html',
+    ]);
+
+    $form->validateForm($formArray, $formState);
+
+    $this->assertArrayHasKey('instructions', $formState->getErrors());
+  }
+
+}


### PR DESCRIPTION
## [1550: Bug: Beacon system instructions treat the recommended 4,000-character length as a hard maximum](https://github.com/yalesites-org/YaleSites-Internal/issues/1550)

### Description of work
- Removed the hard validation error in `SystemInstructionsForm::validateForm()` that blocked saving Beacon system instructions over 4,000 characters — the field's own label and character counter already called this a "recommendation," but the form rejected the save outright. It's now a soft cap: the existing counter still warns editors when they're over (turns to a bold warning/error color), but saving is no longer blocked.
- Renamed `getMaxInstructionsLength()` to `getRecommendedInstructionsLength()` and reworded the config schema label and a stale JS comment that both still described the old hard-cap behavior.
- Added PHPUnit coverage (`tests/src/Unit/SystemInstructionsFormTest.php`) confirming instructions over the configured length validate cleanly, plus a regression check that whitespace/markup-only input is still rejected as empty.

### Functional testing steps:
- [ ] Go to **Configuration → YaleSites Beacon settings → System instructions**
- [ ] Paste or type instructions longer than 4,000 characters
- [ ] Confirm the counter below the editor turns to a bold warning/error color once you're near/over the limit, but nothing blocks you from typing further
- [ ] Click **Save Instructions** — confirm it saves successfully ("System instructions saved as version N.") instead of showing "Instructions are N characters, which exceeds the maximum of 4,000 characters."

References yalesites-org/YaleSites-Internal#1550

<img width="552" height="208" alt="Screenshot 2026-08-14 at 9 00 37 AM" src="https://github.com/user-attachments/assets/90030bc3-124b-4772-87a3-787d3486de61" />

<img width="430" height="170" alt="Screenshot 2026-08-14 at 9 00 34 AM" src="https://github.com/user-attachments/assets/59f90b93-b959-47d9-9c11-879d6111e06c" />
