### PR TITLE
1580: Bug: Beacon indexes PDF filenames instead of PDF content — text extraction never fires

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
@@ -271,14 +271,30 @@ the PDF text layer into a media field that Search API can index:
   shipped in the profile config sync. It is machine-populated, not edited by
   hand. Add it to the Beacon index's `field_settings` to include PDF text in AI
   search.
-- **Asynchronous:** on media insert, and on update when the uploaded file
-  changes, `ys_beacon` queues a `ys_beacon_pdf_text_extraction` job that runs on
-  cron, so uploading a large PDF never slows the editorial save.
+- **Asynchronous:** whenever a media save leaves a document owed extraction,
+  `ys_beacon` queues a `ys_beacon_pdf_text_extraction` job that runs on cron, so
+  uploading a large PDF never slows the editorial save. Because media is
+  excluded from AI indexing by default, in practice the trigger is usually the
+  editor opting the document in rather than the upload itself; replacing the
+  file re-extracts.
+- **Attempted once per file:** each attempt is recorded against the media's
+  source file id, so a scanned, corrupt, oversized, or unreadable PDF is not
+  re-parsed on every later save or sweep. Replacing the file makes it eligible
+  again; `drush ys_beacon:extract-pdf-text --force` clears the records so
+  documents that stored no text are tried again. A document that already holds
+  text is never re-parsed by either route.
+- **Backfill:** `drush ys_beacon:extract-pdf-text` extracts every document still
+  waiting, batched. The same sweep runs inside the batch behind "Index now" and
+  "Re-index all content", and a deploy hook queues the backlog once on sites
+  whose media library predates Beacon.
 - **Opt-out and access respected:** extraction is skipped when
   `ai_disable_indexing` is set, and only runs on sites where Beacon indexing is
   configured.
 - **Image-only PDFs:** scanned PDFs with no text layer extract to an empty
-  string (logged, no error). There is no OCR.
+  string (logged, no error). There is no OCR. A document with no extracted text
+  is left out of the index rather than embedded as a filename-only chunk, which
+  would match filename-shaped queries and cite a document with nothing behind
+  it.
 - **Size limit:** files larger than `ys_beacon.settings:pdf_extraction_max_bytes`
   (default 20 MB) are skipped and logged, to bound memory and time.
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/drush.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/drush.services.yml
@@ -1,6 +1,6 @@
 services:
   ys_beacon.commands:
     class: \Drupal\ys_beacon\Commands\BeaconCommands
-    arguments: ['@ys_beacon.index_manager']
+    arguments: ['@ys_beacon.index_manager', '@ys_beacon.pdf_text_indexer']
     tags:
       - { name: drush.command }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Commands/BeaconCommands.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Commands/BeaconCommands.php
@@ -2,7 +2,9 @@
 
 namespace Drupal\ys_beacon\Commands;
 
+use Drupal\ys_beacon\PdfTextExtractionBatch;
 use Drupal\ys_beacon\Service\BeaconIndexManager;
