### PR TITLE
1542: Feature Request: Office Hours block (wraps Drupal Office Hours contrib module)

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -86,6 +86,7 @@
     "drupal/multiple_fields_remove_button": "2.3",
     "drupal/multivalue_form_element": "1.0.0-beta8",
     "drupal/node_revision_delete": "2.1.1",
+    "drupal/office_hours": "1.29.0",
     "drupal/override_node_options": "2.9.0",
     "drupal/pantheon_advanced_page_cache": "2.3.4",
     "drupal/pantheon_secrets": "1.0.6",

--- a/web/profiles/custom/yalesites_profile/config/sync/block_content.type.office_hours.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/block_content.type.office_hours.yml
@@ -1,0 +1,33 @@
+uuid: 44ee820d-c13a-4b80-b935-fcd8fa518f7a
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_redirect
+third_party_settings:
+  entity_redirect:
+    redirect:
+      add:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+      edit:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+      delete:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+      anonymous:
+        active: 0
+        destination: default
+        url: ''
+        external: ''
+id: office_hours
+label: 'Office Hours'
+revision: true
+description: 'Display opening hours for a location, with a weekly schedule and holiday or exception dates.'

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.office_hours.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.office_hours.default.yml
@@ -1,0 +1,38 @@
+uuid: 9e0a721a-5a4c-4592-958e-7327738a2bb5
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.office_hours
+    - field.field.block_content.office_hours.field_office_hours
+  module:
+    - hide_revision_field
+    - office_hours
+id: block_content.office_hours.default
+targetEntityType: block_content
+bundle: office_hours
+mode: default
+content:
+  field_office_hours:
+    type: office_hours_exceptions
+    weight: 1
+    region: content
+    settings:
+      collapsed: false
+      collapsed_exceptions: true
+    third_party_settings: {  }
+  revision_log:
+    type: hide_revision_field_log_widget
+    weight: 80
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+      show: true
+      default: ''
+      permission_based: false
+      allow_user_settings: true
+      hide_revision: false
+    third_party_settings: {  }
+hidden:
+  info: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.office_hours.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.office_hours.default.yml
@@ -1,0 +1,46 @@
+uuid: 2e7a9621-5bb8-4195-9ecd-14f376654d18
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.office_hours
+    - field.field.block_content.office_hours.field_office_hours
+  module:
+    - office_hours
+id: block_content.office_hours.default
+targetEntityType: block_content
+bundle: office_hours
+mode: default
+content:
+  field_office_hours:
+    type: office_hours_table
+    label: hidden
+    settings:
+      day_format: long
+      time_format: g
+      compress: false
+      grouped: false
+      show_empty: false
+      show_closed: open
+      closed_format: Closed
+      all_day_format: 'All day open'
+      separator:
+        days: '<br />'
+        grouped_days: ' - '
+        day_hours: ': '
+        hours_hours: '-'
+        more_hours: ', '
+      current_status:
+        position: before
+      exceptions:
+        restrict_exceptions_to_num_days: 180
+      timezone_field: ''
+      office_hours_first_day: ''
+      schema:
+        enabled: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  info: true
+  search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.office_hours.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.office_hours.default.yml
@@ -21,7 +21,7 @@ content:
       compress: false
       grouped: false
       show_empty: false
-      show_closed: open
+      show_closed: all
       closed_format: Closed
       all_day_format: 'All day open'
       separator:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.default.yml
@@ -136,6 +136,7 @@ third_party_settings:
               - pull_quote
               - text
               - video
+              - office_hours
             'Inline blocks':
               - 'inline_block:button_link'
               - 'inline_block:divider'
@@ -145,6 +146,7 @@ third_party_settings:
               - 'inline_block:pull_quote'
               - 'inline_block:text'
               - 'inline_block:video'
+              - 'inline_block:office_hours'
         ys_layout_two_column:
           content:
             'Custom block types':
@@ -165,6 +167,7 @@ third_party_settings:
               - text
               - video
               - wrapped_text_callout
+              - office_hours
             'Inline blocks':
               - 'inline_block:accordion'
               - 'inline_block:button_link'
@@ -183,6 +186,7 @@ third_party_settings:
               - 'inline_block:text'
               - 'inline_block:video'
               - 'inline_block:wrapped_text_callout'
+              - 'inline_block:office_hours'
             'YaleSites Layouts': {  }
           sidebar:
             'Custom block types':
@@ -194,6 +198,7 @@ third_party_settings:
               - text
               - video
               - webform
+              - office_hours
             'Inline blocks':
               - 'inline_block:button_link'
               - 'inline_block:divider'
