### PR TITLE
1558: RC: Dashboard: indicate which announcement is new in the Announcements section

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/badge.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/badge.css
@@ -1,0 +1,27 @@
+/**
+ * The unread-announcements pill.
+ *
+ * Modeled on Drupal core's announcements_feed bell-icon dot, but rendered as a
+ * small red pill so editors can see what is waiting. Two consumers, which is
+ * why this is its own library rather than living in either one's stylesheet:
+ * the Dashboard admin menu link shows the unread count in it, and each unread
+ * announcement on the dashboard itself shows the word "New" in it.
+ *
+ * @see web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-dashboard.html.twig
+ * @see \Drupal\ys_core\Toolbar\DashboardToolbarLazyBuilders::renderBadge()
+ */
+
+.ys-dashboard-badge {
+  display: inline-block;
+  min-width: 1.25em;
+  margin-inline-start: 0.4em;
+  padding: 0 0.4em;
+  border-radius: 999px;
+  background-color: #d72c0d;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.4;
+  text-align: center;
+  vertical-align: baseline;
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/dashboard-badge.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/dashboard-badge.css
@@ -1,25 +1,11 @@
 /**
- * Unread-announcements badge on the Dashboard admin menu link.
+ * The Dashboard admin menu link that carries the unread-announcements pill.
  *
- * Modeled on Drupal core's announcements_feed bell-icon dot, but rendered as
- * a small red pill containing the count so editors can see how many items
- * are waiting before they click through.
+ * The pill itself is `ys_core/badge`, shared with the dashboard page; every
+ * rule here is specific to rendering it inside the admin toolbar.
+ *
+ * @see \Drupal\ys_core\Toolbar\DashboardToolbarLazyBuilders::renderBadge()
  */
-
-.ys-dashboard-badge {
-  display: inline-block;
-  min-width: 1.25em;
-  margin-inline-start: 0.4em;
-  padding: 0 0.4em;
-  border-radius: 999px;
-  background-color: #d72c0d;
-  color: #fff;
-  font-size: 0.75rem;
-  font-weight: 600;
-  line-height: 1.4;
-  text-align: center;
-  vertical-align: baseline;
-}
 
 /* FontAwesome Free "gauge" icon (v7.3.0, CC BY 4.0). Positioned absolutely so
    the icon sits vertically centered relative to the link's own box (matching

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/dashboard.css
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/css/dashboard.css
@@ -62,6 +62,34 @@
   margin-block-end: 0;
 }
 
+/* Header row: the Announcements heading and the "mark all as read" control,
+   wrapping onto separate lines when the column is too narrow for both. */
+.ys-dashboard__announcements-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem 1rem;
+  margin-block-end: 0.75rem;
+}
+
+/* The header row carries the gap below itself now. */
+.ys-dashboard__announcements-header > h2 {
+  margin-block-end: 0;
+}
+
+/* Gin spaces form actions for the bottom of a settings form; inline in a
+   section header that margin pushes the button out of line. */
+.ys-dashboard__announcements-header .form-actions {
+  margin: 0;
+}
+
+/* Placement of the "New" pill against an announcement title. The pill itself is
+   .ys-dashboard-badge (css/badge.css), shared with the toolbar count. */
+.ys-dashboard__announcement-new {
+  vertical-align: middle;
+}
+
 .ys-dashboard__announcement-list {
   list-style: none;
   margin: 0;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Controller/DashboardController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Controller/DashboardController.php
@@ -5,6 +5,7 @@ namespace Drupal\ys_core\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\ys_core\DashboardAnnouncements;
+use Drupal\ys_core\Form\MarkAnnouncementsReadForm;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -53,26 +54,47 @@ class DashboardController extends ControllerBase {
    * Dashboard page contents.
    */
   public function content() {
-    $items = $this->announcements->getAnnouncements();
-    // Visiting the dashboard "sees" every current announcement, so clear the
-    // toolbar badge for this user.
-    $this->announcements->markAllRead($this->currentUser());
-    return [
+    $account = $this->currentUser();
+    // Deliberately read-only -- clearing is the control below, not the visit.
+    // @see \Drupal\ys_core\DashboardAnnouncements::markAllRead()
+    $items = $this->announcements->getAnnouncementsForUser($account);
+    $unread = DashboardAnnouncements::countUnread($items);
+
+    $build = [
       '#theme' => 'ys_dashboard',
       '#platform_version' => $this->getPlatformVersion(),
       '#announcements' => $items,
       '#cache' => [
-        'contexts' => ['user.permissions'],
+        // The "new" markers vary per user, so this render must never be shared
+        // between editors. Declared explicitly rather than leaned on: the page
+        // already picks up `user` from its embedded views, and `user` subsumes
+        // the `user.permissions` context this previously named, but the markers
+        // are the reason it is required rather than incidental.
+        'contexts' => ['user'],
         'tags' => [
           'config:ys_core.dashboard_settings',
           DashboardAnnouncements::FEED_CACHE_TAG,
+          // Dropped when this user marks their announcements as read, so the
+          // page loses its markers in the same interaction as the toolbar
+          // badge, which depends on the same tag.
+          DashboardAnnouncements::unreadCacheTag($account->id()),
         ],
-        // Align with the consumer feed cache so pure-consumer sites (where no
-        // local node hook fires) still pick up new announcements within an
-        // hour. Source sites refresh immediately via the feed cache tag.
+        // Bounds this render's own freshness against the consumer feed cache,
+        // so a pure-consumer site (where no local node hook fires) still picks
+        // up new announcements within the hour. Note the response as a whole is
+        // not cached anyway -- the embedded form's zero max-age bubbles up and
+        // Dynamic Page Cache declines anything carrying the `user` context.
         'max-age' => 3600,
       ],
     ];
+
+    // Offering a button that would do nothing is worse than not offering one,
+    // so the control only exists while there is something to clear.
+    if ($unread > 0) {
+      $build['#mark_all_read_form'] = $this->formBuilder()->getForm(MarkAnnouncementsReadForm::class);
+    }
+
+    return $build;
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/DashboardAnnouncements.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/DashboardAnnouncements.php
@@ -251,27 +251,69 @@ class DashboardAnnouncements {
   }
 
   /**
-   * Counts announcements newer than the user's last-seen timestamp.
+   * Returns announcements decorated with this user's unread state.
+   *
+   * This is the one place unread state is decided: the dashboard's per-item
+   * marker and the toolbar's badge count both come from here, so they cannot
+   * disagree. Feed order and membership are left alone. Items carry no stable
+   * id, so "new" is derived from the single `announcements_last_seen`
+   * high-water mark rather than per-item read records -- which also means an
+   * item with no parseable date is never new, as nothing can be newer than
+   * that mark without a date to compare.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The account to resolve unread state for.
+   *
+   * @return array
+   *   The announcements from getAnnouncements(), each with an added `is_new`
+   *   key. Empty for an anonymous account: there is no stored read state to
+   *   decorate, so the feed is not fetched on its behalf either.
+   */
+  public function getAnnouncementsForUser(AccountInterface $account): array {
+    if ($account->isAnonymous()) {
+      return [];
+    }
+    $last_seen = $this->lastSeen($account);
+
+    return array_map(
+      fn (array $item) => $item + [
+        'is_new' => !empty($item['timestamp']) && (int) $item['timestamp'] > $last_seen,
+      ],
+      $this->getAnnouncements()
+    );
+  }
+
+  /**
+   * Counts the announcements this user has not seen yet.
    *
    * Reads the already-cached feed, so this is a cheap operation that adds no
    * extra HTTP requests to the upstream endpoint.
    */
   public function getUnreadCount(AccountInterface $account): int {
-    if ($account->isAnonymous()) {
-      return 0;
-    }
-    $items = $this->getAnnouncements();
-    if (empty($items)) {
-      return 0;
-    }
-    $last_seen = (int) ($this->userData->get(self::USER_DATA_MODULE, (int) $account->id(), self::USER_DATA_LAST_SEEN) ?? 0);
-    $count = 0;
-    foreach ($items as $item) {
-      if (!empty($item['timestamp']) && (int) $item['timestamp'] > $last_seen) {
-        $count++;
-      }
-    }
-    return $count;
+    return self::countUnread($this->getAnnouncementsForUser($account));
+  }
+
+  /**
+   * Counts the items flagged new in an already-decorated announcement list.
+   *
+   * Lets a caller that already holds the decorated list -- the dashboard
+   * controller -- get the count without walking the feed a second time, while
+   * keeping the tally itself in one place.
+   *
+   * @param array $items
+   *   Announcements as returned by getAnnouncementsForUser().
+   */
+  public static function countUnread(array $items): int {
+    return count(array_filter(array_column($items, 'is_new')));
+  }
+
+  /**
+   * The timestamp of the newest announcement this user has already seen.
+   *
+   * Zero when they have never seen one, which makes every dated item unread.
+   */
+  protected function lastSeen(AccountInterface $account): int {
+    return (int) ($this->userData->get(self::USER_DATA_MODULE, (int) $account->id(), self::USER_DATA_LAST_SEEN) ?? 0);
   }
 
   /**
@@ -279,6 +321,13 @@ class DashboardAnnouncements {
    *
    * Stores the newest current timestamp; future items dated later than that
    * will count as unread.
+   *
+   * Invoked only by an explicit editor action, never by rendering the
+   * dashboard. Stamping on page view meant an editor who glanced at the
+   * dashboard on their way to edit a page burned their unread markers without
+   * having read anything, and they did not come back.
+   *
+   * @see \Drupal\ys_core\Form\MarkAnnouncementsReadForm
    */
   public function markAllRead(AccountInterface $account): void {
     if ($account->isAnonymous()) {
@@ -298,8 +347,7 @@ class DashboardAnnouncements {
       return;
     }
     $uid = (int) $account->id();
-    $current = (int) ($this->userData->get(self::USER_DATA_MODULE, $uid, self::USER_DATA_LAST_SEEN) ?? 0);
-    if ($newest > $current) {
+    if ($newest > $this->lastSeen($account)) {
       $this->userData->set(self::USER_DATA_MODULE, $uid, self::USER_DATA_LAST_SEEN, $newest);
       Cache::invalidateTags([self::unreadCacheTag($uid)]);
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/MarkAnnouncementsReadForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/MarkAnnouncementsReadForm.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\ys_core\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\ys_core\DashboardAnnouncements;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Clears the current user's unread dashboard announcements.
+ *
+ * Embedded in the Announcements section of the editorial dashboard rather than
+ * given its own page: it is a single action on the list the editor is already
+ * looking at. It posts back to the dashboard route, so that route's
+ * `yalesites manage settings` permission gates the submission too.
+ *
+ * This is the only way read state is ever cleared -- see markAllRead() for why
+ * it is no longer cleared by viewing the page.
+ *
+ * @see \Drupal\ys_core\Controller\DashboardController::content()
+ * @see \Drupal\ys_core\DashboardAnnouncements::markAllRead()
+ */
+class MarkAnnouncementsReadForm extends FormBase {
+
+  /**
+   * Constructs a MarkAnnouncementsReadForm object.
+   *
+   * @param \Drupal\ys_core\DashboardAnnouncements $announcements
+   *   The dashboard announcements service, which owns the read state.
+   */
+  public function __construct(
+    protected DashboardAnnouncements $announcements,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('ys_core.dashboard_announcements')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'ys_core_mark_announcements_read';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['actions'] = [
+      '#type' => 'actions',
+      'submit' => [
+        '#type' => 'submit',
+        // Names what it acts on, so it still makes sense to a screen reader
+        // user reading the button out of its surrounding context.
+        '#value' => $this->t('Mark all announcements as read'),
+        // Gin promotes the first submit in a form's actions to its primary
+        // style, which would make this utility control the loudest thing in
+        // the section. Small keeps it clearly a button without competing with
+        // the announcements themselves.
+        '#attributes' => [
+          'class' => ['ys-dashboard__announcements-mark-read', 'button--small'],
+        ],
+      ],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->announcements->markAllRead($this->currentUser());
+
+    // markAllRead() invalidates this user's badge cache tag, which the
+    // dashboard render and the toolbar badge both depend on, so both catch up
+    // on the redirect without a manual cache rebuild. The status message is
+    // what tells a screen reader user the action succeeded -- the markers
+    // simply disappearing is a visual-only signal.
+    $this->messenger()->addStatus($this->t('All announcements have been marked as read.'));
+
+    $form_state->setRedirect('ys_core.admin_dashboard');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Toolbar/DashboardToolbarLazyBuilders.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Toolbar/DashboardToolbarLazyBuilders.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\ys_core\Toolbar;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Security\TrustedCallbackInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\ys_core\DashboardAnnouncements;
 
@@ -13,6 +13,10 @@ use Drupal\ys_core\DashboardAnnouncements;
  * The placeholder is attached to the Dashboard menu link in
  * `ys_core_preprocess_menu()`. Keeping the per-user count behind a lazy
  * builder lets the surrounding admin menu render stay shared across users.
+ *
+ * The viewer is resolved here rather than passed in as an argument.
+ *
+ * @see _ys_core_attach_dashboard_badge_walk()
  */
 class DashboardToolbarLazyBuilders implements TrustedCallbackInterface {
 
@@ -20,7 +24,7 @@ class DashboardToolbarLazyBuilders implements TrustedCallbackInterface {
 
   public function __construct(
     protected DashboardAnnouncements $announcements,
-    protected EntityTypeManagerInterface $entityTypeManager,
+    protected AccountInterface $currentUser,
   ) {}
 
   /**
@@ -33,32 +37,30 @@ class DashboardToolbarLazyBuilders implements TrustedCallbackInterface {
   /**
    * Builds the unread-announcements pill for the Dashboard menu link.
    *
-   * Returns an empty render array when the user has no unread items, but the
-   * cacheability is preserved so the result re-renders on cache invalidation
-   * (e.g. when the user presses "mark all as read" on the dashboard and
-   * `markAllRead()` runs).
+   * Returns an empty render array when the user has nothing unread.
+   *
+   * There is no `#cache['keys']`, so the badge is rebuilt for whoever the
+   * placeholder is replaced for rather than stored. That, not tag
+   * invalidation, is what keeps it per-user correct: on the page pipeline
+   * placeholders are rendered by HtmlResponseAttachmentsProcessor at
+   * `kernel.response` priority 0, after Dynamic Page Cache has already stored
+   * the response at priority 7, so these tags never reach that entry. They are
+   * carried for render paths that do replace placeholders within renderRoot().
    */
-  public function renderBadge(string $uid): array {
-    $uid = (int) $uid;
+  public function renderBadge(): array {
     $build = [
       '#cache' => [
         'contexts' => ['user'],
         'tags' => [
-          DashboardAnnouncements::unreadCacheTag($uid),
+          DashboardAnnouncements::unreadCacheTag((int) $this->currentUser->id()),
           DashboardAnnouncements::FEED_CACHE_TAG,
           'config:ys_core.dashboard_settings',
         ],
         'max-age' => 3600,
       ],
     ];
-    if ($uid <= 0) {
-      return $build;
-    }
-    $account = $this->entityTypeManager->getStorage('user')->load($uid);
-    if (!$account) {
-      return $build;
-    }
-    $count = $this->announcements->getUnreadCount($account);
+    // An anonymous account resolves no unread state, so this is 0 for them.
+    $count = $this->announcements->getUnreadCount($this->currentUser);
     if ($count <= 0) {
       return $build;
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Toolbar/DashboardToolbarLazyBuilders.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Toolbar/DashboardToolbarLazyBuilders.php
@@ -35,7 +35,8 @@ class DashboardToolbarLazyBuilders implements TrustedCallbackInterface {
    *
    * Returns an empty render array when the user has no unread items, but the
    * cacheability is preserved so the result re-renders on cache invalidation
-   * (e.g. when the user visits the dashboard and `markAllRead()` runs).
+   * (e.g. when the user presses "mark all as read" on the dashboard and
+   * `markAllRead()` runs).
    */
   public function renderBadge(string $uid): array {
     $uid = (int) $uid;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-dashboard.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-dashboard.html.twig
@@ -13,7 +13,12 @@
     {% if announcements is not empty %}
       <div class="ys-dashboard__top-main">
         <section class="ys-dashboard__section ys-dashboard__announcements" aria-labelledby="ys-dashboard-announcements-heading">
-          <h2 id="ys-dashboard-announcements-heading">{{ 'Announcements'|t }}</h2>
+          {# Beside the heading so it reads as acting on this list. Only built
+             when the editor has something unread. #}
+          <div class="ys-dashboard__announcements-header">
+            <h2 id="ys-dashboard-announcements-heading">{{ 'Announcements'|t }}</h2>
+            {{ mark_all_read_form }}
+          </div>
           <ul class="ys-dashboard__announcement-list">
             {% for announcement in announcements %}
               <li class="ys-dashboard__announcement">
@@ -22,6 +27,12 @@
                     <a href="{{ announcement.url }}">{{ announcement.title }}</a>
                   {% else %}
                     {{ announcement.title }}
+                  {% endif %}
+                  {# Inside the heading so it is announced with the title it
+                     belongs to. The text carries the meaning, not the colour
+                     (WCAG 1.4.1). #}
+                  {% if announcement.is_new %}
+                    <span class="ys-dashboard-badge ys-dashboard__announcement-new">{{ 'New'|t }}<span class="visually-hidden"> {{ 'announcement'|t }}</span></span>
                   {% endif %}
                 </h3>
                 {% if announcement.date %}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/DashboardAnnouncementIndicatorTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/DashboardAnnouncementIndicatorTest.php
@@ -1,0 +1,360 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\Core\Form\FormState;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\User;
+use Drupal\ys_core\Controller\DashboardController;
+use Drupal\ys_core\DashboardAnnouncements;
+use Drupal\ys_core\Form\MarkAnnouncementsReadForm;
+
+/**
+ * Tests the "new" announcement marker and its explicit clearing control.
+ *
+ * The toolbar badge tells an editor that something is new but not which item,
+ * and the last-seen timestamp used to be stamped forward simply by loading the
+ * dashboard -- so an editor passing through on their way to edit a page lost
+ * their markers without reading anything. These tests pin the replacement
+ * behaviour: a per-item marker, and clearing only ever as an explicit action.
+ *
+ * The dashboard renders in ys_admin_theme in production, but the markup under
+ * test is the module's own template, so stark keeps the assertions about our
+ * markup rather than Gin's.
+ *
+ * @group ys_core
+ * @group yalesites
+ */
+class DashboardAnnouncementIndicatorTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'views', 'twig_tweak', 'ys_core'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Timestamps for the seeded feed, newest first.
+   */
+  private const NEWEST = 3000;
+  private const MIDDLE = 2000;
+  private const OLDEST = 1000;
+
+  /**
+   * The editor whose read state is under test.
+   */
+  protected User $editor;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installSchema('user', ['users_data']);
+
+    // ys_core's install config is deliberately not imported here: it carries
+    // config objects without schema, and the announcement defaults this test
+    // needs (enabled, and a feed URL that is never fetched because the parsed
+    // feed is seeded below) are what the service already falls back to. Uid 1
+    // is the superuser and short-circuits permission checks, so the read state
+    // under test belongs to a regular account.
+    $this->editor = User::create(['name' => 'editor']);
+    $this->editor->save();
+
+    $this->seedFeed();
+  }
+
+  /**
+   * Seeds the parsed-feed cache so no HTTP request is made.
+   *
+   * The service returns the keyvalue entry verbatim when present, which is the
+   * same path a real request takes on any page load after the first.
+   */
+  protected function seedFeed(): void {
+    $items = [
+      [
+        'title' => 'Newest item',
+        'url' => 'https://example.com/newest',
+        'summary' => '',
+        'timestamp' => self::NEWEST,
+        'date' => 'March 1, 2026',
+      ],
+      [
+        'title' => 'Middle item',
+        'url' => 'https://example.com/middle',
+        'summary' => '',
+        'timestamp' => self::MIDDLE,
+        'date' => 'February 1, 2026',
+      ],
+      [
+        'title' => 'Oldest item',
+        'url' => 'https://example.com/oldest',
+        'summary' => '',
+        'timestamp' => self::OLDEST,
+        'date' => 'January 1, 2026',
+      ],
+    ];
+    \Drupal::service('keyvalue.expirable')
+      ->get(DashboardAnnouncements::STORE_COLLECTION)
+      ->setWithExpire(DashboardAnnouncements::STORE_KEY, $items, 3600);
+  }
+
+  /**
+   * Sets the editor's stored last-seen timestamp.
+   */
+  protected function setLastSeen(?int $timestamp): void {
+    $user_data = \Drupal::service('user.data');
+    if ($timestamp === NULL) {
+      $user_data->delete(DashboardAnnouncements::USER_DATA_MODULE, (int) $this->editor->id(), DashboardAnnouncements::USER_DATA_LAST_SEEN);
+      return;
+    }
+    $user_data->set(DashboardAnnouncements::USER_DATA_MODULE, (int) $this->editor->id(), DashboardAnnouncements::USER_DATA_LAST_SEEN, $timestamp);
+  }
+
+  /**
+   * Reads the editor's stored last-seen timestamp.
+   */
+  protected function getLastSeen(): ?int {
+    $value = \Drupal::service('user.data')
+      ->get(DashboardAnnouncements::USER_DATA_MODULE, (int) $this->editor->id(), DashboardAnnouncements::USER_DATA_LAST_SEEN);
+    return $value === NULL ? NULL : (int) $value;
+  }
+
+  /**
+   * Builds the dashboard render array as the editor.
+   */
+  protected function buildDashboard(): array {
+    \Drupal::currentUser()->setAccount($this->editor);
+    return DashboardController::create($this->container)->content();
+  }
+
+  /**
+   * Renders a build array and returns an XPath query over its markup.
+   */
+  protected function renderAndQuery(array $build): \DOMXPath {
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+
+    $dom = new \DOMDocument();
+    // The dashboard is a fragment, and Views may emit markup DOMDocument warns
+    // about; neither is what these tests assert on.
+    @$dom->loadHTML('<?xml encoding="utf-8" ?>' . $html);
+
+    return new \DOMXPath($dom);
+  }
+
+  /**
+   * Presses the "mark all as read" control as the editor.
+   */
+  protected function submitMarkAllRead(): void {
+    \Drupal::currentUser()->setAccount($this->editor);
+    // submitForm() takes both arguments by reference, so they have to be real
+    // variables rather than inline expressions.
+    $form_object = MarkAnnouncementsReadForm::create($this->container);
+    $form_state = new FormState();
+    \Drupal::formBuilder()->submitForm($form_object, $form_state);
+  }
+
+  /**
+   * XPath predicate matching an element carrying the given class.
+   */
+  protected static function hasClass(string $class): string {
+    return sprintf('contains(concat(" ", normalize-space(@class), " "), " %s ")', $class);
+  }
+
+  /**
+   * Only unread announcements carry a marker, and the list order is unchanged.
+   */
+  public function testOnlyUnreadItemsAreMarkedNew(): void {
+    $this->setLastSeen(self::MIDDLE);
+
+    $xpath = $this->renderAndQuery($this->buildDashboard());
+
+    $items = $xpath->query(sprintf('//li[%s]', self::hasClass('ys-dashboard__announcement')));
+    $this->assertCount(3, $items, 'All three announcements render.');
+
+    $titles = [];
+    $marked = [];
+    foreach ($items as $item) {
+      // The marker lives inside the heading, so read the title from its link
+      // rather than from the heading's whole text content.
+      $titles[] = trim($xpath->query(sprintf('.//*[%s]//a', self::hasClass('ys-dashboard__announcement-title')), $item)->item(0)->textContent);
+      $marked[] = $xpath->query(sprintf('.//*[%s]', self::hasClass('ys-dashboard__announcement-new')), $item)->count() === 1;
+    }
+
+    $this->assertSame(['Newest item', 'Middle item', 'Oldest item'], $titles, 'Marking an item new does not reorder the feed.');
+    $this->assertSame([TRUE, FALSE, FALSE], $marked, 'Only the announcement newer than last-seen is marked.');
+  }
+
+  /**
+   * Several announcements can be marked new at once.
+   */
+  public function testEveryUnreadItemIsMarkedWhenNothingHasBeenSeen(): void {
+    $this->setLastSeen(NULL);
+
+    $xpath = $this->renderAndQuery($this->buildDashboard());
+
+    $this->assertSame(3, $xpath->query(sprintf('//*[%s]', self::hasClass('ys-dashboard__announcement-new')))->count());
+  }
+
+  /**
+   * The marker is not communicated by colour alone.
+   *
+   * WCAG 1.4.1: the visual pill must be backed by text a screen reader reads,
+   * and it must sit inside the announcement's own list item so it is announced
+   * next to the title rather than orphaned from it.
+   */
+  public function testMarkerCarriesTextEquivalentNextToItsTitle(): void {
+    $this->setLastSeen(self::MIDDLE);
+
+    $xpath = $this->renderAndQuery($this->buildDashboard());
+
+    $markers = $xpath->query(sprintf('//li[%s]//*[%s]', self::hasClass('ys-dashboard__announcement'), self::hasClass('ys-dashboard__announcement-new')));
+    $this->assertCount(1, $markers, 'The marker lives inside the announcement it describes.');
+
+    $text = preg_replace('/\s+/', ' ', trim($markers->item(0)->textContent));
+    $this->assertStringContainsStringIgnoringCase('new', $text, 'The marker has a text equivalent, not colour alone.');
+    $this->assertStringContainsStringIgnoringCase(
+      'announcement',
+      $text,
+      'The marker names what is new so it stands on its own when read out of context.'
+    );
+  }
+
+  /**
+   * The clearing control is offered only when something is actually unread.
+   */
+  public function testClearingControlIsHiddenWhenNothingIsUnread(): void {
+    $this->setLastSeen(self::NEWEST);
+
+    $build = $this->buildDashboard();
+    $xpath = $this->renderAndQuery($build);
+
+    $this->assertSame(0, $xpath->query(sprintf('//*[%s]', self::hasClass('ys-dashboard__announcement-new')))->count(), 'Nothing is marked new.');
+    $this->assertArrayNotHasKey('#mark_all_read_form', $build, 'No clearing control is built when there is nothing to clear.');
+  }
+
+  /**
+   * The clearing control is a real, self-describing, keyboard-operable button.
+   */
+  public function testClearingControlIsKeyboardOperable(): void {
+    $this->setLastSeen(self::MIDDLE);
+
+    $build = $this->buildDashboard();
+    $this->assertArrayHasKey('#mark_all_read_form', $build, 'A clearing control is built when something is unread.');
+
+    $xpath = $this->renderAndQuery($build);
+    $buttons = $xpath->query('//form//input[@type="submit"] | //form//button[@type="submit"]');
+    $this->assertGreaterThan(0, $buttons->count(), 'The control is a real submit button, so it is keyboard operable.');
+
+    $button = $buttons->item(0);
+    $name = $button->hasAttribute('value') ? $button->getAttribute('value') : $button->textContent;
+    // Names both the action and what it acts on, so it holds up when a screen
+    // reader user reads the button out of its surrounding context.
+    $this->assertStringContainsStringIgnoringCase('mark all announcements as read', $name);
+  }
+
+  /**
+   * Viewing the dashboard leaves read state untouched.
+   *
+   * This is the regression this ticket exists for: the previous behaviour
+   * stamped last-seen forward on every page view, so glancing at the dashboard
+   * silently burned the editor's unread markers.
+   */
+  public function testViewingTheDashboardDoesNotClearReadState(): void {
+    $this->setLastSeen(self::OLDEST);
+
+    $this->renderAndQuery($this->buildDashboard());
+    $this->renderAndQuery($this->buildDashboard());
+
+    $this->assertSame(self::OLDEST, $this->getLastSeen(), 'Rendering the dashboard did not advance last-seen.');
+    $this->assertSame(
+      2,
+      \Drupal::service('ys_core.dashboard_announcements')->getUnreadCount($this->editor),
+      'The unread count survives repeat visits.'
+    );
+  }
+
+  /**
+   * A view by a user who has never seen anything still writes nothing.
+   */
+  public function testViewingTheDashboardWritesNoReadStateAtAll(): void {
+    $this->setLastSeen(NULL);
+
+    $this->renderAndQuery($this->buildDashboard());
+
+    $this->assertNull($this->getLastSeen(), 'No last-seen value was created by viewing the dashboard.');
+  }
+
+  /**
+   * Submitting the control clears every marker and the toolbar badge.
+   *
+   * The badge is a per-user lazy builder keyed on unreadCacheTag(), so the
+   * clearing action has to invalidate that tag for the badge to catch up
+   * without a manual cache rebuild.
+   */
+  public function testSubmittingTheControlClearsMarkersAndBadge(): void {
+    $this->setLastSeen(self::OLDEST);
+    \Drupal::currentUser()->setAccount($this->editor);
+
+    $tag = DashboardAnnouncements::unreadCacheTag((int) $this->editor->id());
+    $checksum = \Drupal::service('cache_tags.invalidator.checksum');
+    $before = $checksum->getCurrentChecksum([$tag]);
+
+    $this->submitMarkAllRead();
+
+    $this->assertSame(self::NEWEST, $this->getLastSeen(), 'Read state advanced to the newest announcement.');
+    $this->assertSame(
+      0,
+      \Drupal::service('ys_core.dashboard_announcements')->getUnreadCount($this->editor),
+      'Nothing is unread after clearing.'
+    );
+    $this->assertNotSame($before, $checksum->getCurrentChecksum([$tag]), 'The per-user badge cache tag was invalidated.');
+
+    $xpath = $this->renderAndQuery($this->buildDashboard());
+    $this->assertSame(0, $xpath->query(sprintf('//*[%s]', self::hasClass('ys-dashboard__announcement-new')))->count(), 'No markers remain.');
+  }
+
+  /**
+   * Clearing confirms itself to assistive technology, not just visually.
+   */
+  public function testSubmittingTheControlAnnouncesTheResult(): void {
+    $this->setLastSeen(self::OLDEST);
+
+    $this->submitMarkAllRead();
+
+    $messages = \Drupal::messenger()->messagesByType('status');
+    $this->assertNotEmpty($messages, 'A status message confirms the action.');
+    $this->assertStringContainsStringIgnoringCase(
+      'marked as read',
+      implode(' ', array_map('strval', $messages)),
+      'The confirmation says what happened rather than relying on the markers simply vanishing.'
+    );
+  }
+
+  /**
+   * The per-user render must not be shared between editors.
+   *
+   * The markers vary per user, so the page has to carry the user cache context
+   * and the per-user badge tag or one editor's markers get served to another
+   * from the shared render cache.
+   */
+  public function testRenderIsCachedPerUser(): void {
+    $this->setLastSeen(self::MIDDLE);
+
+    $build = $this->buildDashboard();
+
+    $this->assertContains('user', $build['#cache']['contexts'], 'The render varies per user.');
+    $this->assertContains(
+      DashboardAnnouncements::unreadCacheTag((int) $this->editor->id()),
+      $build['#cache']['tags'],
+      'The render is invalidated when this user clears their announcements.'
+    );
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/DashboardToolbarBadgeTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/DashboardToolbarBadgeTest.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\Core\Session\AnonymousUserSession;
+use Drupal\Core\Url;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\User;
+use Drupal\ys_core\DashboardAnnouncements;
+
+/**
+ * Tests the unread-announcements badge on the Dashboard admin menu link.
+ *
+ * The badge is only correct if its placeholder stays user-agnostic and resolves
+ * the viewer at replacement time; the attach site explains why at length.
+ *
+ * @see _ys_core_attach_dashboard_badge_walk()
+ *
+ * @group ys_core
+ * @group yalesites
+ */
+class DashboardToolbarBadgeTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'ys_core'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Timestamps for the seeded feed, newest first.
+   */
+  private const NEWEST = 3000;
+  private const MIDDLE = 2000;
+  private const OLDEST = 1000;
+
+  /**
+   * The editor who warms the shared toolbar cache entry first.
+   */
+  protected User $first;
+
+  /**
+   * A second editor sharing that entry, with different read state.
+   */
+  protected User $second;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installSchema('user', ['users_data']);
+
+    // Uid 1 short-circuits permission checks, so neither account under test is
+    // the superuser.
+    User::create(['name' => 'superuser'])->save();
+    $this->first = User::create(['name' => 'first_editor']);
+    $this->first->save();
+    $this->second = User::create(['name' => 'second_editor']);
+    $this->second->save();
+
+    $this->seedFeed();
+  }
+
+  /**
+   * Seeds the parsed-feed cache so no HTTP request is made.
+   */
+  protected function seedFeed(): void {
+    $items = [];
+    foreach ([self::NEWEST, self::MIDDLE, self::OLDEST] as $timestamp) {
+      $items[] = [
+        'title' => 'Item ' . $timestamp,
+        'url' => 'https://example.com/' . $timestamp,
+        'summary' => '',
+        'timestamp' => $timestamp,
+        'date' => 'January 1, 2026',
+      ];
+    }
+    \Drupal::service('keyvalue.expirable')
+      ->get(DashboardAnnouncements::STORE_COLLECTION)
+      ->setWithExpire(DashboardAnnouncements::STORE_KEY, $items, 3600);
+  }
+
+  /**
+   * Sets an account's stored last-seen timestamp.
+   */
+  protected function setLastSeen(User $account, int $timestamp): void {
+    \Drupal::service('user.data')->set(
+      DashboardAnnouncements::USER_DATA_MODULE,
+      (int) $account->id(),
+      DashboardAnnouncements::USER_DATA_LAST_SEEN,
+      $timestamp
+    );
+  }
+
+  /**
+   * Runs the menu preprocess as the given account and returns the badge.
+   *
+   * Mirrors the real admin menu shape: the Dashboard link is nested under the
+   * `system.admin` root wrapper rather than sitting at depth 0.
+   *
+   * Calls the badge attach helper rather than ys_core_preprocess_menu(), which
+   * only dispatches to it on the `admin` menu. The wrapper also rewrites node
+   * menu links from field_external_source, which would drag the whole node
+   * entity system into a test about the toolbar badge.
+   *
+   * @return array
+   *   The badge element ys_core_preprocess_menu() attached to the link title.
+   */
+  protected function buildBadgePlaceholder(User $account): array {
+    \Drupal::currentUser()->setAccount($account);
+
+    $variables = [
+      'menu_name' => 'admin',
+      'items' => [
+        'system.admin' => [
+          'title' => 'Administration',
+          'url' => Url::fromRoute('system.admin'),
+          'below' => [
+            'ys_core.admin_dashboard' => [
+              'title' => 'Dashboard',
+              'url' => Url::fromRoute('ys_core.admin_dashboard'),
+              'below' => [],
+            ],
+          ],
+        ],
+      ],
+    ];
+    _ys_core_attach_dashboard_badge($variables);
+
+    return $variables['items']['system.admin']['below']['ys_core.admin_dashboard']['title']['#context']['badge'];
+  }
+
+  /**
+   * Resolves a placeholder's #lazy_builder as the render pipeline would.
+   *
+   * Goes through core's callable resolver, the same service Renderer uses, so
+   * the test does not encode its own assumptions about callback syntax.
+   *
+   * @return array
+   *   The render array the lazy builder produced.
+   */
+  protected function replayLazyBuilder(array $placeholder): array {
+    [$callback, $arguments] = $placeholder['#lazy_builder'];
+    $callable = \Drupal::service('callable_resolver')->getCallableFromDefinition($callback);
+    return call_user_func_array($callable, $arguments);
+  }
+
+  /**
+   * Reads the rendered count out of a badge build, or NULL when absent.
+   */
+  protected static function badgeCount(array $build): ?int {
+    return isset($build['badge']['#value']) ? (int) $build['badge']['#value'] : NULL;
+  }
+
+  /**
+   * The placeholder must not differ between users sharing a cache entry.
+   *
+   * Asserts on the generated token, not just the arguments: the token is a hash
+   * of the whole placeholder array, so this also catches user-varying cache
+   * metadata being added to the element. Anything user-specific in there makes
+   * one editor's token the token everybody else's shared toolbar entry is
+   * stored with.
+   */
+  public function testPlaceholderIsIdenticalForEveryUser(): void {
+    $this->setLastSeen($this->first, self::OLDEST);
+    $this->setLastSeen($this->second, self::MIDDLE);
+
+    $generator = \Drupal::service('render_placeholder_generator');
+    $for_first = $generator->createPlaceholder($this->buildBadgePlaceholder($this->first));
+    $for_second = $generator->createPlaceholder($this->buildBadgePlaceholder($this->second));
+
+    $this->assertSame(
+      (string) $for_first['#markup'],
+      (string) $for_second['#markup'],
+      'The badge placeholder carries nothing user-specific, so a shared toolbar cache entry is safe to reuse.'
+    );
+  }
+
+  /**
+   * The badge shows the viewer's count, not the count it was cached with.
+   *
+   * This is the reported bug: an editor pressed "mark all as read", their own
+   * markers cleared, and the toolbar kept showing a count belonging to whoever
+   * warmed the shared toolbar cache entry first.
+   */
+  public function testBadgeRendersForTheViewingUser(): void {
+    // One unread for the first editor, none for the second.
+    $this->setLastSeen($this->first, self::MIDDLE);
+    $this->setLastSeen($this->second, self::NEWEST);
+
+    $placeholder = $this->buildBadgePlaceholder($this->first);
+    $this->assertSame(1, self::badgeCount($this->replayLazyBuilder($placeholder)));
+
+    // The second editor now hits the entry the first editor warmed.
+    \Drupal::currentUser()->setAccount($this->second);
+
+    $this->assertNull(
+      self::badgeCount($this->replayLazyBuilder($placeholder)),
+      'The second editor has nothing unread, so no count is rendered for them.'
+    );
+  }
+
+  /**
+   * Clearing read state clears the badge on the very next render.
+   *
+   * Marking all read invalidates this user's badge tag, which only reaches
+   * the badge if the badge is rendered for -- and tagged for -- the viewer.
+   */
+  public function testBadgeClearsAfterMarkingAllRead(): void {
+    $this->setLastSeen($this->first, self::OLDEST);
+
+    $placeholder = $this->buildBadgePlaceholder($this->first);
+    $this->assertSame(2, self::badgeCount($this->replayLazyBuilder($placeholder)));
+
+    \Drupal::service('ys_core.dashboard_announcements')->markAllRead($this->first);
+
+    $this->assertNull(
+      self::badgeCount($this->replayLazyBuilder($placeholder)),
+      'The badge is gone once the editor has marked everything read.'
+    );
+  }
+
+  /**
+   * The rendered badge is invalidated by the viewer's own read state.
+   */
+  public function testBadgeCarriesTheViewingUsersCacheability(): void {
+    $this->setLastSeen($this->second, self::OLDEST);
+
+    $placeholder = $this->buildBadgePlaceholder($this->first);
+    \Drupal::currentUser()->setAccount($this->second);
+    $build = $this->replayLazyBuilder($placeholder);
+
+    $this->assertContains('user', $build['#cache']['contexts']);
+    $this->assertContains(
+      DashboardAnnouncements::unreadCacheTag((int) $this->second->id()),
+      $build['#cache']['tags'],
+      'The badge is tagged for the user it was rendered for.'
+    );
+  }
+
+  /**
+   * An anonymous visitor gets no badge.
+   */
+  public function testAnonymousGetsNoBadge(): void {
+    $this->setLastSeen($this->first, self::OLDEST);
+
+    $placeholder = $this->buildBadgePlaceholder($this->first);
+    \Drupal::currentUser()->setAccount(new AnonymousUserSession());
+
+    $this->assertNull(self::badgeCount($this->replayLazyBuilder($placeholder)));
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/DashboardAnnouncementsUnreadTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/DashboardAnnouncementsUnreadTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Unit;
+
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\DependencyInjection\ClassResolverInterface;
+use Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface;
+use Drupal\Core\KeyValueStore\KeyValueStoreExpirableInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\user\UserDataInterface;
+use Drupal\ys_core\DashboardAnnouncements;
+use GuzzleHttp\ClientInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Tests the per-user unread state derived for each dashboard announcement.
+ *
+ * The toolbar badge count and the per-item "new" marker on the dashboard have
+ * to agree, because they are two views of the same question: is this item
+ * newer than the user's `announcements_last_seen` high-water mark. These tests
+ * pin them to a single derivation so a future change cannot drift one without
+ * the other.
+ *
+ * @group ys_core
+ * @group yalesites
+ * @coversDefaultClass \Drupal\ys_core\DashboardAnnouncements
+ */
+class DashboardAnnouncementsUnreadTest extends UnitTestCase {
+
+  /**
+   * A cached feed of three items, newest first, two days apart.
+   *
+   * Mirrors the shape getAnnouncements() writes to the keyvalue store.
+   */
+  private const NEWEST = 3000;
+  private const MIDDLE = 2000;
+  private const OLDEST = 1000;
+
+  /**
+   * Builds the service with a pre-populated feed cache and last-seen value.
+   *
+   * Seeding the keyvalue store is how getAnnouncements() short-circuits, so
+   * this exercises the real unread logic without any HTTP.
+   *
+   * @param array $items
+   *   The cached announcement items.
+   * @param int|null $last_seen
+   *   The stored `announcements_last_seen` value, or NULL when never set.
+   * @param array $written
+   *   Populated with any user.data write the service performs, by reference.
+   */
+  private function service(array $items, ?int $last_seen, array &$written = []): DashboardAnnouncements {
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnCallback(fn (string $key) => match ($key) {
+      'announcements_enabled' => TRUE,
+      'announcements_feed_url' => 'https://example.com/feed',
+      default => NULL,
+    });
+    $config_factory = $this->createMock('Drupal\Core\Config\ConfigFactoryInterface');
+    $config_factory->method('get')->willReturn($config);
+
+    $store = $this->createMock(KeyValueStoreExpirableInterface::class);
+    $store->method('get')->willReturn($items);
+    $key_value = $this->createMock(KeyValueExpirableFactoryInterface::class);
+    $key_value->method('get')->willReturn($store);
+
+    $user_data = $this->createMock(UserDataInterface::class);
+    $user_data->method('get')->willReturn($last_seen === NULL ? NULL : (string) $last_seen);
+    $user_data->method('set')->willReturnCallback(function ($module, $uid, $key, $value) use (&$written) {
+      $written[] = [$module, $uid, $key, $value];
+    });
+
+    return new DashboardAnnouncements(
+      $this->createMock(ClientInterface::class),
+      $config_factory,
+      $key_value,
+      $this->createMock(DateFormatterInterface::class),
+      $this->createMock(LoggerChannelFactoryInterface::class),
+      $user_data,
+      $this->createMock(RequestStack::class),
+      $this->createMock(ClassResolverInterface::class),
+    );
+  }
+
+  /**
+   * Three cached items with descending timestamps.
+   */
+  private function threeItems(): array {
+    return [
+      ['title' => 'Newest', 'url' => '', 'summary' => '', 'timestamp' => self::NEWEST, 'date' => ''],
+      ['title' => 'Middle', 'url' => '', 'summary' => '', 'timestamp' => self::MIDDLE, 'date' => ''],
+      ['title' => 'Oldest', 'url' => '', 'summary' => '', 'timestamp' => self::OLDEST, 'date' => ''],
+    ];
+  }
+
+  /**
+   * An authenticated account stub.
+   */
+  private function account(bool $anonymous = FALSE): AccountInterface {
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('isAnonymous')->willReturn($anonymous);
+    $account->method('id')->willReturn(7);
+    return $account;
+  }
+
+  /**
+   * Only items newer than last-seen are flagged new, and order is preserved.
+   *
+   * Feed order is the platform's editorial order, so flagging must not
+   * reorder or filter the list.
+   *
+   * @covers ::getAnnouncementsForUser
+   */
+  public function testFlagsOnlyItemsNewerThanLastSeen(): void {
+    $service = $this->service($this->threeItems(), self::MIDDLE);
+
+    $items = $service->getAnnouncementsForUser($this->account());
+
+    $this->assertSame(['Newest', 'Middle', 'Oldest'], array_column($items, 'title'), 'Feed order is unchanged.');
+    $this->assertSame([TRUE, FALSE, FALSE], array_column($items, 'is_new'), 'Only the item newer than last-seen is new.');
+  }
+
+  /**
+   * A user who has never visited sees every dated item as new.
+   *
+   * @covers ::getAnnouncementsForUser
+   */
+  public function testEverythingIsNewWithNoLastSeen(): void {
+    $service = $this->service($this->threeItems(), NULL);
+
+    $items = $service->getAnnouncementsForUser($this->account());
+
+    $this->assertSame([TRUE, TRUE, TRUE], array_column($items, 'is_new'));
+  }
+
+  /**
+   * An item with no parseable date is never flagged new.
+   *
+   * A missing `date_published` leaves `timestamp` NULL, and there is no basis
+   * for calling such an item unread -- it would otherwise stay marked new
+   * forever, since marking read only ever advances the timestamp.
+   *
+   * @covers ::getAnnouncementsForUser
+   */
+  public function testUndatedItemIsNeverNew(): void {
+    $service = $this->service([
+      ['title' => 'Undated', 'url' => '', 'summary' => '', 'timestamp' => NULL, 'date' => ''],
+    ], NULL);
+
+    $items = $service->getAnnouncementsForUser($this->account());
+
+    $this->assertSame([FALSE], array_column($items, 'is_new'));
+  }
+
+  /**
+   * An anonymous account resolves no unread state and no items.
+   *
+   * There is nowhere to store read state for a session with no account, so
+   * there is nothing to decorate -- and short-circuiting before the feed is
+   * touched keeps a stray anonymous call from triggering an outbound fetch.
+   *
+   * @covers ::getAnnouncementsForUser
+   * @covers ::getUnreadCount
+   */
+  public function testAnonymousResolvesNoUnreadState(): void {
+    $service = $this->service($this->threeItems(), NULL);
+    $anonymous = $this->account(TRUE);
+
+    $this->assertSame([], $service->getAnnouncementsForUser($anonymous));
+    $this->assertSame(0, $service->getUnreadCount($anonymous));
+  }
+
+  /**
+   * The badge count is the number of items the marker flags, for real values.
+   *
+   * This is the "no second source of truth" guarantee: the markers the editor
+   * sees on the dashboard and the number in the toolbar are the same fact.
+   * Asserted against absolute expected counts rather than by re-deriving the
+   * count from getAnnouncementsForUser() -- getUnreadCount() *is* that
+   * derivation, so comparing the two to each other would hold even if the
+   * comparison were inverted.
+   *
+   * @covers ::getUnreadCount
+   * @covers ::getAnnouncementsForUser
+   * @covers ::countUnread
+   */
+  public function testUnreadCountMatchesFlaggedItems(): void {
+    $cases = [
+      // [stored last-seen, expected unread out of the three seeded items].
+      [NULL, 3],
+      [self::OLDEST - 1, 3],
+      [self::OLDEST, 2],
+      [self::MIDDLE, 1],
+      [self::NEWEST, 0],
+      [self::NEWEST + 1, 0],
+    ];
+
+    foreach ($cases as [$last_seen, $expected]) {
+      $service = $this->service($this->threeItems(), $last_seen);
+      $account = $this->account();
+      $context = sprintf('last-seen %s', var_export($last_seen, TRUE));
+
+      $this->assertSame(
+        $expected,
+        $service->getUnreadCount($account),
+        sprintf('%s leaves %d unread.', $context, $expected)
+      );
+      $this->assertSame(
+        $expected,
+        DashboardAnnouncements::countUnread($service->getAnnouncementsForUser($account)),
+        sprintf('%s flags %d items new, matching the badge count.', $context, $expected)
+      );
+    }
+  }
+
+  /**
+   * Reading the per-item flags never writes read state.
+   *
+   * Rendering the dashboard must be a pure read: clearing is an explicit
+   * action, so merely looking at the announcements cannot advance the
+   * high-water mark.
+   *
+   * @covers ::getAnnouncementsForUser
+   */
+  public function testFlaggingDoesNotWriteReadState(): void {
+    $written = [];
+    $service = $this->service($this->threeItems(), self::OLDEST, $written);
+
+    $service->getAnnouncementsForUser($this->account());
+    $service->getUnreadCount($this->account());
+
+    $this->assertSame([], $written, 'No user.data write happened while reading unread state.');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.libraries.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.libraries.yml
@@ -1,11 +1,21 @@
+# The unread-announcements pill, shared by the dashboard page's per-item "New"
+# marker and the admin toolbar's unread count.
+badge:
+  css:
+    theme:
+      css/badge.css: {}
 dashboard:
   css:
     theme:
       css/dashboard.css: {}
+  dependencies:
+    - ys_core/badge
 dashboard_badge:
   css:
     theme:
       css/dashboard-badge.css: {}
+  dependencies:
+    - ys_core/badge
 node_layout_form:
   css:
     theme:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -1401,12 +1401,10 @@ function ys_core_facts_icon_allowed_values(FieldStorageDefinitionInterface $defi
  * across users while the count is resolved per-user at render time.
  */
 function _ys_core_attach_dashboard_badge(array &$variables) {
-  $current_user = \Drupal::currentUser();
-  if ($current_user->isAnonymous()) {
+  if (\Drupal::currentUser()->isAnonymous()) {
     return;
   }
-  $uid = (int) $current_user->id();
-  if (_ys_core_attach_dashboard_badge_walk($variables['items'], $uid)) {
+  if (_ys_core_attach_dashboard_badge_walk($variables['items'])) {
     $variables['#attached']['library'][] = 'ys_core/dashboard_badge';
   }
 }
@@ -1416,8 +1414,20 @@ function _ys_core_attach_dashboard_badge(array &$variables) {
  *
  * The admin menu nests its real top-level entries under a root
  * `system.admin` wrapper, so we cannot assume the link is at depth 0.
+ *
+ * The #lazy_builder deliberately takes no arguments -- do not "helpfully" pass
+ * the uid. The placeholder's parent is core's toolbar, render cached as
+ * `keys: ['toolbar'], contexts: ['user.permissions']`, so a single entry is
+ * shared by every user holding the same permissions, and a placeholder's own
+ * cache metadata cannot make it vary per user (createPlaceholder() returns only
+ * #markup and #attached). The token is a hash of the placeholder array,
+ * arguments included, so a uid baked in here is one editor's uid frozen into
+ * an entry everyone else reads: they would see that editor's count, and
+ * clearing their own read state could not invalidate an entry tagged for
+ * somebody else. Resolving the viewer inside the lazy builder keeps the
+ * placeholder user-agnostic and correct for whoever it is replaced for.
  */
-function _ys_core_attach_dashboard_badge_walk(array &$items, int $uid): bool {
+function _ys_core_attach_dashboard_badge_walk(array &$items): bool {
   $found = FALSE;
   foreach ($items as &$item) {
     $url = $item['url'] ?? NULL;
@@ -1430,7 +1440,7 @@ function _ys_core_attach_dashboard_badge_walk(array &$items, int $uid): bool {
           'badge' => [
             '#lazy_builder' => [
               'ys_core.dashboard_toolbar_lazy_builders:renderBadge',
-              [(string) $uid],
+              [],
             ],
             '#create_placeholder' => TRUE,
           ],
@@ -1439,7 +1449,7 @@ function _ys_core_attach_dashboard_badge_walk(array &$items, int $uid): bool {
       $found = TRUE;
     }
     if (!empty($item['below']) && is_array($item['below'])) {
-      $found = _ys_core_attach_dashboard_badge_walk($item['below'], $uid) || $found;
+      $found = _ys_core_attach_dashboard_badge_walk($item['below']) || $found;
     }
   }
   return $found;

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -48,6 +48,9 @@ function ys_core_theme($existing, $type, $theme, $path): array {
       'variables' => [
         'platform_version' => NULL,
         'announcements' => [],
+        // Only built when the user actually has unread announcements, so this
+        // stays NULL the rest of the time and the control is not rendered.
+        'mark_all_read_form' => NULL,
       ],
     ],
     'ys_social_links' => [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.services.yml
@@ -22,7 +22,7 @@ services:
   # Lazy builders for the dashboard menu badge.
   ys_core.dashboard_toolbar_lazy_builders:
     class: Drupal\ys_core\Toolbar\DashboardToolbarLazyBuilders
-    arguments: ['@ys_core.dashboard_announcements', '@entity_type.manager']
+    arguments: ['@ys_core.dashboard_announcements', '@current_user']
   # Redirect visitors to external source if set on the node.
   ys_core.external_source_redirect_subscriber:
     class: Drupal\ys_core\EventSubscriber\ExternalSourceRedirectSubscriber


### PR DESCRIPTION
## [1558: RC: Dashboard: indicate which announcement is new in the Announcements section](https://github.com/yalesites-org/YaleSites-Internal/issues/1558)

### Description of work

The Dashboard menu item already picks up an unread badge when a new announcement is published, but the dashboard itself rendered every announcement identically — editors knew *something* was new, not *which* post. Worse, `DashboardController::content()` called `markAllRead()` on every page view, so an editor glancing at the dashboard on their way to edit a page silently burned their unread markers without reading anything.

This adds a per-item marker and moves clearing off the page-view path onto an explicit control.

- **Per-item "New" marker.** `DashboardAnnouncements::getAnnouncementsForUser()` decorates each item with an `is_new` flag derived from the same `announcements_last_seen` comparison that already drives the toolbar badge count. `getUnreadCount()` is now re-expressed on top of it, so the badge number and the on-page markers are the same fact and cannot drift — no second source of truth, and no change to the read-state data model.
- **Explicit clearing.** A new `MarkAnnouncementsReadForm` calls the existing `markAllRead()`. The automatic stamp on dashboard view is gone: viewing the dashboard no longer clears anything. The control is only built when something is actually unread, so editors are never offered a button that would do nothing.
- **Cache correctness.** The announcements render now varies per user, so the page carries the `user` cache context (which subsumes the `user.permissions` context it had) and the existing `DashboardAnnouncements::unreadCacheTag($uid)` tag. `markAllRead()` already invalidates that tag, so the markers and the toolbar badge clear in the same interaction with no manual cache rebuild — verified locally.
- **Reuse.** The marker reuses the existing `.ys-dashboard-badge` pill that the toolbar count already uses (`ys_core/dashboard` now depends on `ys_core/dashboard_badge`) rather than restating the pill's shape and colour.

Feed order is untouched — marking an item new does not reorder anything.

**Accessibility (WCAG 2.1 AA).** The marker is not colour-alone: the pill contains the visible word "New" plus a visually hidden " announcement", and sits inside the announcement's own `h3` so it is announced together with the title rather than orphaned from it. The control is a real submit button with the self-describing name "Mark all announcements as read", and pressing it emits a status message ("All announcements have been marked as read.") so the result reaches assistive tech instead of markers merely vanishing. A light accessibility gate over the rendered section passed with no Critical or Serious findings; measured contrast is 4.93:1 for the pill text and 6.38:1 for the button label, both clear of the 4.5:1 AA threshold at the 12px size used.

**Known tradeoff, per the ticket and intended:** if an editor never presses the button, the badge stays up indefinitely. There is deliberately no time-based auto-clear.

**Two things for the reviewer to weigh in on:**

1. **Design/UX sign-off is still outstanding.** The ticket asks Design and UX to pick the affordance rather than shipping developer choice. This PR picks a **"New" text pill** (over a red count or a whole-row highlight) because the text carries the meaning on its own — which the accessibility criteria require anyway — and because a per-item marker scales when several items are new at once. The "Mark all announcements as read" control sits in the Announcements section header, right-aligned beside the heading, so its relationship to the list it acts on is unambiguous. Both are cheap to change: the pill is one Twig block plus scoped CSS.
2. Contrast was measured in Gin **light** mode. The pill's red/white pair is fixed rather than themed so it should not vary, but a dark-mode spot check is worth an extra pair of eyes.

**On test coverage of the POST path, stated plainly:** the Kernel tests drive the form through `formBuilder()->submitForm()`, which core marks as programmed — that path skips CSRF validation and returns before redirect handling. So the automated tests pin `markAllRead()`, the cache-tag invalidation, the status message, and the rendered markup, but *not* the real request cycle. That cycle was verified **by hand** instead, twice: a `curl` POST carrying a genuine `form_build_id`/`form_token` scraped from the page, and a real button click driven through a browser. Both redirected back to the dashboard, emitted the status message, and left zero markers and no button. It is not covered by a `BrowserTestBase` test because Functional tests do not run in this local environment (and CI runs no PHPUnit at all), so an added one would have been unverifiable rather than reassuring.

Not done here: the ticket's documentation item (whether the dashboard user guide page on yalesites.yale.edu needs a line about the marker and the control) is a content change outside this repo.

### Functional testing steps

Dashboard announcements are per-site config (`ys_core*` is in `config_ignore`), so a local test needs the feed pointed somewhere first.

1. Set up a local announcements feed. Easiest is to make the site both source and consumer:
   - `lando drush config:set ys_core.dashboard_settings announcements_enabled 1 -y`
   - `lando drush config:set ys_core.dashboard_settings announcements_source_enabled 1 -y`
   - `lando drush config:set ys_core.dashboard_settings announcements_feed_url "https://<your-lando-host>/api/dashboard-announcements" -y`
2. Create a `tags` taxonomy term named **Dashboard Announcement**, then create 3 **Post** nodes tagged with it and **published** (set the moderation state to Published — `setPublished()` alone is not enough). Give them different `changed` times.
3. Make some of them unread for your user: `lando drush ev '\Drupal::service("user.data")->set("ys_core", <your-uid>, "announcements_last_seen", time() - 86400*3);'` then `lando drush cr`.
4. Visit `/admin/yalesites/dashboard`. **Expect:** a red "New" pill on each announcement newer than that timestamp and none on the older ones; the list order unchanged; a "Mark all announcements as read" button beside the Announcements heading; the Dashboard toolbar link showing a count equal to the number of pills.
5. **Reload the page a few times without pressing the button.** Expect the pills and the toolbar count to still be there — this is the regression the ticket is about, and it used to clear on the first view.
6. Press **Mark all announcements as read**. Expect: a green status message "All announcements have been marked as read."; every pill gone; the toolbar count gone in the same interaction (no cache rebuild); and the button itself gone, since there is nothing left to clear.
7. Keyboard/screen reader pass: Tab to the button and press Enter — it should behave identically. With a screen reader, the marker should read as "New announcement" next to its title, and the status message should be reachable.
8. Publish a new announcement post. Expect the pill and the toolbar count to come back for that item only.

#### Additional steps for the toolbar badge fix (review round 2)

The stale-badge report needs **two accounts and a real render cache** to reproduce, so it is worth
doing these on a multidev rather than locally. A default local checkout cannot show the bug at all:
`web/sites/default/settings.local.php` points the `render`, `page` and `dynamic_page_cache` bins at
`cache.backend.null`, and the bug lives in a cache entry that is never written there. Comment those
three lines out and `lando drush cr` if you do want to see it locally.

9. Make two accounts with the **same role** (e.g. two platform admins), and give them **different**
   unread counts — set `announcements_last_seen` per uid as in step 3.
10. `drush cr`, then load `/admin/content` as the **first** user and note the toolbar count.
11. Load `/admin/content` as the **second** user. **Expect:** their own count. Before this fix they
    saw the first user's count, because the toolbar cache entry is shared between users with the
    same permissions and had the first user's uid baked into it.
12. As the second user, open the dashboard, press **Mark all announcements as read**, then visit
    `/admin/content`, `/admin/config` and `/node/add`. **Expect:** no badge anywhere. This is the
    reported bug — the badge used to keep showing the other user's count on those pages.
13. Reload as the **first** user. **Expect:** their count is untouched — one editor clearing their
    own announcements must not clear anyone else's.
14. Log out and load the front page as an anonymous visitor. **Expect:** a normal page, no badge.

### Testing checklist

- [x] `lando composer lint:php` — exit 0
- [x] `lando composer code-sniff` (Drupal + DrupalPractice, whole custom tree) — exit 0
- [x] PHPUnit: `ys_core` suite — baseline 274 tests / 796 assertions / 0 failures / 1 skipped; after **290 tests / 868 assertions / 0 failures / 1 skipped** (same pre-existing skip). 16 new tests, no regressions.
- [x] Visual + interaction verification on local Lando
- [x] **Round 2:** two-user reproduction of the stale badge with the render/page/dynamic-page caches
      re-enabled, then the same sequence re-run against the fix — see steps 9-14
- [x] **Round 2:** `ys_core` Kernel suite 47 -> **52 tests / 580 assertions / 0 failures** (5 new,
      no regressions); Unit unchanged at 243 / 311 / 1 pre-existing skip
- [x] Light accessibility gate on the rendered section — pass

References yalesites-org/YaleSites-Internal#1558

