### PR TITLE
1572: Feature Request: Give the orphaned inline block sweep a per-site route beyond a manual drush command

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -114,6 +114,7 @@ dependencies:
     - ys_campus_groups
     - ys_core
     - ys_integrations
+    - ys_layouts
     - ys_localist
 id: platform_admin
 label: 'Platform administrator'
@@ -146,6 +147,7 @@ permissions:
   - 'administer coffee'
   - 'administer google_tag_container'
   - 'administer main menu items'
+  - 'administer orphaned inline blocks'
   - 'administer platform admin settings'
   - 'administer redirects'
   - 'administer users'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/README.md
@@ -73,6 +73,54 @@ Safety guarantees, in order of importance:
 Reusable blocks from the Custom Block Library are never candidates; only `reusable = 0` blocks
 are considered.
 
+### From the admin UI
+
+The command needs terminal access, which means the sweep only ever ran on the sites someone
+remembered to run it on. Platform admins can reach the same sweep per site at:
+
+```
+/admin/yalesites/orphaned-inline-blocks
+```
+
+The screen reports and nothing more; deleting is a separate confirm step at
+`/admin/yalesites/orphaned-inline-blocks/delete`, linked from the report only when there is
+something to delete. Both routes are gated on `administer orphaned inline blocks`, a
+`restrict access: true` permission granted to `platform_admin` alone — deliberately not
+`yalesites manage settings` (site admins hold that) and not `administer site configuration`
+(no role on the platform holds it, so `ys_layouts.settings_form` is effectively user-1-only).
+
+The confirm form deletes *all* orphans rather than a selection, because `deleteOrphans()`
+derives its own list — see guarantee 5 above. The count shown on the report is therefore
+advisory: the list is worked out again when you confirm, so a block that was put back on a
+page in between is left alone. Every deletion is written to the `ys_layouts` log channel with
+the IDs removed, whichever route triggered it.
+
+The sweep runs synchronously in the request. It walks every revision of every layout-bearing
+entity, so cost scales with revision count rather than orphan count; on a site with ~180
+orphans and a normal revision history it completes in about two seconds, comfortably inside a
+web request. The drush command remains the escape hatch if a site ever grows large enough to
+risk a PHP timeout, and is still the right tool for scripting across many sites.
+
+#### Timing: deploys and unsaved layout work
+
+A button can be pressed at any moment, whereas a drush command is run deliberately by someone
+who knows what else is happening on the site. Both timing questions were checked before the
+screen was exposed:
+
+- **Unsaved layout work is invisible to the sweep, so it cannot be collected.** Adding, cloning
+  or detaching a block in Layout Builder carries the new block on the component as
+  `block_serialized` with `block_revision_id` set to `NULL`; no `block_content` row exists until
+  the layout is saved. Confirmed against a tempstore holding an unsaved cloned block: no rows
+  created and no new orphans reported, so an editor's in-progress layout cannot be swept out
+  from under them.
+- **A deploy does not change the sweep's answer.** Its only inputs are saved entity revisions
+  and the Layout Builder defaults in `entity_view_display` config. No default layout in
+  `config/sync` carries a `block_revision_id`, so a `config:import` cannot transiently strip the
+  last reference to a block, and this module ships no update hook that rewrites layout data.
+  Deploys do not enable maintenance mode, so the screen stays reachable while one runs — which
+  is safe today. An update hook that rewrote layouts would reintroduce this risk and should
+  finish before anything sweeps.
+
 ## Running tests
 
 This module has PHPUnit tests under `tests/src/` (`Unit/` and `Kernel/`). Run them from the project root on the local Lando environment, passing the module's `tests` path so PHPUnit only discovers this module's tests (not Drupal core/contrib):

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/README.md
@@ -101,6 +101,14 @@ orphans and a normal revision history it completes in about two seconds, comfort
 web request. The drush command remains the escape hatch if a site ever grows large enough to
 risk a PHP timeout, and is still the right tool for scripting across many sites.
 