@@ -203,6 +208,7 @@ third_party_settings:
               - 'inline_block:pull_quote'
               - 'inline_block:text'
               - 'inline_block:video'
+              - 'inline_block:office_hours'
         ys_layout_two_column_50_50:
           all_regions:
             'Custom block types':
@@ -217,6 +223,7 @@ third_party_settings:
               - text
               - video
               - webform
+              - office_hours
             'Inline blocks':
               - 'inline_block:accordion'
               - 'inline_block:button_link'
@@ -229,6 +236,7 @@ third_party_settings:
               - 'inline_block:tabs'
               - 'inline_block:text'
               - 'inline_block:video'
+              - 'inline_block:office_hours'
       denylisted_blocks: {  }
       restricted_categories:
         ys_layout_two_column:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.single.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.page.single.yml
@@ -74,6 +74,7 @@ third_party_settings:
               - pull_quote
               - text
               - video
+              - office_hours
             'Inline blocks':
               - 'inline_block:button_link'
               - 'inline_block:divider'
@@ -83,6 +84,7 @@ third_party_settings:
               - 'inline_block:pull_quote'
               - 'inline_block:text'
               - 'inline_block:video'
+              - 'inline_block:office_hours'
         ys_layout_two_column:
           content:
             'Custom block types':
@@ -103,6 +105,7 @@ third_party_settings:
               - text
               - video
               - wrapped_text_callout
+              - office_hours
             'Inline blocks':
               - 'inline_block:accordion'
               - 'inline_block:button_link'
@@ -121,6 +124,7 @@ third_party_settings:
               - 'inline_block:text'
               - 'inline_block:video'
               - 'inline_block:wrapped_text_callout'
+              - 'inline_block:office_hours'
             'YaleSites Layouts': {  }
           sidebar:
             'Custom block types':
@@ -132,6 +136,7 @@ third_party_settings:
               - text
               - video
               - webform
+              - office_hours
             'Inline blocks':
               - 'inline_block:button_link'
               - 'inline_block:divider'
@@ -141,6 +146,7 @@ third_party_settings:
               - 'inline_block:pull_quote'
               - 'inline_block:text'
               - 'inline_block:video'
+              - 'inline_block:office_hours'
         ys_layout_two_column_50_50:
           all_regions:
             'Custom block types':
@@ -155,6 +161,7 @@ third_party_settings:
               - text
               - video
               - webform
+              - office_hours
             'Inline blocks':
               - 'inline_block:accordion'
               - 'inline_block:button_link'
@@ -167,6 +174,7 @@ third_party_settings:
               - 'inline_block:tabs'
               - 'inline_block:text'
               - 'inline_block:video'
+              - 'inline_block:office_hours'
       denylisted_blocks: {  }
       restricted_categories:
         ys_layout_two_column:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.post.default.yml
@@ -124,6 +124,7 @@ third_party_settings:
               - text
               - video
               - webform
+              - office_hours
             'Inline blocks':
               - 'inline_block:accordion'
               - 'inline_block:button_link'
@@ -136,6 +137,7 @@ third_party_settings:
               - 'inline_block:tabs'
               - 'inline_block:text'
               - 'inline_block:video'
+              - 'inline_block:office_hours'
       restricted_categories:
         ys_layout_two_column_50_50:
           all_regions:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.default.yml
@@ -173,6 +173,7 @@ third_party_settings:
               - text
               - video
               - wrapped_text_callout
+              - office_hours
             'Inline blocks':
               - 'inline_block:accordion'
               - 'inline_block:button_link'
@@ -190,6 +191,7 @@ third_party_settings:
               - 'inline_block:text'
               - 'inline_block:video'
               - 'inline_block:wrapped_text_callout'
+              - 'inline_block:office_hours'
             'YaleSites Layouts':
               - profile_contact_block
           sidebar:
@@ -204,6 +206,7 @@ third_party_settings:
               - text
               - video
               - webform
+              - office_hours
             'Inline blocks':
               - 'inline_block:accordion'
               - 'inline_block:button_link'
@@ -215,6 +218,7 @@ third_party_settings:
               - 'inline_block:tabs'
               - 'inline_block:text'
               - 'inline_block:video'
+              - 'inline_block:office_hours'
             'YaleSites Layouts':
               - profile_contact_block
       denylisted_blocks:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.single.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.node.profile.single.yml
@@ -97,6 +97,7 @@ third_party_settings:
               - tabs
               - text
               - video
+              - office_hours
             'Inline blocks':
               - 'inline_block:accordion'
               - 'inline_block:button_link'
@@ -107,13 +108,16 @@ third_party_settings:
               - 'inline_block:tabs'
               - 'inline_block:text'
               - 'inline_block:video'
