### PR TITLE
1573: Review whether platform/site admin and editor still need "administer book outlines"

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.editor.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.editor.yml
@@ -114,7 +114,6 @@ permissions:
   - 'access webform overview'
   - 'add any content to books'
   - 'add content to books'
-  - 'administer book outlines'
   - 'administer main menu items'
   - 'administer redirects'
   - 'administer users'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.platform_admin.yml
@@ -142,7 +142,6 @@ permissions:
   - 'administer block content'
   - 'administer block types'
   - 'administer blocks'
-  - 'administer book outlines'
   - 'administer coffee'
   - 'administer google_tag_container'
   - 'administer main menu items'

--- a/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/user.role.site_admin.yml
@@ -122,7 +122,6 @@ permissions:
   - 'access webform overview'
   - 'add any content to books'
   - 'add content to books'
-  - 'administer book outlines'
   - 'administer google_tag_container'
   - 'administer main menu items'
   - 'administer redirects'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/README.md
@@ -6,6 +6,46 @@ CAS-protected (and other access-restricted) published pages remain visible in th
 book navigation — flagged for a lock icon — rather than being filtered out, and
 invalidates collection-navigation caches on book node changes.
 
+## Who can manage content collections
+
+Collection management is gated on contrib book's narrow **`reorder book pages`**
+permission, via the `_ys_book_outline_access` access check
+(`src/Access/BookOutlineAccessCheck.php`). The broad **`administer book
+outlines`** permission is also accepted, so a site that granted it to a role of
+its own keeps working, but no platform role holds it any more.
+
+That check gates the three screens this module owns:
+
+| Screen | Route |
+| --- | --- |
+| Manage Content Collections overview | `book.admin` |
+| Re-order collection pages and titles | `book.admin_edit` |
+| Delete collection | `ys_book.collection_delete` |
+
+It also gates contrib's "Child order" node tab (`book.node_child_ordering`),
+which `ys_book.routing.yml` overrides for exactly that reason. Contrib's own
+access check on that route additionally requires `reorder book pages`, so the
+broad permission alone has never been enough there.
+
+Everything else book-related runs off other permissions and is unaffected: the
+Content Collection widget on the node form, the Outline tab and
+Remove-from-outline (`add content to books`), creating a new collection
+(`create new books`), and the printer-friendly export
+(`access printer-friendly version`).
+
+One cosmetic exception: contrib's `BookOutlineConstraintValidator` uses the broad
+permission only to decide whether its "you can only change the book outline for
+the published version" violation message includes a link to the collections page.
+These roles now see the link-less variant of that message.
+
+`administer book outlines` is contrib book's administer-everything grant, and
+`editor`, `site_admin` and `platform_admin` held it only because these screens
+asked for it. Deleting a collection stays gated at the same level as reordering
+one, which is the access those roles already had; raising that bar would be a
+separate product decision.
+
+See `BookOutlineAccessCheck` and yalesites-org/YaleSites-Internal#1573.
+
 ## Running tests
 
 This module has PHPUnit tests under `tests/src/`. Run them from the project root on the local Lando environment, passing the module's `tests` path so PHPUnit only discovers this module's tests (not Drupal core/contrib):

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/src/Access/BookOutlineAccessCheck.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/src/Access/BookOutlineAccessCheck.php
@@ -8,17 +8,23 @@ use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\Core\Session\AccountInterface;
 
 /**
- * Determines access to the book outline admin edit form.
+ * Determines access to the content collection management screens.
  *
  * Allows access for accounts that have either the broad
  * 'administer book outlines' permission or the narrower 'reorder book pages'
- * permission. This avoids requiring the full administer permission just to
- * reorder content collection pages.
+ * permission. This is what lets the platform's editing roles manage
+ * collections without holding contrib book's administer-everything
+ * permission.
+ *
+ * The broad permission is still accepted so that a site which granted it to a
+ * role of its own does not lose access.
+ *
+ * @see yalesites-org/YaleSites-Internal#1573
  */
 class BookOutlineAccessCheck implements AccessInterface {
 
   /**
-   * Checks access to the book outline admin edit form.
+   * Checks access to a content collection management screen.
    *
    * @param \Drupal\Core\Session\AccountInterface $account
    *   The current user account.
@@ -28,10 +34,11 @@ class BookOutlineAccessCheck implements AccessInterface {
    *   'reorder book pages' permission; neutral otherwise.
    */
   public function access(AccountInterface $account): AccessResultInterface {
-    $allowed = $account->hasPermission('administer book outlines')
-      || $account->hasPermission('reorder book pages');
-
-    return AccessResult::allowedIf($allowed);
+    return AccessResult::allowedIfHasPermissions(
+      $account,
+      ['administer book outlines', 'reorder book pages'],
+      'OR'
+    );
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookCollectionDeleteTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookCollectionDeleteTest.php
@@ -55,8 +55,8 @@ class BookCollectionDeleteTest extends KernelTestBase {
     _ys_book_add_book_title_column();
     $this->installConfig(['node', 'book', 'field']);
 
-    // The delete route is gated on 'administer book outlines'; build the router
-    // so the confirm form's cancel link can resolve the collections overview.
+    // Build the router so the confirm form's cancel link can resolve the
+    // collections overview.
     $this->container->get('router.builder')->rebuild();
 
     NodeType::create(['type' => 'page', 'name' => 'Page'])->save();

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookCollectionPermissionTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/tests/src/Kernel/BookCollectionPermissionTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Drupal\Tests\ys_book\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Tests which permission gates the content collection admin screens.
+ *
+ * Managing collections must be reachable with the narrow 'reorder book pages'
+ * permission alone.
+ *
+ * @see \Drupal\ys_book\Access\BookOutlineAccessCheck
+ * @see yalesites-org/YaleSites-Internal#1573
+ *
+ * @group ys_book
+ * @group yalesites
+ */
+class BookCollectionPermissionTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * The one collection route whose access check belongs to contrib, not us.
+   */
+  private const CONTRIB_GATED_ROUTE = 'book.node_child_ordering';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'node',
+    'book',
+    'custom_book_block',
+    'ys_book',
+  ];
+
+  /**
+   * A user holding only the narrow 'reorder book pages' permission.
+   */
+  protected AccountInterface $reorderOnly;
+
+  /**
+   * A user holding the broad 'administer book outlines' permission.
+   */
+  protected AccountInterface $administer;
+
+  /**
+   * The top-level page of a collection with two sub-pages.
+   */
+  protected Node $collection;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installSchema('node', 'node_access');
+    $this->installSchema('book', ['book']);
+    // Kernel tests never run hook_install(), so add the title column this
+    // module installs on a real site; see _ys_book_add_book_title_column().
+    $this->container->get('module_handler')->loadInclude('ys_book', 'install');
+    _ys_book_add_book_title_column();
+    $this->installConfig(['node', 'book', 'field']);
+    $this->container->get('router.builder')->rebuild();
+
+    NodeType::create(['type' => 'page', 'name' => 'Page'])->save();
+
+    // User 1 gets every permission implicitly, so burn uid 1 before creating
+    // the accounts whose permissions are the subject of the test.
+    $this->createUser();
+    $this->reorderOnly = $this->createUser(['reorder book pages', 'access content']);
+    $this->administer = $this->createUser(['administer book outlines', 'access content']);
+
+    $this->collection = $this->createCollection();
+  }
+
+  /**
+   * Creates a collection whose top-level page has two sub-pages.
+   *
+   * Two are needed rather than one: contrib's child-ordering route is only
+   * available when a collection has more than one sibling to order.
+   *
+   * @return \Drupal\node\Entity\Node
+   *   The reloaded top-level page, carrying its book outline data.
+   *
+   * @see \Drupal\book\Controller\RouteAccessController::access()
+   */
+  private function createCollection(): Node {
+    $root = Node::create([
+      'type' => 'page',
+      'title' => 'Root',
+      'status' => 1,
+      'book' => ['bid' => 'new'],
+    ]);
+    $root->save();
+    $bid = $root->id();
+
+    foreach (['Child one', 'Child two'] as $title) {
+      Node::create([
+        'type' => 'page',
+        'title' => $title,
+        'status' => 1,
+        'book' => ['bid' => $bid, 'pid' => $bid],
+      ])->save();
+    }
+
+    $storage = $this->container->get('entity_type.manager')->getStorage('node');
+    $storage->resetCache([$bid]);
+    return $storage->load($bid);
+  }
+
+  /**
+   * Checks route access for an account.
+   */
+  private function hasRouteAccess(string $route, AccountInterface $account, array $parameters = []): bool {
+    return $this->container->get('access_manager')
+      ->checkNamedRoute($route, $parameters, $account);
+  }
+
+  /**
+   * Every collection screen, keyed by route name, with its route parameters.
+   *
+   * @return array<string, array<string, string>>
+   *   Route parameters keyed by route name.
+   */
+  private function collectionRoutes(): array {
+    $node = ['node' => $this->collection->id()];
+
+    return [
+      'book.admin' => [],
+      'book.admin_edit' => $node,
+      self::CONTRIB_GATED_ROUTE => $node,
+      'ys_book.collection_delete' => $node,
+    ];
+  }
+
+  /**
+   * Every collection screen is reachable with 'reorder book pages' alone.
+   */
+  public function testReorderPermissionReachesCollectionScreens(): void {
+    foreach ($this->collectionRoutes() as $route => $parameters) {
+      $this->assertTrue(
+        $this->hasRouteAccess($route, $this->reorderOnly, $parameters),
+        sprintf('%s is reachable with only the narrow reorder permission.', $route)
+      );
+    }
+  }
+
+  /**
+   * The broad permission still reaches the screens YaleSites gates.
+   *
+   * Sites can grant 'administer book outlines' to a role of their own, and
+   * anyone who already holds it must not lose access when the platform roles
+   * stop relying on it. Child ordering is excluded because contrib gates that
+   * one itself; see testChildOrderingRequiresTheNarrowPermission().
+   */
+  public function testAdministerPermissionStillReachesCollectionScreens(): void {
+    $routes = $this->collectionRoutes();
+    unset($routes[self::CONTRIB_GATED_ROUTE]);
+    $this->assertCount(3, $routes, 'Only child ordering is gated by contrib.');
+
+    foreach ($routes as $route => $parameters) {
+      $this->assertTrue(
+        $this->hasRouteAccess($route, $this->administer, $parameters),
+        sprintf('%s is still reachable with the broad administer permission.', $route)
+      );
+    }
+  }
+
+  /**
+   * Child ordering needs the narrow permission even for administer holders.
+   *
+   * Contrib's own access check on that route tests 'reorder book pages' and
+   * nothing else, so the broad permission has never been enough on its own —
+   * before this ticket the route demanded both. Asserted so the asymmetry is
+   * recorded rather than rediscovered.
+   *
+   * @see \Drupal\book\Controller\RouteAccessController::access()
+   */
+  public function testChildOrderingRequiresTheNarrowPermission(): void {
+    $this->assertFalse(
+      $this->hasRouteAccess(self::CONTRIB_GATED_ROUTE, $this->administer, ['node' => $this->collection->id()]),
+      'Contrib gates child ordering on the narrow permission, which this account lacks.'
+    );
+  }
+
+  /**
+   * A user with neither book permission is denied every collection screen.
+   */
+  public function testNeitherPermissionDeniesCollectionScreens(): void {
+    $neither = $this->createUser(['access content']);
+
+    foreach ($this->collectionRoutes() as $route => $parameters) {
+      $this->assertFalse(
+        $this->hasRouteAccess($route, $neither, $parameters),
+        sprintf('%s is denied without either book permission.', $route)
+      );
+    }
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_book/ys_book.routing.yml
@@ -4,7 +4,7 @@ book.admin:
     _controller: '\Drupal\ys_book\Controller\YsBookController::adminOverview'
     _title: 'Content Collections'
   requirements:
-    _permission: 'administer book outlines'
+    _ys_book_outline_access: 'TRUE'
 
 book.admin_edit:
   path: '/admin/structure/book/{node}'
@@ -22,7 +22,7 @@ ys_book.collection_delete:
     _form: '\Drupal\ys_book\Form\BookCollectionDeleteForm'
     _title: 'Delete collection'
   requirements:
-    _permission: 'administer book outlines'
+    _ys_book_outline_access: 'TRUE'
     _entity_access: 'node.view'
     node: \d+
   options:
@@ -30,3 +30,26 @@ ys_book.collection_delete:
       node:
         type: 'entity:node'
     _admin_route: TRUE
+
+# Copied verbatim from contrib book's book.routing.yml, with the permission
+# requirement swapped for the collection-management access check. Contrib's own
+# _custom_access still applies, so the narrow 'reorder book pages' permission
+# is still required and the tab still only appears for a collection with more
+# than one sibling to order.
+#
+# @see yalesites-org/YaleSites-Internal#1573
+book.node_child_ordering:
+  path: '/node/{node}/child-ordering'
+  defaults:
+    _form: 'Drupal\book\Form\BookAdminEditForm'
+    _title: 'Re-order book pages and change titles'
+    parameters:
+      node:
+        type: entity:node
+  options:
+    _admin_route: TRUE
+  requirements:
+    _ys_book_outline_access: 'TRUE'
+    _entity_access: 'node.view'
+    _custom_access: '\Drupal\book\Controller\RouteAccessController::access'
+    node: \d+


### PR DESCRIPTION
## [1573: Review whether platform/site admin and editor still need "administer book outlines"](https://github.com/yalesites-org/YaleSites-Internal/issues/1573)

### Description of work

**What the permission actually grants (the review half of the ticket).** The live book module is
contrib `drupal/book` 2.0.4, not core's deprecated copy, and `administer book outlines` gates
exactly four things here:

| Surface | Gate before | Affected |
| --- | --- | --- |
| `/admin/structure/book` — the "Content Collections" overview | `administer book outlines` | lost without it |
| `/admin/structure/book/{node}` — reorder pages and titles | `_ys_book_outline_access` (added by #1145) | already safe |
| `/node/{node}/child-ordering` — the "Child order" node tab | `administer book outlines` **AND** contrib's own check, which requires `reorder book pages` | lost without it (needed *both*) |
| `/admin/structure/book/{node}/delete` — Delete collection | `administer book outlines` | lost without it |

Everything else book-related runs off other permissions the roles keep: the Content Collection
widget on the node form, the Outline tab and Remove-from-outline (`add content to books`), creating
a collection (`create new books`), printer-friendly export (`access printer-friendly version`).
`/admin/structure/book/settings` needs `administer site configuration`, which no role has.

One cosmetic behaviour does change: contrib's `BookOutlineConstraintValidator` uses the broad
permission only to decide whether its "you can only change the book outline for the published
version" violation message includes a link to the collections page, so these roles now see the
link-less variant. Reachable (a draft of a published collection page hits it), cosmetic, and in
contrib — noted rather than patched.

**So the original worry does not hold: nothing was exposed.** `/admin/structure/book` is not a
leaked contrib admin page — `ys_book` overrides that route with its own controller and re-parents
its menu link under Content as "Manage Content Collections". It is a first-class editor surface.
What *was* wrong is the shape of the grant: our own screens demanded contrib's
administer-everything permission, so every editing role had to hold it.

**What changed.**
- `book.admin` and `ys_book.collection_delete` now use the existing `_ys_book_outline_access` check
  (narrow `reorder book pages` OR the broad permission) instead of requiring the broad permission.
- Reinstated a `ys_book` override of contrib's `book.node_child_ordering` with the same swap, so the
  "Child order" tab keeps working. That override was deliberately removed in `0f8334bd4` as
  unneeded — it was, while every role held the broad permission, and it is needed again precisely
  because that is what this ticket removes. Contrib's own `_custom_access` still applies, so the
  narrow permission is still required and the tab still only appears when a collection has more
  than one sibling to order.
- `BookOutlineAccessCheck` now returns `AccessResult::allowedIfHasPermissions(..., 'OR')`. The old
  `AccessResult::allowedIf($a || $b)` carried no `user.permissions` cache context — a latent
  caching bug on one route that would have become a real one on four.
- Removed `administer book outlines` from `editor`, `site_admin` and `platform_admin` in
  `config/sync`. `reorder book pages` and the other book permissions are untouched.
- Documented the gate and the reasoning in `ys_book/README.md`.

**No update hook, deliberately.** Roles ship only from `config/sync` (nothing in any module
`config/install`/`config/optional`, and `config_ignore` has no `user.role*` pattern), so
`drush deploy`'s `config:import` phase applies the revocation on its own. A revoking hook would be
redundant with config import and could fight it. A site that granted the broad permission to a
custom role of its own is untouched by config import and keeps working, because every re-gated
check still accepts that permission — there is a test for exactly that.

**Two decisions worth a reviewer's attention.**
1. **Collection delete stays at the same level as reorder.** `ys_book.collection_delete` was gated
   on the broad permission, so removing it from a role would also have removed that role's ability
   to delete a collection. Rather than let that fall out by accident, delete is re-gated on the same
   check as reorder, which preserves exactly the access editors have today. Making delete a higher
   bar than reordering is defensible, but it is a behaviour change for editors and a separate product
   decision — say the word and it is a small follow-up. The sharpest way to state the consequence:
   `reorder book pages` now also permits dismantling a collection, so a site-specific role given
   that permission alone would get delete along with reorder. No such role exists today.
2. **`platform_admin` loses it too, not just editor and site_admin.** After the re-gate nothing on
   the platform requires the broad permission, so leaving it on platform_admin would grant only
   contrib breadth nobody uses — including any future contrib book route that lands gated on it.

**Tests.** New `BookCollectionPermissionTest` (4 tests, 72 assertions) asserts all four screens are
reachable with `reorder book pages` alone, that the broad permission still reaches the three screens
we gate, and that neither permission means denied. It also records the asymmetry the work turned up:
contrib gates child ordering on the narrow permission and nothing else, so the broad permission alone
has never been enough there. `BookCollectionDeleteTest` stays green at 14/14 (unchanged from
baseline); one comment in it had gone stale and was corrected.

**Known follow-up, not done here:** five `ys_book` kernel tests now hand-copy the same `setUp()`
fixture recipe and two have already drifted from it. Extracting a shared trait is the right call but
means editing four test files outside this ticket, so it is left as a follow-up rather than folded
into a permissions change.

### Functional testing steps:

- [x] As an **editor**, go to Content → Manage Content Collections. The overview loads and lists the site's collections.
- [x] Open a collection's re-order screen, change the order of its pages, and save. The new order sticks after a reload.
- [x] On a collection page with two or more sub-pages, open the **Child order** tab, reorder, and save. The new order sticks.
- [x] From the Collections overview, use **Delete collection** on a test collection. The confirmation appears, and after confirming the collection is gone while every page survives as standalone content.
- [x] Repeat all four steps as a **site admin** and as a **platform admin**.
- [x] Check `/admin/people/permissions` — "Administer book outlines" is unchecked for Editor, Site Admin and Platform Admin, while "Reorder child page of a book" stays checked.
- [x] As a **contributor** (who has neither book permission), confirm Manage Content Collections is still not reachable — this should be unchanged.
- [x] On a node edit form, confirm the Content Collection section still appears and a page can still be added to, or removed from, a collection.

References yalesites-org/YaleSites-Internal#1573