+Both tables page at 50 rows. Paging bounds the work that scales with how many blocks were
+found — each row loads a `block_content` entity, so an unpaged report on a site holding
+thousands of orphans would load and render thousands of entities — but it cannot make the
+sweep itself cheaper, because `analyze()` has to walk every revision before it knows what is
+orphaned. Each table pages on its own pager element, so paging one leaves the other where it
+was, and each caption states the full total rather than the number of rows on screen. The
+delete button always counts every orphan, never just the page in front of you.
+
 #### Timing: deploys and unsaved layout work
 
 A button can be pressed at any moment, whereas a drush command is run deliberately by someone

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Controller/OrphanedInlineBlockReportController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Controller/OrphanedInlineBlockReportController.php
@@ -4,6 +4,7 @@ namespace Drupal\ys_layouts\Controller;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Pager\PagerManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\ys_layouts\Service\OrphanedInlineBlockCleanerInterface;
@@ -27,16 +28,37 @@ class OrphanedInlineBlockReportController implements ContainerInjectionInterface
   use StringTranslationTrait;
 
   /**
+   * How many blocks each table lists per page.
+   */
+  const ITEMS_PER_PAGE = 50;
+
+  /**
+   * Pager element index for the deletable orphans table.
+   */
+  const ORPHANS_PAGER = 0;
+
+  /**
+   * Pager element index for the revision-only table.
+   *
+   * Distinct from ORPHANS_PAGER because both tables render on one page: sharing
+   * an element would make paging either table move both.
+   */
+  const REVISION_ONLY_PAGER = 1;
+
+  /**
    * Constructs an OrphanedInlineBlockReportController.
    *
    * @param \Drupal\ys_layouts\Service\OrphanedInlineBlockCleanerInterface $cleaner
    *   The orphaned inline block cleaner.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager.
+   * @param \Drupal\Core\Pager\PagerManagerInterface $pagerManager
+   *   The pager manager.
    */
   public function __construct(
     protected OrphanedInlineBlockCleanerInterface $cleaner,
     protected EntityTypeManagerInterface $entityTypeManager,
+    protected PagerManagerInterface $pagerManager,
   ) {}
 
   /**
@@ -46,6 +68,7 @@ class OrphanedInlineBlockReportController implements ContainerInjectionInterface
     return new static(
       $container->get('ys_layouts.orphaned_inline_block_cleaner'),
       $container->get('entity_type.manager'),
+      $container->get('pager.manager'),
     );
   }
 
@@ -77,19 +100,29 @@ class OrphanedInlineBlockReportController implements ContainerInjectionInterface
     // association is worth stating rather than left to inference.
     $build['orphans'] = [
       '#type' => 'table',
-      '#caption' => $this->t('Unreferenced inline blocks'),
+      // Both captions carry the full total because the tables are paged: the
+      // rows on screen are only a window onto the set.
+      '#caption' => $this->t('Unreferenced inline blocks (@count total)', [
+        '@count' => count($report['orphans']),
+      ]),
       '#header' => [
         ['data' => $this->t('Block ID'), 'scope' => 'col'],
         ['data' => $this->t('Type'), 'scope' => 'col'],
         ['data' => $this->t('Label'), 'scope' => 'col'],
       ],
-      '#rows' => $this->describe($report['orphans']),
+      '#rows' => $this->describe($this->currentPageOf($report['orphans'], self::ORPHANS_PAGER)),
       '#empty' => $this->t('No orphaned inline blocks found.'),
     ];
+    $build['orphans_pager'] = [
+      '#type' => 'pager',
+      '#element' => self::ORPHANS_PAGER,
+    ];
 
-    // The delete action sits directly under the table it acts on. Built before
-    // the revision-only table for that reason: rendering it last would put a
-    // delete button immediately below the one table it must never touch.
+    // The delete action stays with the table it acts on, below that table and
+    // its pager. Built before the revision-only table for that reason:
+    // rendering it last would put a delete button immediately below the one
+    // table it must never touch. Its label counts every orphan, not the page on
+    // screen, because the confirm step re-derives and removes the whole set.
     if ($report['orphans']) {
       $build['actions'] = [
         '#type' => 'container',
@@ -114,13 +147,21 @@ class OrphanedInlineBlockReportController implements ContainerInjectionInterface
       ];
       $build['revision_only'] = [
         '#type' => 'table',
-        '#caption' => $this->t('Referenced only by an older revision — never deleted'),
+        // This table has no delete button to state its magnitude, so the total
+        // in the caption is the only place an operator can read it.
+        '#caption' => $this->t('Referenced only by an older revision — never deleted (@count total)', [
+          '@count' => count($report['revision_only']),
+        ]),
         '#header' => [
           ['data' => $this->t('Block ID'), 'scope' => 'col'],
           ['data' => $this->t('Type'), 'scope' => 'col'],
           ['data' => $this->t('Label'), 'scope' => 'col'],
         ],
-        '#rows' => $this->describe($report['revision_only']),
+        '#rows' => $this->describe($this->currentPageOf($report['revision_only'], self::REVISION_ONLY_PAGER)),
+      ];
+      $build['revision_only_pager'] = [
+        '#type' => 'pager',
+        '#element' => self::REVISION_ONLY_PAGER,
       ];
     }
 
@@ -128,13 +169,44 @@ class OrphanedInlineBlockReportController implements ContainerInjectionInterface
   }
 
   /**
+   * Narrows a set of block IDs to the page currently being viewed.
+   *
+   * Paging cannot make the sweep itself cheaper: analyze() has to walk every
+   * layout revision to decide what is orphaned, so it necessarily returns the
+   * whole ID set. What this bounds is the per-ID work downstream. describe()
+   * loads a block_content entity for every ID it is handed, so on a site
+   * carrying thousands of orphans an unpaged report loads and renders thousands
+   * of entities to fill a table nobody scrolls. Sites where analyze() itself is
+   * the problem still have the drush command as the escape hatch.
+   *
+   * The Pager returned by createPager() clamps its own current page into range,
+   * so a ?page= beyond the end lands on the last page rather than an empty
+   * table.
+   *
+   * @param int[] $block_ids
+   *   The full set of block content entity IDs.
+   * @param int $element
+   *   The pager element index to page this set on.
+   *
+   * @return int[]
+   *   The IDs on the current page, in the order the cleaner sorted them.
+   */
+  protected function currentPageOf(array $block_ids, int $element): array {
+    $pager = $this->pagerManager->createPager(count($block_ids), self::ITEMS_PER_PAGE, $element);
+    return array_slice($block_ids, $pager->getCurrentPage() * self::ITEMS_PER_PAGE, self::ITEMS_PER_PAGE);
+  }
+
+  /**
    * Builds table rows describing the given blocks.
    *
-   * A row is emitted for every ID the sweep reported rather than only for the
-   * ones that still load; dropping one would understate what the operator is
-   * about to act on. In practice every reported ID had a block_content row when
-   * the sweep queried, so the fallback row only shows up if something deleted
-   * the block between that query and this load.
+   * A row is emitted for every ID passed in rather than only for the ones that
+   * still load; dropping one would understate what the operator is about to act
+   * on. In practice every reported ID had a block_content row when the sweep
+   * queried, so the fallback row only shows up if something deleted the block
+   * between that query and this load.
+   *
+   * Callers hand this the current page's IDs, not the whole reported set - see
+   * currentPageOf().
    *
    * Rows are built from $block_ids rather than from the loaded entities so the
    * order the cleaner sorted them into survives; loadMultiple() makes no

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Controller/OrphanedInlineBlockReportController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Controller/OrphanedInlineBlockReportController.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Drupal\ys_layouts\Controller;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+use Drupal\ys_layouts\Service\OrphanedInlineBlockCleanerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Reports Layout Builder inline blocks no layout references any more.
+ *
+ * The sweep itself is OrphanedInlineBlockCleaner and predates this screen; it
+ * was reachable only as `drush ys-layouts:orphaned-blocks`, which meant someone
+ * with terminal access had to run it site by site. This controller is the route
+ * onto an individual site for whoever administers it, and it deliberately keeps
+ * the command's posture: it only ever reports. Deleting is a separate,
+ * explicitly confirmed step in OrphanedInlineBlockDeleteForm.
+ *
+ * @see \Drupal\ys_layouts\Service\OrphanedInlineBlockCleaner
+ * @see \Drupal\ys_layouts\Form\OrphanedInlineBlockDeleteForm
+ */
+class OrphanedInlineBlockReportController implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * Constructs an OrphanedInlineBlockReportController.
+   *
+   * @param \Drupal\ys_layouts\Service\OrphanedInlineBlockCleanerInterface $cleaner
+   *   The orphaned inline block cleaner.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(
+    protected OrphanedInlineBlockCleanerInterface $cleaner,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('ys_layouts.orphaned_inline_block_cleaner'),
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * Builds the orphaned inline block report.
+   *
+   * @return array
+   *   A render array.
+   */
+  public function build(): array {
+    $report = $this->cleaner->analyze();
+
+    $build = [
+      // The report is a live read of the database that any layout save can
+      // invalidate, and it is the basis for a destructive action, so a cached
+      // copy would show counts that are no longer true.
+      '#cache' => ['max-age' => 0],
+    ];
+
+    $build['description'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('Removing a non-reusable block from a page leaves its content behind in the database, where no other admin screen can reach it. Drupal cannot clean these up on its own for a page that still exists. Nothing on this screen changes anything until you confirm a deletion.'),
+    ];
+
+    // Header cells carry an explicit scope: template_preprocess_table() hands a
+    // plain string header an empty Attribute bag, so a bare string renders as a
+    // <th> with no scope at all. These are two real data tables, so the column
+    // association is worth stating rather than left to inference.
+    $build['orphans'] = [
+      '#type' => 'table',
+      '#caption' => $this->t('Unreferenced inline blocks'),
+      '#header' => [
+        ['data' => $this->t('Block ID'), 'scope' => 'col'],
+        ['data' => $this->t('Type'), 'scope' => 'col'],
+        ['data' => $this->t('Label'), 'scope' => 'col'],
+      ],
+      '#rows' => $this->describe($report['orphans']),
+      '#empty' => $this->t('No orphaned inline blocks found.'),
+    ];
+
+    // The delete action sits directly under the table it acts on. Built before
+    // the revision-only table for that reason: rendering it last would put a
+    // delete button immediately below the one table it must never touch.
+    if ($report['orphans']) {
+      $build['actions'] = [
+        '#type' => 'container',
+        'delete' => [
+          '#type' => 'link',
+          '#title' => $this->formatPlural(
+            count($report['orphans']),
+            'Delete 1 orphaned inline block',
+            'Delete @count orphaned inline blocks'
+          ),
+          '#url' => Url::fromRoute('ys_layouts.orphaned_blocks_delete'),
+          '#attributes' => ['class' => ['button', 'button--danger']],
+        ],
+      ];
+    }
+
+    if ($report['revision_only']) {
+      $build['revision_only_description'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('These blocks are not on any current page, but an older revision of a page still points at them. Reverting a page to such a revision would put the block back on it, so deletion leaves them alone.'),
+      ];
+      $build['revision_only'] = [
+        '#type' => 'table',
+        '#caption' => $this->t('Referenced only by an older revision — never deleted'),
+        '#header' => [
+          ['data' => $this->t('Block ID'), 'scope' => 'col'],
+          ['data' => $this->t('Type'), 'scope' => 'col'],
+          ['data' => $this->t('Label'), 'scope' => 'col'],
+        ],
+        '#rows' => $this->describe($report['revision_only']),
+      ];
+    }
+
+    return $build;
+  }
+
+  /**
+   * Builds table rows describing the given blocks.
+   *
+   * A row is emitted for every ID the sweep reported rather than only for the
+   * ones that still load; dropping one would understate what the operator is
+   * about to act on. In practice every reported ID had a block_content row when
+   * the sweep queried, so the fallback row only shows up if something deleted
+   * the block between that query and this load.
+   *
+   * Rows are built from $block_ids rather than from the loaded entities so the
+   * order the cleaner sorted them into survives; loadMultiple() makes no
+   * ordering promise.
+   *
+   * Deliberately not shared with YaleSitesLayoutsCommands::describe(): two
+   * occurrences of three-column row building do not yet justify pulling a
+   * presentation concern into the cleaner service, whose return value is a pure
+   * ID set that a text table and a render array can each shape for themselves.
+   * A third caller would justify extracting it.
+   *
+   * The two are not byte-identical, and should not be: the fallback cells here
+   * are translated for an admin table ('missing', 'n/a') where the command
+   * emits bare strings to a terminal. That divergence argues for extracting
+   * carefully rather than eagerly — a shared helper would have to parameterise
+   * the fallbacks to serve both media.
+   *
+   * @param int[] $block_ids
+   *   The block content entity IDs.
+   *
+   * @return array[]
+   *   Rows of block ID, block type and label.
+   */
+  protected function describe(array $block_ids): array {
+    $blocks = $this->entityTypeManager->getStorage('block_content')->loadMultiple($block_ids);
+    $rows = [];
+    foreach ($block_ids as $block_id) {
+      $block = $blocks[$block_id] ?? NULL;
+      $rows[] = [
+        $block_id,
+        $block ? $block->bundle() : $this->t('missing'),
+        $block ? (string) $block->label() : $this->t('n/a'),
+      ];
+    }
+    return $rows;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Form/OrphanedInlineBlockDeleteForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/src/Form/OrphanedInlineBlockDeleteForm.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\ys_layouts\Form;
+
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
+use Drupal\ys_layouts\Service\OrphanedInlineBlockCleanerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Confirms deletion of every orphaned Layout Builder inline block.
+ *
+ * The equivalent of `drush ys-layouts:orphaned-blocks --delete`, reachable from
+ * the report screen so a site does not need terminal access to be swept.
+ *
+ * It confirms "delete all orphans" rather than a selection on purpose:
+ * OrphanedInlineBlockCleaner::deleteOrphans() accepts no IDs and re-derives the
+ * list itself, which is what makes deleting a block that is still on a page
+ * structurally impossible rather than merely guarded against. Offering
+ * checkboxes here would hand that guarantee back to the caller.
+ *
+ * @see \Drupal\ys_layouts\Controller\OrphanedInlineBlockReportController
+ */
+class OrphanedInlineBlockDeleteForm extends ConfirmFormBase {
+
+  /**
+   * Constructs an OrphanedInlineBlockDeleteForm.
+   *
+   * @param \Drupal\ys_layouts\Service\OrphanedInlineBlockCleanerInterface $cleaner
+   *   The orphaned inline block cleaner.
+   */
+  public function __construct(
+    protected OrphanedInlineBlockCleanerInterface $cleaner,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static($container->get('ys_layouts.orphaned_inline_block_cleaner'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'ys_layouts_orphaned_inline_block_delete';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion(): TranslatableMarkup {
+    // No count in the question: the list is re-derived when you confirm, so any
+    // number shown here could already be out of date by then.
+    return $this->t('Delete every orphaned inline block on this site?');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription(): TranslatableMarkup {
+    return $this->t("Only blocks that no page layout references are deleted, and the list is worked out again at the moment you confirm — so a block that has since been put back on a page is left alone. Blocks held only by an older revision of a page are never deleted. Reusable blocks from the block library are never touched. This cannot be undone.");
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText(): TranslatableMarkup {
+    return $this->t('Delete orphaned blocks');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl(): Url {
+    return Url::fromRoute('ys_layouts.orphaned_blocks_report');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $deleted = $this->cleaner->deleteOrphans();
+
+    // Deleting nothing is a normal outcome — someone may have swept already, or
+    // the last orphan may have been re-referenced — so it still gets reported
+    // rather than looking like the action did not run.
+    $this->messenger()->addStatus($deleted
+      ? $this->formatPlural($deleted, 'Deleted 1 orphaned inline block.', 'Deleted @count orphaned inline blocks.')
+      : $this->t('No orphaned inline blocks were found, so nothing was deleted.'));
+
+    $form_state->setRedirectUrl($this->getCancelUrl());
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/OrphanedInlineBlockDeleteFormTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/OrphanedInlineBlockDeleteFormTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Drupal\Tests\ys_layouts\Unit;
+
+use Drupal\Core\Form\FormState;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_layouts\Form\OrphanedInlineBlockDeleteForm;
+use Drupal\ys_layouts\Service\OrphanedInlineBlockCleanerInterface;
+
+/**
+ * Tests the orphaned inline block deletion confirm form.
+ *
+ * The form is the only UI path to a destructive sweep, so these tests pin the
+ * two things that keep it safe: it takes no block IDs from the request (the
+ * cleaner derives its own list), and it always lands the operator back on the
+ * report so the result is visible.
+ *
+ * @coversDefaultClass \Drupal\ys_layouts\Form\OrphanedInlineBlockDeleteForm
+ *
+ * @group yalesites
+ * @group ys_layouts
+ */
+class OrphanedInlineBlockDeleteFormTest extends UnitTestCase {
+
+  /**
+   * The orphaned inline block cleaner mock.
+   *
+   * @var \Drupal\ys_layouts\Service\OrphanedInlineBlockCleanerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $cleaner;
+
+  /**
+   * The messenger mock.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $messenger;
+
+  /**
+   * The form under test.
+   *
+   * @var \Drupal\ys_layouts\Form\OrphanedInlineBlockDeleteForm
+   */
+  protected $form;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->cleaner = $this->createMock(OrphanedInlineBlockCleanerInterface::class);
+    $this->messenger = $this->createMock(MessengerInterface::class);
+
+    $this->form = new OrphanedInlineBlockDeleteForm($this->cleaner);
+    $this->form->setStringTranslation($this->getStringTranslationStub());
+    $this->form->setMessenger($this->messenger);
+  }
+
+  /**
+   * The form ID matches the machine name the route is built around.
+   *
+   * @covers ::getFormId
+   */
+  public function testGetFormId(): void {
+    $this->assertSame('ys_layouts_orphaned_inline_block_delete', $this->form->getFormId());
+  }
+
+  /**
+   * Cancelling returns to the report rather than a generic admin page.
+   *
+   * @covers ::getCancelUrl
+   */
+  public function testGetCancelUrlReturnsToTheReport(): void {
+    $this->assertSame(
+      'ys_layouts.orphaned_blocks_report',
+      $this->form->getCancelUrl()->getRouteName()
+    );
+  }
+
+  /**
+   * Confirming deletes the orphans the cleaner derives for itself.
+   *
+   * The form deliberately passes no IDs: deleteOrphans() re-runs the analysis,
+   * so a block that became referenced between the report and the confirmation
+   * is left alone.
+   *
+   * @covers ::submitForm
+   */
+  public function testSubmitDeletesOrphansAndRedirectsToTheReport(): void {
+    $this->cleaner->expects($this->once())
+      ->method('deleteOrphans')
+      ->willReturn(3);
+
+    $form_state = $this->submit('Deleted 3 orphaned inline blocks.');
+
+    $this->assertSame(
+      'ys_layouts.orphaned_blocks_report',
+      $form_state->getRedirect()->getRouteName()
+    );
+  }
+
+  /**
+   * Deleting nothing still reports back instead of failing silently.
+   *
+   * @covers ::submitForm
+   */
+  public function testSubmitReportsWhenThereWasNothingToDelete(): void {
+    $this->cleaner->method('deleteOrphans')->willReturn(0);
+
+    $form_state = $this->submit(
+      'No orphaned inline blocks were found, so nothing was deleted.'
+    );
+
+    $this->assertSame(
+      'ys_layouts.orphaned_blocks_report',
+      $form_state->getRedirect()->getRouteName()
+    );
+  }
+
+  /**
+   * One deletion is reported in the singular.
+   *
+   * @covers ::submitForm
+   */
+  public function testSubmitUsesTheSingularForOneDeletion(): void {
+    $this->cleaner->method('deleteOrphans')->willReturn(1);
+
+    $this->submit('Deleted 1 orphaned inline block.');
+  }
+
+  /**
+   * Submits the form, asserting the exact status message it sets.
+   *
+   * The message text is pinned rather than merely counted: asserting only that
+   * addStatus() was called once passes even with the two messages swapped, so
+   * the deleted-something and deleted-nothing branches would then be
+   * indistinguishable.
+   *
+   * @param string $expected_message
+   *   The status message the submission must set.
+   *
+   * @return \Drupal\Core\Form\FormState
+   *   The form state the submission acted on.
+   */
+  protected function submit(string $expected_message): FormState {
+    $this->messenger->expects($this->once())
+      ->method('addStatus')
+      ->with($this->callback(
+        fn($message) => (string) $message === $expected_message
+      ));
+
+    $form = [];
+    $form_state = new FormState();
+    $this->form->submitForm($form, $form_state);
+
+    return $form_state;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/OrphanedInlineBlockReportControllerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/OrphanedInlineBlockReportControllerTest.php
@@ -1,0 +1,326 @@
+<?php
+
+namespace Drupal\Tests\ys_layouts\Unit;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\block_content\BlockContentInterface;
+use Drupal\ys_layouts\Controller\OrphanedInlineBlockReportController;
+use Drupal\ys_layouts\Service\OrphanedInlineBlockCleanerInterface;
+
+/**
+ * Tests the orphaned inline block report screen.
+ *
+ * The screen is the platform admin's route onto a sweep that previously only
+ * existed as a drush command. Its job is to show what would be deleted BEFORE
+ * offering to delete it, so these tests pin that ordering: the delete action is
+ * absent when there is nothing to delete, and the revision-only blocks the
+ * cleaner refuses to collect are reported separately rather than folded into
+ * the deletable list.
+ *
+ * @coversDefaultClass \Drupal\ys_layouts\Controller\OrphanedInlineBlockReportController
+ *
+ * @group yalesites
+ * @group ys_layouts
+ */
+class OrphanedInlineBlockReportControllerTest extends UnitTestCase {
+
+  /**
+   * The orphaned inline block cleaner mock.
+   *
+   * @var \Drupal\ys_layouts\Service\OrphanedInlineBlockCleanerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $cleaner;
+
+  /**
+   * The block content storage mock.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $blockStorage;
+
+  /**
+   * The controller under test.
+   *
+   * @var \Drupal\ys_layouts\Controller\OrphanedInlineBlockReportController
+   */
+  protected $controller;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->cleaner = $this->createMock(OrphanedInlineBlockCleanerInterface::class);
+    $this->blockStorage = $this->createMock(EntityStorageInterface::class);
+
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->willReturnMap([
+      ['block_content', $this->blockStorage],
+    ]);
+
+    $this->controller = new OrphanedInlineBlockReportController($this->cleaner, $entity_type_manager);
+    $this->controller->setStringTranslation($this->getStringTranslationStub());
+  }
+
+  /**
+   * Builds a block content mock with the given bundle and label.
+   *
+   * @param string $bundle
+   *   The block type.
+   * @param string $label
+   *   The block label.
+   *
+   * @return \Drupal\block_content\BlockContentInterface|\PHPUnit\Framework\MockObject\MockObject
+   *   The mocked block.
+   */
+  protected function block(string $bundle, string $label) {
+    $block = $this->createMock(BlockContentInterface::class);
+    $block->method('bundle')->willReturn($bundle);
+    $block->method('label')->willReturn($label);
+    return $block;
+  }
+
+  /**
+   * Each orphan is listed with its ID, block type and label.
+   *
+   * @covers ::build
+   */
+  public function testBuildListsEachOrphanWithTypeAndLabel(): void {
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => [7, 9],
+      'revision_only' => [],
+    ]);
+    $this->blockStorage->method('loadMultiple')->with([7, 9])->willReturn([
+      7 => $this->block('text', 'Leftover text'),
+      9 => $this->block('accordion', 'Leftover accordion'),
+    ]);
+
+    $build = $this->controller->build();
+
+    $this->assertSame([
+      [7, 'text', 'Leftover text'],
+      [9, 'accordion', 'Leftover accordion'],
+    ], $build['orphans']['#rows']);
+  }
+
+  /**
+   * A reported orphan whose block row is already gone is still listed.
+   *
+   * Every ID the sweep reports had a block_content row when it queried, so this
+   * is the narrow case where something deleted the block in between. The row is
+   * kept regardless: dropping it would hide an ID from the count the operator
+   * is about to act on.
+   *
+   * @covers ::build
+   */
+  public function testBuildListsOrphansWhoseBlockEntityIsMissing(): void {
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => [7, 404],
+      'revision_only' => [],
+    ]);
+    $this->blockStorage->method('loadMultiple')->willReturn([
+      7 => $this->block('text', 'Leftover text'),
+    ]);
+
+    $build = $this->controller->build();
+
+    $rows = array_map(
+      fn(array $row) => array_map('strval', $row),
+      $build['orphans']['#rows']
+    );
+    $this->assertSame([
+      ['7', 'text', 'Leftover text'],
+      ['404', 'missing', 'n/a'],
+    ], $rows);
+  }
+
+  /**
+   * The delete action counts the orphans it is about to remove.
+   *
+   * @covers ::build
+   */
+  public function testBuildDeleteActionReportsTheOrphanCount(): void {
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => [7, 9, 11],
+      'revision_only' => [],
+    ]);
+    $this->blockStorage->method('loadMultiple')->willReturn([]);
+
+    $build = $this->controller->build();
+
+    $this->assertSame(
+      'Delete 3 orphaned inline blocks',
+      (string) $build['actions']['delete']['#title']
+    );
+  }
+
+  /**
+   * Revision-only blocks alone produce a table but no delete action.
+   *
+   * The state most easily got wrong: there is something to show, but nothing
+   * this screen is allowed to delete, so the destructive affordance must be
+   * absent even though the page is not empty.
+   *
+   * @covers ::build
+   */
+  public function testBuildOffersNoDeleteActionForRevisionOnlyBlocks(): void {
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => [],
+      'revision_only' => [11],
+    ]);
+    $this->blockStorage->method('loadMultiple')->willReturn([
+      11 => $this->block('text', 'Held by an old revision'),
+    ]);
+
+    $build = $this->controller->build();
+
+    $this->assertArrayNotHasKey('actions', $build);
+    $this->assertArrayHasKey('revision_only', $build);
+    $this->assertSame([[11, 'text', 'Held by an old revision']], $build['revision_only']['#rows']);
+  }
+
+  /**
+   * Each table's explanation renders above its own rows.
+   *
+   * Ordering is behaviour here, not cosmetics: built in the wrong order, the
+   * delete button lands directly beneath the revision-only table - the one
+   * table it must never act on.
+   *
+   * @covers ::build
+   */
+  public function testBuildOrdersDeleteActionAboveTheRevisionOnlyTable(): void {
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => [7],
+      'revision_only' => [11],
+    ]);
+    $this->blockStorage->method('loadMultiple')->willReturn([
+      7 => $this->block('text', 'Leftover text'),
+      11 => $this->block('text', 'Held by an old revision'),
+    ]);
+
+    $build = $this->controller->build();
+
+    $order = array_values(array_filter(
+      array_keys($build),
+      fn($key) => !str_starts_with($key, '#')
+    ));
+    $this->assertSame([
+      'description',
+      'orphans',
+      'actions',
+      'revision_only_description',
+      'revision_only',
+    ], $order);
+  }
+
+  /**
+   * The delete action is offered only when there is something to delete.
+   *
+   * @covers ::build
+   */
+  public function testBuildOffersNoDeleteActionWithoutOrphans(): void {
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => [],
+      'revision_only' => [],
+    ]);
+    $this->blockStorage->method('loadMultiple')->willReturn([]);
+
+    $build = $this->controller->build();
+
+    $this->assertArrayNotHasKey('actions', $build);
+    $this->assertArrayHasKey('#empty', $build['orphans']);
+  }
+
+  /**
+   * With orphans present, the delete action links to the confirm step.
+   *
+   * Deletion is never a one-click action from the report: the link goes to a
+   * separate confirm form, which is what keeps the drush command's
+   * report-by-default posture intact in the UI.
+   *
+   * @covers ::build
+   */
+  public function testBuildLinksDeleteActionToConfirmForm(): void {
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => [7],
+      'revision_only' => [],
+    ]);
+    $this->blockStorage->method('loadMultiple')->willReturn([
+      7 => $this->block('text', 'Leftover text'),
+    ]);
+
+    $build = $this->controller->build();
+
+    $this->assertSame(
+      'ys_layouts.orphaned_blocks_delete',
+      $build['actions']['delete']['#url']->getRouteName()
+    );
+  }
+
+  /**
+   * Revision-only blocks are reported apart from the deletable orphans.
+   *
+   * The cleaner never deletes these, because a node rollback would make them
+   * live again. Listing them in the same table would misrepresent what the
+   * delete action is about to do.
+   *
+   * @covers ::build
+   */
+  public function testBuildSeparatesRevisionOnlyBlocksFromOrphans(): void {
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => [7],
+      'revision_only' => [11],
+    ]);
+    $this->blockStorage->method('loadMultiple')->willReturnMap([
+      [[7], [7 => $this->block('text', 'Leftover text')]],
+      [[11], [11 => $this->block('text', 'Held by an old revision')]],
+    ]);
+
+    $build = $this->controller->build();
+
+    $this->assertSame([[7, 'text', 'Leftover text']], $build['orphans']['#rows']);
+    $this->assertSame([[11, 'text', 'Held by an old revision']], $build['revision_only']['#rows']);
+  }
+
+  /**
+   * The revision-only table is omitted when there are none.
+   *
+   * @covers ::build
+   */
+  public function testBuildOmitsRevisionOnlyTableWhenEmpty(): void {
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => [],
+      'revision_only' => [],
+    ]);
+    $this->blockStorage->method('loadMultiple')->willReturn([]);
+
+    $build = $this->controller->build();
+
+    $this->assertArrayNotHasKey('revision_only', $build);
+  }
+
+  /**
+   * The report is never cached.
+   *
+   * It is a live view of the database that an editor's next layout save can
+   * invalidate, and it is the basis for a destructive action, so serving a
+   * cached copy would show an operator counts that are no longer true.
+   *
+   * @covers ::build
+   */
+  public function testBuildIsNotCached(): void {
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => [],
+      'revision_only' => [],
+    ]);
+    $this->blockStorage->method('loadMultiple')->willReturn([]);
+
+    $build = $this->controller->build();
+
+    $this->assertSame(0, $build['#cache']['max-age']);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/OrphanedInlineBlockReportControllerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/tests/src/Unit/OrphanedInlineBlockReportControllerTest.php
@@ -4,6 +4,8 @@ namespace Drupal\Tests\ys_layouts\Unit;
 
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Pager\Pager;
+use Drupal\Core\Pager\PagerManagerInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\block_content\BlockContentInterface;
 use Drupal\ys_layouts\Controller\OrphanedInlineBlockReportController;