+              - 'inline_block:office_hours'
             'YaleSites Layouts':
               - profile_contact_block
           sidebar:
             'Custom block types':
               - text
+              - office_hours
             'Inline blocks':
               - 'inline_block:text'
+              - 'inline_block:office_hours'
             'YaleSites Layouts':
               - profile_contact_block
       denylisted_blocks: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.extension.yml
@@ -114,6 +114,7 @@ module:
   mysql: 0
   node: 0
   node_revision_delete: 0
+  office_hours: 0
   options: 0
   override_node_options: 0
   page_cache: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.office_hours.field_office_hours.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.office_hours.field_office_hours.yml
@@ -1,0 +1,21 @@
+uuid: 04f25f2e-8f93-41d6-89ee-8529655df59a
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.office_hours
+    - field.storage.block_content.field_office_hours
+  module:
+    - office_hours
+id: block_content.office_hours.field_office_hours
+field_name: field_office_hours
+entity_type: block_content
+bundle: office_hours
+label: Hours
+description: 'Set the opening and closing time for each day. Leave a day blank to show it as closed. Use "Add exception" for holidays and one-off closures.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: office_hours

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.office_hours.field_office_hours.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.office_hours.field_office_hours.yml
@@ -12,7 +12,7 @@ field_name: field_office_hours
 entity_type: block_content
 bundle: office_hours
 label: Hours
-description: 'Set the opening and closing time for each day. Leave a day blank to show it as closed. Use "Add exception" for holidays and one-off closures.'
+description: 'Set the opening and closing time for each day. Tick Closed to show a day as closed, or All day for a day that is open around the clock. Use "Add exception" for holidays and one-off closures.'
 required: false
 translatable: true
 default_value: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_office_hours.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_office_hours.yml
@@ -1,0 +1,32 @@
+uuid: 6a519de7-817a-4197-81ee-72a37a855f07
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - office_hours
+id: block_content.field_office_hours
+field_name: field_office_hours
+entity_type: block_content
+type: office_hours
+settings:
+  time_format: g
+  element_type: office_hours_datetime
+  increment: 30
+  valhrs: false
+  required_start: false
+  limit_start: ''
+  required_end: false
+  limit_end: ''
+  all_day: true
+  exceptions: true
+  seasons: false
+  comment: 1
+  cardinality_per_day: 2
+module: office_hours
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/layout_builder_browser.layout_builder_browser_block.office_hours.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/layout_builder_browser.layout_builder_browser_block.office_hours.yml
@@ -1,0 +1,11 @@
+uuid: 7755b16e-6721-4378-b3f4-1e6307a70283
+langcode: en
+status: true
+dependencies: {  }
+id: office_hours
+block_id: 'inline_block:office_hours'
+category: text_and_content
+label: 'Office Hours'
+image_path: /profiles/custom/yalesites_profile/modules/custom/ys_core/images/preview-icons/office-hours.svg
+image_alt: ''
+weight: -10

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/images/preview-icons/office-hours.svg
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/images/preview-icons/office-hours.svg
@@ -1,0 +1,19 @@
+<svg width="501" height="261" viewBox="0 0 501 261" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="501" height="261" fill="white"/>
+<circle cx="70" cy="60" r="18" stroke="#222222" stroke-width="3"/>
+<path d="M70 50V60L77 65" stroke="#222222" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="102" y="50" width="120" height="8" rx="4" fill="#222222"/>
+<rect x="102" y="66" width="76" height="6" rx="3" fill="#8C8C8C"/>
+<line x1="36" y1="100" x2="465" y2="100" stroke="#222222" stroke-width="2"/>
+<rect x="36" y="114" width="86" height="7" rx="3.5" fill="#222222"/>
+<rect x="250" y="114" width="104" height="7" rx="3.5" fill="#8C8C8C"/>
+<line x1="36" y1="136" x2="465" y2="136" stroke="#D8D8D8" stroke-width="2"/>
+<rect x="36" y="150" width="96" height="7" rx="3.5" fill="#222222"/>
+<rect x="250" y="150" width="104" height="7" rx="3.5" fill="#8C8C8C"/>
+<line x1="36" y1="172" x2="465" y2="172" stroke="#D8D8D8" stroke-width="2"/>
+<rect x="36" y="186" width="78" height="7" rx="3.5" fill="#222222"/>
+<rect x="250" y="186" width="72" height="7" rx="3.5" fill="#8C8C8C"/>
+<line x1="36" y1="208" x2="465" y2="208" stroke="#D8D8D8" stroke-width="2"/>
+<rect x="36" y="222" width="110" height="7" rx="3.5" fill="#222222"/>
+<rect x="250" y="222" width="88" height="7" rx="3.5" fill="#8C8C8C"/>
+</svg>

