### PR TITLE
1565: Bug: MathJax loads from cdnjs with no integrity protection; self-host it instead

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,23 @@
           "reference": "2.2.1"
         }
       }
+    },
+    "mathjax": {
+      "type": "package",
+      "package": {
+        "name": "mathjax/mathjax",
+        "version": "2.7.9",
+        "type": "drupal-library",
+        "license": "Apache-2.0",
+        "dist": {
+          "url": "https://registry.npmjs.org/mathjax/-/mathjax-2.7.9.tgz",
+          "type": "tar",
+          "shasum": "d6b67955c173e7d719fcb2fc0288662884eb7d3d"
+        },
+        "extra": {
+          "installer-name": "MathJax"
+        }
+      }
     }
   },
   "require": {

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -114,6 +114,7 @@
     "drupal/webprofiler": "10.3.1",
     "drupal/workflow_buttons": "1.0-beta7",
     "jjj/chosen": "2.2.1",
+    "mathjax/mathjax": "2.7.9",
     "smalot/pdfparser": "2.11.0",
     "yalesites-org/ai_engine": "1.2.18",
     "yalesites-org/atomic": "1.81.0",

--- a/web/profiles/custom/yalesites_profile/config/sync/mathjax.settings.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/mathjax.settings.yml
@@ -1,6 +1,6 @@
 _core:
   default_config_hash: UOFmZIwiZl6qJ50XXrC2r_F26ZTYR_3-d93LAnL8J4w
-use_cdn: 1
+use_cdn: 0
 cdn_url: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
 config_type: 0
 default_config_string: '{"tex2jax":{"inlineMath":[["\\(","\\)"]],"displayMath":[["$$","$$"],["\\[","\\]"]],"processEscapes":true},"showProcessingMessages":false,"messageStyle":"none"}'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/README.md
@@ -50,4 +50,24 @@ page loads.
   typogrify (`basic_html`, `heading_html`, `restricted_html`), not just the ones
   with the MathJax filter enabled.
 - Delimiters and MathJax options are configured in `mathjax.settings`
-  (`config_type: 0`, single-dollar inline math disabled).
+  (`config_type: 0`, single-dollar inline math disabled, and `use_cdn: 0` so the
+  library is self-hosted rather than loaded from a CDN).
+- The library itself comes from the `mathjax` package repository in the **root**
+  `composer.json` and is installed by `composer install` into
+  `web/libraries/MathJax` — capital M, capital J, which the contrib module
+  hardcodes. If a checkout has no `web/libraries/MathJax`, math silently stops
+  rendering and the status report shows the contrib module's "local library
+  files could not be found" error; run `composer install` rather than
+  re-enabling the CDN.
+- **The pin must stay on MathJax 2.7.1 or later.** Contrib `mathjax` 4.x still
+  targets the MathJax 2.x API, so this is deliberately not a 3.x/4.x library.
+  Within 2.x, 2.7.0 and earlier fetch the accessibility menu from `[Contrib]`,
+  a path hardcoded to `cdn.mathjax.org`; 2.7.1+ bundle the a11y extensions and
+  reference them locally, which is what removes the last third-party origin.
+  `tests/src/Unit/MathjaxLibraryInstallTest.php` guards both the install path
+  and that property.
+- `cdn_url` is deliberately left at the contrib default. It is dead while
+  `use_cdn: 0`, the config schema wants a value, and `drush deploy` re-imports
+  `use_cdn: 0` anyway — so there is nothing to gain from editing it. Be aware
+  that it still names 2.7.0, the one build this module must not use, so toggling
+  the CDN back on for debugging is not a like-for-like comparison.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/tests/src/Kernel/MathjaxSelfHostedTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/tests/src/Kernel/MathjaxSelfHostedTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\Tests\ys_mathjax\Kernel;
+
+use Drupal\Core\Serialization\Yaml;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests that MathJax is served from this site rather than a third-party CDN.
+ *
+ * MathJax pulls its config, output jax, font data and extensions at runtime
+ * through its own loader, and those follow-up requests carry no integrity
+ * hashes. Serving the entry point from a third-party CDN therefore hands that
+ * origin arbitrary JavaScript execution on every public page containing math,
+ * and a subresource integrity hash on the entry point would not cover it. The
+ * platform ships `use_cdn: 0` so every MathJax asset comes from the site
+ * domain; this asserts the config a site actually runs with still does that.
+ *
+ * @group ys_mathjax
+ * @group yalesites
+ */
+class MathjaxSelfHostedTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['mathjax'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // The shipped config is what a site actually runs with, so it — not the
+    // contrib module's install defaults — is what this test asserts against.
+    $path = \Drupal::root() . '/profiles/custom/yalesites_profile/config/sync/mathjax.settings.yml';
+    $settings = Yaml::decode(file_get_contents($path));
+    unset($settings['_core']);
+    $this->config('mathjax.settings')->setData($settings)->save();
+  }
+
+  /**
+   * The shipped config disables the CDN and resolves the library locally.
+   */
+  public function testShippedConfigServesMathjaxLocally(): void {
+    $this->assertSame(0, $this->config('mathjax.settings')->get('use_cdn'), 'mathjax.settings must ship with use_cdn disabled so no third-party origin serves MathJax.');
+
+    $library = \Drupal::service('library.discovery')->getLibraryByName('mathjax', 'source');
+    $this->assertNotFalse($library, 'The mathjax/source library should be discoverable.');
+    $this->assertStringStartsWith('/libraries/MathJax/MathJax.js', $library['js'][0]['data'], 'The MathJax entry point should be a site-relative path, not a URL to another origin.');
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/tests/src/Unit/MathjaxLibraryInstallTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/tests/src/Unit/MathjaxLibraryInstallTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\Tests\ys_mathjax\Unit;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the composer-installed MathJax library the platform self-hosts.
+ *
+ * Serving MathJax from a third-party CDN hands that origin arbitrary
+ * JavaScript execution on every public page containing math: MathJax pulls its
+ * config, output jax, font data and extensions at runtime through its own
+ * loader, and none of those follow-up requests carry an integrity hash. The
+ * platform therefore installs the library itself, and these assertions cover
+ * the two ways that install can be subtly wrong while still looking fine.
+ *
+ * These assert build state rather than code: they read the composer-installed
+ * tree under `web/libraries/`, which is gitignored. A failure here means the
+ * checkout has not been built (run `composer install`) or the pin moved to a
+ * version that no longer satisfies the constraint — not that module code broke.
+ *
+ * @group ys_mathjax
+ * @group yalesites
+ */
+class MathjaxLibraryInstallTest extends UnitTestCase {
+
+  /**
+   * The library directory the contrib module hardcodes.
+   *
+   * `mathjax_library_info_build()` points at `/libraries/MathJax/MathJax.js`,
+   * so a package installed under any other casing silently fails to load.
+   */
+  protected const LIBRARY_DIR = 'libraries/MathJax';
+
+  /**
+   * The library is installed on disk at the casing the module expects.
+   *
+   * Composer must place the library at `web/libraries/MathJax`; a package that
+   * lands at `web/libraries/mathjax` resolves to a 404 and math stops
+   * rendering, with nothing in the page to say why.
+   */
+  public function testLibraryIsInstalledAtTheExpectedPath(): void {
+    $this->assertFileExists($this->libraryPath('MathJax.js'), 'MathJax must be composer-installed to web/libraries/MathJax (capital M, capital J).');
+  }
+
+  /**
+   * The installed build resolves its accessibility extensions locally.
+   *
+   * MathJax loads the combined config at runtime, and up to 2.7.0 that config
+   * pulled the accessibility menu from `[Contrib]` — a path hardcoded to
+   * cdn.mathjax.org — because the a11y extensions were not part of the
+   * distribution. Self-hosting the entry point alone would therefore leave one
+   * third-party script fetch behind. Builds from 2.7.1 on ship those
+   * extensions and reference them under `[MathJax]`, so the version pin is
+   * what actually removes the last external origin; this asserts the pinned
+   * build is one of them.
+   */
+  public function testAccessibilityExtensionsAreBundled(): void {
+    $this->assertFileExists($this->libraryPath('extensions/a11y/accessibility-menu.js'), 'The pinned MathJax build must bundle the a11y extensions rather than fetching them from cdn.mathjax.org.');
+
+    $config = $this->libraryPath('config/TeX-AMS-MML_HTMLorMML.js');
+    $this->assertFileExists($config);
+    $this->assertStringContainsString('[MathJax]/extensions/a11y/accessibility-menu.js', file_get_contents($config), 'The combined MathJax config must load the accessibility menu from the local [MathJax] path, not from [Contrib] (cdn.mathjax.org).');
+  }
+
+  /**
+   * Builds an absolute path to a file inside the installed MathJax library.
+   */
+  protected function libraryPath(string $relative): string {
+    return DRUPAL_ROOT . '/' . self::LIBRARY_DIR . '/' . $relative;
+  }
+
+}


### PR DESCRIPTION
## [1565: Bug: MathJax loads from cdnjs with no integrity protection; self-host it instead](https://github.com/yalesites-org/YaleSites-Internal/issues/1565)

### Description of work

- Adds MathJax as a composer-managed `drupal-library` so it installs into `web/libraries/`, matching how `chosen` / `nouislider` / the other third-party libraries are already handled. Nothing is committed into a Yale repo, and nothing goes into `component-library-twig` or `atomic`.
- Sets `use_cdn: 0` in the exported `mathjax.settings`, so the contrib module loads `/libraries/MathJax/MathJax.js` instead of `cdnjs.cloudflare.com`. `mathjax.settings` is not in `config_ignore`, so `drush deploy` -> `config:import` carries this to existing sites; no update hook needed.
- Pins the install directory to `MathJax` (capital M, capital J) via `extra.installer-name` on the package definition. The contrib module hardcodes that path, and a package landing at `web/libraries/mathjax` would 404 silently. `installer-name` is applied to `{$name}` *before* the `installer-paths` lookup, so it holds regardless of rule ordering — an `installer-paths` entry keyed by package name would only have worked if inserted above the generic `"web/libraries/{$name}": ["type:drupal-library"]` rule, which is a quieter way to break.
- Adds tests in `ys_mathjax`: a Kernel test asserting the shipped config resolves `mathjax/source` to a site-relative URL, and a Unit test asserting the library is installed at the right casing and that the pinned build bundles its a11y extensions locally.
- Adds a developer note to the `ys_mathjax` README.
- No change was needed in `ys_mathjax` itself — selective loading still runs entirely through `MathDelimiterDetector::hasMath()`, and library attachment still comes from the contrib parent filter.

**Two decisions worth a reviewer's attention:**

1. **Pinned 2.7.9, not the 2.7.0 the ticket names.** Self-hosting 2.7.0 was tried first and a network capture showed a request the ticket's evidence table does not list: `https://cdn.mathjax.org/mathjax/contrib/a11y/accessibility-menu.js`. MathJax 2.7.0's combined config does `MathJax.Hub.Config({extensions: ['[Contrib]/a11y/accessibility-menu.js']})`, and `[Contrib]` is hardcoded to `https://cdn.mathjax.org/mathjax/contrib` inside `MathJax.js`; the a11y extensions are not in the 2.7.0 payload. So self-hosting 2.7.0 would have left a third-party script origin in place — on a domain MathJax retired in 2017, which is a worse exposure than cdnjs, not a better one. 2.7.1+ bundles `extensions/a11y/` and references it under `[MathJax]`. This is a patch-level pin inside the same 2.7 line — same API, same `tex2jax` config syntax, same output — so the "no 3.x/4.x migration" decision on the ticket still holds.
2. **Installed from the npm distribution rather than the GitHub tag archive.** The GitHub archive of the same release is 173 MB / 32,069 files, 29,012 of them legacy PNG image fonts for browsers with no web-font support. The npm distribution is 66 MB / 3,147 files and drops only those PNG fallbacks and dev files. This matters because CI force-adds `web/libraries/**` into the Pantheon artifact on every deploy. The package definition records the tarball's `shasum`, so composer verifies the download at build time — build-time integrity checking of the whole payload, which is what SRI could not give us.

### Verification (all on local Lando, nothing touched remotely)

**Before** — page with math served `<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML">` with `integrity`/`crossorigin` absent, and `mathjax/source` resolved to that URL with no `attributes`.

**After** — browser network capture on a page with inline math, `$$…$$`, `\[…\]`, a `pmatrix` and an integral:

- 8 MathJax-related requests, **all** from the site origin. Zero requests to `cdnjs.cloudflare.com` and zero to `cdn.mathjax.org`. The only remaining third-party origins on the page are `yale-webfonts.yalespace.org` and the pre-existing AddToAny share widget.
- 5 expressions rendered, 5 `.MJX_Assistive_MathML` nodes present, 0 `.MathJax_Error`, `window.MathJax.version === "2.7.9"`. A wider sample (adding `\frac`, Greek, and `Tickets are $5` as plain prose) rendered 10/10 with 10 assistive MathML nodes, 0 errors, and left the single dollar sign alone — single-dollar inline math stays disabled.
- Selective loading intact: three math-free pages fetch no MathJax assets at all.
- No status-report error from `mathjax_requirements()` (it errors when `use_cdn: 0` and the local files are missing).
- MathJax payload on a math-heavy page is ~448 KB across 7 files. Locally Lando serves these uncompressed, but core's own `/core/misc/drupal.js` behaves identically in that environment — Pantheon's Global CDN handles compression and caching for static assets under the docroot, and `/libraries/` is not in `protected_web_paths`.
- Tests: the new assertions were written first and were red against the unchanged code for the right reasons (`Failed asserting that 'https://cdnjs.cloudflare.com/…' does not contain "cdnjs.cloudflare.com"`, and `web/libraries/MathJax/MathJax.js` missing). Now green: `ys_mathjax` Unit 35 tests / 55 assertions (was 33 / 51), Kernel 1 test / 3 assertions.
- `lando composer code-sniff` (Drupal + DrupalPractice over the whole custom tree) exits 0; `composer lint:php` clean. Both CI composer guards pass — no `drupal/*` in the root `require`, and the new profile requirement is pinned.

### Functional testing steps:

- [ ] On a page with math notation, open devtools Network and confirm every MathJax request is served from the site domain — no `cdnjs.cloudflare.com` and no `cdn.mathjax.org`.
- [ ] Confirm the math still renders: inline `\(a^2 + b^2 = c^2\)`, display `$$\sum_{i=1}^{n} i = \frac{n(n+1)}{2}$$`, a `\begin{pmatrix}` matrix, and `\[\int_0^1 x^2 \, dx = \tfrac{1}{3}\]`.
- [ ] Confirm the accessible output is still emitted — a `.MJX_Assistive_MathML` element with `<math xmlns="http://www.w3.org/1998/Math/MathML">` inside each rendered expression.
- [ ] Load a page with no math and confirm no MathJax assets are requested at all.
- [ ] Check `/admin/reports/status` for the MathJax "local library files could not be found" error — it should not be present.
- [ ] Confirm `/libraries/MathJax/MathJax.js` returns 200 on the multidev.

### Known cost, and a follow-up worth its own ticket

The installed payload is 66 MB / 3,147 files, and CI force-adds `web/libraries/**` into the Pantheon artifact. About a third of that is dead weight at runtime: `unpacked/` (22 MB, 1,264 files — unminified duplicates of the packed `jax/`, `extensions/` and `config/` that `MathJax.js` never loads) plus `test/` and `docs/`. Composer cannot filter paths inside a package, so pruning needs a `post-install-cmd` step — new build machinery that the ticket explicitly said was not needed, on a size-S change, so it is deliberately **not** in this PR. Git dedupes identical blobs, so the Pantheon repo cost is a one-time ~20-25 MB rather than per-deploy growth. Happy to open a follow-up if we want the prune.

References yalesites-org/YaleSites-Internal#1565
