### PR TITLE
1531: Release Feedback: Export Content Events Add Dates

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_content_export/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_content_export/README.md
@@ -12,12 +12,26 @@ includes one row per item with these columns:
 
 - **Title**, **URL** (path alias), **Published** (Yes/No), and
   **CAS Protected** (Yes/No — whether the item requires CAS login)
+- The type's date column, immediately after Title — **Dates** (Events),
+  **Resource Publication Date** (Resources). Other types have no date column.
 - **Tags**, **Audience**, **Custom Vocab** (on every type)
 - The type's category column — **Category** (Pages, Posts), **Event Category**,
   **Resource Category** — or **Affiliation** (Profiles)
 
 Taxonomy cells list every applied term, separated by ", " (matching the on-screen
-columns). The export reflects the same items you see in the Manage view — including
+columns).
+
+The Events **Dates** cell lists *every* occurrence of the event, oldest first,
+separated by ", " — so a recurring series shows all of its dates, where the
+on-screen Date column shows only the first and last. Dates render in the site's
+timezone, and an all-day occurrence reads "(All day)" rather than a 12:00 am to
+11:59 pm range. **Resource Publication Date** is the same `YYYY-MM-DD` shown on
+the Manage Resources screen. An item with no date exports an empty cell.
+
+Note that a cell holding many dates cannot be sorted as a date in a spreadsheet;
+that trade-off was accepted in favour of showing every occurrence.
+
+The export reflects the same items you see in the Manage view — including
 any filters or search you have applied — and both published and unpublished items,
 subject to your access.
 