--- a/web/themes/custom/ys_admin_theme/css/admin-ui.css
+++ b/web/themes/custom/ys_admin_theme/css/admin-ui.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 :root {
   --drupal-displace-offset-top: 35rem;
   --drupal-displace-offset-bottom: 35rem;
@@ -25,4 +26,53 @@
 .gin--dark-mode .layout-builder-configure-block .form-boolean.error:checked:hover, .gin--dark-mode .layout-builder-configure-block .form-boolean.error:checked:active, .gin--dark-mode .layout-builder-configure-block .form-boolean.error:checked:active:hover {
   border-color: var(--gin-color-info);
   color: white;
+}
+
+.field--type-office-hours .claro-details__description {
+  margin-top: 0.75rem;
+}
+.field--type-office-hours .office-hours-closed {
+  text-align: center;
+  vertical-align: middle;
+}
+.field--type-office-hours .ys-office-hours-actions {
+  position: relative;
+  display: inline-block;
+}
+.field--type-office-hours .ys-office-hours-actions__toggle {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  border-radius: 4px;
+  list-style: none;
+}
+.field--type-office-hours .ys-office-hours-actions__toggle::-webkit-details-marker {
+  display: none;
+}
+.field--type-office-hours .ys-office-hours-actions__toggle::after {
+  content: "⋯";
+  font-size: 1.25rem;
+  line-height: 1;
+}
+.field--type-office-hours .ys-office-hours-actions__toggle:hover {
+  background-color: var(--gin-bg-layer2);
+}
+.field--type-office-hours .ys-office-hours-actions__toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 1px var(--gin-color-focus-border), 0 0 0 4px var(--gin-color-focus);
+}
+.field--type-office-hours .ys-office-hours-actions__menu {
+  position: absolute;
+  z-index: 1;
+  inset-inline-end: 0;
+  min-width: 11rem;
+  padding: 0.5rem;
+  border: 1px solid var(--gin-border-color);
+  border-radius: 4px;
+  background-color: var(--gin-bg-layer);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.gin--dark-mode .field--type-office-hours .form-element[disabled] {
+  background-color: var(--gin-bg-layer) !important;
 }

--- a/web/themes/custom/ys_admin_theme/js/office-hours-widget.js
+++ b/web/themes/custom/ys_admin_theme/js/office-hours-widget.js
@@ -1,0 +1,295 @@
+/**
+ * @file
+ * Editor affordances for the contrib Office Hours widget.
+ *
+ * The contrib widget stores exactly two states per weekday: a day with time
+ * slots (open) or a day with none (closed). "All day" is stored as 00:00-00:00,
+ * and there is no third column to record "closed" separately from "not filled
+ * in yet". Rather than leave "empty" carrying that meaning silently, this adds
+ * an explicit Closed checkbox per day that mirrors the stored state, and
+ * collapses the three per-row operation links into one overflow menu.
+ */
+
+((Drupal) => {
+  const TIME_FIELDS = "input.form-time, select.form-select";
+
+  /**
+   * Collects the time inputs belonging to one weekday, across its slot rows.
+   *
+   * @param {Array<HTMLTableRowElement>} dayRows
+   *   Every slot row for a single weekday.
+   *
+   * @return {Array<HTMLElement>}
+   *   The day's start/end time inputs.
+   */
+  const timeFields = (dayRows) =>
+    dayRows.reduce(
+      (fields, row) =>
+        fields.concat(Array.from(row.querySelectorAll(TIME_FIELDS))),
+      []
+    );
+
+  /**
+   * Tells a day's first slot row from its continuation rows.
+   *
+   * Contrib marks the first slot of each day with a `th` first cell and its
+   * continuation slots with a `td`.
+   *
+   * @param {HTMLTableRowElement} row
+   *   A slot row.
+   *
+   * @return {boolean}
+   *   TRUE for the first slot of a day.
+   */
+  const isFirstSlotRow = (row) =>
+    !!row.cells[0] && row.cells[0].tagName === "TH";
+
+  /**
+   * Reads the day label that a slot row belongs under.
+   *
+   * Only a day's first slot row carries the real label - continuation rows
+   * carry contrib's "and" connector - so walk back to the first slot row.
+   *
+   * @param {HTMLTableRowElement} row
+   *   A slot row.
+   *
+   * @return {string}
+   *   The day name, or an empty string on an as-yet-undated exception row.
+   */
+  const dayLabelOf = (row) => {
+    let candidate = row;
+    while (candidate && !isFirstSlotRow(candidate)) {
+      candidate = candidate.previousElementSibling;
+    }
+    return candidate ? candidate.cells[0].textContent.trim() : "";
+  };
+
+  /**
+   * Adds a Closed control to one weekday.
+   *
+   * The control is not submitted: a closed day is stored as a day with no
+   * hours, which is what the checkbox reflects. Ticking it clears the day's
+   * times; entering a time unticks it again.
+   *
+   * @param {Array<HTMLTableRowElement>} dayRows
+   *   Every slot row for a single weekday, first slot first.
+   *
+   * @return {number}
+   *   The cell index the Closed column occupies, or -1 if none was added.
+   */
+  const addClosedControl = (dayRows) => {
+    const firstRow = dayRows[0];
+    const allDay = firstRow.querySelector(
+      'input[type="checkbox"][data-drupal-selector$="-all-day"]'
+    );
+    // The All day column is optional in the field settings. Without it there
+    // is nothing to sit beside and nothing to be mutually exclusive with.
+    if (!allDay) {
+      return -1;
+    }
+    const allDayCell = allDay.closest("td");
+    const allDayIndex = allDayCell.cellIndex;
+
+    const closed = document.createElement("input");
+    closed.type = "checkbox";
+    closed.id = `${allDay.id}-ys-closed`;
+    // Deliberately not "form-checkbox": contrib's Clear and Copy handlers act
+    // on every .form-checkbox in a row and expect a named all_day input.
+    closed.className =
+      "form-boolean form-boolean--type-checkbox office-hours-closed__input";
+
+    const label = document.createElement("label");
+    label.className = "form-item__label visually-hidden";
+    label.setAttribute("for", closed.id);
+    // Name it per day: seven checkboxes all called "Closed" are useless to a
+    // screen reader user tabbing the widget.
+    label.textContent = Drupal.t("Closed on @day", {
+      "@day": dayLabelOf(firstRow),
+    });
+
+    const cell = document.createElement("td");
+    cell.className = "office-hours-closed";
+    cell.append(label, closed);
+    // Sits directly after the All day cell.
+    allDayCell.after(cell);
+
+    // Keep the remaining slot rows of this day aligned with the new column.
+    // Their all_day input is a hidden field, so match on cell position.
+    dayRows.slice(1).forEach((row) => {
+      const spacer = document.createElement("td");
+      spacer.className = "office-hours-closed";
+      row.children[allDayIndex].after(spacer);
+    });
+
+    const sync = () => {
+      const hasHours = timeFields(dayRows).some((field) => field.value !== "");
+      closed.checked = !allDay.checked && !hasHours;
+      // A day cannot be both open around the clock and closed.
+      closed.disabled = allDay.checked;
+    };
+
+    closed.addEventListener("change", () => {
+      const fields = timeFields(dayRows);
+      if (closed.checked) {
+        fields.forEach((field) => {
+          const input = field;
+          input.value = "";
+        });
+        return;
+      }
+      // Unticking means "I am about to set hours". Deliberately do NOT re-sync
+      // here, or the box would immediately tick itself again; move the cursor
+      // to the day's first From field instead. Entering a time settles it.
+      if (fields.length) {
+        fields[0].focus();
+      }
+    });
+
+    // Contrib disables the time fields itself on All day, but leaves the
+    // Closed state stale on the way back out, so recompute both directions.
+    allDay.addEventListener("change", sync);
+
+    timeFields(dayRows).forEach((field) => {
+      field.addEventListener("change", sync);
+    });
+
+    // Contrib's Clear and Copy links rewrite the inputs without firing events.
+    dayRows.forEach((row) => {
+      row
+        .querySelectorAll(
+          '[data-drupal-selector$="clear"], [data-drupal-selector$="copy"]'
+        )
+        .forEach((link) => {
+          link.addEventListener("click", () => {
+            window.setTimeout(sync, 0);
+          });
+        });
+    });
+
+    sync();
+    return allDayIndex + 1;
+  };
+
+  /**
+   * Adds the Closed column to a weekday table.
+   *
+   * @param {HTMLTableElement} table
+   *   The weekday table.
+   */
+  const addClosedColumn = (table) => {
+    const byDay = new Map();
+    table.querySelectorAll("tbody tr.office-hours-slot").forEach((row) => {
+      const day = row.getAttribute("office_hours_day");
+      if (day === null) {
+        return;
+      }
+      if (!byDay.has(day)) {
+        byDay.set(day, []);
+      }
+      byDay.get(day).push(row);
+    });
+
+    // Add the body cells first: the header only earns its place once at least
+    // one day actually got a control, otherwise the columns would shift.
+    let columnIndex = -1;
+    byDay.forEach((dayRows) => {
+      columnIndex = Math.max(columnIndex, addClosedControl(dayRows));
+    });
+    if (columnIndex < 0) {
+      return;
+    }
+
+    const headerRow = table.querySelector("thead tr");
+    if (headerRow && headerRow.cells[columnIndex - 1]) {
+      const header = document.createElement("th");
+      header.className = "th__closed";
+      header.textContent = Drupal.t("Closed");
+      headerRow.cells[columnIndex - 1].after(header);
+    }
+  };
+
+  /**
+   * Collapses a row's operation links into a single overflow menu.
+   *
+   * @param {HTMLTableRowElement} row
+   *   A slot row of either the weekday or the exceptions table.
+   */
+  const collapseOperations = (row) => {
+    const cell = row.querySelector("td:last-child");
+    const links = cell
+      ? Array.from(cell.querySelectorAll("a.js-office-hours-operation"))
+      : [];
+    if (!links.length) {
+      return;
+    }
+
+    // Name every toggle distinctly - a form can carry a dozen of them.
+    const dayLabel = dayLabelOf(row);
+
+    const name = document.createElement("span");
+    name.className = "visually-hidden";
+    if (!dayLabel) {
+      name.textContent = Drupal.t("Actions for this exception");
+    } else if (isFirstSlotRow(row)) {
+      name.textContent = Drupal.t("Actions for @day", { "@day": dayLabel });
+    } else {
+      name.textContent = Drupal.t("Actions for @day, extra time slot", {
+        "@day": dayLabel,
+      });
+    }
+
+    const toggle = document.createElement("summary");
+    toggle.className = "ys-office-hours-actions__toggle";
+    toggle.append(name);
+
+    const menu = document.createElement("div");
+    menu.className = "ys-office-hours-actions__menu";
+    menu.append(...links);
+
+    const details = document.createElement("details");
+    details.className = "ys-office-hours-actions";
+    details.append(toggle, menu);
+
+    // Contrib's handlers preventDefault, so close the menu ourselves.
+    menu.addEventListener("click", () => {
+      details.open = false;
+    });
+
+    cell.append(details);
+  };
+
+  /**
+   * Tells the weekday table apart from the exceptions table.
+   *
+   * Both render the same columns, so this keys off the day cell: the weekday
+   * widget renders it as a hidden input, the exceptions widget as a date
+   * field. Header text is not usable here - Gin derives its `th__*` classes
+   * from the translated header label, so they change with the interface
+   * language.
+   *
+   * @param {HTMLTableElement} table
+   *   A table inside an office hours widget.
+   *
+   * @return {boolean}
+   *   TRUE for the Sun-Sat table.
+   */
+  const isWeekdayTable = (table) =>
+    !table.querySelector('tbody input[type="date"]') &&
+    !!table.querySelector(
+      'tbody input[type="checkbox"][data-drupal-selector$="-all-day"]'
+    );
+
+  Drupal.behaviors.ysAdminThemeOfficeHours = {
+    attach(context) {
+      once("ys-office-hours-closed", ".field--type-office-hours table", context)
+        .filter(isWeekdayTable)
+        .forEach(addClosedColumn);
+
+      once(
+        "ys-office-hours-actions",
+        ".field--type-office-hours tr.office-hours-slot",
+        context
+      ).forEach(collapseOperations);
+    },
+  };
+})(Drupal);

--- a/web/themes/custom/ys_admin_theme/scss/admin-ui.scss
+++ b/web/themes/custom/ys_admin_theme/scss/admin-ui.scss
@@ -40,3 +40,75 @@
     }
   }
 }