+use Drupal\ys_beacon\Service\PdfTextIndexer;
 use Drush\Commands\DrushCommands;
 
 /**
@@ -12,6 +14,7 @@ class BeaconCommands extends DrushCommands {
 
   public function __construct(
     protected BeaconIndexManager $indexManager,
+    protected PdfTextIndexer $pdfTextIndexer,
   ) {
     parent::__construct();
   }
@@ -39,6 +42,43 @@ class BeaconCommands extends DrushCommands {
       '@url' => $url,
       '@name' => $name,
     ]));
+  }
+
+  /**
+   * Extracts text from PDF documents that have never been processed.
+   *
+   * The one-time backfill for documents that predate working extraction. Text
+   * is extracted in place and stored on the media, which re-tracks the item
+   * for indexing on its own. Documents already attempted are skipped, so the
+   * command is safe to re-run; --force clears those records so documents that
+   * were attempted but stored no text are tried again - after raising
+   * pdf_extraction_max_bytes, or once missing files are restored. A document
+   * that already holds text is never re-parsed either way; replace the file to
+   * force that.
+   *
+   * @param array $options
+   *   The command options.
+   *
+   * @command ys_beacon:extract-pdf-text
+   * @aliases ys-beacon-extract-pdf-text
+   * @option force Retry documents that were attempted but stored no text.
+   * @usage ys_beacon:extract-pdf-text
+   *   Extracts text from every PDF document still waiting for it.
+   * @usage ys_beacon:extract-pdf-text --force
+   *   Retries documents that were attempted but produced no text.
+   */
+  public function extractPdfText(array $options = ['force' => FALSE]): void {
+    if ($options['force']) {
+      $this->pdfTextIndexer->forgetAllAttempts();
+    }
+    $batch = PdfTextExtractionBatch::build($this->pdfTextIndexer->pendingMediaIds());
+    if (!$batch) {
+      $this->logger()->success(dt('No PDF documents are waiting for text extraction.'));
+      return;
+    }
+    batch_set($batch);
+    drush_backend_batch_process();
+    $this->logger()->success(dt('PDF text extraction finished.'));
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/BeaconIndexingControlsTrait.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/BeaconIndexingControlsTrait.php
@@ -5,7 +5,9 @@ namespace Drupal\ys_beacon\Form;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\search_api\SearchApiException;
 use Drupal\search_api\Utility\IndexingBatchHelperInterface;
+use Drupal\ys_beacon\PdfTextExtractionBatch;
 use Drupal\ys_beacon\Service\BeaconIndexStatus;
+use Drupal\ys_beacon\Service\PdfTextIndexer;
 
 /**
  * Shared Beacon indexing controls and their submit handlers.
@@ -19,8 +21,8 @@ use Drupal\ys_beacon\Service\BeaconIndexStatus;
  * BeaconIndexStatus rather than to this trait: the Beacon section of the
  * Platform Admin Settings page shows the same status but is a plugin rather
  * than a form, so it cannot use this trait and previously carried its own copy
- * of every read. A consuming form must set $indexStatus and
- * $indexingBatchHelper in its create().
+ * of every read. A consuming form must set $indexStatus,
+ * $indexingBatchHelper and $pdfTextIndexer in its create().
  */
 trait BeaconIndexingControlsTrait {
 
@@ -37,6 +39,13 @@ trait BeaconIndexingControlsTrait {
    * @var \Drupal\search_api\Utility\IndexingBatchHelperInterface
    */
   protected IndexingBatchHelperInterface $indexingBatchHelper;
+
+  /**
+   * The PDF text indexer.
+   *
+   * @var \Drupal\ys_beacon\Service\PdfTextIndexer
+   */
+  protected PdfTextIndexer $pdfTextIndexer;
 
   /**
    * Builds the "Indexing" details with the status summary and controls.
@@ -113,6 +122,9 @@ trait BeaconIndexingControlsTrait {
       // re-queueing tracked content; reindex() would only do the latter
       // (issue #1383).
       $index->rebuildTracker();
+      // Documents whose text was never extracted would be re-indexed as
+      // filename-only chunks, so sweep them in the same click.
+      $this->setPdfExtractionBatch();
       $this->messenger()->addStatus($this->t('All content has been queued for re-indexing into the Beacon vector database.'));
     }
     else {
@@ -140,12 +152,23 @@ trait BeaconIndexingControlsTrait {
       $this->messenger()->addWarning($this->t('The Beacon index is not enabled on this site. Enable the chat widget first.'));
       return;
     }
+    // Extract any missing PDF text first, so a document reaches the vector
+    // database with its content rather than just its filename. Batch-set
+    // before the Search API batch so the two run in order and no PDF is
+    // parsed in this submit handler. Note this button is disabled unless
+    // something is already waiting to be indexed, so a site whose only
+    // outstanding work is extraction has to use "Re-index all content" or the
+    // Drush backfill; $extracting therefore only matters in the race the
+    // comment below describes.
+    $extracting = $this->setPdfExtractionBatch();
     // Re-check the queue server-side: the button's #disabled state is only
     // evaluated at render time, so a stale page or a queue drained by cron
     // between render and submit could otherwise start an empty batch, which
     // Search API reports as a failure rather than a no-op.
     if ($this->indexStatus->remainingItems() < 1) {
-      $this->messenger()->addStatus($this->t('There is no content waiting to be indexed.'));
+      if (!$extracting) {
+        $this->messenger()->addStatus($this->t('There is no content waiting to be indexed.'));
+      }
       return;
     }
     try {
@@ -154,6 +177,21 @@ trait BeaconIndexingControlsTrait {
     catch (SearchApiException $e) {
       $this->messenger()->addWarning($this->t('Unable to start indexing right now. Please try again shortly.'));
     }
+  }
+
+  /**
+   * Sets a batch extracting text from documents that still lack it.
+   *
+   * @return bool
+   *   TRUE when a batch was set, FALSE when no document needed extraction.
+   */
+  protected function setPdfExtractionBatch(): bool {
+    $batch = PdfTextExtractionBatch::build($this->pdfTextIndexer->pendingMediaIds());
+    if (!$batch) {
+      return FALSE;
+    }
+    batch_set($batch);
+    return TRUE;
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconAdminSettings.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconAdminSettings.php
@@ -47,6 +47,7 @@ class YsBeaconAdminSettings extends ConfigFormBase {
     $instance->indexManager = $container->get('ys_beacon.index_manager');
     $instance->indexStatus = $container->get('ys_beacon.index_status');
     $instance->indexingBatchHelper = $container->get('search_api.indexing_batch_helper');
+    $instance->pdfTextIndexer = $container->get('ys_beacon.pdf_text_indexer');
     return $instance;
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconSettings.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconSettings.php
@@ -50,6 +50,7 @@ class YsBeaconSettings extends ConfigFormBase {
     // renders those controls.
     $instance->indexStatus = $container->get('ys_beacon.index_status');
     $instance->indexingBatchHelper = $container->get('search_api.indexing_batch_helper');
+    $instance->pdfTextIndexer = $container->get('ys_beacon.pdf_text_indexer');
     return $instance;
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/PdfTextExtractionBatch.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/PdfTextExtractionBatch.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Drupal\ys_beacon;
+
+/**
+ * Batch callbacks extracting PDF text for documents that still lack it.
+ *
+ * Both the "Index now" / "Re-index all content" controls and the backfill Drush
+ * command need the same sweep, and it has to run in a batch: parsing PDFs is
+ * pure PHP and a library of a few hundred documents would time out a form
+ * submit. Methods are static because Drupal's Batch API serializes callback
+ * names as strings and may invoke them in a separate PHP request.
+ */
+class PdfTextExtractionBatch {
+
+  /**
+   * How many documents one batch operation examines.
+   *
+   * One: a batch operation cannot be interrupted part-way, so this is the only
+   * value that keeps a single request bounded by a single parse. Documents may
+   * be up to pdf_extraction_max_bytes (20 MB by default) of pure-PHP parsing,
+   * and several of those in one request would risk max_execution_time on the
+   * web tier. Drupal runs as many operations per request as its own time limit
+   * allows, so the extra operations cost progress-bar granularity, not speed.
+   */
+  protected const CHUNK = 1;
+
+  /**
+   * Builds the batch definition for the documents still owed extraction.
+   *
+   * @param array $media_ids
+   *   The media ids to sweep, from PdfTextIndexer::pendingMediaIds().
+   *
+   * @return array|null
+   *   A batch definition, or NULL when there is nothing to sweep and the
+   *   caller should not start a batch at all.
+   */
+  public static function build(array $media_ids): ?array {
+    if (!$media_ids) {
+      return NULL;
+    }
+    $ids = array_values($media_ids);
+    $operations = [];
+    foreach (array_chunk($ids, self::CHUNK) as $chunk) {
+      $operations[] = [[static::class, 'process'], [$chunk]];
+    }
+    return [
+      'title' => t('Extracting text from PDF documents'),
+      'operations' => $operations,
+      'finished' => [static::class, 'finished'],
+      'progress_message' => t('Checked @current of @total document batches.'),
+    ];
+  }
+
+  /**
+   * Extracts text for one chunk of media ids.
+   *
+   * @param array $media_ids
+   *   The media ids to examine.
+   * @param array $context
+   *   The batch context.
+   */
+  public static function process(array $media_ids, array &$context): void {
+    // phpcs:ignore DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
+    $indexer = \Drupal::service('ys_beacon.pdf_text_indexer');
+    // phpcs:ignore DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
+    $storage = \Drupal::entityTypeManager()->getStorage('media');
+    $context['results']['checked'] ??= 0;
+
+    foreach ($storage->loadMultiple($media_ids) as $media) {
+      // pendingMediaIds() only narrows the field; needsExtraction() is the
+      // authority, and it is re-checked here because the sweep can be queued
+      // well before the operation runs.
+      if (!$indexer->needsExtraction($media)) {
+        continue;
+      }
+      $indexer->extractAndStore($media->id());
+      $context['results']['checked']++;
+    }
+  }
+
+  /**
+   * Reports how many documents were processed.
+   *
+   * @param bool $success
+   *   Whether the batch completed without an uncaught error.
+   * @param array $results
+   *   The accumulated batch results.
+   * @param array $operations
+   *   Any operations that did not run.
+   */
+  public static function finished(bool $success, array $results, array $operations): void {
+    // phpcs:ignore DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
+    $messenger = \Drupal::messenger();
+    if (!$success) {
+      $messenger->addWarning(t('PDF text extraction did not finish. Any documents it did not reach are picked up by the next run.'));
+      return;
+    }
+    $checked = $results['checked'] ?? 0;
+    if ($checked) {
+      // "Checked", not "extracted": a scanned, corrupt, oversized or
+      // unreadable PDF is processed here but legitimately stores no text.
+      $messenger->addStatus(t('Checked @count PDF document(s) for extractable text.', ['@count' => $checked]));
+    }
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/search_api/processor/ExcludeAiDisabled.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/search_api/processor/ExcludeAiDisabled.php
@@ -4,9 +4,11 @@ namespace Drupal\ys_beacon\Plugin\search_api\processor;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\media\MediaInterface;
 use Drupal\search_api\Attribute\SearchApiProcessor;
 use Drupal\search_api\Processor\ProcessorPluginBase;
 use Drupal\ys_beacon\Service\BeaconIndexability;
+use Drupal\ys_beacon\Service\PdfTextIndexer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -18,11 +20,17 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * already-indexed entity stops being indexable and is saved, Search API
  * re-tracks it, this processor drops it, and the AI Search backend removes
  * its chunks from the vector database.
+ *
+ * A PDF document with no extracted text is dropped for the same reason: its
+ * only remaining body is the rendered file link, so it would be embedded as a
+ * filename-only chunk that matches filename-shaped queries and cites a
+ * document with nothing behind it. Once the text is stored the media save
+ * re-tracks the item and it is indexed normally.
  */
 #[SearchApiProcessor(
   id: 'ys_beacon_exclude_ai_disabled',
   label: new TranslatableMarkup('Beacon AI indexing exclusion'),
-  description: new TranslatableMarkup('Excludes unpublished, access-restricted, and AI-disabled content from the Beacon index.'),
+  description: new TranslatableMarkup('Excludes unpublished, access-restricted, and AI-disabled content, and documents with no extracted text, from the Beacon index.'),
   stages: [
     'alter_items' => 0,
   ],
@@ -37,11 +45,19 @@ class ExcludeAiDisabled extends ProcessorPluginBase {
   protected BeaconIndexability $indexability;
 
   /**
+   * The PDF text indexer.
+   *
+   * @var \Drupal\ys_beacon\Service\PdfTextIndexer
+   */
+  protected PdfTextIndexer $pdfTextIndexer;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     $processor = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $processor->indexability = $container->get('ys_beacon.indexability');
+    $processor->pdfTextIndexer = $container->get('ys_beacon.pdf_text_indexer');
     return $processor;
   }
 
@@ -55,6 +71,12 @@ class ExcludeAiDisabled extends ProcessorPluginBase {
         continue;
       }
       if (!$this->indexability->isIndexable($entity)) {
+        unset($items[$item_id]);
+        continue;
+      }
+      // A PDF still waiting on extraction has nothing but its filename to
+      // contribute; leave it out until its text lands.
+      if ($entity instanceof MediaInterface && $this->pdfTextIndexer->lacksExtractedText($entity)) {
         unset($items[$item_id]);
       }
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/PdfTextIndexer.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/PdfTextIndexer.php
@@ -3,8 +3,11 @@
 namespace Drupal\ys_beacon\Service;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
+use Drupal\Core\KeyValueStore\KeyValueStoreInterface;
 use Drupal\file\FileInterface;
 use Drupal\media\MediaInterface;
 use Psr\Log\LoggerInterface;
@@ -25,9 +28,21 @@ class PdfTextIndexer {
   public const FIELD = 'field_ai_pdf_text';
 
   /**
+   * The key/value collection recording which file each attempt was made on.
+   */
+  public const ATTEMPT_COLLECTION = 'ys_beacon.pdf_extraction';
+
+  /**
    * Fallback maximum PDF size to extract, in bytes, when unset in config.
    */
   protected const DEFAULT_MAX_BYTES = 20971520;
+
+  /**
+   * Records the source file id each media item was last attempted against.
+   *
+   * @var \Drupal\Core\KeyValueStore\KeyValueStoreInterface
+   */
+  protected KeyValueStoreInterface $attempts;
 
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,
@@ -36,7 +51,10 @@ class PdfTextIndexer {
     protected BeaconIndexability $indexability,
     protected ConfigFactoryInterface $configFactory,
     protected LoggerInterface $logger,
+    protected EntityFieldManagerInterface $entityFieldManager,
+    KeyValueFactoryInterface $keyValueFactory,
   ) {
+    $this->attempts = $keyValueFactory->get(self::ATTEMPT_COLLECTION);
   }
 
   /**
@@ -61,6 +79,82 @@ class PdfTextIndexer {
   }
 
   /**
+   * Whether a media entity still needs its PDF text extracted.
+   *
+   * This is the single trigger rule, shared by the insert and update hooks and
+   * by the backfill: extraction is owed whenever the media is an extractable
+   * PDF that has not yet been attempted against the file it currently holds.
+   * Because the attempt is recorded before the extracted text is written back,
+   * that write - itself a media save - never re-queues the work; because the
+   * record is keyed to the source file id, replacing the file does.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *   The media entity.
+   *
+   * @return bool
+   *   TRUE when extraction should be queued or run for this media.
+   */
+  public function needsExtraction(MediaInterface $media): bool {
+    if (!$this->isExtractable($media)) {
+      return FALSE;
+    }
+    return $this->attempts->get((string) $media->id()) !== $this->sourceFid($media);
+  }
+
+  /**
+   * Whether an indexable PDF has no extracted text to offer the index.
+   *
+   * A document indexed with an empty text field contributes only its filename
+   * and metadata, which still matches filename-shaped queries and returns a
+   * citation with nothing behind it. Callers use this to keep such a document
+   * out of the index until its text lands.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *   The media entity.
+   *
+   * @return bool
+   *   TRUE for an extractable PDF whose stored text is empty.
+   */
+  public function lacksExtractedText(MediaInterface $media): bool {
+    return $this->isExtractable($media)
+      && trim((string) $media->get(self::FIELD)->value) === '';
+  }
+
+  /**
+   * Returns the ids of media that may still be owed text extraction.
+   *
+   * Narrowed to media that could plausibly need work - the bundles carrying the
+   * storage field and holding no text are selected in the database, then
+   * already-attempted ones are dropped in PHP - so a caller does not load the
+   * whole media library to find out. It is a filter,
+   * not the decision: needsExtraction() is still the authority on each item.
+   * A replaced file whose previous extraction was attempted is excluded here
+   * and covered by the update hook instead.
+   *
+   * @return array
+   *   Media ids, as strings.
+   */
+  public function pendingMediaIds(): array {
+    $bundles = $this->entityFieldManager->getFieldMap()['media'][self::FIELD]['bundles'] ?? [];
+    if (!$bundles) {
+      return [];
+    }
+    $query = $this->entityTypeManager->getStorage('media')->getQuery()->accessCheck(FALSE);
+    $empty = $query->orConditionGroup()
+      ->notExists(self::FIELD)
+      ->condition(self::FIELD, '');
+    $ids = $query->condition('bundle', $bundles, 'IN')
+      ->condition($empty)
+      ->execute();
+
+    $attempted = $this->attempts->getAll();
+    return array_values(array_filter(
+      array_map('strval', $ids),
+      static fn (string $id): bool => !array_key_exists($id, $attempted)
+    ));
+  }
+
+  /**
    * Extracts and stores the text for a queued media id.
    *
    * @param int|string $media_id
@@ -68,9 +162,24 @@ class PdfTextIndexer {
    */
   public function extractAndStore(int|string $media_id): void {
     $media = $this->entityTypeManager->getStorage('media')->load($media_id);
-    if (!$media instanceof MediaInterface || !$this->isExtractable($media)) {
+    // needsExtraction() rather than isExtractable(): the queue does not
+    // de-duplicate, and the trigger now fires on every media update, so an
+    // editor who saves a document several times before cron runs leaves
+    // several items pointing at it. Without this the second and later items
+    // re-parse the whole PDF for a result that is already stored.
+    if (!$media instanceof MediaInterface || !$this->needsExtraction($media)) {
       return;
     }
+
+    // Record the attempt before doing anything else: every path from here is a
+    // final decision about this file, and an unrecorded one would be selected
+    // again by every later save, sweep and backfill. That matters most for the
+    // unreadable-file case below, which is not rare in bulk - a migrated site
+    // with dangling file rows would otherwise carry a backlog that can never
+    // drain. Restoring a missing file does not re-trigger extraction on its
+    // own; replacing the file does, and `drush ys_beacon:extract-pdf-text
+    // --force` clears the records outright.
+    $this->recordAttempt($media);
 
     $file = $this->sourceFile($media);
     $path = $file ? $this->fileSystem->realpath($file->getFileUri()) : NULL;
@@ -122,6 +231,56 @@ class PdfTextIndexer {
   }
 
   /**
+   * Forgets the recorded extraction attempt for a media item.
+   *
+   * @param int|string $media_id
+   *   The media entity id.
+   */
+  public function forgetAttempt(int|string $media_id): void {
+    $this->attempts->delete((string) $media_id);
+  }
+
+  /**
+   * Forgets every recorded extraction attempt, so all documents are retried.
+   */
+  public function forgetAllAttempts(): void {
+    $this->attempts->deleteAll();
+  }
+
+  /**
+   * Records that this media has been attempted against its current file.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *   The media entity.
+   */
+  protected function recordAttempt(MediaInterface $media): void {
+    $fid = $this->sourceFid($media);
+    if ($fid !== NULL) {
+      $this->attempts->set((string) $media->id(), $fid);
+    }
+  }
+
+  /**
+   * Returns the source file id of a media entity, or NULL.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *   The media entity.
+   *
+   * @return string|null
+   *   The source file id, or NULL when the media has no file source.
+   */
+  protected function sourceFid(MediaInterface $media): ?string {
+    try {
+      $fid = $media->getSource()->getSourceFieldValue($media);
+      return $fid !== NULL ? (string) $fid : NULL;
+    }
+    catch (\Throwable $e) {
+      // Non-file media source: no file to identify.
+      return NULL;
+    }
+  }
+
+  /**
    * Loads the source file entity behind a media item.
    *
    * @param \Drupal\media\MediaInterface $media
@@ -131,15 +290,10 @@ class PdfTextIndexer {
    *   The source file, or NULL when unavailable.
    */
   protected function sourceFile(MediaInterface $media): ?FileInterface {
-    try {
-      $fid = $media->getSource()->getSourceFieldValue($media);
-      if ($fid && is_numeric($fid)) {
-        $file = $this->entityTypeManager->getStorage('file')->load($fid);
-        return $file instanceof FileInterface ? $file : NULL;
-      }
-    }
-    catch (\Throwable $e) {
-      // Non-file media source: not extractable.
+    $fid = $this->sourceFid($media);
+    if ($fid !== NULL && is_numeric($fid)) {
+      $file = $this->entityTypeManager->getStorage('file')->load($fid);
+      return $file instanceof FileInterface ? $file : NULL;
     }
     return NULL;
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/PdfTextExtractionTriggerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/PdfTextExtractionTriggerTest.php
@@ -1,0 +1,350 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Kernel;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\file\Entity\File;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\media\Entity\Media;
+use Drupal\media\Entity\MediaType;
+use Drupal\ys_beacon\BeaconAuthorization;
+use Drupal\ys_beacon\PdfTextExtractionBatch;
+use Drupal\ys_beacon\Service\BeaconIndexability;
+use Drupal\ys_beacon\Service\PdfTextExtractorInterface;
+use Drupal\ys_beacon\Service\PdfTextIndexer;
+
+/**
+ * Proves PDF text extraction is queued for every way a document is opted in.
+ *
+ * Media is excluded from AI indexing by default, so a document is never
+ * extractable at upload time and an editor has to opt it in afterwards - which
+ * is a plain media update. The trigger this replaces only fired when the source
+ * file id changed, so extraction could never run for a document uploaded and
+ * opted in through the normal editorial flow (issue #1580). These tests drive
+ * the hooks directly rather than enabling ys_beacon, whose dependency graph is
+ * heavy, following BeaconImmediateRemovalTest; the indexability, authorization
+ * and extractor collaborators are doubled so each transition can be scripted.
+ *
+ * The sweep is covered here too, because it answers the same question from the
+ * other side: it is what picks up the documents the hooks never fired for. One
+ * mechanism backs both the backfill and the "Index now" / "Re-index all
+ * content" controls, so proving it once proves both. What extraction itself
+ * stores is covered by PdfTextIndexerTest.
+ *
+ * @group ys_beacon
+ */
+class PdfTextExtractionTriggerTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'field', 'file', 'image', 'media'];
+
+  /**
+   * Whether the doubled indexability service reports media as opted out.
+   */
+  private bool $optedOut = TRUE;
+
+  /**
+   * The text the doubled parser returns.
+   */
+  private string $extractedText = 'Extracted body text';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('media');
+    $this->installSchema('file', ['file_usage']);
+    $this->installConfig(['field', 'system']);
+
+    $media_type = MediaType::create([
+      'id' => 'document',
+      'label' => 'Document',
+      'source' => 'file',
+    ]);
+    $media_type->save();
+    $source_field = $media_type->getSource()->createSourceField($media_type);
+    $source_field->getFieldStorageDefinition()->save();
+    $source_field->save();
+    $media_type->set('source_configuration', ['source_field' => $source_field->getName()])->save();
+
+    FieldStorageConfig::create([
+      'field_name' => PdfTextIndexer::FIELD,
+      'entity_type' => 'media',
+      'type' => 'string_long',
+    ])->save();
+    FieldConfig::create([
+      'field_name' => PdfTextIndexer::FIELD,
+      'entity_type' => 'media',
+      'bundle' => 'document',
+      'label' => 'AI extracted text',
+    ])->save();
+
+    // The hooks read ys_beacon.settings directly. That config's schema ships
+    // with the (here-disabled) ys_beacon module, so write it straight to the
+    // config storage rather than through the schema-validating save path.
+    \Drupal::service('config.storage')->write('ys_beacon.settings', [
+      'azure_index_name' => 'test-index',
+    ]);
+    \Drupal::configFactory()->reset('ys_beacon.settings');
+
+    $indexability = $this->createMock(BeaconIndexability::class);
+    $indexability->method('isIndexingDisabled')->willReturnCallback(fn () => $this->optedOut);
+    // The update hook's other job - removing chunks the moment content stops
+    // being indexable - bails on still-indexable content, which keeps these
+    // tests on the extraction path.
+    $indexability->method('isIndexable')->willReturn(TRUE);
+    $this->container->set('ys_beacon.indexability', $indexability);
+
+    $authorization = $this->createMock(BeaconAuthorization::class);
+    $authorization->method('isAuthorized')->willReturn(TRUE);
+    $this->container->set('ys_beacon.authorization', $authorization);
+
+    $extractor = $this->createMock(PdfTextExtractorInterface::class);
+    $extractor->method('extractText')->willReturnCallback(fn () => $this->extractedText);
+    $this->container->set('ys_beacon.pdf_text_indexer', new PdfTextIndexer(
+      $this->container->get('entity_type.manager'),
+      $this->container->get('file_system'),
+      $extractor,
+      $indexability,
+      $this->container->get('config.factory'),
+      $this->container->get('logger.factory')->get('ys_beacon'),
+      $this->container->get('entity_field.manager'),
+      $this->container->get('keyvalue'),
+    ));
+
+    // ys_beacon is not enabled here, so its hooks are included and invoked
+    // directly. The file has no include-time side effects.
+    require_once dirname(__DIR__, 3) . '/ys_beacon.module';
+  }
+
+  /**
+   * Opting an existing document in queues its extraction.
+   *
+   * The reported bug: the opt-in save carries the same source file, so the
+   * old file-changed trigger never fired and the document stayed empty.
+   */
+  public function testOptingInQueuesExtraction(): void {
+    $media = $this->createPdfMedia();
+    ys_beacon_entity_insert($media);
+    $this->assertSame(0, $this->queueDepth(), 'A document uploaded while opted out queues nothing.');
+
+    $this->optedOut = FALSE;
+    $media->original = clone $media;
+    ys_beacon_entity_update($media);
+
+    $this->assertSame(1, $this->queueDepth(), 'Opting the document in queues its text extraction.');
+  }
+
+  /**
+   * A document created already opted in is queued at insert.
+   *
+   * Programmatic and migration paths can set the metatag at insert time.
+   */
+  public function testDocumentCreatedOptedInIsQueued(): void {
+    $this->optedOut = FALSE;
+    $media = $this->createPdfMedia();
+
+    ys_beacon_entity_insert($media);
+
+    $this->assertSame(1, $this->queueDepth(), 'A document that is already opted in is queued on creation.');
+  }
+
+  /**
+   * A document left opted out is never queued, however often it is saved.
+   */
+  public function testOptedOutDocumentIsNeverQueued(): void {
+    $media = $this->createPdfMedia();
+    ys_beacon_entity_insert($media);
+    $media->original = clone $media;
+    ys_beacon_entity_update($media);
+
+    $this->assertSame(0, $this->queueDepth(), 'The editor opt-out must keep the document out of extraction entirely.');
+  }
+
+  /**
+   * Storing the extracted text does not queue the work again.
+   *
+   * Extraction saves the media, which is itself an update: without the
+   * recorded attempt the new trigger would re-queue on its own output.
+   */
+  public function testStoringExtractedTextDoesNotRequeue(): void {
+    $this->optedOut = FALSE;
+    $media = $this->createPdfMedia();
+    ys_beacon_entity_insert($media);
+    $this->assertSame(1, $this->queueDepth());
+
+    $this->indexer()->extractAndStore($media->id());
+    $stored = Media::load($media->id());
+    $this->assertSame('Extracted body text', $stored->get(PdfTextIndexer::FIELD)->value);
+
+    $stored->original = clone $stored;
+    ys_beacon_entity_update($stored);
+
+    $this->assertSame(1, $this->queueDepth(), 'Writing the extracted text back must not queue extraction again.');
+  }
+
+  /**
+   * A PDF with no text layer is attempted once, not on every later save.
+   */
+  public function testImageOnlyPdfIsNotReattempted(): void {
+    $this->optedOut = FALSE;
+    $this->extractedText = '';
+    $media = $this->createPdfMedia();
+
+    $this->indexer()->extractAndStore($media->id());
+    $reloaded = Media::load($media->id());
+    $reloaded->original = clone $reloaded;
+    ys_beacon_entity_update($reloaded);
+
+    $this->assertSame(0, $this->queueDepth(), 'A scanned PDF that legitimately yields no text is not parsed again.');
+    $this->assertSame([], $this->indexer()->pendingMediaIds(), 'An attempted document drops out of the backfill sweep.');
+  }
+
+  /**
+   * Replacing the file re-queues extraction for the new document.
+   */
+  public function testReplacingTheFileRequeuesExtraction(): void {
+    $this->optedOut = FALSE;
+    $media = $this->createPdfMedia();
+    $this->indexer()->extractAndStore($media->id());
+
+    $replacement = $this->createPdfFile('replacement.pdf');
+    $reloaded = Media::load($media->id());
+    $reloaded->original = clone $reloaded;
+    $reloaded->set('field_media_file', ['target_id' => $replacement->id()]);
+    ys_beacon_entity_update($reloaded);
+
+    $this->assertSame(1, $this->queueDepth(), 'A replaced file is a different document and is extracted again.');
+  }
+
+  /**
+   * Documents still owed extraction are the ones the backfill sweeps.
+   */
+  public function testPendingMediaIdsListsUnextractedDocuments(): void {
+    $this->optedOut = FALSE;
+    $first = $this->createPdfMedia();
+    $second = $this->createPdfMedia('second.pdf');
+
+    $this->assertEqualsCanonicalizing(
+      [(string) $first->id(), (string) $second->id()],
+      $this->indexer()->pendingMediaIds(),
+      'Both documents are waiting for extraction.',
+    );
+
+    $this->indexer()->extractAndStore($first->id());
+
+    $this->assertSame(
+      [(string) $second->id()],
+      $this->indexer()->pendingMediaIds(),
+      'An extracted document is no longer swept.',
+    );
+  }
+
+  /**
+   * The queued payload is the media id the worker expects.
+   */
+  public function testQueuedItemCarriesTheMediaId(): void {
+    $this->optedOut = FALSE;
+    $media = $this->createPdfMedia();
+    ys_beacon_entity_insert($media);
+
+    $item = \Drupal::queue('ys_beacon_pdf_text_extraction')->claimItem();
+
+    $this->assertSame(['media_id' => $media->id()], $item->data);
+  }
+
+  /**
+   * The sweep extracts every document still waiting for it.
+   *
+   * This is the backfill and the "Index now" pre-pass: one mechanism, so the
+   * documents no editorial save ever queued are picked up by both.
+   */
+  public function testSweepExtractsPendingDocuments(): void {
+    $this->optedOut = FALSE;
+    $first = $this->createPdfMedia();
+    $second = $this->createPdfMedia('second.pdf');
+
+    $context = [];
+    PdfTextExtractionBatch::process($this->indexer()->pendingMediaIds(), $context);
+
+    $this->assertSame('Extracted body text', Media::load($first->id())->get(PdfTextIndexer::FIELD)->value);
+    $this->assertSame('Extracted body text', Media::load($second->id())->get(PdfTextIndexer::FIELD)->value);
+    $this->assertSame(2, $context['results']['checked']);
+  }
+
+  /**
+   * The sweep never extracts a document the editor opted out of.
+   */
+  public function testSweepSkipsOptedOutDocuments(): void {
+    $media = $this->createPdfMedia();
+
+    $context = [];
+    PdfTextExtractionBatch::process([$media->id()], $context);
+
+    $this->assertSame('', (string) Media::load($media->id())->get(PdfTextIndexer::FIELD)->value);
+  }
+
+  /**
+   * The sweep is chunked, so a large library is not one batch operation.
+   *
+   * A batch operation cannot be interrupted part-way, so a chunk has to stay
+   * small enough that one request only ever parses one document.
+   */
+  public function testSweepIsChunkedAcrossOperations(): void {
+    $batch = PdfTextExtractionBatch::build(range(1, 25));
+
+    $this->assertCount(25, $batch['operations'], '25 documents are split one per operation.');
+  }
+
+  /**
+   * No batch is started when no document needs extraction.
+   */
+  public function testNoBatchWhenNothingIsPending(): void {
+    $this->assertNull(PdfTextExtractionBatch::build([]));
+  }
+
+  /**
+   * The PDF text indexer under test.
+   */
+  private function indexer(): PdfTextIndexer {
+    return $this->container->get('ys_beacon.pdf_text_indexer');
+  }
+
+  /**
+   * The number of items waiting in the extraction queue.
+   */
+  private function queueDepth(): int {
+    return (int) \Drupal::queue('ys_beacon_pdf_text_extraction')->numberOfItems();
+  }
+
+  /**
+   * Creates a saved PDF file entity.
+   */
+  private function createPdfFile(string $filename): File {
+    $uri = 'public://' . $filename;
+    file_put_contents($uri, 'dummy');
+    $file = File::create(['uri' => $uri, 'filename' => $filename, 'filemime' => 'application/pdf']);
+    $file->save();
+    return $file;
+  }
+
+  /**
+   * Creates a document media entity wrapping a saved PDF file.
+   */
+  private function createPdfMedia(string $filename = 'report.pdf'): Media {
+    $media = Media::create([
+      'bundle' => 'document',
+      'name' => $filename,
+      'field_media_file' => ['target_id' => $this->createPdfFile($filename)->id()],
+    ]);
+    $media->save();
+    return $media;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/PdfTextIndexerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Kernel/PdfTextIndexerTest.php
@@ -136,6 +136,45 @@ class PdfTextIndexerTest extends KernelTestBase {
   }
 
   /**
+   * An extractable PDF with no stored text is reported as having none.
+   *
+   * The index drops such a document rather than embedding a chunk whose only
+   * content is its filename.
+   *
+   * @covers ::lacksExtractedText
+   */
+  public function testPdfWithoutStoredTextLacksExtractedText(): void {
+    $media = $this->createPdfMedia('empty.pdf', 'application/pdf', 'dummy');
+
+    $this->assertTrue($this->indexer($this->stubExtractor(''))->lacksExtractedText($media));
+  }
+
+  /**
+   * A PDF that has been extracted is not reported as lacking text.
+   *
+   * @covers ::lacksExtractedText
+   */
+  public function testExtractedPdfDoesNotLackText(): void {
+    $media = $this->createPdfMedia('full.pdf', 'application/pdf', 'dummy');
+    $indexer = $this->indexer($this->stubExtractor('Extracted body text'));
+
+    $indexer->extractAndStore($media->id());
+
+    $this->assertFalse($indexer->lacksExtractedText(Media::load($media->id())));
+  }
+
+  /**
+   * A non-PDF is never reported as lacking text; it is not ours to gate.
+   *
+   * @covers ::lacksExtractedText
+   */
+  public function testNonPdfDoesNotLackText(): void {
+    $media = $this->createPdfMedia('photo.jpg', 'image/jpeg', 'binary');
+
+    $this->assertFalse($this->indexer($this->stubExtractor(''))->lacksExtractedText($media));
+  }
+
+  /**
    * Creates a document media entity wrapping a written file.
    */
   private function createPdfMedia(string $filename, string $mime, string $contents): Media {
@@ -192,6 +231,8 @@ class PdfTextIndexerTest extends KernelTestBase {
       $indexability,
       $configFactory,
       $this->container->get('logger.factory')->get('ys_beacon'),
+      $this->container->get('entity_field.manager'),
+      $this->container->get('keyvalue'),
     );
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconPdfBackfillDeployTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconPdfBackfillDeployTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\BeaconAuthorization;
+use Drupal\ys_beacon\Service\PdfTextIndexer;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Tests that the PDF backfill deploy hook only runs where Beacon is on.
+ *
+ * Beacon is authorized per site by a platform administrator, so most sites
+ * receiving this deploy do not have it switched off-and-on but simply off. The
+ * per-item queueing helper already refuses to queue there, but the enumeration
+ * feeding it - an entity query over the media library plus chunked entity
+ * loads - would still run on every site in the platform to achieve nothing.
+ * These tests prove the hook decides once, before touching any content.
+ *
+ * The container deliberately omits entity_type.manager: if the hook ever gets
+ * past the guard it fails loudly rather than silently doing the work.
+ *
+ * @group ys_beacon
+ */
+class BeaconPdfBackfillDeployTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 3) . '/ys_beacon.deploy.php';
+  }
+
+  /**
+   * An unauthorized site queues nothing and never reads its media library.
+   */
+  public function testSkipsWhenBeaconIsNotAuthorized(): void {
+    $this->containerWith(authorized: FALSE, indexName: 'some-index');
+
+    $sandbox = [];
+    $result = ys_beacon_deploy_10002($sandbox);
+
+    $this->assertSame(
+      'Beacon is not enabled on this site; no PDF text extraction was queued.',
+      (string) $result,
+    );
+    $this->assertSame(1, $sandbox['#finished'], 'The hook reports itself complete.');
+  }
+
+  /**
+   * A site with no Azure index configured is skipped for the same reason.
+   */
+  public function testSkipsWhenNoIndexNameIsConfigured(): void {
+    $this->containerWith(authorized: TRUE, indexName: '');
+
+    $sandbox = [];
+    $result = ys_beacon_deploy_10002($sandbox);
+
+    $this->assertSame(
+      'Beacon is not enabled on this site; no PDF text extraction was queued.',
+      (string) $result,
+    );
+    $this->assertSame(1, $sandbox['#finished']);
+  }
+
+  /**
+   * An enabled site gets past the guard and consults the pending documents.
+   */
+  public function testEnabledSiteEnumeratesPendingDocuments(): void {
+    $indexer = $this->createMock(PdfTextIndexer::class);
+    $indexer->expects($this->once())->method('pendingMediaIds')->willReturn([]);
+    $this->containerWith(authorized: TRUE, indexName: 'some-index', indexer: $indexer);
+
+    $sandbox = [];
+    $result = ys_beacon_deploy_10002($sandbox);
+
+    $this->assertSame(
+      'No PDF documents were waiting for text extraction.',
+      (string) $result,
+      'With nothing pending the hook completes without loading any media.',
+    );
+    $this->assertSame(1, $sandbox['#finished']);
+  }
+
+  /**
+   * Builds the minimal container the guard needs.
+   *
+   * @param bool $authorized
+   *   Whether a platform administrator has authorized Beacon for the site.
+   * @param string $indexName
+   *   The configured Azure index name.
+   * @param \Drupal\ys_beacon\Service\PdfTextIndexer|null $indexer
+   *   The PDF text indexer, when the test expects the guard to be passed.
+   */
+  private function containerWith(bool $authorized, string $indexName, ?PdfTextIndexer $indexer = NULL): void {
+    $authorization = $this->createMock(BeaconAuthorization::class);
+    $authorization->method('isAuthorized')->willReturn($authorized);
+
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->with('azure_index_name')->willReturn($indexName);
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->with('ys_beacon.settings')->willReturn($config);
+
+    $container = new ContainerBuilder();
+    // setUp() has already required the deploy file, so the module handler only
+    // has to accept the loadInclude() call.
+    $container->set('module_handler', $this->createMock(ModuleHandlerInterface::class));
+    $container->set('ys_beacon.authorization', $authorization);
+    $container->set('config.factory', $configFactory);
+    $container->set('string_translation', $this->getStringTranslationStub());
+    if ($indexer) {
+      $container->set('ys_beacon.pdf_text_indexer', $indexer);
+    }
+    \Drupal::setContainer($container);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/ExcludeAiDisabledProcessorTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/ExcludeAiDisabledProcessorTest.php
@@ -4,10 +4,12 @@ namespace Drupal\Tests\ys_beacon\Unit;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\TypedData\ComplexDataInterface;
+use Drupal\media\MediaInterface;
 use Drupal\search_api\Item\ItemInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\ys_beacon\Plugin\search_api\processor\ExcludeAiDisabled;
 use Drupal\ys_beacon\Service\BeaconIndexability;
+use Drupal\ys_beacon\Service\PdfTextIndexer;
 
 /**
  * Proves the Search API processor drops non-indexable items before indexing.
@@ -15,7 +17,8 @@ use Drupal\ys_beacon\Service\BeaconIndexability;
  * ExcludeAiDisabled is the write-path gate: Search API collects tracked items
  * and this processor removes any whose entity fails BeaconIndexability, so a
  * protected or AI-disabled entity is never embedded into the shared vector
- * database. This isolates the processor's own drop logic; the indexability
+ * database. It also drops documents whose PDF text has not been extracted.
+ * This isolates the processor's own drop logic; the indexability
  * decision itself is covered by BeaconIndexabilityAccessTest and
  * BeaconIndexabilityTest.
  *
@@ -67,6 +70,54 @@ class ExcludeAiDisabledProcessorTest extends UnitTestCase {
   }
 
   /**
+   * A document whose PDF text was never extracted is dropped.
+   *
+   * Indexing it would embed a chunk whose only content is the filename: it
+   * matches filename-shaped queries and cites a document with nothing behind
+   * it, which is the whole of issue #1580's user-visible damage.
+   *
+   * @covers ::alterIndexedItems
+   */
+  public function testDocumentWithoutExtractedTextIsDropped(): void {
+    $withText = $this->createMock(MediaInterface::class);
+    $withoutText = $this->createMock(MediaInterface::class);
+
+    $indexability = $this->createMock(BeaconIndexability::class);
+    $indexability->method('isIndexable')->willReturn(TRUE);
+    $pdfTextIndexer = $this->createMock(PdfTextIndexer::class);
+    $pdfTextIndexer->method('lacksExtractedText')
+      ->willReturnCallback(fn ($entity) => $entity === $withoutText);
+
+    $items = [
+      'keep' => $this->item($withText),
+      'drop' => $this->item($withoutText),
+    ];
+
+    $this->processor($indexability, $pdfTextIndexer)->alterIndexedItems($items);
+
+    $this->assertArrayHasKey('keep', $items, 'A document with extracted text is indexed.');
+    $this->assertArrayNotHasKey('drop', $items, 'A document with no extracted text is kept out of the index.');
+  }
+
+  /**
+   * A node is never put through the document text gate.
+   *
+   * @covers ::alterIndexedItems
+   */
+  public function testNonMediaIsNotGatedOnExtractedText(): void {
+    $indexability = $this->createMock(BeaconIndexability::class);
+    $indexability->method('isIndexable')->willReturn(TRUE);
+    $pdfTextIndexer = $this->createMock(PdfTextIndexer::class);
+    $pdfTextIndexer->expects($this->never())->method('lacksExtractedText');
+
+    $items = ['keep' => $this->item($this->createMock(EntityInterface::class))];
+
+    $this->processor($indexability, $pdfTextIndexer)->alterIndexedItems($items);
+
+    $this->assertArrayHasKey('keep', $items);
+  }
+
+  /**
    * Wraps an entity in a Search API item, as the processor receives it.
    */
   private function item(EntityInterface $entity): ItemInterface {
@@ -80,10 +131,12 @@ class ExcludeAiDisabledProcessorTest extends UnitTestCase {
   /**
    * Builds the processor with the indexability service injected.
    */
-  private function processor(BeaconIndexability $indexability): ExcludeAiDisabled {
+  private function processor(BeaconIndexability $indexability, ?PdfTextIndexer $pdfTextIndexer = NULL): ExcludeAiDisabled {
     $processor = (new \ReflectionClass(ExcludeAiDisabled::class))->newInstanceWithoutConstructor();
     $property = new \ReflectionProperty(ExcludeAiDisabled::class, 'indexability');
     $property->setValue($processor, $indexability);
+    $property = new \ReflectionProperty(ExcludeAiDisabled::class, 'pdfTextIndexer');
+    $property->setValue($processor, $pdfTextIndexer ?? $this->createMock(PdfTextIndexer::class));
     return $processor;
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/IndexNowFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/IndexNowFormTest.php
@@ -13,6 +13,7 @@ use Drupal\search_api\Utility\IndexingBatchHelperInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\ys_beacon\Form\YsBeaconSettings;
 use Drupal\ys_beacon\Service\BeaconIndexStatus;
+use Drupal\ys_beacon\Service\PdfTextIndexer;
 
 /**
  * Tests the "Index now" button state and submit handler on the Beacon form.
@@ -47,6 +48,12 @@ class IndexNowFormTest extends UnitTestCase {
     $form = (new \ReflectionClass(YsBeaconSettings::class))->newInstanceWithoutConstructor();
     $this->setProtected($form, 'indexStatus', $this->buildIndexStatus($index));
     $this->setProtected($form, 'indexingBatchHelper', $helper ?? $this->createMock(IndexingBatchHelperInterface::class));
+    // No document is waiting on extraction, so the handlers under test do not
+    // reach batch_set(); the sweep itself is covered by
+    // PdfTextExtractionTriggerTest.
+    $pdfTextIndexer = $this->createMock(PdfTextIndexer::class);
+    $pdfTextIndexer->method('pendingMediaIds')->willReturn([]);
+    $this->setProtected($form, 'pdfTextIndexer', $pdfTextIndexer);
     $this->setProtected($form, 'messenger', $messenger ?? $this->createMock(MessengerInterface::class));
     $this->setProtected($form, 'stringTranslation', $this->getStringTranslationStub());
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/YsBeaconAdminSettingsTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/YsBeaconAdminSettingsTest.php
@@ -16,6 +16,7 @@ use Drupal\Tests\UnitTestCase;
 use Drupal\ys_beacon\Form\YsBeaconAdminSettings;
 use Drupal\ys_beacon\Service\BeaconIndexManager;
 use Drupal\ys_beacon\Service\BeaconIndexStatus;
+use Drupal\ys_beacon\Service\PdfTextIndexer;
 
 /**
  * Tests the Beacon administration settings form.
@@ -102,6 +103,11 @@ class YsBeaconAdminSettingsTest extends UnitTestCase {
     $form = (new \ReflectionClass(YsBeaconAdminSettings::class))->newInstanceWithoutConstructor();
     $this->setProtected($form, 'indexStatus', $index_status);
     $this->setProtected($form, 'indexingBatchHelper', $helper ?? $this->createMock(IndexingBatchHelperInterface::class));
+    // No document is waiting on extraction, so the mirrored handlers do not
+    // reach batch_set(); the sweep is covered by PdfTextExtractionTriggerTest.
+    $pdfTextIndexer = $this->createMock(PdfTextIndexer::class);
+    $pdfTextIndexer->method('pendingMediaIds')->willReturn([]);
+    $this->setProtected($form, 'pdfTextIndexer', $pdfTextIndexer);
     $this->setProtected($form, 'configFactory', $config_factory);
     $this->setProtected($form, 'messenger', $messenger ?? $this->createMock(MessengerInterface::class));
     $this->setProtected($form, 'stringTranslation', $this->getStringTranslationStub());

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.deploy.php
@@ -79,15 +79,30 @@ function ys_beacon_deploy_10001() {
  * ys_beacon_pdf_text_extraction worker already drains on cron, so the deploy
  * window stays short. The sandbox pages through the library because loading
  * every media item at once would not survive a large one. Sites where Beacon
- * is unauthorized or unconfigured queue nothing - the shared gate in
- * _ys_beacon_queue_pdf_extraction() decides, so it cannot drift from the
- * editorial path.
+ * is unauthorized or unconfigured are skipped outright, before the library is
+ * enumerated at all; the per-item gate in _ys_beacon_queue_pdf_extraction()
+ * still decides each document, so the rule cannot drift from the editorial
+ * path.
  */
 function ys_beacon_deploy_10002(array &$sandbox) {
   // Belt and braces: deploy:hook runs at full bootstrap, so the module file
   // holding the queueing helper is already loaded. Asking for it explicitly
   // costs nothing and keeps this hook honest about what it depends on.
   \Drupal::moduleHandler()->loadInclude('ys_beacon', 'module');
+
+  // Beacon is authorized per site by a platform administrator and a site can
+  // be left without an index name, so most sites receiving this deploy have it
+  // switched off. _ys_beacon_queue_pdf_extraction() gates on exactly these two
+  // conditions and would queue nothing anyway, but the enumeration that feeds
+  // it - an entity query over the media library plus chunked entity loads -
+  // still costs real deploy time on a large site to achieve nothing. Decide
+  // once, up front. Deploy hooks run after config:import, so this reads the
+  // site's post-import state, which is the state the queue would run against.
+  if (!\Drupal::service('ys_beacon.authorization')->isAuthorized()
+    || !\Drupal::config('ys_beacon.settings')->get('azure_index_name')) {
+    $sandbox['#finished'] = 1;
+    return t('Beacon is not enabled on this site; no PDF text extraction was queued.');
+  }
 
   if (!isset($sandbox['ids'])) {
     $sandbox['ids'] = \Drupal::service('ys_beacon.pdf_text_indexer')->pendingMediaIds();

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.deploy.php
@@ -64,3 +64,54 @@ function ys_beacon_deploy_10001() {
     ? t('Filled in Beacon settings defaults missing from an incomplete configuration.')
     : t('Beacon settings are complete; nothing to restore.');
 }
+
+/**
+ * Queues PDF text extraction for documents that predate the trigger fix.
+ *
+ * Until issue #1580 extraction only ever fired when a media item's source file
+ * changed, so no document uploaded and opted in through the normal editorial
+ * flow has ever had its text extracted. On sites migrated from another
+ * platform the whole media library predates Beacon and no editor action will
+ * ever trigger it, so the backlog has to be swept once here rather than left
+ * to the fixed trigger.
+ *
+ * This only queues: parsing PDFs is pure PHP, and the existing
+ * ys_beacon_pdf_text_extraction worker already drains on cron, so the deploy
+ * window stays short. The sandbox pages through the library because loading
+ * every media item at once would not survive a large one. Sites where Beacon
+ * is unauthorized or unconfigured queue nothing - the shared gate in
+ * _ys_beacon_queue_pdf_extraction() decides, so it cannot drift from the
+ * editorial path.
+ */
+function ys_beacon_deploy_10002(array &$sandbox) {
+  // Belt and braces: deploy:hook runs at full bootstrap, so the module file
+  // holding the queueing helper is already loaded. Asking for it explicitly
+  // costs nothing and keeps this hook honest about what it depends on.
+  \Drupal::moduleHandler()->loadInclude('ys_beacon', 'module');
+
+  if (!isset($sandbox['ids'])) {
+    $sandbox['ids'] = \Drupal::service('ys_beacon.pdf_text_indexer')->pendingMediaIds();
+    $sandbox['total'] = count($sandbox['ids']);
+    $sandbox['queued'] = 0;
+  }
+  if (!$sandbox['total']) {
+    $sandbox['#finished'] = 1;
+    return t('No PDF documents were waiting for text extraction.');
+  }
+
+  $storage = \Drupal::entityTypeManager()->getStorage('media');
+  foreach ($storage->loadMultiple(array_splice($sandbox['ids'], 0, 50)) as $media) {
+    if (_ys_beacon_queue_pdf_extraction($media)) {
+      $sandbox['queued']++;
+    }
+  }
+
+  if ($sandbox['ids']) {
+    $sandbox['#finished'] = 1 - (count($sandbox['ids']) / $sandbox['total']);
+    return NULL;
+  }
+  $sandbox['#finished'] = 1;
+  return t('Queued @count PDF document(s) for text extraction; cron extracts them.', [
+    '@count' => $sandbox['queued'],
+  ]);
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.module
@@ -111,15 +111,13 @@ function ys_beacon_entity_update(EntityInterface $entity) {
   $original = $entity->original ?? NULL;
 
   if ($entity instanceof MediaInterface) {
-    // Re-extract PDF text only on a genuine file replacement: there must be a
-    // prior revision to compare against and the source file id must differ.
-    // New media are handled by hook_entity_insert, and a save with no original
-    // (some programmatic saves) is not treated as a file change - this also
-    // ensures saving our own extracted-text field back never re-queues.
-    if ($original instanceof MediaInterface
-      && _ys_beacon_media_source_fid($entity) !== _ys_beacon_media_source_fid($original)) {
-      _ys_beacon_queue_pdf_extraction($entity);
-    }
+    // One rule covers every way a document comes to be owed extraction: an
+    // editor opting it in to AI indexing, a bulk opt-in action, and a file
+    // replacement are all plain media updates, and the fid-comparison this
+    // replaced saw only the last of them. PdfTextIndexer::needsExtraction()
+    // records its attempt before writing the extracted text back, so that
+    // save - itself an update - does not re-queue the work.
+    _ys_beacon_queue_pdf_extraction($entity);
   }
 
   if (!in_array($entity->getEntityTypeId(), ['node', 'media'], TRUE)) {
@@ -317,45 +315,43 @@ function ys_beacon_entity_insert(EntityInterface $entity) {
 }
 
 /**
- * Queues background PDF text extraction for a media entity when appropriate.
+ * Implements hook_entity_delete().
  *
- * @param \Drupal\media\MediaInterface $media
- *   The media entity that may hold a PDF.
+ * Forgets the media's PDF extraction attempt record, which would otherwise
+ * outlive the media it describes.
  */
-function _ys_beacon_queue_pdf_extraction(MediaInterface $media) {
-  // Nothing runs on sites where a platform admin has not authorized Beacon.
-  if (!\Drupal::service('ys_beacon.authorization')->isAuthorized()) {
-    return;
-  }
-  // Only extract on sites where Beacon indexing is configured; without an
-  // index there is nothing to feed the extracted text into.
-  if (!\Drupal::config('ys_beacon.settings')->get('azure_index_name')) {
-    return;
-  }
-  /** @var \Drupal\ys_beacon\Service\PdfTextIndexer $indexer */
-  $indexer = \Drupal::service('ys_beacon.pdf_text_indexer');
-  if ($indexer->isExtractable($media)) {
-    \Drupal::queue('ys_beacon_pdf_text_extraction')->createItem(['media_id' => $media->id()]);
+function ys_beacon_entity_delete(EntityInterface $entity) {
+  if ($entity instanceof MediaInterface) {
+    \Drupal::service('ys_beacon.pdf_text_indexer')->forgetAttempt($entity->id());
   }
 }
 
 /**
- * Returns the source file id of a media entity, or NULL.
+ * Queues background PDF text extraction for a media entity when appropriate.
  *
  * @param \Drupal\media\MediaInterface $media
- *   The media entity.
+ *   The media entity that may hold a PDF.
  *
- * @return string|null
- *   The source file id, or NULL when the media has no file source.
+ * @return bool
+ *   TRUE when an extraction item was queued.
  */
-function _ys_beacon_media_source_fid(MediaInterface $media): ?string {
-  try {
-    $fid = $media->getSource()->getSourceFieldValue($media);
-    return $fid !== NULL ? (string) $fid : NULL;
+function _ys_beacon_queue_pdf_extraction(MediaInterface $media): bool {
+  // Nothing runs on sites where a platform admin has not authorized Beacon.
+  if (!\Drupal::service('ys_beacon.authorization')->isAuthorized()) {
+    return FALSE;
   }
-  catch (\Throwable $e) {
-    return NULL;
+  // Only extract on sites where Beacon indexing is configured; without an
+  // index there is nothing to feed the extracted text into.
+  if (!\Drupal::config('ys_beacon.settings')->get('azure_index_name')) {
+    return FALSE;
   }
+  /** @var \Drupal\ys_beacon\Service\PdfTextIndexer $indexer */
+  $indexer = \Drupal::service('ys_beacon.pdf_text_indexer');
+  if (!$indexer->needsExtraction($media)) {
+    return FALSE;
+  }
+  \Drupal::queue('ys_beacon_pdf_text_extraction')->createItem(['media_id' => $media->id()]);
+  return TRUE;
 }
 
 /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.services.yml
@@ -100,6 +100,8 @@ services:
       - '@ys_beacon.indexability'
       - '@config.factory'
       - '@logger.channel.ys_beacon'
+      - '@entity_field.manager'
+      - '@keyvalue'
 
   ys_beacon.content_feed_builder:
     class: Drupal\ys_beacon\Service\ContentFeedBuilder


### PR DESCRIPTION
## [1580: Bug: Beacon indexes PDF filenames instead of PDF content — text extraction never fires](https://github.com/yalesites-org/YaleSites-Internal/issues/1580)

### Description of work

The extraction pipeline already existed and worked; the trigger never fired. Media is excluded from AI indexing by default, so a document is not extractable at upload, and the editor opting it in afterwards is a media update with an **unchanged** source file id — which the old `ys_beacon_entity_update()` gate ignored, because it only queued on a file-id change. No document uploaded and opted in through the normal editorial flow had ever had its text extracted.

- **Trigger.** One rule replaces the file-id comparison: queue whenever `PdfTextIndexer::needsExtraction()` is TRUE. That covers the opt-in save, the bulk opt-in action, a document created already opted in, and a file replacement. The now-unused `_ys_beacon_media_source_fid()` is deleted.
- **Attempts are recorded** in a key/value collection keyed by media id and valued by the source file id. A scanned, corrupt, or oversized PDF is not re-parsed on every later save or sweep; replacing the file makes it eligible again. The record is written *before* the extracted text is stored, so that write — itself a media update — cannot re-queue itself. Records are dropped on media delete.
- **"Index now" and "Re-index all content"** now sweep documents still owed extraction *inside the batch*, before Search API indexes anything. Pure-PHP PDF parsing never runs in the submit handler.
- **Backfill** for documents that predate the fix: `drush ys_beacon:extract-pdf-text` (batched, with `--force` to retry documents that stored no text) plus `ys_beacon_deploy_10002()`, which is sandbox-batched and only *queues* — the existing cron worker drains it, so a site with thousands of documents spreads the parsing across cron runs rather than the deploy window. The deploy hook skips outright on a site where Beacon is unauthorized or has no index name, before the media library is enumerated at all, so sites that do not run Beacon pay nothing for it.
- **A document with no extractable text is no longer indexed.** Its only remaining body is the rendered file link, so it was being embedded as a filename-only chunk that matches filename-shaped queries and returns a citation with nothing behind it. `ExcludeAiDisabled` now drops it. Because Search API deletes processor-rejected items from the server, an existing filename-only chunk is also **removed** on the next index run.
- README's "PDF text extraction" section is corrected — it documented the broken trigger.

This resolves the ticket's open question ("skip it entirely, or index it with a flag") in favour of skipping. Flagging would require a new field in the Azure index schema and a change on the Beacon retrieval side, neither of which lives in this repo. Reversing the decision is a single guard in `ExcludeAiDisabled::alterIndexedItems()`.

Verified against a local rebuild of a real Beacon site (18 document media, 15 already opted in, **0 with any extracted text** — the bug at scale). After this branch: the backfill extracted **12 of 18** documents (largest 17,102 characters); opting a document in took the extraction queue from **0 to 1** and the queue worker stored **9,673 characters**; re-saving it left the queue at 0. Three encrypted PDFs failed as designed — logged, attempt recorded so they are not retried, and excluded from the index rather than indexed as filenames.

### Functional testing steps:
- [ ] On a site with Beacon authorized and an index configured, upload a text-layer PDF as a Document media item. Confirm nothing is queued yet (media is excluded from AI indexing by default).
- [ ] Edit the media, uncheck "Disable indexing for AI feeds", and save. Confirm an item appears in the `ys_beacon_pdf_text_extraction` queue.
- [ ] Run cron. Confirm the media's `field_ai_pdf_text` is now populated with the document's text.
- [ ] Save that media again. Confirm no new queue item is created (the extraction write-back must not re-queue itself).
- [ ] Replace the PDF with a different file and save. Confirm extraction is queued again and the text updates.
- [ ] Re-check a document marked "Disable indexing for AI feeds": confirm its text is never extracted and it is not indexed.
- [ ] Run `drush ys_beacon:extract-pdf-text` on a site with pre-existing documents. Confirm it batches, populates text, and that a second run does not re-parse the same documents.
- [ ] Deploy to a site where Beacon is **not** enabled. Confirm `ys_beacon_deploy_10002()` reports that Beacon is not enabled, queues nothing, and does not enumerate the media library.
- [ ] Upload a scanned/image-only or password-protected PDF. Confirm it is logged, left empty, not retried on a second backfill run, and does not appear in the index as a filename-only result.
- [ ] Click "Index now" and "Re-index all content" on the Beacon admin form. Confirm extraction runs inside the batch and the form submit does not time out.
- [ ] In the vector index, confirm an indexed multi-page PDF produces multiple chunks (`…:0`, `…:1`, …) whose content is document text rather than the file path.

References yalesites-org/YaleSites-Internal#1580