@@ -25,7 +39,12 @@ subject to your access.
 
 - `ContentExportBuilder` — pure column map + row builder; `sanitizeCell()`
   neutralises CSV formula injection (values starting with `=`, `+`, `-`, `@`,
-  tab or carriage return are prefixed with a quote). Unit tested.
+  tab or carriage return are prefixed with a quote). Unit tested. It takes no
+  injected services, so a `DateFormatterInterface` is passed into `getRow()`
+  rather than resolved inside it; event dates reuse the platform's existing
+  `event_date_only` / `event_time_only` date formats. The resource publication
+  date is a date-only field already stored as `Y-m-d`, so it is emitted verbatim
+  — reformatting it would only risk a timezone shift of a day.
 - `Controller\ContentExportController::export($bundle, $request)` — resolves the
   matching Manage view's filtered node ids (replaying the request's exposed-filter
   query) and streams the CSV in chunks, gated by the `yalesites manage settings`

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_content_export/src/ContentExportBuilder.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_content_export/src/ContentExportBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\ys_content_export;
 
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\node\NodeInterface;
 
 /**
@@ -38,6 +39,18 @@ class ContentExportBuilder {
   ];
 
   /**
+   * The date column specific to each content type.
+   *
+   * Keyed by bundle, then by field machine name, with the column header as the
+   * value. Headers match the wording editors already see on the matching Manage
+   * screen. Bundles absent from this map export no date column.
+   */
+  const BUNDLE_DATE = [
+    'event' => ['field_event_date' => 'Dates'],
+    'resource' => ['field_publish_date' => 'Resource Publication Date'],
+  ];
+
+  /**
    * Returns the ordered export columns for a content type.
    *
    * @param string $bundle
@@ -48,8 +61,11 @@ class ContentExportBuilder {
    *   title/url/published/cas_protected) to its header label.
    */
   public static function getColumns(string $bundle): array {
-    $columns = [
-      'title' => 'Title',
+    // The date column sits immediately after Title so the file reads in roughly
+    // the same order as the on-screen Manage table it was exported from.
+    $columns = ['title' => 'Title'];
+    $columns += self::BUNDLE_DATE[$bundle] ?? [];
+    $columns += [
       'url' => 'URL',
       'published' => 'Published',
       'cas_protected' => 'CAS Protected',
@@ -66,15 +82,18 @@ class ContentExportBuilder {
    *   The node to export.
    * @param string $bundle
    *   The node bundle machine name.
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
+   *   The date formatter, used for the event date column. Passed in rather than
+   *   injected so this class stays service-free and directly unit testable.
    *
    * @return array
    *   The row values, in the same order as getColumns(), each passed through
    *   sanitizeCell().
    */
-  public static function getRow(NodeInterface $node, string $bundle): array {
+  public static function getRow(NodeInterface $node, string $bundle, DateFormatterInterface $date_formatter): array {
     $row = [];
     foreach (array_keys(self::getColumns($bundle)) as $key) {
-      $row[] = self::sanitizeCell(self::cellValue($node, $key));
+      $row[] = self::sanitizeCell(self::cellValue($node, $key, $date_formatter));
     }
     return $row;
   }
@@ -82,7 +101,7 @@ class ContentExportBuilder {
   /**
    * Resolves the raw value for a single column of a node.
    */
-  protected static function cellValue(NodeInterface $node, string $key): string {
+  protected static function cellValue(NodeInterface $node, string $key, DateFormatterInterface $date_formatter): string {
     switch ($key) {
       case 'title':
         return (string) $node->label();
@@ -97,7 +116,16 @@ class ContentExportBuilder {
         return $node->hasField('field_login_required') && $node->get('field_login_required')->value
           ? 'Yes' : 'No';
 
+      case 'field_event_date':
+        return self::eventDates($node, $date_formatter);
+
+      case 'field_publish_date':
+        return self::publishDate($node);
+
       default:
+        // Any remaining column is assumed to be an entity reference, so a new
+        // non-reference field needs an explicit case above rather than relying
+        // on this branch.
         if (!$node->hasField($key)) {
           return '';
         }
@@ -107,6 +135,131 @@ class ContentExportBuilder {
         }
         return implode(', ', $names);
     }
+  }
+
+  /**
+   * Lists every instance of an event's date field, oldest first.
+   *
+   * Smart Date stores each occurrence as its own field item, and stored delta
+   * order is not chronological, so the instances are sorted before rendering.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The event node.
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
+   *   The date formatter.
+   *
+   * @return string
+   *   Every instance, comma separated, or an empty string when the event has
+   *   no dates.
+   */
+  protected static function eventDates(NodeInterface $node, DateFormatterInterface $date_formatter): string {
+    if (!$node->hasField('field_event_date')) {
+      return '';
+    }
+
+    $instances = [];
+    foreach ($node->get('field_event_date') as $item) {
+      $start = (int) $item->value;
+      if (!$start) {
+        continue;
+      }
+      // A Smart Date item always stores an end, but fall back to the start so a
+      // partially written value still exports as a point in time.
+      $instances[] = [$start, (int) $item->end_value ?: $start];
+    }
+    usort($instances, fn(array $a, array $b) => $a <=> $b);
+
+    $rendered = [];
+    foreach ($instances as [$start, $end]) {
+      $rendered[] = self::eventInstance($start, $end, $date_formatter);
+    }
+    return implode(', ', $rendered);
+  }
+
+  /**
+   * Renders one event occurrence in the site's configured timezone.
+   *
+   * Uses the platform's existing event_date_only and event_time_only date
+   * formats rather than a new pattern. The end date is only repeated when the
+   * occurrence crosses midnight, and an all-day occurrence is labelled instead
+   * of being shown as a 12:00 am to 11:59 pm range.
+   *
+   * @param int $start
+   *   The occurrence start, as a UNIX timestamp.
+   * @param int $end
+   *   The occurrence end, as a UNIX timestamp.
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
+   *   The date formatter.
+   *
+   * @return string
+   *   The rendered occurrence.
+   */
+  protected static function eventInstance(int $start, int $end, DateFormatterInterface $date_formatter): string {
+    $start_date = $date_formatter->format($start, 'event_date_only');
+    $end_date = $date_formatter->format($end, 'event_date_only');
+    $spans_days = $end_date !== $start_date;
+
+    if (self::isAllDay($start, $end, $date_formatter)) {
+      return $spans_days
+        ? $start_date . ' - ' . $end_date . ' (All day)'
+        : $start_date . ' (All day)';
+    }
+
+    $start_time = $date_formatter->format($start, 'event_time_only');
+    $end_time = $date_formatter->format($end, 'event_time_only');
+    // A zero-duration occurrence is a point in time, not a range.
+    if (!$spans_days && $start_time === $end_time) {
+      return $start_date . ' ' . $start_time;
+    }
+    // The end date is only repeated when the occurrence crosses midnight.
+    $end_label = $spans_days ? $end_date . ' ' . $end_time : $end_time;
+    return $start_date . ' ' . $start_time . ' - ' . $end_label;
+  }
+
+  /**
+   * Determines whether an occurrence covers whole days.
+   *
+   * Mirrors how Smart Date itself defines all-day (see
+   * SmartDateTrait::isAllDay): the occurrence starts at midnight and ends a
+   * minute before it. Compared through the date formatter so the clock times
+   * are read in the site's timezone. The 'custom' format type is what lets the
+   * formatter use the pattern directly; a named type would make it load a date
+   * format config entity on every call.
+   *
+   * @param int $start
+   *   The occurrence start, as a UNIX timestamp.
+   * @param int $end
+   *   The occurrence end, as a UNIX timestamp.
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
+   *   The date formatter.
+   *
+   * @return bool
+   *   TRUE when the occurrence is all-day.
+   */
+  protected static function isAllDay(int $start, int $end, DateFormatterInterface $date_formatter): bool {
+    return $date_formatter->format($start, 'custom', 'H:i') === '00:00'
+      && $date_formatter->format($end, 'custom', 'H:i') === '23:59';
+  }
+
+  /**
+   * Returns a resource's publication date.
+   *
+   * The field is date-only, stored as Y-m-d, which is already the format the
+   * Manage Resources column renders. The stored value is emitted verbatim so
+   * there is no timestamp round-trip whose only possible effect would be
+   * shifting the date by a day across a timezone boundary.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The resource node.
+   *
+   * @return string
+   *   The publication date, or an empty string when unset.
+   */
+  protected static function publishDate(NodeInterface $node): string {
+    if (!$node->hasField('field_publish_date')) {
+      return '';
+    }
+    return (string) $node->get('field_publish_date')->value;
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_content_export/src/Controller/ContentExportController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_content_export/src/Controller/ContentExportController.php
@@ -3,6 +3,7 @@
 namespace Drupal\ys_content_export\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\views\Views;
 use Drupal\ys_content_export\ContentExportBuilder;
@@ -48,20 +49,33 @@ class ContentExportController extends ControllerBase {
   protected $nodeStorage;
 
   /**
+   * The date formatter.
+   *
+   * @var \Drupal\Core\Datetime\DateFormatterInterface
+   */
+  protected $dateFormatter;
+
+  /**
    * Constructs the controller.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
+   *   The date formatter, handed to the export builder for date columns.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, DateFormatterInterface $date_formatter) {
     $this->nodeStorage = $entity_type_manager->getStorage('node');
+    $this->dateFormatter = $date_formatter;
   }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static($container->get('entity_type.manager'));
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('date.formatter')
+    );
   }
 
   /**
@@ -93,7 +107,7 @@ class ContentExportController extends ControllerBase {
         $nodes = $this->nodeStorage->loadMultiple($chunk);
         foreach ($chunk as $nid) {
           if (isset($nodes[$nid])) {
-            fputcsv($handle, ContentExportBuilder::getRow($nodes[$nid], $bundle));
+            fputcsv($handle, ContentExportBuilder::getRow($nodes[$nid], $bundle, $this->dateFormatter));
           }
         }
         // Release the chunk so memory stays bounded on large content lists.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_content_export/tests/src/Unit/ContentExportBuilderTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_content_export/tests/src/Unit/ContentExportBuilderTest.php
@@ -2,8 +2,10 @@
 
 namespace Drupal\Tests\ys_content_export\Unit;
 
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use Drupal\Core\Url;
 use Drupal\Tests\UnitTestCase;
 use Drupal\node\NodeInterface;
 use Drupal\ys_content_export\ContentExportBuilder;
@@ -93,6 +95,257 @@ class ContentExportBuilderTest extends UnitTestCase {
       $this->assertArrayHasKey('field_audience', $columns);
       $this->assertArrayHasKey('field_custom_vocab', $columns);
     }
+
+    // Only events and resources carry a date column.
+    $this->assertArrayNotHasKey('field_event_date', $page);
+    $this->assertArrayNotHasKey('field_publish_date', $page);
+    foreach (['post', 'profile'] as $bundle) {
+      $columns = ContentExportBuilder::getColumns($bundle);
+      $this->assertArrayNotHasKey('field_event_date', $columns);
+      $this->assertArrayNotHasKey('field_publish_date', $columns);
+    }
+  }
+
+  /**
+   * Tests the date column sits immediately after Title, with the AC's header.
+   *
+   * The spreadsheet is meant to read in roughly the same order as the on-screen
+   * Manage table, which puts the date next to the title.
+   *
+   * @param string $bundle
+   *   The node bundle machine name.
+   * @param string $key
+   *   The expected date column key.
+   * @param string $header
+   *   The expected date column header.
+   *
+   * @dataProvider dateColumnProvider
+   * @covers ::getColumns
+   */
+  public function testDateColumnFollowsTitle(string $bundle, string $key, string $header): void {
+    $columns = ContentExportBuilder::getColumns($bundle);
+    $this->assertSame(['title', $key], array_slice(array_keys($columns), 0, 2));
+    $this->assertSame($header, $columns[$key]);
+  }
+
+  /**
+   * Provides the bundles that gain a date column.
+   *
+   * @return array
+   *   Cases: [bundle, column key, header].
+   */
+  public static function dateColumnProvider(): array {
+    return [
+      'events' => ['event', 'field_event_date', 'Dates'],
+      'resources' => ['resource', 'field_publish_date', 'Resource Publication Date'],
+    ];
+  }
+
+  /**
+   * Tests the Dates cell for an event.
+   *
+   * @param array $instances
+   *   Stored field values, in delta order: each [value, end_value].
+   * @param string $expected
+   *   The expected cell output.
+   *
+   * @dataProvider eventDatesProvider
+   * @covers ::cellValue
+   */
+  public function testEventDatesCell(array $instances, string $expected): void {
+    $items = [];
+    foreach ($instances as [$start, $end]) {
+      $items[] = (object) ['value' => $start, 'end_value' => $end];
+    }
+
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('hasField')->with('field_event_date')->willReturn(TRUE);
+    $node->method('get')->with('field_event_date')->willReturn($items);
+
+    $method = new \ReflectionMethod(ContentExportBuilder::class, 'cellValue');
+    $method->setAccessible(TRUE);
+    $this->assertSame(
+      $expected,
+      $method->invoke(NULL, $node, 'field_event_date', $this->dateFormatter())
+    );
+  }
+
+  /**
+   * Provides stored event date instances and their expected cell output.
+   *
+   * Timestamps are the real values pulled from node__field_event_date on a
+   * local database, so the recurring case also covers the fact that stored
+   * delta order is not chronological.
+   *
+   * @return array
+   *   Cases: [instances, expected].
+   */
+  public static function eventDatesProvider(): array {
+    return [
+      'single timed instance' => [
+        [[2125173600, 2125177200]],
+        'Tuesday, May 5th, 2037 6:00 pm EDT - 7:00 pm EDT',
+      ],
+      'all day, single day' => [
+        [[1818043200, 1818129540]],
+        'Thursday, August 12th, 2027 (All day)',
+      ],
+      'all day, spanning several days' => [
+        [[2098670400, 2098929540]],
+        'Thursday, July 3rd, 2036 - Saturday, July 5th, 2036 (All day)',
+      ],
+      'recurring, stored out of chronological order' => [
+        [
+          [2112127200, 2112130800],
+          [1875308940, 1875312540],
+          [1707058800, 1707062400],
+        ],
+        'Sunday, February 4th, 2024 10:00 am EST - 11:00 am EST, '
+        . 'Monday, June 4th, 2029 7:09 pm EDT - 8:09 pm EDT, '
+        . 'Friday, December 5th, 2036 5:00 pm EST - 6:00 pm EST',
+      ],
+      'timed instance spanning midnight' => [
+        [[2112127200, 2112156000]],
+        'Friday, December 5th, 2036 5:00 pm EST - Saturday, December 6th, 2036 1:00 am EST',
+      ],
+      'zero duration instance' => [
+        [[2112127200, 2112127200]],
+        'Friday, December 5th, 2036 5:00 pm EST',
+      ],
+      'missing end falls back to the start' => [
+        [[2112127200, 0]],
+        'Friday, December 5th, 2036 5:00 pm EST',
+      ],
+      'instance with no start timestamp is skipped' => [
+        [[0, 0]],
+        '',
+      ],
+      'no instances at all' => [
+        [],
+        '',
+      ],
+    ];
+  }
+
+  /**
+   * Tests an event whose date field is absent exports an empty cell.
+   *
+   * @covers ::cellValue
+   */
+  public function testEventDatesCellWithoutField(): void {
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('hasField')->with('field_event_date')->willReturn(FALSE);
+    $node->expects($this->never())->method('get');
+
+    $method = new \ReflectionMethod(ContentExportBuilder::class, 'cellValue');
+    $method->setAccessible(TRUE);
+    $this->assertSame(
+      '',
+      $method->invoke(NULL, $node, 'field_event_date', $this->dateFormatter())
+    );
+  }
+
+  /**
+   * Tests the Resource Publication Date cell.
+   *
+   * The field is date-only and stored as Y-m-d, which is already the format
+   * the Manage Resources column renders, so the stored value is emitted as-is
+   * with no timezone conversion that could shift the date by a day.
+   *
+   * @param bool $has_field
+   *   Whether the node has the field.
+   * @param string|null $value
+   *   The stored date string, or NULL for an empty field.
+   * @param string $expected
+   *   The expected cell output.
+   *
+   * @dataProvider publishDateProvider
+   * @covers ::cellValue
+   */
+  public function testPublishDateCell(bool $has_field, ?string $value, string $expected): void {
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('hasField')->with('field_publish_date')->willReturn($has_field);
+    if ($has_field) {
+      $node->method('get')->with('field_publish_date')->willReturn((object) ['value' => $value]);
+    }
+
+    $method = new \ReflectionMethod(ContentExportBuilder::class, 'cellValue');
+    $method->setAccessible(TRUE);
+    $this->assertSame(
+      $expected,
+      $method->invoke(NULL, $node, 'field_publish_date', $this->dateFormatter())
+    );
+  }
+
+  /**
+   * Provides resource publication date states and expected cell output.
+   *
+   * @return array
+   *   Cases: [has_field, stored value, expected].
+   */
+  public static function publishDateProvider(): array {
+    return [
+      'date present' => [TRUE, '2026-04-01', '2026-04-01'],
+      'field empty' => [TRUE, NULL, ''],
+      'field absent' => [FALSE, NULL, ''],
+    ];
+  }
+
+  /**
+   * Tests a date cell is sanitised like every other cell.
+   *
+   * Guards the AC that both new columns pass through sanitizeCell(), so a date
+   * value can never be read as a spreadsheet formula.
+   *
+   * @covers ::getRow
+   */
+  public function testDateCellIsSanitised(): void {
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('label')->willReturn('A resource');
+    $url = $this->createMock(Url::class);
+    $url->method('toString')->willReturn('/resource/a-resource');
+    $node->method('toUrl')->willReturn($url);
+    $node->method('isPublished')->willReturn(TRUE);
+    $node->method('hasField')->willReturnMap([
+      ['field_login_required', FALSE],
+      ['field_publish_date', TRUE],
+      ['field_tags', FALSE],
+      ['field_audience', FALSE],
+      ['field_custom_vocab', FALSE],
+      ['field_category', FALSE],
+    ]);
+    // A leading "-" would otherwise be evaluated as a formula by Excel.
+    $node->method('get')->with('field_publish_date')
+      ->willReturn((object) ['value' => '-2026-04-01']);
+
+    $row = ContentExportBuilder::getRow($node, 'resource', $this->dateFormatter());
+    $this->assertSame("'-2026-04-01", $row[1]);
+  }
+
+  /**
+   * Builds a date formatter that renders in the site timezone.
+   *
+   * Mirrors the platform's system.date settings: America/New_York, with
+   * per-user timezones off. Unit tests get no container, so the two event date
+   * formats are resolved from their known config patterns.
+   *
+   * @return \Drupal\Core\Datetime\DateFormatterInterface
+   *   A date formatter test double.
+   */
+  protected function dateFormatter(): DateFormatterInterface {
+    $patterns = [
+      'event_date_only' => 'l, F jS, Y',
+      'event_time_only' => 'g:i a T',
+    ];
+    $formatter = $this->createMock(DateFormatterInterface::class);
+    $formatter->method('format')->willReturnCallback(
+      function ($timestamp, $type = 'medium', $format = '', $timezone = NULL) use ($patterns) {
+        $date = new \DateTime('@' . $timestamp);
+        $date->setTimezone(new \DateTimeZone($timezone ?? 'America/New_York'));
+        return $date->format($patterns[$type] ?? $format);
+      }
+    );
+    return $formatter;
   }
 
   /**
@@ -119,7 +372,7 @@ class ContentExportBuilderTest extends UnitTestCase {
 
     $method = new \ReflectionMethod(ContentExportBuilder::class, 'cellValue');
     $method->setAccessible(TRUE);
-    $this->assertSame($expected, $method->invoke(NULL, $node, 'cas_protected'));
+    $this->assertSame($expected, $method->invoke(NULL, $node, 'cas_protected', $this->dateFormatter()));
   }
 
   /**
@@ -145,7 +398,7 @@ class ContentExportBuilderTest extends UnitTestCase {
 
     $method = new \ReflectionMethod(ContentExportBuilder::class, 'cellValue');
     $method->setAccessible(TRUE);
-    $this->assertSame('Alpha, Beta', $method->invoke(NULL, $node, 'field_tags'));
+    $this->assertSame('Alpha, Beta', $method->invoke(NULL, $node, 'field_tags', $this->dateFormatter()));
   }
 
   /**


### PR DESCRIPTION
## [1531: Release Feedback: Export Content Events Add Dates](https://github.com/yalesites-org/YaleSites-Internal/issues/1531)

### Description of work

- Adds a **Dates** column to the Events CSV export and a **Resource Publication Date** column to the Resources CSV export. Both sit immediately after Title, so the file reads in roughly the same order as the Manage table it was exported from.
- The Events **Dates** cell lists *every* occurrence of the event, oldest first, separated by `", "`. Stored Smart Date delta order is not chronological, so the occurrences are sorted before rendering — a recurring series exports all of its dates, where the on-screen Date column shows only the first and last (it is labelled "Date (First and last only)").
- Occurrences render in the site's configured timezone using the platform's existing `event_date_only` and `event_time_only` date formats rather than a new pattern — the same pair `ys_localist`'s `MetaFieldsManager::orderEventDates()` already uses. An all-day occurrence reads `(All day)` instead of a 12:00 am to 11:59 pm range, and an occurrence that crosses midnight repeats the end date.
- **Resource Publication Date** is emitted verbatim from storage. The field is date-only and already stored as `Y-m-d`, which is exactly what the Manage Resources column renders via `html_date` — so there is no `strtotime()` round-trip whose only possible effect would be shifting the date by a day across a timezone boundary.
- An event with no dates, or a resource with no publication date, exports an empty cell. No placeholder text, no 1970 fallback.
- Both new columns go through `ContentExportBuilder::sanitizeCell()` like every other cell, so a date value can never be read as a spreadsheet formula.
- `ContentExportBuilder` stays free of injected services so its column map remains directly unit testable: the `DateFormatterInterface` is a `getRow()` parameter, and `ContentExportController` injects `date.formatter` and passes it down. There is no `\Drupal::` call in the builder.
- 15 new unit tests in `ContentExportBuilderTest` (16 -> 31 tests, 41 -> 65 assertions). The event fixtures use real timestamps pulled from `node__field_event_date`, including a series whose stored deltas run 2036, 2029, 2024, 2025, 2027 — so the chronological sort is actually exercised.
- Updates the column list in `ys_content_export/README.md`. The user-guide page is tracked separately in yalesites-org/YaleSites-Internal#1472.

Known trade-off, accepted during grooming: a weekly recurring series produces a long cell, and a cell holding many dates cannot be sorted as a date in a spreadsheet. If editors later ask to sort or filter by date, a separate first-instance start column can be added as a follow-up.

No config changes, no new module dependencies, and no update hook.

### Functional testing steps:

- [ ] Go to **Manage Events** (`/admin/content/manage-events`) and press **Export to CSV**. Confirm the file has a **Dates** column immediately after Title.
- [ ] Open the file in Excel *and* Google Sheets. Confirm the dates are intact, accented characters still render (e.g. the en-dash in "K–12 Environmental Science Curriculum Guide" on Resources), and a multi-date cell stays in a single cell rather than spilling across columns.
- [ ] Find a recurring event with several occurrences and confirm the CSV lists **all** of them, oldest first — not just the first and last that the on-screen column shows.
- [ ] Confirm an all-day event reads as `(All day)` rather than showing a 12:00 am to 11:59 pm range, and that a multi-day all-day event shows both its start and end date.
- [ ] Confirm times show in Eastern time (`EST`/`EDT` as appropriate for that date) and not as raw UTC.
- [ ] Create or find an event with no date and confirm its Dates cell is empty — no placeholder, no 1970 date.
- [ ] Apply an exposed filter or search on Manage Events, then export, and confirm the export still matches what is on screen and still has the Dates column.
- [ ] Repeat on **Manage Resources**: confirm a **Resource Publication Date** column immediately after Title, formatted `YYYY-MM-DD`, matching the value shown in the on-screen column for the same row.
- [ ] Clear the publication date on a resource and confirm its cell exports empty.
- [ ] Spot-check that the other exports (Pages, Posts, Profiles) are unchanged — they should have no date column.

References yalesites-org/YaleSites-Internal#1531