+
+// Contrib Office Hours widget (the Office Hours block's Hours field).
+// js/office-hours-widget.js adds the Closed column and the per-row operations
+// menu; the rules below style those, separate the field description from the
+// details summary, and fix the disabled treatment in Gin dark mode.
+.field--type-office-hours {
+  // Claro renders the field description flush against the details summary.
+  .claro-details__description {
+    margin-top: 0.75rem;
+  }
+
+  .office-hours-closed {
+    text-align: center;
+    vertical-align: middle;
+  }
+
+  .ys-office-hours-actions {
+    position: relative;
+    display: inline-block;
+
+    &__toggle {
+      display: inline-block;
+      padding: 0.25rem 0.5rem;
+      cursor: pointer;
+      border-radius: 4px;
+      list-style: none;
+
+      // Safari still paints the default disclosure triangle without this.
+      &::-webkit-details-marker {
+        display: none;
+      }
+
+      &::after {
+        content: "\22ef";
+        font-size: 1.25rem;
+        line-height: 1;
+      }
+
+      &:hover {
+        background-color: var(--gin-bg-layer2);
+      }
+
+      // Claro/Gin strip the browser default ring from summary elements, so
+      // reinstate Gin's own focus treatment rather than a bespoke one.
+      &:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 1px var(--gin-color-focus-border),
+          0 0 0 4px var(--gin-color-focus);
+      }
+    }
+
+    &__menu {
+      position: absolute;
+      z-index: 1;
+      inset-inline-end: 0;
+      min-width: 11rem;
+      padding: 0.5rem;
+      border: 1px solid var(--gin-border-color);
+      border-radius: 4px;
+      background-color: var(--gin-bg-layer);
+      box-shadow: 0 2px 6px rgb(0 0 0 / 15%);
+    }
+  }
+}
+
+// Gin's disabled background sits within a few percent of its input background
+// in dark mode, so an all-day-disabled From/To field still reads as editable.
+// Recess it onto the layer colour instead. Gin sets its own background-color
+// with !important, so overriding it needs the same.
+.gin--dark-mode .field--type-office-hours .form-element[disabled] {
+  background-color: var(--gin-bg-layer) !important;
+}

