### PR TITLE
1553: Bug: composer.json prettier drift causes false-positive husky failures on every atomic/CL version bump

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -123,7 +123,9 @@
   "prefer-stable": true,
   "config": {
     "audit": {
-      "ignore": ["SA-CONTRIB-2025-060"]
+      "ignore": [
+        "SA-CONTRIB-2025-060"
+      ]
     },
     "sort-packages": true
   },


### PR DESCRIPTION
## [1553: Bug: composer.json prettier drift causes false-positive husky failures on every atomic/CL version bump](https://github.com/yalesites-org/YaleSites-Internal/issues/1553)

### Description of work

- Reformats the `config.audit.ignore` array in `web/profiles/custom/yalesites_profile/composer.json` from a single inline entry to multi-line, so the file is Prettier-clean. Whitespace only — the ignored advisory (`SA-CONTRIB-2025-060`) and every other value are unchanged, and the file still parses as identical JSON.
- **Why Prettier wanted this:** Prettier infers the `json-stringify` parser for any file named `composer.json` (`npx prettier --file-info` reports `"inferredParser": "json-stringify"`). That parser emits `JSON.stringify(value, null, 2)` output, which always expands arrays across multiple lines however short they are. The repo has no Prettier config on this path, so those defaults applied. Because `lint-staged` runs `prettier --ignore-unknown --list-different` against the *whole* staged file rather than the diff, this one pre-existing line made **every** commit touching this file fail the husky pre-commit hook — including routine, correctly-formatted atomic/component-library version bumps during the RC process.
- **The issue's stated premise turned out to be wrong, and that changed the fix.** The ticket assumed `composer require`/`composer update` rewrites the file in its own JSON style and would therefore re-introduce the drift on every bump, which would have meant excluding composer-managed JSON from the Prettier check instead. Tested directly before implementing: re-running `composer require yalesites-org/atomic:1.81.0 --no-update` against the unfixed file produced a **zero-byte diff**. `composer require` uses `JsonManipulator`, which makes surgical edits to the `require` block and preserves the rest of the document (and its detected indentation) byte-for-byte. So the drift was a one-time historical artifact, not something Composer regenerates — reformatting it once is a complete and durable fix, and no `lint-staged`/`.prettierignore` change is needed.
- Worth knowing (pre-existing, not a regression, and not changed here): Composer's *full* re-encode path — `JsonFile::encode`, used by e.g. `composer config` — writes 4-space indentation, whereas this file is 2-space. A command that re-encodes the whole document would therefore reflow it and re-break the Prettier check. That was equally true before this change, and the RC path in question (`composer require ... --no-update`) uses the surgical `JsonManipulator` path instead, which was verified above to leave the file untouched.
- No `.prettierignore` or `package.json` `lint-staged` changes. No Drupal config, hooks, templates, or runtime code touched — this is build tooling only, with no user-facing or editor-facing behavior change.

**Noted for a separate ticket (deliberately not fixed here):** `npm run prettier` across the repo reports 457 drifted files. 411 are inside `web/themes/contrib/atomic`, a gitignored contrib install that is never staged, so the hook never sees them. The remaining **46 are tracked files in our own tree** (43 `.md` READMEs/docs, plus JS in `ys_core`, `ys_themes`, `ys_book`, `ys_beacon` and `ys_views_basic`, `ys_admin_theme/scss/gin-custom.scss`, and `ys_beacon/react/index.html`). Each will cause this same class of false-positive pre-commit failure for whoever edits it next. Fixing them is a 46-file no-behavior-change reformat that would swamp this diff, so it belongs in its own ticket. Worth noting `npm run prettier` is not part of the CI gate (`.ci/test/static/run` runs `lint:php`, `code-sniff`, `lint:styles`), which is how the drift accumulated unnoticed.

### Functional testing steps:

- [ ] Confirm the file is now Prettier-clean: `npx prettier --ignore-unknown --list-different web/profiles/custom/yalesites_profile/composer.json` prints nothing and exits `0`. On `develop` the same command prints the file path and exits `1`.
- [ ] Confirm the JSON is semantically unchanged apart from whitespace: `git diff develop -- web/profiles/custom/yalesites_profile/composer.json` shows only the `ignore` array reflow, and `SA-CONTRIB-2025-060` is still the only ignored advisory.
- [ ] Simulate an RC bump **on this branch** (no need to modify `develop`): `cd web/profiles/custom/yalesites_profile && lando composer require yalesites-org/atomic:1.80.0 --no-update`, then `git add` that file and run `npx lint-staged` — it now passes. Before this change the same sequence failed with `prettier --ignore-unknown --list-different [FAILED]`.
- [ ] While that bump is still applied, confirm Composer did not undo the fix: the `ignore` array is still multi-line and `npx prettier --ignore-unknown --list-different` on the file still exits `0`. Then discard the bump with `git restore --staged --worktree -- web/profiles/custom/yalesites_profile/composer.json`.
- [ ] Confirm the CI gate is unaffected: `lando composer code-sniff` and `lando composer lint:php` both exit `0`.

References yalesites-org/YaleSites-Internal#1553