@@ -48,6 +50,16 @@ class OrphanedInlineBlockReportControllerTest extends UnitTestCase {
   protected $controller;
 
   /**
+   * The current page per pager element, keyed by element index.
+   *
+   * Stands in for the ?page= query parameter: the real PagerManager reads it
+   * from the request, so a test sets it here to place itself on a given page.
+   *
+   * @var int[]
+   */
+  protected $currentPage = [];
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -61,7 +73,15 @@ class OrphanedInlineBlockReportControllerTest extends UnitTestCase {
       ['block_content', $this->blockStorage],
     ]);
 
-    $this->controller = new OrphanedInlineBlockReportController($this->cleaner, $entity_type_manager);
+    // A real Pager rather than a mock: its own constructor clamps an
+    // out-of-range page into the result set, which is behaviour these tests
+    // rely on rather than something worth restating in a stub.
+    $pager_manager = $this->createMock(PagerManagerInterface::class);
+    $pager_manager->method('createPager')->willReturnCallback(
+      fn($total, $limit, $element = 0) => new Pager($total, $limit, $this->currentPage[$element] ?? 0)
+    );
+
+    $this->controller = new OrphanedInlineBlockReportController($this->cleaner, $entity_type_manager, $pager_manager);
     $this->controller->setStringTranslation($this->getStringTranslationStub());
   }
 
