### PR TITLE
1569: Bug: Collection top-page delete shows contrib "child pages will be relocated" above the YaleSites copy

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookCollectionDeleteTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookCollectionDeleteTest.php
@@ -407,6 +407,54 @@ class BookCollectionDeleteTest extends KernelTestBase {
   }
 
   /**
+   * The collection top page drops contrib book's relocation warning.
+   *
+   * Contrib book_form_node_confirm_form_alter() adds "the child pages will be
+   * relocated automatically" to every book page that has children. On a
+   * collection's top page that is no longer what happens: ys_book takes the
+   * collection apart and the sub-pages stay put as standalone content. Showing
+   * both sentences tells the editor two contradictory things about the same
+   * irreversible action.
+   */
+  public function testDeleteConfirmFormDropsContribWarningOnCollectionTop(): void {
+    [$root] = $this->createCollection();
+
+    $form = $this->container->get('entity.form_builder')
+      ->getForm($this->reload($root), 'delete');
+
+    $this->assertArrayNotHasKey(
+      'book_warning',
+      $form,
+      "Contrib's relocation warning is wrong for a collection top page."
+    );
+    $this->assertArrayHasKey(
+      'ys_book_collection_notice',
+      $form,
+      'The accurate YaleSites copy is still the one the editor sees.'
+    );
+  }
+
+  /**
+   * Mid-collection pages keep contrib book's relocation warning.
+   *
+   * Deleting a page from the middle of a collection really does move its
+   * children up under its parent and leave the collection intact, so contrib's
+   * wording is accurate there and must survive.
+   */
+  public function testDeleteConfirmFormKeepsContribWarningMidCollection(): void {
+    [, $child] = $this->createCollection();
+
+    $form = $this->container->get('entity.form_builder')
+      ->getForm($this->reload($child), 'delete');
+
+    $this->assertArrayHasKey(
+      'book_warning',
+      $form,
+      'A mid-collection page really does have its children relocated.'
+    );
+  }
+
+  /**
    * Pages taken out of the outline are hidden from contrib book's predelete.
    *
    * Contrib book_node_predelete() only checks the in-memory copy of the book

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.module
@@ -241,12 +241,33 @@ function ys_book_form_alter(&$form, FormStateInterface $form_state, $form_id) {
 }
 
 /**
+ * Checks whether a node is the top-level page of a content collection.
+ *
+ * A collection's outline rows all carry the top page's node ID as their book
+ * ID, so the top page is the one whose book ID is its own node ID.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node to check.
+ *
+ * @return bool
+ *   TRUE if the node is a collection's top-level page.
+ */
+function _ys_book_is_collection_top(NodeInterface $node): bool {
+  return !empty($node->book['bid']) && $node->book['bid'] == $node->id();
+}
+
+/**
  * Explains that a deleted collection root's sub-pages are kept.
  *
  * The Manage Content delete route uses the generic content-delete
  * confirmation, whose only description is "This action cannot be undone".
  * Losing a whole collection to it is a surprise worth spelling out, the way
  * the Manage Content Collections confirmation already does.
+ *
+ * Contrib book adds its own warning to the same page, so this also takes that
+ * one away -- see the comment at the unset() below. Adding ours and removing
+ * contrib's happen together, under one condition, so the editor can never be
+ * left reading both or neither.
  *
  * @param array $form
  *   The delete confirmation form.
@@ -259,7 +280,7 @@ function _ys_book_add_collection_delete_notice(array &$form, FormStateInterface 
   $node = $form_state->getFormObject()->getEntity();
 
   // Only a collection's top-level page loses a collection when it is deleted.
-  if (!$node instanceof NodeInterface || empty($node->book['bid']) || $node->book['bid'] != $node->id()) {
+  if (!$node instanceof NodeInterface || !_ys_book_is_collection_top($node)) {
     return;
   }
 
@@ -267,6 +288,18 @@ function _ys_book_add_collection_delete_notice(array &$form, FormStateInterface 
   if (count(_ys_book_get_all_book_nids((int) $node->id())) < 2) {
     return;
   }
+
+  // Contrib's book_form_node_confirm_form_alter() has already put "the child
+  // pages will be relocated automatically" on this page. That stopped being
+  // true for a collection's top page when ys_book_node_predelete() started
+  // taking the collection apart and leaving its pages standalone, and read
+  // together with the copy below it tells the editor two contradictory things
+  // about the same irreversible action. It is still accurate for a page in the
+  // middle of a collection, which never reaches this function.
+  // (Both modules are weight 0 and ModuleHandler::alter() runs a module's
+  // alters as a block, so every book_* alter has run by the time any ys_book_*
+  // one does -- the same ordering ys_book_module_implements_alter() relies on.)
+  unset($form['book_warning']);
 
   $form['ys_book_collection_notice'] = [
     '#type' => 'html_tag',
@@ -789,8 +822,7 @@ function ys_book_node_predelete($node) {
     return;
   }
 
-  // A collection's top-level page is the one whose book ID is its own node ID.
-  if ($node->book['bid'] == $node->id()) {
+  if (_ys_book_is_collection_top($node)) {
     _ys_book_dismantle_collection((int) $node->book['bid']);
   }
 


### PR DESCRIPTION
## [1569: Bug: Collection top-page delete shows contrib "child pages will be relocated" above the YaleSites copy](https://github.com/yalesites-org/YaleSites-Internal/issues/1569)

### Description of work

Deleting a content collection's top page from Manage Content showed two contradictory sentences about the same irreversible action. Contrib Book's warning came first -- "...the child pages will be relocated automatically" -- followed by the accurate YaleSites copy added in #1511: "The other pages in the collection won't be deleted; they'll stay published as standalone content." Only the second is true, because `ys_book_node_predelete()` takes the collection apart and leaves its pages as standalone content.

- `_ys_book_add_collection_delete_notice()` now unsets contrib's `book_warning` element as well as adding our own copy, so a collection's top page shows only the accurate message. Both happen in one function under one condition, so the two messages cannot get out of step with each other.
- Contrib's warning is left alone everywhere else. Deleting a page from the middle of a collection really does move its children up under its parent, so the contrib wording is correct there, and a new test pins that it stays.
- Extracted the "is this the collection's top page" test (`book['bid'] == nid`) into `_ys_book_is_collection_top()` and pointed `ys_book_node_predelete()` at it too -- that is the code that actually dismantles the collection, so the message and the behaviour it describes now share one definition instead of restating the rule separately.

The fix stays inside `ys_book` with no patch to contrib Book, matching the constraint #1511 worked under.

Two new Kernel tests in `BookCollectionDeleteTest`: one asserts the top page's confirm form has no `book_warning` but still has the YaleSites notice, the other asserts a mid-collection page still has `book_warning`. Full `ys_book` Kernel suite green (37 tests, 473 assertions); `composer code-sniff` exit 0.

### Functional testing steps:

- [ ] Create a content collection with a top page and at least two sub-pages, one of them nested two levels deep.
- [ ] From Manage Content, delete the collection's **top** page. Confirm the confirmation page shows only "This page is the top of a content collection... they'll stay published as standalone content", and no longer says the child pages will be relocated automatically.
- [ ] Cancel, then delete a page from the **middle** of the collection (one that has a child of its own). Confirm it still shows "...is part of a book outline, and has associated child pages. If you proceed with deletion, the child pages will be relocated automatically" -- that message is accurate here and must not have disappeared.
- [ ] Delete a leaf sub-page and confirm nothing changed: the plain "This action cannot be undone" confirmation only.
- [ ] Confirm the top-page delete still behaves as #1511 established -- the sub-pages survive as standalone published content and are not promoted into new collections.
- [ ] Accessibility: on the top-page delete confirmation, confirm the heading order still runs down to the `<h1>` "Are you sure you want to delete the content item..." with no level skipped, and that tabbing still reaches Delete then Cancel.

References yalesites-org/YaleSites-Internal#1569