--- a/web/themes/custom/ys_admin_theme/ys_admin_theme.libraries.yml
+++ b/web/themes/custom/ys_admin_theme/ys_admin_theme.libraries.yml
@@ -2,6 +2,11 @@ global:
   css:
     theme:
       css/admin-ui.css: {}
+  js:
+    js/office-hours-widget.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
 
 tokens:
   css:


### PR DESCRIPTION
## [1542: Feature Request: Office Hours block (wraps Drupal Office Hours contrib module)](https://github.com/yalesites-org/YaleSites-Internal/issues/1542)

### Description of work

Adds an **Office Hours block** that editors can place in every content section layout, wrapping the contrib [Office Hours](https://www.drupal.org/project/office_hours) module.

**No custom PHP was needed.** The contrib module supplies the field type, widget and table formatter, so this is config plus one preview icon. The issue proposed following the `ys_alert` pattern — that turned out to be the wrong shape (see "Why not `ys_alert`" below).

**The module**
- `drupal/office_hours` **1.29.0** added to the *profile* `composer.json`, pinned exactly, and enabled. Core-only dependencies, no new contrib pulled in.

**The block**
- `block_content` type `office_hours` with a multi-value `field_office_hours`.
- Field storage enables **exceptions** (holidays) and **all-day**, and uses a **12-hour** clock. Seasons are off for v1.
- Form display uses the *week with exceptions* widget: the Sun–Sat grid, per-day "Add time slot" / "Clear" / "Copy previous day", and an **Add exception** control for holidays.
- View display uses the table formatter with:
  - `show_closed: open` — **only the days the editor filled in are rendered**, no blank days (an explicit AC, met by config rather than code).
  - current status shown above the table ("Currently open!" / "Currently closed").
  - exception horizon raised from the contrib default of **7 days** to **180**, so a Thanksgiving closure is visible in advance rather than only during that week.

**Placement — all sections and regions**
- Layout Builder Browser entry under **Text and Content**, with a new preview icon.
- Added to the `layout_builder_restrictions_by_region` allow-lists for **70/30 (content *and* sidebar), 50/50, and 33/33/33** across the five view displays that restrict those categories.
- **Full width (`layout_onecol`) needed no entry.** `Custom block types` and `Inline blocks` are not in `restricted_categories` there, and per the plugin's logic (`EntityViewModeRestrictionByRegion.php` lines 132–140) a category with no allow-list key and no restriction permits everything — so adding a key there would have *newly restricted* the category. Worth knowing for the next block.
- Banner and page-meta layouts are deliberately excluded.

**Verified on the running site** — the block appears in all **eight** content regions across the four layouts, is correctly **absent** from the banner region, and renders in a 33% column:

| Region | Result |
|---|---|
| Full width (`layout_onecol`) | pass |
| 70% content | pass |
| 30% sidebar | pass |
| 50/50 primary + secondary | pass |
| 33/33/33 primary + secondary + tertiary | pass |
| Banner (should be excluded) | correctly excluded |

<details>
<summary><b>Evaluation notes and known follow-ups</b></summary>

#### Why not the `ys_alert` pattern
The issue description proposed following `ys_alert`. That is a singleton block placed sitewide in the atomic `header` region via Block Layout, and its category sits in `restricted_categories` for *every* layout and region — it is deliberately excluded from Layout Builder. The right precedent is the component-block pattern (accordion / text / quick_links): a `block_content` type + field + browser entry + per-region allow-lists, which is what this PR does.

#### What contrib gives us for free
Weekly Sun–Sat schedule, up to 2 time slots per day, closed days, holiday/exception dates (rendered as a separate "Exception hours" table with full dates), seasons, open/closed status, and a schema.org `openingHours` formatter.

#### Still to do (not in this PR)
1. **Theming — the main gap.** The table currently renders **contrib markup** with contrib's own zebra striping, not Yale design tokens. Needs a CLT/atomic component + Twig override. **Blocked on @atiddei's mockup**, which is the real critical path.
2. **Narrow-column behaviour.** With comments filled in, the 3-column table **overflows at 33%** — the Comment column clips mid-word and time ranges wrap ("9:00 am-5:00 / pm"). With comments empty it fits fine. This is the concrete thing the mockup needs to solve: stacked day/time, comment on its own line, or drop the comment column below a breakpoint.
3. **Accessibility.** Contrib renders through core's `stable9` table template as `<th colspan="3" class="visually-hidden">Day</th>` with **no `scope` attributes**, and the `colspan="3"` does not line up with the 3 body cells. The ticket's "proper table headers/scope attributes; WCAG 2.1 AA" AC needs the Twig override in (1). Flagging rather than silently passing.
4. **Style dials.** No `field_style_*` / padding options yet — deferred until the mockup says which dials apply.

#### Open questions
1. **The reusable-block question is already answered by the platform** — the inline-block form shows the standard "Reusable Block" toggle, so the editor chooses at creation. Suggest closing that AC.
2. Seasons (summer/winter hours) come free from contrib. In or out of v1? Currently **out**.
3. schema.org `openingHours` formatter — worth enabling for SEO? Currently **out**.
4. Is 180 days the right exception horizon?
5. Should this also be allowed on Event and Resource nodes? Currently it follows the existing per-display restrictions: Page, Post (50/50 only), Profile, and Resource (unrestricted, so allowed automatically).

</details>

### Functional testing steps:
- [ ] Pull the branch, run `lando composer install`, then `npm run confim` and `lando drush cr`.
- [ ] Edit any Page → **Edit Layout and Content** → add a section, click **Add block** → confirm **Office Hours** appears under **Text and Content** with its preview icon.
- [ ] Repeat in each layout and region: full width, 70% content, 30% sidebar, both 50/50 regions, all three 33/33/33 regions. It should be offered in all of them.
- [ ] Confirm it is **not** offered in the Banner section.
- [ ] Add the block, set hours for a few days, leave at least one day blank, and add a holiday via **Add exception**. Save.
- [ ] On the rendered page confirm: the filled days show a 12-hour range and the open/closed status shows above the table. *(Superseded by round 2: blank days now render as "Closed" rather than being omitted.)*
- [ ] Toggle **Reusable Block** on a second instance and confirm it is reusable across pages.
- [ ] Known and expected at this stage: the table is unstyled contrib markup pending the design mockup, and it overflows in a 33% column when comments are filled in. Please review those against the mockup rather than as blockers here.

#### Review round 2 - editor form changes (yalesites-org/yalesites-project#1477 review of 2026-08-18)

- [ ] Re-run `npm run confim` and `lando drush cr` after pulling, so the updated field description and formatter settings land.
- [ ] Open **Edit Layout and Content** -> add an **Office Hours** block. Confirm the Hours help text is separated from the "Hours" summary above it and now reads "Tick Closed to show a day as closed, or All day for a day that is open around the clock."
- [ ] Confirm the widget table has a **Closed** column between **All day** and **From**, and that each row's three action links are now behind a single **...** overflow menu.
- [ ] On a day: enter a From/To time and confirm **Closed** unticks. Tick **Closed** and confirm both times clear. Tick **All day** and confirm **Closed** unticks, greys out, and the From/To fields become visibly disabled. Untick **All day** and confirm everything re-enables.
- [ ] Open the **...** menu and use **Clear** (times clear, Closed re-ticks) and **Copy previous day** (times copy, Closed unticks). Confirm the menu closes after each.
- [ ] Tab to a **...** toggle and confirm it takes a visible focus ring and opens with Enter or Space.
- [ ] Repeat the above with Gin dark mode on: the disabled From/To fields should now read clearly darker than the editable ones.
- [ ] Untick **Closed** on a day and confirm the cursor jumps to that day's **From** field.
- [ ] Fill Mon-Fri, leave Sun and Sat closed, add an exception for a date marking it closed, and save. On the rendered page confirm every weekday now shows a row - filled days with hours, untouched days as **Closed** - and that the exception still appears under its own **Exception hours** heading.
- [ ] Reopen the block and confirm the **Closed** ticks match what you saved.
- [ ] Still known and expected: the rendered table is unstyled contrib markup pending April's mockup, and a near-term exception does not yet replace its weekday row (see the summary comment for the three options and why the contrib setting alone is not enough).

References yalesites-org/YaleSites-Internal#1542
