### PR TITLE
1551: Bug: Link/heading text-shadow descender-gap halo hardcoded to white, breaks on non-white themes/backgrounds — For multidev only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # YaleSites Project
 
+<!-- Multidev-only branch for yalesites-org/YaleSites-Internal#1551 -->
+
 YaleSites Project is a **Pantheon custom upstream for Drupal 10** that serves as the foundation for Yale's web platform. The YaleSites platform empowers the Yale community to create digital experiences for the web in applications that are secure, cost-effective, accessible, and sustainable.
 
 This is a sophisticated multi-repository system that includes:

--- a/docs/color-theme.md
+++ b/docs/color-theme.md
@@ -108,7 +108,8 @@ global-themes:
       slot-nine:
         value: "{color.gray.100.value}"
   ```
-  - `slot-nine` is reserved for the secondary background variant in our global theme palettes. In the current implementation, ONHA uses `soft-oceanic` and the other themes use a neutral gray background.
+  - `slot-nine` is reserved for the secondary background variant in our global theme palettes. In the current implementation, ONHA uses `soft-oceanic` and the other themes use a neutral gray background. It is always paired with `slot-seven` as the foreground/text color — that pairing is contrast-safe (AA) across all 7 global themes; see the Storybook contrast matrix story (`?path=/docs/tokens-colors-contrast-matrix--docs`) rather than a hardcoded table here, since it recomputes live from `tokens.json`.
+  - Layout Section's "Component theme" picker exposes this as option `'five'` (labeled "Five" in the admin UI), not a `'six'` option like block-level component pickers — Sections have their own slot mapping (see `ColorTokenResolver::getColorStylesForEntity()`'s `layout_section` case) that omits `slot-three` by design. Don't be misled by the option label: `'five'` resolves to `slot-nine`, not `slot-five`.
   - Add your new theme, following the same convention shown above. If there are `three` themes already entered, and yours would be number `four`, name it accordingly.
   - For example (say we wanted to use the new `brown` value we added above): 
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/two_column/layout--two-column.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/layouts/two_column/layout--two-column.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a one-column layout.
+ * Default theme implementation to display a two-column (70/30) layout.
  *
  * Available variables:
  * - in_preview: Whether the plugin is being rendered in preview mode.
@@ -11,24 +11,28 @@
  * @ingroup themeable
  */
 #}
-
-{% set layout__base_class = layout__base_class|default('yds-two-column') %}
-
-{% set classes = ['layout', 'yds-two-column'] %}
-
 {% if content %}
-	<div{{ attributes.addClass(classes).setAttribute('data-component-padding', settings['padding']|default('default')).setAttribute('data-component-width', layout__width|default('site')).setAttribute('data-embedded-components', 'true') }}>
-		<div {{ bem('inner', [], layout__base_class)}}>
-			{% if content.content %}
-				<div {{ region_attributes.content.addClass('yds-two-column__primary') }}>
-					{{ content.content }}
-				</div>
-			{% endif %}
-			{% if content.sidebar %}
-				<div {{ region_attributes.sidebar.addClass('yds-two-column__secondary') }}>
-					{{ content.sidebar }}
-				</div>
-			{% endif %}
-		</div>
-	</div>
+  {% if in_preview %}
+    <div {{ attributes}}>
+  {% endif %}
+  {% embed "@organisms/layout/layout/yds-layout.twig" with {
+    component__layout: 'seventy-thirty',
+    layout__padding: settings.padding|default('default'),
+    layout__divider: settings.divider ? 'true' : 'false',
+    component__theme: settings.theme|default('default'),
+  } %}
+    {% block layout__primary %}
+      <div {{ region_attributes.content }}>
+        {{ content.content }}
+      </div>
+    {% endblock %}
+    {% block layout__secondary %}
+      <div {{ region_attributes.sidebar }}>
+        {{ content.sidebar }}
+      </div>
+    {% endblock %}
+  {% endembed %}
+  {% if in_preview %}
+    </div>
+  {% endif %}
 {% endif %}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/YsLayoutsDefinitionsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/YsLayoutsDefinitionsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\Tests\ys_layouts\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_layouts\Plugin\Layout\YSLayoutOptions;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests which layout plugin definitions expose the color theme picker.
+ *
+ * @group yalesites
+ * @group ys_layouts
+ */
+class YsLayoutsDefinitionsTest extends UnitTestCase {
+
+  /**
+   * Parses the layout plugin definitions.
+   *
+   * @return array
+   *   The decoded ys_layouts.layouts.yml content.
+   */
+  protected function getLayoutDefinitions(): array {
+    $path = __DIR__ . '/../../../ys_layouts.layouts.yml';
+    return Yaml::parseFile($path);
+  }
+
+  /**
+   * Two Column (70/30) is wired to the same layout class as 50/50 and 33/33/33.
+   *
+   * Two Column (70/30) previously used core LayoutDefault with no color
+   * theme picker at all, unlike Two Column (50/50) and Three Column
+   * (33/33/33). This pins the plugin definition's `class` key to
+   * YSLayoutOptions for all three -- the actual form/picker behavior that
+   * class provides is covered separately by YSLayoutOptionsTest.
+   */
+  public function testTwoColumnUsesLayoutOptionsClass(): void {
+    $definitions = $this->getLayoutDefinitions();
+
+    // Also pin the layouts that already had it, so a future edit that
+    // removes the class from one of these is caught here too.
+    foreach ([
+      'ys_layout_two_column',
+      'ys_layout_two_column_50_50',
+      'ys_layout_three_column_33_33_33',
+    ] as $id) {
+      $this->assertSame('\\' . YSLayoutOptions::class, $definitions[$id]['class'] ?? NULL, $id);
+    }
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.layouts.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.layouts.yml
@@ -16,6 +16,7 @@ ys_layout_two_column:
   path: layouts/two_column
   template: layout--two-column
   library: ys_layouts/ys_layout_two_column
+  class: '\Drupal\ys_layouts\Plugin\Layout\YSLayoutOptions'
   category: 'Columns: 2'
   default_region: content
   icon_map:


### PR DESCRIPTION
## [1551: Bug: Link/heading text-shadow descender-gap halo hardcoded to white, breaks on non-white themes/backgrounds](https://github.com/yalesites-org/YaleSites-Internal/issues/1551)

### Description of work

No functional changes in this repo — this branch exists only so pushing it builds a Pantheon multidev, which the build pulls the matching component-library-twig branch into (regardless of atomic's pinned CLT version), so the fix can be reviewed and tested on a live site rather than just Storybook.

- Other work completed in: yalesites-org/component-library-twig#691

### Functional testing steps:
- [ ] Wait for the multidev build to complete, then open the multidev site.
- [ ] View any page with a themed section/component containing links or linked card/heading titles — confirm no mismatched white halo behind the text.
- [ ] See yalesites-org/component-library-twig#691 for the full functional testing steps (basic themes, card collections in a themed layout, callout/alert/inline-message).

References yalesites-org/YaleSites-Internal#1551
