### PR TITLE
1575: Bug: Pre-built Form (Contact Us): restore access to submission results via the Layout Builder edit icon

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/WebformContextualLinksSuppressor.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/WebformContextualLinksSuppressor.php
@@ -5,38 +5,27 @@ namespace Drupal\ys_core;
 use Drupal\Core\Security\TrustedCallbackInterface;
 
 /**
- * Decides when to strip the Webform module's contextual "edit" links.
+ * Strips the Webform module's contextual "edit" links.
  *
  * The Webform module unconditionally attaches a "webform" contextual-links
  * group (Test / Results / Build / Settings) to every rendered submission form.
  * On YaleSites that surfaces an edit icon — and a direct link to submission
  * data — to anyone with "access contextual links" who merely views a page
- * containing a Pre-Built Form block, outside of Layout Builder's "Edit Layout
- * and Content" mode. The rule for when to remove that group is centralised here
- * so it is unit-testable in isolation from the render pipeline.
+ * containing a Pre-Built Form block (issue #929).
+ *
+ * The group is removed everywhere. It used to be kept on Layout Builder routes,
+ * but that surfaced nothing: the group is attached deep inside the submission
+ * form rather than to the block, so it never reaches the block's contextual
+ * pencil. Editors reach their submissions through the pencil's
+ * "View form submissions" link instead, which offers only that one link and is
+ * access-checked on the webform's own results route
+ * (yalesites-org/YaleSites-Internal#1575).
  *
  * @see \_webform_form_webform_submission_form_after_build()
  * @see ys_core_form_alter()
+ * @see \Drupal\ys_layouts\WebformResultsLinkBuilder
  */
 class WebformContextualLinksSuppressor implements TrustedCallbackInterface {
-
-  /**
-   * Determines whether the webform contextual links should be removed.
-   *
-   * They are kept only while editing in Layout Builder (its routes are prefixed
-   * with "layout_builder."); on every view route — and defensively when no
-   * route matched — they are removed so the edit icon cannot leak submission
-   * data on the live page.
-   *
-   * @param string|null $route_name
-   *   The current route name, or NULL when no route matched.
-   *
-   * @return bool
-   *   TRUE if the webform contextual links should be removed.
-   */
-  public static function shouldSuppress(?string $route_name): bool {
-    return $route_name === NULL || !str_starts_with($route_name, 'layout_builder.');
-  }
 
   /**
    * Pre-render callback that strips the webform contextual-links group.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/WebformContextualLinksSuppressorTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Unit/WebformContextualLinksSuppressorTest.php
@@ -11,9 +11,12 @@ use Drupal\ys_core\WebformContextualLinksSuppressor;
  * Regression coverage for the bug where the Webform module's contextual links
  * group (Test / Results / Build / Settings) — including access to submission
  * data — appeared as an edit icon on Pre-Built Form blocks while a page was
- * merely being viewed, outside of Layout Builder's "Edit Layout and Content".
- * The links must stay only on Layout Builder editing routes and be removed on
- * every view route.
+ * merely being viewed (issue #929). The group is now removed on every route,
+ * including Layout Builder's: keeping it there surfaced nothing, because it is
+ * attached inside the submission form rather than to the block, so it never
+ * reached the block's contextual pencil. The submissions link editors need is
+ * added to that pencil instead, and is covered by
+ * \Drupal\Tests\ys_layouts\Unit\WebformResultsLinkBuilderTest.
  *
  * @coversDefaultClass \Drupal\ys_core\WebformContextualLinksSuppressor
  *
@@ -22,50 +25,8 @@ use Drupal\ys_core\WebformContextualLinksSuppressor;
 class WebformContextualLinksSuppressorTest extends UnitTestCase {
 
   /**
-   * @covers ::shouldSuppress
+   * The webform group goes, whatever route the form was rendered on.
    *
-   * @dataProvider routeProvider
-   */
-  public function testShouldSuppress(?string $route_name, bool $expected): void {
-    $this->assertSame(
-      $expected,
-      WebformContextualLinksSuppressor::shouldSuppress($route_name)
-    );
-  }
-
-  /**
-   * Provides route names with the expected suppression decision.
-   *
-   * @return array
-   *   Each case: [route name, expected shouldSuppress()].
-   */
-  public static function routeProvider(): array {
-    return [
-      // View routes suppress the leaking edit icon.
-      'node canonical suppressed' => ['entity.node.canonical', TRUE],
-      'standalone webform page suppressed' => ['entity.webform.canonical', TRUE],
-      'front page suppressed' => ['view.frontpage.page_1', TRUE],
-      'node preview suppressed' => ['entity.node.preview', TRUE],
-
-      // Webform's own admin/test routes are suppressed too, by design: the same
-      // links exist there as local-task tabs, so removing the contextual pencil
-      // loses nothing (the target pages stay permission-gated regardless).
-      'webform test form suppressed' => ['entity.webform.test_form', TRUE],
-      'webform submission edit suppressed' => ['entity.webform_submission.edit_form', TRUE],
-
-      // Layout Builder editing routes keep the links (Edit Layout and Content).
-      'lb overrides view kept' => ['layout_builder.overrides.node.view', FALSE],
-      'lb defaults view kept' => ['layout_builder.defaults.node.view', FALSE],
-      'lb add block kept' => ['layout_builder.add_block', FALSE],
-      'lb configure block kept' => ['layout_builder.configure_block', FALSE],
-
-      // Defensive: no matched route removes the icon (fail closed on the leak).
-      'null route suppressed' => [NULL, TRUE],
-      'empty route suppressed' => ['', TRUE],
-    ];
-  }
-
-  /**
    * @covers ::preRender
    */
   public function testPreRenderRemovesWebformGroup(): void {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -133,14 +133,12 @@ function ys_core_linkit_uri_selector(array $element) {
  */
 function ys_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Strip the Webform module's contextual "edit" links (Test, Results, Build,
-  // Settings) from Pre-Built Form submission forms when the page is being
-  // viewed rather than edited in Layout Builder. Without this, users with
-  // "access contextual links" get an edit icon exposing submission data on the
-  // live page. The links are attached in the Webform module's #after_build, so
-  // a #pre_render (a later phase) reliably removes them before the contextual
-  // placeholder is built.
-  if (str_starts_with($form_id, 'webform_submission')
-    && WebformContextualLinksSuppressor::shouldSuppress(\Drupal::routeMatch()->getRouteName())) {
+  // Settings) from every Pre-Built Form submission form. Left in place, users
+  // with "access contextual links" get an edit icon exposing submission data on
+  // the rendered page (issue #929). The links are attached in the Webform
+  // module's #after_build, so a #pre_render (a later phase) reliably removes
+  // them before the contextual placeholder is built.
+  if (str_starts_with($form_id, 'webform_submission')) {
     $form['#pre_render'][] = [WebformContextualLinksSuppressor::class, 'preRender'];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/WebformResultsLinkBuilder.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/WebformResultsLinkBuilder.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_layouts;
+
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Render\Element;
+use Drupal\Core\Security\TrustedCallbackInterface;
+
+/**
+ * Adds a "View form submissions" contextual link to Pre-Built Form blocks.
+ *
+ * The Webform module attaches its own contextual group (Test / Results / Build
+ * / Settings) to every rendered submission form, which leaked a link to
+ * submission data onto the live page; ys_core strips it (issue #929). That left
+ * editors with no in-context route to their submissions at all, so this
+ * restores the one link they actually need - the form's results - in Layout
+ * Builder, where the platform already keeps its editing affordances.
+ *
+ * Core writes the shared `layout_builder_block` group (Configure / Move /
+ * Remove) onto every component in
+ * \Drupal\layout_builder\Element\LayoutBuilder::buildAdministrativeSection().
+ * A separate group attached to the same element merges into the same pencil and
+ * sorts with it by weight, which is how the "Clone" action is added - so this
+ * follows that pattern rather than altering core's group, whose route
+ * parameters describe a layout component and cannot address a webform route.
+ *
+ * The webform is read off the block content entity Layout Builder has already
+ * put in the component's render array, rather than reloaded from the section
+ * storage. That is both cheaper (no entity load per placed block, and a block
+ * revision load is not served from the entity cache) and more correct: the
+ * rendered entity is the pending one, so a block placed or repointed at another
+ * form during this editing session links to the form the editor is looking at
+ * rather than to the last saved revision.
+ *
+ * Access is not checked here: ContextualLinkManager access-checks every link's
+ * route, and entity.webform.results_submissions requires the
+ * webform.submission_view_any operation (the "view any webform submission"
+ * permission), so the link appears exactly for the users allowed to follow it.
+ *
+ * @see ys_layouts_element_info_alter()
+ * @see \Drupal\ys_layouts\CloneBlockLinkBuilder
+ * @see \Drupal\ys_core\WebformContextualLinksSuppressor
+ */
+class WebformResultsLinkBuilder implements TrustedCallbackInterface {
+
+  /**
+   * Pre-render callback: link each form block to its own submissions.
+   *
+   * @param array $element
+   *   The built `layout_builder` render element.
+   *
+   * @return array
+   *   The element with results links attached to Pre-Built Form blocks.
+   */
+  public static function preRender(array $element): array {
+    if (isset($element['layout_builder'])) {
+      static::attachResultsLinks($element['layout_builder']);
+    }
+    return $element;
+  }
+
+  /**
+   * Recursively attaches the results link to form-block render arrays.
+   *
+   * The contextual links live on components nested under section and region
+   * keys, so the whole subtree is walked rather than a fixed depth assumed.
+   *
+   * @param array $build
+   *   A render array to walk.
+   */
+  protected static function attachResultsLinks(array &$build): void {
+    foreach (Element::children($build) as $key) {
+      if (isset($build[$key]['#contextual_links']['layout_builder_block'])) {
+        $webform_id = static::webformId($build[$key]['content'] ?? []);
+        if ($webform_id !== NULL) {
+          $build[$key]['#contextual_links']['ys_layouts_webform_results'] = [
+            'route_parameters' => ['webform' => $webform_id],
+          ];
+        }
+      }
+      static::attachResultsLinks($build[$key]);
+    }
+  }
+
+  /**
+   * Reads the webform a component's block content references, if any.
+   *
+   * The entity view builder puts the entity being rendered in the build under a
+   * key named for its entity type, which is also how _ys_layouts_add_layout_
+   * section() reaches a placed block's content.
+   *
+   * Matched on the field's type rather than a hardcoded field or bundle name,
+   * so the link keeps working for any block type that references a webform.
+   *
+   * @param array $content
+   *   The component's block content render array.
+   *
+   * @return string|null
+   *   The referenced webform id, or NULL when the component renders no webform.
+   */
+  protected static function webformId(array $content): ?string {
+    $block_content = $content['#block_content'] ?? NULL;
+    if (!$block_content instanceof FieldableEntityInterface) {
+      return NULL;
+    }
+
+    foreach ($block_content->getFields() as $items) {
+      if ($items->getFieldDefinition()->getType() !== 'webform') {
+        continue;
+      }
+      $target_id = $items->getValue()[0]['target_id'] ?? NULL;
+      if ($target_id !== NULL && $target_id !== '') {
+        return (string) $target_id;
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function trustedCallbacks() {
+    return ['preRender'];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/BlockContextualLinksTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/BlockContextualLinksTest.php
@@ -12,7 +12,14 @@ use Symfony\Component\Yaml\Yaml;
  *
  * Two review requirements on issue #190: the actions read "Clone" and "Remove"
  * (not "Clone block" / "Remove block"), and "Remove" stays the last item in the
- * menu now that this module adds a fourth link.
+ * menu now that this module adds links of its own.
+ *
+ * The asserted set is every link the module can contribute, not what any one
+ * block shows: "Make non-reusable" is attached only to reusable placements,
+ * and "View form submissions" only to blocks referencing a webform
+ * (yalesites-org/YaleSites-Internal#1575), and both are access-filtered per
+ * user. What matters here is that whenever they do appear they read correctly
+ * and sit between the layout actions and the destructive one.
  *
  * Ordering is not testable from the "Clone" definition alone, because core's
  * Configure/Move/Remove links ship no weight and so all sort equal — the
@@ -44,21 +51,23 @@ class BlockContextualLinksTest extends UnitTestCase {
   }
 
   /**
-   * Tests that the menu reads Configure, Move, Clone, Remove — in that order.
+   * Tests the menu order: layout actions, then this module's, then Remove.
    */
   public function testRemoveStaysLastAndLabelsDropTheWordBlock(): void {
     $core_group = $this->definitions($this->root . '/core/modules/layout_builder/layout_builder.links.contextual.yml');
-    $clone_group = $this->definitions(dirname(__DIR__, 3) . '/ys_layouts.links.contextual.yml');
+    $ys_groups = $this->definitions(dirname(__DIR__, 3) . '/ys_layouts.links.contextual.yml');
 
     // preRenderLinks() unions the groups in the order they are attached to the
     // element, so assert the result for both possible orders.
     $expected = [
       'layout_builder_block_update' => 'Configure',
       'layout_builder_block_move' => 'Move',
+      'ys_layouts_block_detach' => 'Make non-reusable',
       'layout_builder_block_clone' => 'Clone',
+      'ys_layouts_webform_results' => 'View form submissions',
       'layout_builder_block_remove' => 'Remove',
     ];
-    foreach ([$core_group + $clone_group, $clone_group + $core_group] as $items) {
+    foreach ([$core_group + $ys_groups, $ys_groups + $core_group] as $items) {
       uasort($items, [SortArray::class, 'sortByWeightElement']);
 
       $this->assertSame($expected, array_map(fn (array $item) => (string) $item['title'], $items));

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/WebformResultsLinkBuilderTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/WebformResultsLinkBuilderTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ys_layouts\Unit;
+
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_layouts\WebformResultsLinkBuilder;
+
+/**
+ * Tests the "View form submissions" link added to a form block's pencil.
+ *
+ * Regression coverage for the gap left by yalesites-org/YaleSites-Internal#929:
+ * hiding the Webform module's own contextual links removed the only in-context
+ * route an editor had to their submissions, so the Layout Builder pencil on a
+ * Pre-Built Form block now carries a link to that form's results.
+ *
+ * @coversDefaultClass \Drupal\ys_layouts\WebformResultsLinkBuilder
+ *
+ * @group yalesites
+ * @group ys_layouts
+ */
+class WebformResultsLinkBuilderTest extends UnitTestCase {
+
+  /**
+   * Route parameters core puts on a component's contextual links.
+   */
+  protected const ROUTE_PARAMETERS = [
+    'section_storage_type' => 'overrides',
+    'section_storage' => 'node.3',
+    'delta' => 2,
+    'region' => 'content',
+    'uuid' => 'c32a5017-2f68-457d-90f1-c4753a19bed3',
+  ];
+
+  /**
+   * Tests that a form block's pencil gets a link to that form's results.
+   *
+   * The webform is read off the block content entity already in the component's
+   * render array, so the link follows whatever Layout Builder rendered —
+   * including a block placed or repointed in an unsaved editing session, which
+   * has no saved revision to load.
+   *
+   * @covers ::preRender
+   */
+  public function testAttachesResultsLinkToFormBlock(): void {
+    $element = $this->buildElement($this->blockContent('webform', 'contact'));
+
+    $result = WebformResultsLinkBuilder::preRender($element);
+    $links = $result['layout_builder']['0']['content']['#contextual_links'];
+
+    $this->assertSame(
+      ['route_parameters' => ['webform' => 'contact']],
+      $links['ys_layouts_webform_results']
+    );
+    // Core's own group is left exactly as it was.
+    $this->assertSame(
+      self::ROUTE_PARAMETERS,
+      $links['layout_builder_block']['route_parameters']
+    );
+  }
+
+  /**
+   * Tests that a block with no webform field is left alone.
+   *
+   * @covers ::preRender
+   */
+  public function testIgnoresBlockWithoutWebformField(): void {
+    $element = $this->buildElement($this->blockContent('text', 'contact'));
+
+    $result = WebformResultsLinkBuilder::preRender($element);
+
+    $this->assertArrayNotHasKey(
+      'ys_layouts_webform_results',
+      $result['layout_builder']['0']['content']['#contextual_links']
+    );
+  }
+
+  /**
+   * Tests that a webform field referencing nothing attaches no link.
+   *
+   * @covers ::preRender
+   */
+  public function testIgnoresEmptyWebformField(): void {
+    $element = $this->buildElement($this->blockContent('webform', NULL));
+
+    $result = WebformResultsLinkBuilder::preRender($element);
+
+    $this->assertArrayNotHasKey(
+      'ys_layouts_webform_results',
+      $result['layout_builder']['0']['content']['#contextual_links']
+    );
+  }
+
+  /**
+   * Tests that a component rendering no block content is skipped.
+   *
+   * Most placed blocks are not content blocks at all (views, the page meta
+   * block, and so on), and every one of them reaches this code.
+   *
+   * @covers ::preRender
+   */
+  public function testIgnoresComponentWithoutBlockContent(): void {
+    $element = [
+      'layout_builder' => [
+        '0' => [
+          'content' => [
+            '#contextual_links' => [
+              'layout_builder_block' => ['route_parameters' => self::ROUTE_PARAMETERS],
+            ],
+            'content' => ['#markup' => 'a view, not a content block'],
+          ],
+        ],
+      ],
+    ];
+
+    $result = WebformResultsLinkBuilder::preRender($element);
+
+    $this->assertArrayNotHasKey(
+      'ys_layouts_webform_results',
+      $result['layout_builder']['0']['content']['#contextual_links']
+    );
+  }
+
+  /**
+   * Tests that components are found however deeply the layout nests them.
+   *
+   * @covers ::preRender
+   */
+  public function testAttachesAtAnyNestingDepth(): void {
+    $element = [
+      'layout_builder' => [
+        '0' => [
+          'layout' => [
+            'first' => [
+              'c32a5017' => [
+                '#contextual_links' => [
+                  'layout_builder_block' => ['route_parameters' => self::ROUTE_PARAMETERS],
+                ],
+                'content' => ['#block_content' => $this->blockContent('webform', 'apply')],
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+
+    $result = WebformResultsLinkBuilder::preRender($element);
+
+    $this->assertSame(
+      ['route_parameters' => ['webform' => 'apply']],
+      $result['layout_builder']['0']['layout']['first']['c32a5017']['#contextual_links']['ys_layouts_webform_results']
+    );
+  }
+
+  /**
+   * Tests that an element with no built layout is returned untouched.
+   *
+   * @covers ::preRender
+   */
+  public function testNoOpWithoutBuiltLayout(): void {
+    $element = ['#section_storage' => 'overrides', '#markup' => 'nothing built'];
+
+    $this->assertSame($element, WebformResultsLinkBuilder::preRender($element));
+  }
+
+  /**
+   * The pre-render callback must be trusted or the renderer throws.
+   *
+   * @covers ::trustedCallbacks
+   */
+  public function testPreRenderIsTrusted(): void {
+    $this->assertContains('preRender', WebformResultsLinkBuilder::trustedCallbacks());
+  }
+
+  /**
+   * Builds a layout_builder element holding one placed block component.
+   *
+   * Mirrors the real build: core's contextual group on the component, and the
+   * rendered entity under the entity-type key of the component's content.
+   *
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $block_content
+   *   The block content entity the component renders.
+   *
+   * @return array
+   *   The layout_builder render element.
+   */
+  protected function buildElement(FieldableEntityInterface $block_content): array {
+    return [
+      'layout_builder' => [
+        '0' => [
+          'content' => [
+            '#contextual_links' => [
+              'layout_builder_block' => ['route_parameters' => self::ROUTE_PARAMETERS],
+            ],
+            'content' => ['#block_content' => $block_content],
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Mocks a block content entity carrying one field.
+   *
+   * @param string $field_type
+   *   The field's type — 'webform' for a Pre-Built Form block.
+   * @param string|null $target_id
+   *   The referenced webform id, or NULL for an empty field.
+   *
+   * @return \Drupal\Core\Entity\FieldableEntityInterface
+   *   The mocked block content entity.
+   */
+  protected function blockContent(string $field_type, ?string $target_id): FieldableEntityInterface {
+    $definition = $this->createMock(FieldDefinitionInterface::class);
+    $definition->method('getType')->willReturn($field_type);
+
+    $field = $this->createMock(FieldItemListInterface::class);
+    $field->method('getFieldDefinition')->willReturn($definition);
+    $field->method('getValue')->willReturn($target_id === NULL ? [] : [['target_id' => $target_id]]);
+
+    $block_content = $this->createMock(FieldableEntityInterface::class);
+    $block_content->method('getFields')->willReturn(['field_form' => $field]);
+
+    return $block_content;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.links.contextual.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.links.contextual.yml
@@ -19,3 +19,13 @@ layout_builder_block_clone:
   options:
     attributes:
       class: ['use-ajax']
+
+ys_layouts_webform_results:
+  # Worded for editors rather than reusing Webform's own "Results" label, which
+  # says nothing about forms out of context.
+  title: 'View form submissions'
+  route_name: 'entity.webform.results_submissions'
+  group: 'ys_layouts_webform_results'
+  # Sorts after the in-place layout actions and before Remove, which
+  # ys_layouts_contextual_links_plugins_alter() weights last.
+  weight: 6

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.module
@@ -12,6 +12,7 @@ use Drupal\Core\Plugin\Context\Context;
 use Drupal\Core\Plugin\Context\EntityContextDefinition;
 use Drupal\ys_layouts\CloneBlockLinkBuilder;
 use Drupal\ys_layouts\Render\DetachContextualOperations;
+use Drupal\ys_layouts\WebformResultsLinkBuilder;
 
 /**
  * Add template files.
@@ -289,15 +290,18 @@ function ys_layouts_form_ys_layouts_detach_reusable_block_alter(&$form, FormStat
 /**
  * Implements hook_element_info_alter().
  *
- * Registers the "Make non-reusable" and "Clone" actions in Layout Builder's
- * contextual link metadata. Without this, adding an action never changes the
- * contextual link id, so browsers keep replaying the previously cached menu out
- * of sessionStorage and never ask the server for the new link.
+ * Registers the "Make non-reusable", "Clone" and "View form submissions"
+ * actions in Layout Builder's contextual link metadata. Without this, adding an
+ * action never changes the contextual link id, so browsers keep replaying the
+ * previously cached menu out of sessionStorage and never ask the server for the
+ * new link.
  *
- * "Clone" is attached to inline blocks only (issue #190).
+ * "Clone" is attached to inline blocks only (issue #190), and
+ * "View form submissions" only to blocks that reference a webform.
  *
  * @see \Drupal\ys_layouts\Render\DetachContextualOperations
  * @see \Drupal\ys_layouts\CloneBlockLinkBuilder
+ * @see \Drupal\ys_layouts\WebformResultsLinkBuilder
  */
 function ys_layouts_element_info_alter(array &$info) {
   if (isset($info['layout_builder'])) {
@@ -309,6 +313,10 @@ function ys_layouts_element_info_alter(array &$info) {
     ];
     $info['layout_builder']['#pre_render'][] = [
       CloneBlockLinkBuilder::class,
+      'preRender',
+    ];
+    $info['layout_builder']['#pre_render'][] = [
+      WebformResultsLinkBuilder::class,
       'preRender',
     ];
   }


### PR DESCRIPTION
## [1575: Bug: Pre-built Form (Contact Us): restore access to submission results via the Layout Builder edit icon](https://github.com/yalesites-org/YaleSites-Internal/issues/1575)

### Description of work

- Adds a **View form submissions** item to the Layout Builder contextual pencil of any block that references a webform, so editors have an in-context route to their Pre-Built Form submissions again. yalesites-org/YaleSites-Internal#929 correctly hid the Webform module's own edit icon from rendered pages, but that removed the only path editors had to their submission data.
- Implemented the way this module already adds an action to that pencil: a new contextual-links group (`ys_layouts_webform_results` in `ys_layouts.links.contextual.yml`) attached by a `#pre_render` on the `layout_builder` element (`WebformResultsLinkBuilder`), registered in `ys_layouts_element_info_alter()` alongside `CloneBlockLinkBuilder`. Groups attached to the same element merge into one pencil and sort by weight, so nothing about core's group is altered — which matters, because core's route parameters describe a layout component and cannot address a webform route.
- The webform is read off the block content entity **Layout Builder has already put in the component's render array** (`content['#block_content']`, the same path `_ys_layouts_add_layout_section()` uses) rather than reloaded from section storage. That is deliberate on two counts. It costs no entity load at all — resolving through the section storage instead meant a `loadRevision()` per placed block, which the entity cache does not serve, so a 20-block page paid ~19 avoidable queries per render. And it is more correct: the rendered entity is the *pending* one, so a form block placed (or repointed at a different form) in an unsaved editing session links to the form the editor is actually looking at, where `block_revision_id` would have been `NULL` or stale.
- **Permission gating is inherited, not re-implemented.** `ContextualLinkManager` access-checks every link's route, and `entity.webform.results_submissions` requires the `webform.submission_view_any` operation — i.e. the `view any webform submission` permission. So the link appears exactly for the users allowed to follow it, driven off the real permission rather than a role list, as the scoping comment on the issue asks.
- **Only the Results link is surfaced.** Webform's own group also carries Test / Build / Settings; those are redundant with the Webform admin tabs and would take the pencil past eight items, so they are deliberately left out (the issue's "does not become cluttered" criterion). The label is worded for editors — "View form submissions" rather than Webform's bare "Results" — and it sorts after the in-place layout actions and before the destructive Remove. It has no `use-ajax`/dialog options, unlike its two siblings, because it navigates to a full admin page; pending layout edits survive in the tempstore.
- **`ys_core` now strips the Webform group on every route**, dropping the old `layout_builder.*` exception and `WebformContextualLinksSuppressor::shouldSuppress()`. That exception surfaced nothing: the group is attached deep inside the submission form rather than to the block, so it never reached the block's pencil. Verified in the browser before changing anything — the server did emit `data-contextual-id="webform:webform=contact"` inside the `<form>` on `/node/3/layout`, and `/contextual/render` returned Test/Results/Build/Settings for it, but none of the contextual widgets actually rendered on the page were that group. Keeping it would have meant two mechanisms for one affordance, the dead one of which exposes the three links we just decided not to show.
- Unit tests: new `WebformResultsLinkBuilderTest` (7 tests) covering a form block, a block with no webform field, an empty webform reference, a component that renders no block content at all, arbitrary nesting depth, the no-built-layout no-op, and the trusted-callback registration. `BlockContextualLinksTest` now asserts the full pencil order including the new link.

**Verified locally on Lando** (`lando composer code-sniff` and `lando composer lint:php` both exit 0):

- The pencil on a form block reads Configure / Move / Clone / **View form submissions** / Remove, resolving to that form's results page; non-form blocks' pencils are unchanged.
- On a page with two different Pre-Built Form blocks, each pencil resolves to its own form (`.../manage/contact/...` and `.../manage/contact_two/...`), not a shared or first-found one.
- A form block added through the real add-block form and **not yet saved** still gets the link, pointing at the right form.
- As a role with layout-edit access but without `view any webform submission`, the pencil shows no submissions link, and the rendered page shows no contextual icon at all — so #929 is not regressed.
- Light accessibility pass on the open menu: the new item's accessible name is the plain text "View form submissions", the pencil opens with Enter and Tab reaches the link, and the link text is ~4.98:1 against its background.

**Two notes for the reviewer**

- `BlockContextualLinksTest` was **already failing on `develop`** before this branch — its expected menu omitted `ys_layouts_block_detach` ("Make non-reusable"), which was added to the same YAML after the test was written. Since this change adds another link to that file the expectation had to be updated anyway, so that drift is fixed here; it is not new breakage.
- `attachResultsLinks()` walks the built layout the same way `CloneBlockLinkBuilder::attachCloneLinks()` does, so that recursion shape now exists twice (three times counting `DetachContextualOperations`). Extracting a shared "walk the layout and attach a group" helper is the obvious next step, but it would mean refactoring existing code that has no unit coverage on its walk, on a Hotfix-priority bug fix — so it is left as a follow-up. Happy to fold it in here if you would rather it land together.
- The issue's documentation criterion (updating user-guide content about how editors find their submissions) is **not** covered by this PR — that content lives outside this repo.

### Functional testing steps:

- [ ] As an administrator or editor, visit a page containing a Pre-Built Form (Contact Us) block in normal view (**not** Edit Layout and Content). Confirm there is still no edit icon on the form and no visible link to submission data, and that the form still renders and can be submitted.
- [ ] Enter **Edit Layout and Content** on that page and open the pencil on the Pre-Built Form block. Confirm it reads Configure / Move / Clone / **View form submissions** / Remove, and that the new link lands on that form's own results page.
- [ ] On a page with **two different** Pre-Built Form blocks, confirm each pencil links to its own form's results, not a shared or first-found one.
- [ ] Add a new Pre-Built Form block and, **without saving the layout**, confirm its pencil already offers the link and points at the form you just chose.
- [ ] Confirm the pencils on non-form blocks on the same page are unchanged (no submissions link).
- [ ] As a role with layout-edit access but **without** `view any webform submission`, confirm the pencil on the form block shows no submissions link, and the rendered page still shows no webform edit icon.
- [ ] With the menu open, confirm it is still keyboard-operable: Tab to the pencil, open it with Enter, and Tab to reach "View form submissions".

References yalesites-org/YaleSites-Internal#1575
