### PR TITLE
1566: Bug: ys_node_access_update_10001 runs an unbatched node_access_rebuild during drush deploy

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/tests/src/Kernel/NodeAccessRebuildUpdateTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/tests/src/Kernel/NodeAccessRebuildUpdateTest.php
@@ -1,0 +1,371 @@
+<?php
+
+namespace Drupal\Tests\ys_node_access\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\user\Entity\User;
+use Drupal\ys_node_access\NodeAccessManager;
+
+/**
+ * Tests the batched node access grant rebuild in ys_node_access.install.
+ *
+ * See _ys_node_access_rebuild_grants() for why the rebuild the two update
+ * hooks share is batched rather than a call to core's node_access_rebuild().
+ * These tests pin the properties that make it safe to run during a deploy:
+ * it is chunked over several passes via $sandbox, it never empties
+ * node_access, and it still clears the nid 0 wildcard grant that the rebuild
+ * it replaces removed. Issue #1566.
+ *
+ * @group yalesites
+ * @group ys_node_access
+ */
+class NodeAccessRebuildUpdateTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'node',
+    'field',
+    'text',
+    'user',
+    'ys_node_access',
+  ];
+
+  /**
+   * Number of nodes the multi-pass tests build.
+   *
+   * Deliberately larger than the rebuild's batch size (50) so a complete
+   * rebuild has to span more than one pass -- that is the behaviour under
+   * test. Raising the batch size past this would make those tests fail.
+   */
+  const NODE_COUNT = 60;
+
+  /**
+   * Guard against a rebuild that never reports itself finished.
+   */
+  const MAX_PASSES = 20;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['node', 'user']);
+
+    NodeType::create(['type' => 'page', 'name' => 'Page'])->save();
+
+    // The update hooks live in ys_node_access.install, which is not loaded
+    // for a kernel test the way it is during updatedb.
+    \Drupal::moduleHandler()->loadInclude('ys_node_access', 'install');
+  }
+
+  /**
+   * Tests that a full rebuild is chunked over more than one pass.
+   *
+   * An unbatched rebuild does all of its work in a single call and never
+   * reports progress, so a large site's rebuild is one unbounded unit of work
+   * that a PHP limit can kill outright.
+   */
+  public function testRebuildRunsAcrossMultiplePasses() {
+    $this->createNodes(self::NODE_COUNT);
+
+    $passes = $this->runRebuild('ys_node_access_update_10001');
+
+    $this->assertGreaterThan(
+      1,
+      $passes,
+      'The rebuild is chunked over multiple passes rather than done in one unbounded call.'
+    );
+    $this->assertNodesHaveGrants();
+  }
+
+  /**
+   * Tests that the second update hook runs the same batched rebuild.
+   */
+  public function testUpdate10002RunsTheSameRebuild() {
+    $this->createNodes(3);
+
+    $this->runRebuild('ys_node_access_update_10002');
+
+    $this->assertNodesHaveGrants();
+  }
+
+  /**
+   * Tests that the rebuild never empties the node_access table.
+   *
+   * This is the property that makes the rebuild safe to interrupt. A row that
+   * belongs to no node is used as the sentinel: core's node_access_rebuild()
+   * truncates the entire table, so the sentinel would not survive it, whereas
+   * a per-node rewrite only ever touches rows for the node it is rewriting.
+   */
+  public function testRebuildDoesNotTruncateTheNodeAccessTable() {
+    $this->createNodes(3);
+    $this->insertGrantRow(999999, 'ys_test_sentinel');
+
+    $this->runRebuild('ys_node_access_update_10001');
+
+    $this->assertEquals(
+      1,
+      $this->grantRowCount(999999),
+      'The rebuild replaces rows node by node instead of truncating node_access.'
+    );
+  }
+
+  /**
+   * Tests that the rebuild still clears the nid 0 wildcard grant.
+   *
+   * NodeGrantDatabaseStorage::access() treats a row with nid 0 as a grant over
+   * every published node, so leaving one behind would hand every visitor view
+   * access to CAS-protected pages. The rebuild this replaces removed it as a
+   * side effect of truncating; the per-node rewrite has to do it on purpose.
+   */
+  public function testRebuildRemovesTheNidZeroWildcardGrant() {
+    $this->createNodes(3);
+    $this->insertGrantRow(0, 'all');
+
+    $this->runRebuild('ys_node_access_update_10001');
+
+    $this->assertEquals(0, $this->grantRowCount(0));
+  }
+
+  /**
+   * Tests that nodes a pass has not reached yet keep their existing grants.
+   *
+   * Between passes the site is still serving traffic, so every node must be
+   * viewable throughout -- under its old grants until the rebuild reaches it,
+   * under its new ones afterwards.
+   */
+  public function testNodesKeepGrantsBetweenPasses() {
+    $this->createNodes(self::NODE_COUNT);
+
+    $sandbox = [];
+    ys_node_access_update_10001($sandbox);
+    $this->assertLessThan(1, $sandbox['#finished'], 'One pass is not the whole rebuild.');
+
+    $this->assertNodesHaveGrants();
+  }
+
+  /**
+   * Tests that a rebuild abandoned part way can simply be run again.
+   *
+   * Drush drops $sandbox if updatedb dies, so the re-run starts over rather
+   * than resuming. That is fine as long as rewriting a node's grants twice is
+   * harmless and the end state is the same as an uninterrupted rebuild.
+   */
+  public function testInterruptedRebuildCanBeRerunFromScratch() {
+    $this->createNodes(self::NODE_COUNT);
+    $unpublished = $this->makeStaleUnpublishedNode();
+
+    // A rebuild that dies after its first pass.
+    $abandoned = [];
+    ys_node_access_update_10001($abandoned);
+
+    // The re-run drush would perform on the next deploy attempt.
+    $this->runRebuild('ys_node_access_update_10001');
+
+    $this->assertNodesHaveGrants();
+    $this->assertUnpublishedGrantsAreCorrect($unpublished);
+  }
+
+  /**
+   * Tests that the rebuild replaces stale rows written by the old grant logic.
+   *
+   * This is what the update hooks exist for: an unpublished node saved before
+   * the fix still carries a public grant row until its grants are rewritten.
+   */
+  public function testRebuildReplacesStaleGrantRows() {
+    $node = $this->makeStaleUnpublishedNode();
+
+    $this->runRebuild('ys_node_access_update_10001');
+
+    $this->assertUnpublishedGrantsAreCorrect($node);
+  }
+
+  /**
+   * Tests that a completed rebuild clears the "needs rebuild" flag.
+   */
+  public function testCompletedRebuildClearsTheNeedsRebuildFlag() {
+    $this->createNodes(5);
+    node_access_needs_rebuild(TRUE);
+
+    $this->runRebuild('ys_node_access_update_10001');
+
+    $this->assertFalse(\Drupal::state()->get('node.node_access_needs_rebuild', FALSE));
+  }
+
+  /**
+   * Tests that the rebuild copes with a site that has no nodes at all.
+   */
+  public function testRebuildOnAnEmptySiteFinishesImmediately() {
+    $sandbox = [];
+    ys_node_access_update_10001($sandbox);
+
+    $this->assertEquals(1, $sandbox['#finished']);
+  }
+
+  /**
+   * Runs an update hook to completion and returns the number of passes taken.
+   *
+   * @param string $update_hook
+   *   The update hook function name.
+   *
+   * @return int
+   *   How many passes the rebuild took.
+   */
+  protected function runRebuild($update_hook) {
+    $sandbox = [];
+    $passes = 0;
+    $finished = 0;
+
+    do {
+      $update_hook($sandbox);
+      $passes++;
+      // Both update.php and drush read #finished out of the sandbox and then
+      // unset it before the next pass; mirror that so the hook cannot rely on
+      // its own flag surviving.
+      $finished = $sandbox['#finished'] ?? 0;
+      unset($sandbox['#finished']);
+    } while ($passes < self::MAX_PASSES && $finished < 1);
+
+    $this->assertEquals(1, $finished, 'The rebuild reported itself finished.');
+
+    return $passes;
+  }
+
+  /**
+   * Creates published page nodes.
+   *
+   * @param int $count
+   *   How many nodes to create.
+   */
+  protected function createNodes($count) {
+    for ($i = 0; $i < $count; $i++) {
+      Node::create([
+        'type' => 'page',
+        'title' => 'Node ' . $i,
+        'status' => 1,
+        'uid' => 1,
+      ])->save();
+    }
+  }
+
+  /**
+   * Creates an unpublished node carrying pre-fix (public) grant rows.
+   *
+   * @return \Drupal\node\NodeInterface
+   *   The unpublished node.
+   */
+  protected function makeStaleUnpublishedNode() {
+    $owner = User::create(['name' => 'owner', 'uid' => 5]);
+    $owner->save();
+
+    $node = Node::create([
+      'type' => 'page',
+      'title' => 'Draft',
+      'status' => 0,
+      'uid' => $owner->id(),
+    ]);
+    $node->save();
+
+    \Drupal::database()->delete('node_access')->condition('nid', $node->id())->execute();
+    $this->insertGrantRow($node->id(), NodeAccessManager::YS_NODE_ACCESS_REALM);
+
+    return $node;
+  }
+
+  /**
+   * Inserts a view grant row directly, bypassing the grants system.
+   *
+   * @param int $nid
+   *   The node ID the row is written for.
+   * @param string $realm
+   *   The grant realm.
+   */
+  protected function insertGrantRow($nid, $realm) {
+    \Drupal::database()->insert('node_access')
+      ->fields([
+        'nid' => $nid,
+        'langcode' => 'en',
+        'fallback' => 1,
+        'realm' => $realm,
+        'gid' => NodeAccessManager::YS_NODE_ACCESS_GRANT_ID_PUBLIC,
+        'grant_view' => 1,
+        'grant_update' => 0,
+        'grant_delete' => 0,
+      ])
+      ->execute();
+  }
+
+  /**
+   * Asserts every node in the site has at least one grant row.
+   */
+  protected function assertNodesHaveGrants() {
+    $nids = array_values(\Drupal::entityQuery('node')->accessCheck(FALSE)->execute());
+
+    $granted = \Drupal::database()->select('node_access', 'na')
+      ->fields('na', ['nid'])
+      ->condition('na.nid', $nids, 'IN')
+      ->distinct()
+      ->execute()
+      ->fetchCol();
+
+    $this->assertEmpty(
+      array_diff($nids, $granted),
+      'Every node holds grant rows at this point in the rebuild.'
+    );
+  }
+
+  /**
+   * Asserts an unpublished node carries the unpublished grants, not public.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The unpublished node.
+   */
+  protected function assertUnpublishedGrantsAreCorrect($node) {
+    $rows = \Drupal::database()->select('node_access', 'na')
+      ->fields('na', ['realm', 'gid', 'grant_view'])
+      ->condition('na.nid', $node->id())
+      ->orderBy('na.realm')
+      ->execute()
+      ->fetchAll(\PDO::FETCH_ASSOC);
+
+    $this->assertEquals([
+      [
+        'realm' => NodeAccessManager::YS_NODE_ACCESS_UNPUBLISHED_REALM,
+        'gid' => (string) NodeAccessManager::YS_NODE_ACCESS_GRANT_ID_UNPUBLISHED_ANY,
+        'grant_view' => '1',
+      ],
+      [
+        'realm' => NodeAccessManager::YS_NODE_ACCESS_UNPUBLISHED_OWNER_REALM,
+        'gid' => (string) $node->getOwnerId(),
+        'grant_view' => '1',
+      ],
+    ], $rows);
+  }
+
+  /**
+   * Counts the grant rows held by a node ID.
+   *
+   * @param int $nid
+   *   The node ID.
+   *
+   * @return int
+   *   The number of node_access rows for that node ID.
+   */
+  protected function grantRowCount($nid) {
+    return (int) \Drupal::database()->select('node_access', 'na')
+      ->condition('na.nid', $nid)
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.install
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_node_access/ys_node_access.install
@@ -9,6 +9,10 @@
  * Implements hook_install().
  *
  * Rebuild the node access permissions to remove default nid 0 entry.
+ *
+ * Left unbatched deliberately, unlike the update hooks below: hook_install()
+ * has no $sandbox to return to, and it runs at profile install time when there
+ * is no content for a rebuild to walk.
  */
 function ys_node_access_install() {
   node_access_rebuild();
@@ -22,8 +26,8 @@ function ys_node_access_install() {
  * records in the node_access table until a rebuild. Rebuild so the fix applies
  * to content that already exists, not only to nodes saved after this deploy.
  */
-function ys_node_access_update_10001() {
-  node_access_rebuild();
+function ys_node_access_update_10001(array &$sandbox) {
+  return _ys_node_access_rebuild_grants($sandbox);
 }
 
 /**
@@ -33,6 +37,103 @@ function ys_node_access_update_10001() {
  * record needed replacing. Rebuild so already-unpublished nodes get the
  * corrected grant rows, not just nodes saved after this deploy.
  */
-function ys_node_access_update_10002() {
-  node_access_rebuild();
+function ys_node_access_update_10002(array &$sandbox) {
+  return _ys_node_access_rebuild_grants($sandbox);
+}
+
+/**
+ * Rewrites every node's access grant rows, one page of nodes per pass.
+ *
+ * Core's node_access_rebuild() truncates the whole node_access table before it
+ * rewrites anything, so no node is viewable for the duration of its single
+ * unbounded pass, and if that pass dies on a PHP time or memory limit the
+ * table stays empty for every node it never reached -- a site-wide 403 for
+ * anonymous visitors lasting until someone re-runs updatedb. See issue #1566.
+ *
+ * This rewrites grants node by node instead, so a node always holds either its
+ * old grants or its new ones and never none.
+ * \Drupal\node\NodeGrantDatabaseStorage::write() already replaces the rows of
+ * the node it is handed, so no table-wide delete is needed. The one row that
+ * belongs to no node is the nid 0 default grant, which
+ * \Drupal\node\NodeGrantDatabaseStorage::access() treats as a wildcard over
+ * every published node -- the first pass deletes it, because the rebuild this
+ * replaces did. Rows left behind by deleted nodes are inert, since a row is
+ * only ever read by nid, and are not worth a full table scan to hunt down.
+ *
+ * @param array $sandbox
+ *   The update hook sandbox, carried between passes.
+ *
+ * @return \Drupal\Core\StringTranslation\TranslatableMarkup
+ *   A progress message.
+ *
+ * @see _node_access_rebuild_batch_operation()
+ *   Core's batch equivalent, which this mirrors. It is not called directly:
+ *   it is a private core API and takes a batch $context, not a $sandbox.
+ */
+function _ys_node_access_rebuild_grants(array &$sandbox) {
+  $batch_size = 50;
+
+  if (!isset($sandbox['processed'])) {
+    $sandbox['processed'] = 0;
+    $sandbox['current_nid'] = 0;
+    $sandbox['total'] = (int) \Drupal::entityQuery('node')
+      ->accessCheck(FALSE)
+      ->count()
+      ->execute();
+
+    // Belongs to no node, so the per-node rewrite below never reaches it.
+    \Drupal::database()->delete('node_access')->condition('nid', 0)->execute();
+  }
+
+  // Paged on the node ID rather than on an offset so the cursor stays valid
+  // when content is created or deleted while the deploy runs, and so the
+  // sandbox stays small -- it is serialised between passes, and holding a
+  // snapshot of every nid is the memory this is trying not to use.
+  $nids = \Drupal::entityQuery('node')
+    ->accessCheck(FALSE)
+    ->condition('nid', $sandbox['current_nid'], '>')
+    ->sort('nid')
+    ->range(0, $batch_size)
+    ->execute();
+
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+  $access_control_handler = \Drupal::entityTypeManager()->getAccessControlHandler('node');
+  $grant_storage = \Drupal::service('node.grant_storage');
+
+  foreach ($node_storage->loadMultiple($nids) as $node) {
+    $grant_storage->write($node, $access_control_handler->acquireGrants($node));
+    $sandbox['processed']++;
+  }
+
+  // Only an empty page ends the rebuild. A short one would be the cheaper
+  // test, but the query pages over rows of node_field_data, so on a site with
+  // translations a full page can still collapse to fewer than $batch_size
+  // nodes -- and stopping there would leave the rest of the site on its stale
+  // grants. The extra pass costs one query that returns nothing.
+  if ($nids) {
+    // Advance past every nid this page asked for, not just the ones that
+    // loaded, so a node deleted mid-deploy cannot stall the cursor.
+    $sandbox['current_nid'] = max($nids);
+
+    // Release the nodes this pass loaded. Drush runs every pass in a single
+    // PHP process, so without this the entity static cache accumulates the
+    // whole node table and the batching would bound time but not memory.
+    \Drupal::service('entity.memory_cache')->deleteAll();
+
+    // The total is a snapshot taken before an editor could add or delete
+    // anything, so it drives this progress fraction and nothing else.
+    $sandbox['#finished'] = min(0.99, $sandbox['processed'] / max(1, $sandbox['total']));
+
+    return t('Rebuilt node access grants for @processed of about @total nodes.', [
+      '@processed' => $sandbox['processed'],
+      '@total' => $sandbox['total'],
+    ]);
+  }
+
+  $sandbox['#finished'] = 1;
+  node_access_needs_rebuild(FALSE);
+
+  return t('Rebuilt node access grants for @processed nodes.', [
+    '@processed' => $sandbox['processed'],
+  ]);
 }


### PR DESCRIPTION
## [1566: Bug: ys_node_access_update_10001 runs an unbatched node_access_rebuild during drush deploy](https://github.com/yalesites-org/YaleSites-Internal/issues/1566)

### Description of work

The ticket asked to measure the risk first and batch only if the timing was uncomfortable. Measuring turned up something worse than a slow deploy, so this batches both hooks.

**What the measurement found.** Core's `node_access_rebuild()` calls `deleteGrants()` — a truncate of the entire `node_access` table — *before* it rewrites anything, then rebuilds every node in one unbounded pass. So the exposure is not only "it might time out": for the whole duration of the rebuild, successful or not, no node has grant rows. Reproduced locally by replaying exactly what `ys_node_access_update_10001()` does and stopping it part way, standing in for a PHP time or memory limit:

```
rows_before=77  rows_after_deleteGrants=0  rows_after_5_of_71=9
/empty-testing-page      HTTP 200 -> 403
/content-types/resource  HTTP 200 -> 403
/content-types/profile   HTTP 200 -> 403
```

Every page a visitor can reach 403s, and stays that way until someone re-runs `updatedb`. Update hooks run in the `updatedb` phase of `drush deploy`, so this lands mid-deploy on a live site.

On timing, against 2,071 nodes generated locally: about **2.5 ms and 20 KB of unreleased memory per node**, both linear. Time alone would clear core's own `Environment::setTimeLimit(240)` up to roughly 36k nodes, so **memory is the binding constraint** and it is the one that produces the half-rebuilt table. I could not measure the largest real site — nothing in this ticket touched a remote environment — so treat the absolute node counts as indicative; the shape is what matters.

**The change.** Both `ys_node_access_update_10001()` and `ys_node_access_update_10002()` now delegate to a shared `_ys_node_access_rebuild_grants(array &$sandbox)`:

- Chunked over passes via `$sandbox`, 50 nodes at a time, with per-pass progress in the deploy log.
- **No table-wide delete.** `NodeGrantDatabaseStorage::write()` already replaces the rows of the node handed to it, so a per-node rewrite is self-cleaning. A node therefore always holds either its old grants or its new ones — never none — which is what removes the blackout entirely.
- **The `nid = 0` wildcard grant is deleted explicitly on the first pass.** This one is worth a close look: `NodeGrantDatabaseStorage::access()` ORs `nid = 0` into the query for published nodes and `node_access_grants()` always contributes realm `all` / gid 0, so a surviving nid-0 row grants view on every published node to everyone, CAS-protected pages included. `node_access_rebuild()` removed it as a side effect of truncating (that is what the comment on `ys_node_access_install()` is about); a per-node rewrite never reaches it, so it has to be removed on purpose. Covered by `testRebuildRemovesTheNidZeroWildcardGrant`.
- Paged on a **keyset cursor** (`nid > current_nid`, sorted ASC) rather than an offset. `$sandbox` is serialised to `key_value` between passes, and holding a snapshot of every nid on a large site is exactly the memory this change exists to avoid. The cursor advances past every nid the page asked for, not just the ones that loaded, so a node deleted mid-deploy cannot stall it.
- The entity static cache is released after each pass. Without that, drush running every pass in one PHP process means the batching bounds time but not memory — which would have left the real failure mode in place.
- Terminates on an **empty** page rather than a short one. A short page is the cheaper test, but the query pages over rows of `node_field_data`, so on a site with translations a full page can collapse to fewer than 50 nodes and stopping there would leave the rest of the site on stale grants. Not reachable today (no `language` / `content_translation` / `locale` in `core.extension.yml`), and the extra pass costs one query that returns nothing.

**One trade worth a reviewer's eye:** an aborted `updatedb` now fails *open* rather than *closed*. Previously an abort left the table empty and everything 403'd; now the nodes the rebuild never reached keep their pre-deploy rows, which for these two hooks means unpublished drafts keep the over-permissive grant until a successful re-run. That state is identical to not having run the update at all, the hook's schema version is not advanced so the next deploy re-runs it from scratch, and `drush deploy` aborts loudly — whereas the fail-closed version took the whole site down. I think that is the right trade, but it is a deliberate one rather than an accident.

`ys_node_access_install()` is deliberately left unbatched: `hook_install()` has no `$sandbox` to return to, and it runs at profile install time before any content exists. There is now a comment saying so.

**Release note:** no site should see a longer-than-usual deploy window from this — the rebuild is faster and bounded, not slower. Both hooks run back to back on any site upgrading past this release, so a large site pays the (now safe) rebuild twice; deduplicating them was considered and left alone, since the correct mechanism is a process-scoped static and the saving is seconds.

### Functional testing steps:

- [ ] Pull a real site database locally (not a fresh `site:install` — the whole point is that this runs against existing content).
- [ ] Roll `ys_node_access` back so the hooks re-run: `lando drush php:eval '\Drupal::keyValue("system.schema")->set("ys_node_access", 10000);'`
- [ ] Run `lando drush updatedb -y`. It should report per-pass progress (`Rebuilt node access grants for 50 of about N nodes.`) and finish with `Rebuilt node access grants for N nodes.`
- [ ] While it is running, load a published page as an anonymous visitor (a private/incognito window). It should return 200 throughout — no 403s at any point during the rebuild. This is the regression being fixed.
- [ ] After it finishes, confirm `ys_node_access` is at schema 10002 and that the "content access permissions need to be rebuilt" warning is **not** showing on `/admin/reports/status`.
- [ ] Confirm access still behaves: a published page is visible to anonymous; a page with "CAS login required" set redirects anonymous to CAS and renders for a logged-in user; an unpublished draft is visible to its owner and to a site admin in `/admin/content`, and not to an unrelated authenticated user.
- [ ] Interrupt it: roll the schema back to 10000 again, start `updatedb`, and kill it part way. Confirm the site still serves published pages (200, not 403), then re-run `updatedb` and confirm it completes cleanly from the start.

References yalesites-org/YaleSites-Internal#1566