@@ -210,9 +230,11 @@ class OrphanedInlineBlockReportControllerTest extends UnitTestCase {
     $this->assertSame([
       'description',
       'orphans',
+      'orphans_pager',
       'actions',
       'revision_only_description',
       'revision_only',
+      'revision_only_pager',
     ], $order);
   }
 
@@ -321,6 +343,167 @@ class OrphanedInlineBlockReportControllerTest extends UnitTestCase {
     $build = $this->controller->build();
 
     $this->assertSame(0, $build['#cache']['max-age']);
+  }
+
+  /**
+   * Only the current page of orphans is loaded from storage.
+   *
+   * This is the point of paginating: describe() loads a block_content entity
+   * per reported ID, so on a site with thousands of orphans an unpaginated
+   * report loads thousands of entities to render a table nobody reads past the
+   * first screen of. The pager bounds the entity load, not just the markup.
+   *
+   * @covers ::build
+   */
+  public function testBuildLoadsOnlyTheCurrentPageOfOrphans(): void {
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => range(1, 120),
+      'revision_only' => [],
+    ]);
+    $loaded = $this->captureLoads();
+
+    $build = $this->controller->build();
+
+    $this->assertSame([range(1, 50)], $loaded->calls);
+    $this->assertCount(50, $build['orphans']['#rows']);
+  }
+
+  /**
+   * The requested page determines which slice of orphans is loaded.
+   *
+   * @covers ::build
+   */
+  public function testBuildLoadsTheRequestedPageOfOrphans(): void {
+    $this->currentPage = [0 => 1];
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => range(1, 120),
+      'revision_only' => [],
+    ]);
+    $loaded = $this->captureLoads();
+
+    $this->controller->build();
+
+    $this->assertSame([range(51, 100)], $loaded->calls);
+  }
+
+  /**
+   * A page beyond the end of the result set falls back to the last page.
+   *
+   * The page number arrives from a query parameter, so it is user input. 120
+   * orphans at 50 per page is three pages, and asking for page 99 must land on
+   * the last one rather than render a table with no rows in it.
+   *
+   * @covers ::build
+   */
+  public function testBuildClampsAnOutOfRangePageIntoTheResultSet(): void {
+    $this->currentPage = [0 => 99];
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => range(1, 120),
+      'revision_only' => [],
+    ]);
+    $loaded = $this->captureLoads();
+
+    $build = $this->controller->build();
+
+    $this->assertSame([range(101, 120)], $loaded->calls);
+    $this->assertCount(20, $build['orphans']['#rows']);
+  }
+
+  /**
+   * The delete action counts every orphan, not just the page on screen.
+   *
+   * The confirm form re-derives the full orphan set and deletes all of it, so a
+   * button labelled with the page size would understate what confirming does.
+   *
+   * @covers ::build
+   */
+  public function testBuildDeleteActionCountsEveryOrphanNotJustThePage(): void {
+    $this->currentPage = [0 => 1];
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => range(1, 120),
+      'revision_only' => [],
+    ]);
+    $this->captureLoads();
+
+    $build = $this->controller->build();
+
+    $this->assertSame(
+      'Delete 120 orphaned inline blocks',
+      (string) $build['actions']['delete']['#title']
+    );
+  }
+
+  /**
+   * Each table pages independently on its own pager element.
+   *
+   * Two pagers on one page collide unless they carry distinct element indexes:
+   * paging the orphans would otherwise jump the revision-only table too.
+   *
+   * @covers ::build
+   */
+  public function testBuildPagesEachTableOnItsOwnPagerElement(): void {
+    $this->currentPage = [0 => 1, 1 => 0];
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => range(1, 60),
+      'revision_only' => range(101, 160),
+    ]);
+    $loaded = $this->captureLoads();
+
+    $build = $this->controller->build();
+
+    $this->assertSame([range(51, 60), range(101, 150)], $loaded->calls);
+    $this->assertSame('pager', $build['orphans_pager']['#type']);
+    $this->assertSame(0, $build['orphans_pager']['#element']);
+    $this->assertSame('pager', $build['revision_only_pager']['#type']);
+    $this->assertSame(1, $build['revision_only_pager']['#element']);
+  }
+
+  /**
+   * Each caption states the full total, not the number of rows shown.
+   *
+   * Paginating hides magnitude: the revision-only table has no delete button to
+   * carry a count, so without this an operator on page 2 cannot tell whether
+   * the site holds sixty of these or six thousand.
+   *
+   * @covers ::build
+   */
+  public function testBuildCaptionsStateTheFullTotal(): void {
+    $this->currentPage = [0 => 1, 1 => 1];
+    $this->cleaner->method('analyze')->willReturn([
+      'orphans' => range(1, 120),
+      'revision_only' => range(201, 260),
+    ]);
+    $this->captureLoads();
+
+    $build = $this->controller->build();
+
+    $this->assertStringContainsString('120', (string) $build['orphans']['#caption']);
+    $this->assertStringContainsString('60', (string) $build['revision_only']['#caption']);
+  }
+
+  /**
+   * Records the ID sets passed to loadMultiple(), in call order.
+   *
+   * @return object
+   *   An object whose $calls property collects each call's ID array.
+   */
+  protected function captureLoads(): object {
+    $recorder = new class() {
+      /**
+       * The ID arrays passed to loadMultiple(), in call order.
+       *
+       * @var array[]
+       */
+      public array $calls = [];
+
+    };
+    $this->blockStorage->method('loadMultiple')->willReturnCallback(
+      function (array $ids) use ($recorder) {
+        $recorder->calls[] = $ids;
+        return [];
+      }
+    );
+    return $recorder;
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.info.yml
@@ -9,4 +9,5 @@ dependencies:
   - drupal:block_content
   - drupal:layout_builder
   - quick_node_clone
+  - ys_core
   - ys_localist

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.links.menu.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.links.menu.yml
@@ -4,3 +4,14 @@ ys_layouts.settings:
   parent: system.admin_config_system
   route_name: ys_layouts.settings_form
   weight: 100
+
+# Parent is ys_core's /admin/yalesites section. Modules that hang a link there
+# declare ys_core as a dependency (ys_alert, ys_integrations both do), so
+# ys_layouts.info.yml now does too rather than relying on the profile always
+# installing it.
+ys_layouts.orphaned_blocks_report:
+  title: 'Orphaned inline blocks'
+  description: 'Review inline blocks left behind when a non-reusable block was removed from a page, and delete them.'
+  parent: ys_core.admin_yalesites
+  route_name: ys_layouts.orphaned_blocks_report
+  weight: 40

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.permissions.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.permissions.yml
@@ -1,0 +1,9 @@
+# Deliberately its own permission rather than reusing 'administer platform admin
+# settings' or 'administer site configuration': this one authorises deleting
+# editor-created block content, so it should be re-scopable on its own without
+# dragging unrelated capabilities along. Granted to platform_admin only (user 1
+# bypasses permission checks).
+administer orphaned inline blocks:
+  title: 'Administer orphaned inline blocks'
+  description: 'Review Layout Builder inline blocks that no page layout references any more, and delete them.'
+  restrict access: true

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_layouts/ys_layouts.routing.yml
@@ -48,3 +48,23 @@ ys_layouts.clone_block:
     parameters:
       section_storage:
         layout_builder_tempstore: TRUE
+
+# Reports Layout Builder inline blocks left behind when a non-reusable block was
+# removed from a layout. Report-only; deletion is the separate confirm step
+# below. Lives under /admin/yalesites rather than beside
+# ys_layouts.settings_form, whose 'administer site configuration' permission no
+# role on the platform actually holds. No _admin_route needed: already /admin/*.
+ys_layouts.orphaned_blocks_report:
+  path: '/admin/yalesites/orphaned-inline-blocks'
+  defaults:
+    _controller: '\Drupal\ys_layouts\Controller\OrphanedInlineBlockReportController::build'
+    _title: 'Orphaned inline blocks'
+  requirements:
+    _permission: 'administer orphaned inline blocks'
+ys_layouts.orphaned_blocks_delete:
+  path: '/admin/yalesites/orphaned-inline-blocks/delete'
+  defaults:
+    _form: '\Drupal\ys_layouts\Form\OrphanedInlineBlockDeleteForm'
+    _title: 'Delete orphaned inline blocks'
+  requirements:
+    _permission: 'administer orphaned inline blocks'


### PR DESCRIPTION
## [1572: Feature Request: Give the orphaned inline block sweep a per-site route beyond a manual drush command](https://github.com/yalesites-org/YaleSites-Internal/issues/1572)

### Description of work

The orphaned inline block sweep from yalesites-org/YaleSites-Internal#1503 only existed as `drush ys-layouts:orphaned-blocks`, so it only ever ran on the sites someone with terminal access remembered to run it on. This gives it a route onto an individual site without trading away any of the safety posture that made it worth shipping.

**The decision AC#1 asks for: an on-demand UI action for platform admins, report-first.** Not a scheduled job — silent platform-wide deletion is exactly what #1503's guardrails exist to prevent, and a scheduled report nobody reads is the same toil in a different place.

- Adds a report screen at `/admin/yalesites/orphaned-inline-blocks` listing every unreferenced inline block by ID, type and label, plus a separate table for blocks held only by an older page revision (which the sweep never deletes, because a rollback would make them live again).
- Deletion is a separate confirm step at `/admin/yalesites/orphaned-inline-blocks/delete`, linked from the report **only when there is something to delete**. The report itself never mutates anything.
- Gated on a new `administer orphaned inline blocks` permission (`restrict access: true`), granted to `platform_admin` alone. Deliberately its own permission rather than reusing `administer platform admin settings`, so a destructive capability can be re-scoped on its own later.
- Lives under `/admin/yalesites` rather than beside the existing `ys_layouts` settings form, because that form requires `administer site configuration` — which **no role in `config/sync` actually holds**, making it effectively user-1-only. Putting the new screen there would have shipped a page platform admins get a 403 on.
- The confirm form deletes *all* orphans rather than a selection: `deleteOrphans()` accepts no IDs and re-derives the list at the moment you confirm, which is what makes deleting a still-referenced block structurally impossible rather than merely guarded against. A block put back on a page between the report and the confirmation is left alone.
- Every UI-triggered deletion is written to the `ys_layouts` log channel with the IDs removed, identically to a drush-triggered one.
- Developer docs added to `ys_layouts/README.md` (AC#6 — developer-facing only).

**On AC#5 (behaviour mid-deploy or with a stale layout tempstore)** — both checked before exposing the button, and documented in the README:

- *Unsaved layout work is invisible to the sweep.* Adding, cloning or detaching a block in Layout Builder carries the new block as `block_serialized` with `block_revision_id` set to `NULL`, so no `block_content` row exists until the layout is saved. Verified against a tempstore holding an unsaved cloned block: 0 rows created, 0 new orphans reported. An editor's in-progress layout cannot be swept out from under them.
- *A deploy does not change the sweep's answer.* Its only inputs are saved entity revisions and the Layout Builder defaults in `entity_view_display` config. No default layout in `config/sync` carries a `block_revision_id`, so a `config:import` cannot transiently strip a block's last reference, and `ys_layouts` ships no update hook that rewrites layout data.

**Still open for discussion (AC#4):** platform-wide orphan magnitude is not established here, because measuring it means running the sweep against every Pantheon site and this work was done entirely against local Lando. The one real data point: this checkout's DB, pulled from an ordinary production site, had **177 orphans**. This screen is what makes per-site measurement possible without terminal access.

**Accessibility (light gate):** both data tables use real `<caption>` elements and now carry explicit `scope="col"` on every `<th>` (Drupal's `template_preprocess_table()` hands a plain-string header cell an empty attribute bag, so a bare string renders a scopeless `<th>`). The danger delete link measures 4.71:1 and the confirm submit 4.99:1, both passing; no missing `alt`, no unlabelled controls, no empty accessible names. One finding is **not actionable**: the Gin admin toolbar's active nav item measures 1.53:1, which is contrib chrome present on every admin page in the platform and would need a contrib patch to fix.

**Heads-up unrelated to this branch:** `ys_layouts`' Unit suite has one pre-existing failure on `develop` — `BlockContextualLinksTest::testRemoveStaysLastAndLabelsDropTheWordBlock` expects the contextual link set *without* `ys_layouts_block_detach`, while the code now adds it. Neither that test nor its subject is touched here (suite goes 106→110 tests, same single failure), but it will show up if you run the suite.

### Functional testing steps:

- [ ] As a **platform administrator**, go to `/admin/yalesites/orphaned-inline-blocks` (also reachable from the YaleSites admin menu as "Orphaned inline blocks"). Confirm the page loads and lists any unreferenced inline blocks with their ID, type and label.
- [ ] Confirm that when blocks are held only by an older page revision, they appear in the second table ("Referenced only by an older revision — never deleted") and **not** in the deletable list.
- [ ] On a site with no orphans, confirm the page reads "No orphaned inline blocks found." and that **no delete button is shown**.
- [ ] As an **editor** or **site administrator**, confirm both `/admin/yalesites/orphaned-inline-blocks` and `/admin/yalesites/orphaned-inline-blocks/delete` return **403**. Confirm anonymous also gets 403.
- [ ] As a platform administrator, click the "Delete N orphaned inline blocks" button, confirm you land on a confirmation screen that explains what will and will not be deleted, and that **Cancel** returns you to the report without deleting anything.
- [ ] Confirm the deletion, then confirm the report shows the empty state, the delete button is gone, and the blocks held by older revisions are **still listed and untouched**.
- [ ] Confirm `lando drush ys-layouts:orphaned-blocks` agrees with what the screen showed, and that `drush watchdog:show --type=ys_layouts` records the deletion with the IDs removed.
- [ ] Take a page that has a non-reusable block, remove the block from the layout, save, and confirm it then appears on the report.
- [ ] Open a page in Layout Builder, add or clone a block but **do not save the layout**, then load the report and confirm the unsaved block does **not** appear as an orphan.

**Pagination (added after functional review):** both tables page at 50 rows, each on its own pager element.

- [ ] On a site with more than 50 blocks held only by an older revision, confirm the "Referenced only by an older revision" table shows 50 rows with a pager beneath it, and that the caption states the **full** total rather than the number of rows shown.
- [ ] Page that table to page 2 and confirm the remaining rows appear, and that the **unreferenced** table above it did **not** move — the two tables page independently.
- [ ] Confirm the "Delete N orphaned inline blocks" button reads the **full** orphan count on every page, not the number of rows currently displayed.
- [ ] On a table with 50 or fewer rows, confirm **no** pager is rendered at all.
- [ ] Append a nonsense page to the URL (`?page=999`) and confirm you land on the last page of results, not an empty table.

**Note:** the heads-up above about a pre-existing `BlockContextualLinksTest` failure is now stale — develop fixed it, and the `ys_layouts` Unit suite is fully green (123 tests, 123 pass).

References yalesites-org/YaleSites-Internal#1572

