### PR TITLE
1563: Add config schema for ys_core.site, ys_core.header_settings, ys_core.footer_settings, and ys_core.social_links

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/README.md
@@ -39,24 +39,13 @@ someone runs them locally.
 Recorded here so they are visible to anyone working in this module, particularly
 during the staged cleanup tracked in yalesites-org/YaleSites-Internal#579.
 
-- **No config schema for this module's settings objects.** `config/schema/ys_core.schema.yml`
-  covers only `ys_core.dashboard_settings`. `ys_core.site`, `ys_core.header_settings`,
-  `ys_core.footer_settings`, and `ys_core.social_links` have none, so a kernel test
-  that installs this module's config fails with `SchemaIncompleteException` under
-  PHPUnit's default strict schema checking. That blocks kernel-level characterization
-  of every service that reads these objects, so the tests here work around it by
-  exercising only code paths that need no config save. Adding the schema is not
-  test-only work: `environment_indicator.show` ships as boolean `true` in
-  `config/install` but `SiteSettingsForm` saves integer `1`, and `custom_favicon` /
-  `site_name_image` are declared as `''` but hold arrays of file IDs, so no schema
-  type validates both the install defaults and real saved values without also
-  correcting those.
-- **`getFavicons()` custom-favicon branch is only partly pinned.** The test for it
-  stubs a single image style for all four sizes, so it cannot show that each size
-  resolves to its own distinct URL. Verifying that needs a real image style and a
-  saved `custom_favicon` value, so it is blocked on the missing schema above. The
-  fallback branch is covered against the real filesystem and the shipped image
-  style config in `YaleSitesMediaManagerTest`.
+- **`installConfig(['ys_core'])` needs more modules than a settings test wants.**
+  All four settings objects now have a schema, so saving them under strict schema
+  checking works and `CoreSettingsSchemaTest` pins that. Installing the *whole*
+  `config/install` directory additionally installs the `grand_hero`
+  `field_display_mode` field, which pulls in `block_content`, `field` and
+  `options` and needs the block type to exist. A kernel test that only needs the
+  settings objects should save them directly, as `CoreSettingsSchemaTest` does.
 - **`CoreTwigExtension::getAssetPath()`'s `_yale-packages` fallback is uncovered.**
   A normal checkout has an asset manifest under the theme's `node_modules`, so the
   first path always wins; the fallback only runs where the theme's npm assets are

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/install/ys_core.header_settings.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/install/ys_core.header_settings.yml
@@ -1,7 +1,7 @@
 header_variation: 'basic'
 nav_position: 'left'
 focus_header_image: ''
-site_name_image: ''
+site_name_image: []
 search:
   enable_search_form: 1
   enable_cas_search: 0

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/install/ys_core.site.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/install/ys_core.site.yml
@@ -6,6 +6,6 @@ seo:
   google_analytics_id: ''
 image_fallback:
   teaser: ''
-custom_favicon: ''
+custom_favicon: []
 environment_indicator:
   show: true

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/schema/ys_core.schema.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/config/schema/ys_core.schema.yml
@@ -20,3 +20,219 @@ ys_core.dashboard_settings:
     announcements_source_term:
       type: string
       label: 'Taxonomy term name used to tag announcement posts'
+
+ys_core.site:
+  type: config_object
+  label: 'YaleSites site settings'
+  mapping:
+    page:
+      type: mapping
+      label: 'Landing pages'
+      mapping:
+        posts:
+          type: string
+          label: 'Relative path of the posts landing page, for example /post'
+        events:
+          type: string
+          label: 'Relative path of the events calendar page, for example /events'
+    search:
+      type: mapping
+      label: 'Search (superseded by ys_core.header_settings by ys_core_update_9002; still exported)'
+      mapping:
+        enable_search_form:
+          type: integer
+          label: 'Show the search form'
+    seo:
+      type: mapping
+      label: 'SEO'
+      mapping:
+        google_site_verification:
+          type: string
+          label: 'Google site verification token'
+        google_analytics_id:
+          type: string
+          label: 'Google Analytics ID (unused; Google Tag Manager replaced it)'
+    image_fallback:
+      type: mapping
+      label: 'Fallback images'
+      mapping:
+        teaser:
+          type: string
+          label: 'Media ID used when a teaser has no image'
+    taxonomy:
+      type: mapping
+      label: 'Taxonomy'
+      mapping:
+        custom_vocab_name:
+          type: string
+          label: 'Editor-facing label of the custom vocabulary'
+    custom_favicon:
+      type: sequence
+      label: 'Uploaded favicon (a managed_file value, so a list holding at most one file ID)'
+      sequence:
+        type: integer
+        label: 'File ID'
+    font_pairing:
+      type: string
+      label: 'Sitewide font pairing'
+    cas_app_name:
+      type: string
+      label: 'CAS application name used for Yale search'
+    environment_indicator:
+      type: mapping
+      label: 'Environment indicator'
+      mapping:
+        show:
+          type: boolean
+          label: 'Show the environment indicator banner'
+
+ys_core.header_settings:
+  type: config_object
+  label: 'YaleSites header settings'
+  mapping:
+    header_variation:
+      type: string
+      label: 'Header variation'
+    nav_position:
+      type: string
+      label: 'Navigation position'
+    focus_header_image:
+      type: string
+      label: 'Media ID of the focus header image'
+    site_name_image:
+      type: sequence
+      label: 'Site name image (a managed_file value, so a list holding at most one file ID)'
+      sequence:
+        type: integer
+        label: 'File ID'
+    site_wide_branding_name:
+      type: label
+      label: 'Sitewide branding name'
+    site_wide_branding_link:
+      type: string
+      label: 'Sitewide branding link'
+    cta_content:
+      type: label
+      label: 'Call to action text'
+    cta_url:
+      type: string
+      label: 'Call to action link'
+    dropdown_button_title:
+      type: label
+      label: 'Utility navigation dropdown button title'
+    search:
+      type: mapping
+      label: 'Search'
+      mapping:
+        enable_search_form:
+          type: integer
+          label: 'Show the search form'
+        enable_cas_search:
+          type: integer
+          label: 'Offer the CAS-restricted search scope'
+        enable_all_yale_search:
+          type: integer
+          label: 'Offer the all-of-Yale search scope'
+
+ys_core.footer_settings:
+  type: config_object
+  label: 'YaleSites footer settings'
+  mapping:
+    footer_variation:
+      type: string
+      label: 'Footer variation'
+    content:
+      type: mapping
+      label: 'Footer content'
+      mapping:
+        logos:
+          type: sequence
+          label: 'Footer logos'
+          sequence:
+            type: mapping
+            label: 'Footer logo'
+            mapping:
+              logo:
+                type: string
+                label: 'Media ID of the logo'
+              logo_url:
+                type: string
+                label: 'Link the logo points to'
+        school_logo:
+          type: string
+          label: 'Media ID of the school logo'
+        school_logo_url:
+          type: string
+          label: 'Link the school logo points to'
+        text:
+          type: mapping
+          label: 'Footer text'
+          mapping:
+            value:
+              type: text
+              label: 'Text'
+            format:
+              type: string
+              label: 'Text format'
+    links:
+      type: mapping
+      label: 'Footer links'
+      mapping:
+        links_col_1_heading:
+          type: label
+          label: 'Heading of the first links column'
+        links_col_2_heading:
+          type: label
+          label: 'Heading of the second links column'
+        links_col_1:
+          type: sequence
+          label: 'Links in the first column'
+          sequence:
+            type: mapping
+            label: 'Footer link'
+            mapping:
+              link_url:
+                type: string
+                label: 'Link URL'
+              link_title:
+                type: label
+                label: 'Link title'
+        links_col_2:
+          type: sequence
+          label: 'Links in the second column'
+          sequence:
+            type: mapping
+            label: 'Footer link'
+            mapping:
+              link_url:
+                type: string
+                label: 'Link URL'
+              link_title:
+                type: label
+                label: 'Link title'
+
+ys_core.social_links:
+  type: config_object
+  label: 'YaleSites social links'
+  mapping:
+    facebook:
+      type: string
+      label: 'Facebook URL'
+    instagram:
+      type: string
+      label: 'Instagram URL'
+    x-twitter:
+      type: string
+      label: 'X URL'
+    youtube:
+      type: string
+      label: 'YouTube URL'
+    weibo:
+      type: string
+      label: 'Weibo URL'
+    linkedin:
+      type: string
+      label: 'LinkedIn URL'
+    bluesky:
+      type: string
+      label: 'Bluesky URL'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -439,7 +439,11 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
     // Save environment indicator setting if the field was present
     // (platform admin only).
     if (ys_core_allow_secret_items($this->currentUserSession)) {
-      $yaleSiteConfig->set('environment_indicator.show', $form_state->getValue('environment_indicator_show') ?? TRUE);
+      // Cast to bool, as DashboardSettingsForm does. The sibling search
+      // checkboxes stay integers because that is what their install defaults
+      // and stored values already are; this one's install default ships
+      // boolean true, so the checkbox's integer needed normalising instead.
+      $yaleSiteConfig->set('environment_indicator.show', (bool) ($form_state->getValue('environment_indicator_show') ?? TRUE));
     }
 
     $yaleSiteConfig->save();

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/CoreSettingsSchemaTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/CoreSettingsSchemaTest.php
@@ -195,6 +195,30 @@ class CoreSettingsSchemaTest extends KernelTestBase {
   }
 
   /**
+   * The declared types are what comes back out, not merely what is accepted.
+   *
+   * Every other test here asserts the schema does not reject a form-shaped
+   * value, which a wrong-but-permissive declaration would also satisfy. These
+   * read-backs are the other half: Config::save() casts to the declared type,
+   * so a form's string '1' returning as int 1 is what proves the integer,
+   * boolean and sequence declarations are the types actually being stored.
+   */
+  public function testDeclaredTypesAreWhatIsStored(): void {
+    $this->config('ys_core.site')
+      // The shapes a Form API element hands over: a checkbox's string value,
+      // an integer standing in for a boolean, and file IDs as strings.
+      ->set('search.enable_search_form', '1')
+      ->set('environment_indicator.show', 1)
+      ->set('custom_favicon', ['9'])
+      ->save();
+
+    $site = $this->config('ys_core.site');
+    $this->assertSame(1, $site->get('search.enable_search_form'));
+    $this->assertSame(TRUE, $site->get('environment_indicator.show'));
+    $this->assertSame([9], $site->get('custom_favicon'));
+  }
+
+  /**
    * Saves the given keys onto a config object and asserts the result validates.
    *
    * The save itself is half the assertion: with strict schema checking on, an

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/CoreSettingsSchemaTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/CoreSettingsSchemaTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\Core\Serialization\Yaml;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\SchemaCheckTestTrait;
+
+/**
+ * Tests that ys_core's sitewide settings objects have a config schema.
+ *
+ * Config schema is what validates that a settings value is the shape it is
+ * supposed to be. Without it these four objects are unvalidated in production,
+ * so a bad value can be written and nothing catches it until something
+ * downstream breaks.
+ *
+ * The values asserted here are deliberately the ones the settings forms
+ * actually write, not the tidier shapes the install YAML used to declare: the
+ * schema has to describe reality or it would reject real sites' stored config.
+ * That is why `custom_favicon` and `site_name_image` are arrays of file IDs,
+ * the `search` flags are integers, and the footer's logo/link collections are
+ * sequences of mappings with potentially sparse keys.
+ *
+ * @group ys_core
+ * @group yalesites
+ */
+class CoreSettingsSchemaTest extends KernelTestBase {
+
+  use SchemaCheckTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'ys_core'];
+
+  /**
+   * The settings objects this module owns, beyond the dashboard settings.
+   */
+  private const SETTINGS = [
+    'ys_core.site',
+    'ys_core.header_settings',
+    'ys_core.footer_settings',
+    'ys_core.social_links',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Saving each settings object individually rather than installConfig(),
+    // which would also install this module's grand_hero field config and so
+    // drag block_content, field and options into a test about config schema.
+    // Strict schema checking is on by default in kernel tests, so the save
+    // itself is the gate the missing schema used to fail with
+    // SchemaIncompleteException.
+    foreach (self::SETTINGS as $name) {
+      $this->config($name)->setData($this->installDefaults($name))->save();
+    }
+  }
+
+  /**
+   * Every settings object this module ships is covered by a schema.
+   */
+  public function testEverySettingsObjectHasSchema(): void {
+    $typed = $this->container->get('config.typed');
+    foreach (self::SETTINGS as $name) {
+      $this->assertTrue(
+        $typed->hasConfigSchema($name),
+        "$name has no config schema, so its values are never validated."
+      );
+    }
+  }
+
+  /**
+   * The shipped install defaults validate against the schema.
+   */
+  public function testInstallDefaultsValidate(): void {
+    $typed = $this->container->get('config.typed');
+    foreach (self::SETTINGS as $name) {
+      $this->assertConfigSchema($typed, $name, $this->installDefaults($name));
+    }
+  }
+
+  /**
+   * Reads a settings object's shipped defaults from config/install.
+   */
+  private function installDefaults(string $name): array {
+    $path = \Drupal::root() . '/'
+      . \Drupal::service('extension.list.module')->getPath('ys_core')
+      . '/config/install/' . $name . '.yml';
+
+    return Yaml::decode(file_get_contents($path));
+  }
+
+  /**
+   * Site settings validate in the shape SiteSettingsForm writes them.
+   */
+  public function testSiteSettingsAsSavedByTheFormValidate(): void {
+    $this->assertSavedConfigValid('ys_core.site', [
+      'page.posts' => '12',
+      'page.events' => '13',
+      'search.enable_search_form' => 1,
+      'seo.google_site_verification' => 'abc123',
+      'seo.google_analytics_id' => '',
+      'image_fallback.teaser' => '7',
+      'taxonomy.custom_vocab_name' => 'Custom Vocab',
+      // A managed_file with #multiple => FALSE writes an array of file IDs.
+      'custom_favicon' => [9],
+      'font_pairing' => 'yalenew',
+      'cas_app_name' => 'yalesites',
+      'environment_indicator.show' => TRUE,
+    ]);
+  }
+
+  /**
+   * Header settings validate in the shape HeaderSettingsForm writes them.
+   */
+  public function testHeaderSettingsAsSavedByTheFormValidate(): void {
+    $this->assertSavedConfigValid('ys_core.header_settings', [
+      'header_variation' => 'focus',
+      'nav_position' => 'center',
+      'focus_header_image' => '42',
+      'site_name_image' => [9],
+      'site_wide_branding_name' => 'Yale University',
+      'site_wide_branding_link' => 'https://www.yale.edu',
+      'cta_content' => 'Apply now',
+      'cta_url' => '/admissions',
+      'dropdown_button_title' => 'More',
+      'search.enable_search_form' => 1,
+      'search.enable_cas_search' => 0,
+      'search.enable_all_yale_search' => 0,
+    ]);
+  }
+
+  /**
+   * Footer settings validate in the shape FooterSettingsForm writes them.
+   *
+   * The logo and link collections come from a multivalue form element that
+   * preserves its element keys, so a saved value can be sparsely indexed.
+   */
+  public function testFooterSettingsAsSavedByTheFormValidate(): void {
+    $this->assertSavedConfigValid('ys_core.footer_settings', [
+      'footer_variation' => 'mega',
+      'content.logos' => [
+        ['logo_url' => 'https://www.yale.edu', 'logo' => '3'],
+        2 => ['logo_url' => NULL, 'logo' => '4'],
+      ],
+      'content.school_logo' => '5',
+      'content.school_logo_url' => 'https://www.yale.edu',
+      'content.text' => ['value' => '<p>Footer text</p>', 'format' => 'restricted_html'],
+      'links.links_col_1_heading' => 'Resources',
+      'links.links_col_2_heading' => '',
+      'links.links_col_1' => [
+        ['link_url' => '/about', 'link_title' => 'About'],
+        3 => ['link_url' => 'https://www.yale.edu', 'link_title' => 'Yale'],
+      ],
+      'links.links_col_2' => [],
+    ]);
+  }
+
+  /**
+   * Social links validate for every network the platform offers.
+   */
+  public function testSocialLinksAsSavedByTheFormValidate(): void {
+    $this->assertSavedConfigValid('ys_core.social_links', [
+      'facebook' => 'https://facebook.com/yale',
+      'instagram' => 'https://instagram.com/yale',
+      // The stored key is hyphenated, unlike every other network id.
+      'x-twitter' => 'https://x.com/yale',
+      'youtube' => 'https://youtube.com/yale',
+      'weibo' => '',
+      'linkedin' => 'https://linkedin.com/school/yale-university',
+      // Offered by SocialLinksManager::SITES but absent from the install
+      // defaults, so it only ever appears once an editor saves the form.
+      'bluesky' => 'https://bsky.app/profile/yale.edu',
+    ]);
+  }
+
+  /**
+   * A real site can hold NULL where the install default declares a string.
+   *
+   * Both of these are NULL on a pulled production database: the teaser fallback
+   * when no media was ever chosen, and the focus header image once
+   * _ys_core_clear_focus_header_image_config() clears a deleted reference.
+   */
+  public function testNullValuesFromRealSitesValidate(): void {
+    $this->assertSavedConfigValid('ys_core.site', [
+      'image_fallback.teaser' => NULL,
+    ]);
+    $this->assertSavedConfigValid('ys_core.header_settings', [
+      'focus_header_image' => NULL,
+    ]);
+  }
+
+  /**
+   * Saves the given keys onto a config object and asserts the result validates.
+   *
+   * The save itself is half the assertion: with strict schema checking on, an
+   * invalid value throws SchemaIncompleteException before it is ever stored.
+   */
+  private function assertSavedConfigValid(string $name, array $values): void {
+    $config = $this->config($name);
+    foreach ($values as $key => $value) {
+      $config->set($key, $value);
+    }
+    $config->save();
+
+    $this->assertConfigSchemaByName($name);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/CustomFaviconTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/CustomFaviconTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Serialization\Yaml;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\file\Entity\File;
+use Drupal\ys_core\YaleSitesMediaManager;
+
+/**
+ * Tests the custom-favicon branch of YaleSitesMediaManager::getFavicons().
+ *
+ * The unit test for this branch stubs a single image style for all four sizes,
+ * so it cannot show that each size resolves to its own distinct URL. Proving
+ * that needs the real shipped image styles and a real saved `custom_favicon`
+ * value, which means saving ys_core config -- impossible until this module's
+ * settings objects had a config schema (yalesites-org/YaleSites-Internal#1563).
+ *
+ * The image styles are loaded from the profile's own config/sync rather than a
+ * fixture, so this fails if the shipped styles stop producing four distinct
+ * derivatives.
+ *
+ * @group ys_core
+ * @group yalesites
+ */
+class CustomFaviconTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'file', 'image', 'ys_core'];
+
+  /**
+   * The image styles getFavicons() renders each favicon size through.
+   */
+  private const STYLES = [
+    'favicon_180x180',
+    'favicon_32x32',
+    'favicon_16x16',
+    'favicon_16x16_ico',
+  ];
+
+  /**
+   * The uploaded favicon.
+   */
+  protected File $favicon;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installSchema('file', 'file_usage');
+    $this->installConfig(['system', 'file', 'image']);
+
+    foreach (self::STYLES as $style) {
+      $this->installProfileImageStyle($style);
+    }
+
+    $this->favicon = $this->uploadFavicon();
+  }
+
+  /**
+   * A saved custom favicon overrides every fallback with its own derivative.
+   */
+  public function testEverySizeResolvesToItsOwnDerivative(): void {
+    $this->saveCustomFavicon();
+
+    $favicons = $this->mediaManager()->getFavicons();
+
+    $this->assertSame(
+      ['apple-touch-icon', 'icon-32', 'icon-16', 'icon-ico'],
+      array_keys($favicons),
+      'A resolvable custom favicon keeps all four sizes.'
+    );
+
+    $hrefs = [];
+    foreach ($favicons as $key => $favicon) {
+      $href = $favicon['#attributes']['href'];
+      $this->assertStringContainsString(
+        '/styles/' . $favicon['#image_style'] . '/',
+        $href,
+        "$key was not rendered through its own image style."
+      );
+      $this->assertStringNotContainsString(
+        '/images/favicons/',
+        $href,
+        "$key still points at the shipped fallback file."
+      );
+      $hrefs[$key] = $href;
+    }
+
+    // The whole point of four image styles: four distinct derivative URLs.
+    $this->assertCount(4, array_unique($hrefs), 'Two sizes resolved to the same URL.');
+  }
+
+  /**
+   * With no custom favicon saved, the shipped fallback files are used.
+   */
+  public function testFallbackIsUsedWhenNoCustomFaviconIsSaved(): void {
+    $favicons = $this->mediaManager()->getFavicons();
+
+    $this->assertCount(4, $favicons);
+    foreach ($favicons as $key => $favicon) {
+      $this->assertStringContainsString(
+        '/images/favicons/',
+        $favicon['#attributes']['href'],
+        "$key did not fall back to a shipped favicon file."
+      );
+    }
+  }
+
+  /**
+   * A size whose image style is missing is dropped rather than left stale.
+   */
+  public function testSizeIsDroppedWhenItsImageStyleIsMissing(): void {
+    $this->saveCustomFavicon();
+
+    $this->container->get('entity_type.manager')
+      ->getStorage('image_style')
+      ->load('favicon_16x16_ico')
+      ->delete();
+
+    $favicons = $this->mediaManager()->getFavicons();
+
+    $this->assertArrayNotHasKey('icon-ico', $favicons);
+    $this->assertCount(3, $favicons);
+  }
+
+  /**
+   * Points the site's custom favicon setting at the uploaded file.
+   */
+  private function saveCustomFavicon(): void {
+    $this->config('ys_core.site')
+      ->set('custom_favicon', [(int) $this->favicon->id()])
+      ->save();
+  }
+
+  /**
+   * The media manager service under test.
+   */
+  private function mediaManager(): YaleSitesMediaManager {
+    // The service is shared, and it holds the immutable Config object it read
+    // at construction - but ConfigFactory re-initialises that same object's
+    // data on every save, so it does see a newly saved favicon.
+    return $this->container->get('ys_core.media_manager');
+  }
+
+  /**
+   * Copies a shipped favicon into the file system and registers it as a file.
+   */
+  private function uploadFavicon(): File {
+    $source = \Drupal::root() . '/'
+      . \Drupal::service('extension.list.module')->getPath('ys_core')
+      . '/images/favicons/apple-touch-icon.png';
+
+    $file_system = $this->container->get('file_system');
+    $directory = 'public://favicons';
+    $file_system->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY);
+    $uri = $file_system->copy($source, $directory . '/custom-favicon.png');
+
+    $file = File::create(['uri' => $uri]);
+    $file->setPermanent();
+    $file->save();
+
+    return $file;
+  }
+
+  /**
+   * Creates one of the profile's exported image styles.
+   */
+  private function installProfileImageStyle(string $name): void {
+    $path = \Drupal::root() . '/'
+      . \Drupal::service('extension.list.profile')->getPath('yalesites_profile')
+      . '/config/sync/image.style.' . $name . '.yml';
+    $data = Yaml::decode(file_get_contents($path));
+    unset($data['_core']);
+
+    $this->container->get('entity_type.manager')
+      ->getStorage('image_style')
+      ->create($data)
+      ->save();
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/LegacyConfigShapeSaveTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/LegacyConfigShapeSaveTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\ys_core\Traits\LegacyConfigFixtureTrait;
+
+/**
+ * Tests that saving config a real site already holds still works.
+ *
+ * Adding a config schema (issue #1563) changes what Config::save() does: it
+ * only casts values against a schema when one exists, so shapes that used to
+ * pass straight through are now handed to
+ * \Drupal\Core\Config\StorableConfigBase::castValue(). Two of the shapes
+ * production databases hold reach that code, and they behave differently:
+ *
+ * - A legacy scalar meeting a `sequence` element is left alone, because
+ *   castValue() only coerces for a PrimitiveInterface element and Sequence is
+ *   not one. This is the backward-compatibility claim the schema rests on, and
+ *   it is reachable: HeaderSettingsForm writes `site_name_image` only inside a
+ *   ys_core_allow_secret_items() check, so a site_admin saving the header form
+ *   saves an object still holding the legacy `''`.
+ * - An array meeting the scalar `focus_header_image` element is NOT left
+ *   alone: castValue() recurses and looks up `focus_header_image.0`, which
+ *   does not exist under a string element, and throws an uncaught
+ *   \InvalidArgumentException. That array shape is real - ys_core_module's
+ *   render-path guard was added for it by a production hotfix - so anything
+ *   that saves ys_core.header_settings on such a site aborts, including
+ *   ys_core_deploy_10008().
+ *
+ * Strict schema checking is off here on purpose. ConfigSchemaChecker validates
+ * the data POST-cast, so with it on it would correctly reject the legacy
+ * scalar and the assertion could not be made at all - the point is what
+ * production, which has no such checker, does with these values.
+ *
+ * @group ys_core
+ * @group yalesites
+ */
+class LegacyConfigShapeSaveTest extends KernelTestBase {
+
+  use LegacyConfigFixtureTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'ys_core'];
+
+  /**
+   * {@inheritdoc}
+   *
+   * The legacy shapes tested here are exactly the ones a schema checker
+   * refuses, so leaving it on would fail the save for the wrong reason.
+   *
+   * DrupalPractice forbids this on the grounds that a module should declare
+   * its schema properly instead - which is precisely what the rest of this
+   * change does. The values under test predate that schema, so no declaration
+   * can make them valid; ConfigSchemaChecker validates the data POST-cast, and
+   * asserting what production does with an uncast legacy value is impossible
+   * with a checker in the way. Suppressed for this class only.
+   */
+  // phpcs:ignore DrupalPractice.Objects.StrictSchemaDisabled.StrictConfigSchema
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->requireDeployHooks();
+  }
+
+  /**
+   * A legacy scalar under a sequence element survives an unrelated save.
+   *
+   * This is the scenario a site_admin hits saving /admin/yalesites/header:
+   * the form never writes site_name_image for them, so the legacy '' is still
+   * in the object's data when Config::save() casts it.
+   */
+  public function testLegacyScalarUnderSequenceSurvivesSave(): void {
+    $this->storeLegacy('ys_core.header_settings', ['site_name_image' => '']);
+
+    $this->config('ys_core.header_settings')->set('nav_position', 'center')->save();
+
+    $this->assertSame('center', $this->config('ys_core.header_settings')->get('nav_position'));
+    $this->assertSame('', $this->config('ys_core.header_settings')->get('site_name_image'));
+  }
+
+  /**
+   * An array focus_header_image is repaired instead of aborting the hook.
+   *
+   * The fixture is the combination a real site holds: the array the render
+   * path guards against, alongside the legacy managed_file scalar the deploy
+   * hook is there to normalise. Writing site_name_image first would serialise
+   * the whole object - array included - and throw, so this also pins the order
+   * the repairs run in.
+   */
+  public function testArrayFocusHeaderImageIsClearedByNormalization(): void {
+    $this->storeLegacy('ys_core.header_settings', [
+      'focus_header_image' => ['12'],
+      'site_name_image' => '',
+    ]);
+
+    $report = ys_core_normalize_settings_shapes();
+
+    $this->assertNull($this->config('ys_core.header_settings')->get('focus_header_image'));
+    $this->assertSame([], $this->config('ys_core.header_settings')->get('site_name_image'));
+    $this->assertCount(2, $report['changes']);
+  }
+
+  /**
+   * Once repaired, saving the object again works and stays repaired.
+   */
+  public function testRepairedConfigCanBeSavedAgain(): void {
+    $this->storeLegacy('ys_core.header_settings', ['focus_header_image' => ['12']]);
+
+    ys_core_normalize_settings_shapes();
+    $this->config('ys_core.header_settings')->set('nav_position', 'center')->save();
+
+    $this->assertSame('center', $this->config('ys_core.header_settings')->get('nav_position'));
+    $this->assertNull($this->config('ys_core.header_settings')->get('focus_header_image'));
+    $this->assertSame([], ys_core_normalize_settings_shapes()['changes']);
+  }
+
+  /**
+   * A dry run reports the array without clearing it.
+   */
+  public function testDryRunReportsArrayWithoutClearing(): void {
+    $this->storeLegacy('ys_core.header_settings', ['focus_header_image' => ['12']]);
+
+    $report = ys_core_normalize_settings_shapes(TRUE);
+
+    $this->assertCount(1, $report['changes']);
+    $this->assertSame(['12'], $this->config('ys_core.header_settings')->get('focus_header_image'));
+  }
+
+  /**
+   * A scalar focus_header_image is a usable media ID and is left alone.
+   */
+  public function testScalarFocusHeaderImageIsUntouched(): void {
+    $this->config('ys_core.header_settings')->set('focus_header_image', '42')->save();
+
+    $this->assertSame([], ys_core_normalize_settings_shapes()['changes']);
+    $this->assertSame('42', $this->config('ys_core.header_settings')->get('focus_header_image'));
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/SettingsShapeNormalizationTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/SettingsShapeNormalizationTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\ys_core\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\SchemaCheckTestTrait;
+use Drupal\Tests\ys_core\Traits\LegacyConfigFixtureTrait;
 
 /**
  * Tests normalising settings values that predate the ys_core config schema.
@@ -28,6 +29,7 @@ use Drupal\Tests\SchemaCheckTestTrait;
  */
 class SettingsShapeNormalizationTest extends KernelTestBase {
 
+  use LegacyConfigFixtureTrait;
   use SchemaCheckTestTrait;
 
   /**
@@ -41,9 +43,7 @@ class SettingsShapeNormalizationTest extends KernelTestBase {
   protected function setUp(): void {
     parent::setUp();
 
-    // The helper lives in ys_core.deploy.php, which is loaded only by
-    // drush deploy:hook, not for a module that is merely enabled.
-    require_once __DIR__ . '/../../../ys_core.deploy.php';
+    $this->requireDeployHooks();
   }
 
   /**
@@ -140,18 +140,6 @@ class SettingsShapeNormalizationTest extends KernelTestBase {
 
     $this->assertCount(1, $report['changes']);
     $this->assertSame('', $this->config('ys_core.site')->get('custom_favicon'));
-  }
-
-  /**
-   * Writes a pre-schema shape straight to storage, as a live site holds it.
-   *
-   * Going through the config factory would put the value past the schema
-   * checker, which is exactly what these shapes fail.
-   */
-  private function storeLegacy(string $name, array $data): void {
-    $this->container->get('config.storage')->write($name, $data);
-    // Drop the factory's cached copy so the next read sees the raw write.
-    $this->container->get('config.factory')->reset($name);
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/SettingsShapeNormalizationTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/SettingsShapeNormalizationTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\SchemaCheckTestTrait;
+
+/**
+ * Tests normalising settings values that predate the ys_core config schema.
+ *
+ * Adding a schema (issue #1563) only validates values written from then on.
+ * Existing sites still store the shapes written before it: an empty string
+ * where a managed_file only ever writes a list of file IDs, and an integer
+ * where the environment indicator's install default ships a boolean. Nothing
+ * rewrites them on its own, so ys_core_deploy_10008() is what brings them into
+ * line - a deploy hook rather than a hook_update_N because it writes to active
+ * config, and drush deploy runs updatedb before config:import.
+ *
+ * The legacy fixtures are written straight to the config storage rather than
+ * saved through the config factory. Strict schema checking would refuse the
+ * save - correctly, since the whole point is that these shapes are invalid -
+ * and a direct write is also the more honest fixture: it reproduces what is
+ * already sitting in an existing site's database rather than an impossible
+ * save.
+ *
+ * @group ys_core
+ * @group yalesites
+ */
+class SettingsShapeNormalizationTest extends KernelTestBase {
+
+  use SchemaCheckTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'ys_core'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // The helper lives in ys_core.deploy.php, which is loaded only by
+    // drush deploy:hook, not for a module that is merely enabled.
+    require_once __DIR__ . '/../../../ys_core.deploy.php';
+  }
+
+  /**
+   * A pre-schema empty string becomes the empty list a managed_file writes.
+   */
+  public function testLegacyEmptyStringBecomesEmptyList(): void {
+    $this->storeLegacy('ys_core.site', ['custom_favicon' => '']);
+    $this->storeLegacy('ys_core.header_settings', ['site_name_image' => '']);
+
+    $report = ys_core_normalize_settings_shapes();
+
+    $this->assertSame([], $this->config('ys_core.site')->get('custom_favicon'));
+    $this->assertSame([], $this->config('ys_core.header_settings')->get('site_name_image'));
+    $this->assertCount(2, $report['changes']);
+    $this->assertConfigSchemaByName('ys_core.site');
+    $this->assertConfigSchemaByName('ys_core.header_settings');
+  }
+
+  /**
+   * A scalar file ID is kept rather than discarded as a real upload.
+   */
+  public function testScalarFileIdBecomesSingleItemList(): void {
+    $this->storeLegacy('ys_core.site', ['custom_favicon' => '9']);
+
+    ys_core_normalize_settings_shapes();
+
+    $this->assertSame([9], $this->config('ys_core.site')->get('custom_favicon'));
+    $this->assertConfigSchemaByName('ys_core.site');
+  }
+
+  /**
+   * The environment indicator's stored integer becomes the boolean it declares.
+   */
+  public function testLegacyIntegerBecomesBoolean(): void {
+    $this->storeLegacy('ys_core.site', ['environment_indicator' => ['show' => 1]]);
+
+    ys_core_normalize_settings_shapes();
+
+    $this->assertTrue($this->config('ys_core.site')->get('environment_indicator.show'));
+    $this->assertConfigSchemaByName('ys_core.site');
+  }
+
+  /**
+   * A falsy integer survives as FALSE rather than being flipped to TRUE.
+   *
+   * This is the value that hides the banner, so turning it into TRUE would
+   * reveal an environment indicator on every site that had switched it off.
+   */
+  public function testLegacyZeroBecomesFalseNotTrue(): void {
+    $this->storeLegacy('ys_core.site', ['environment_indicator' => ['show' => 0]]);
+
+    ys_core_normalize_settings_shapes();
+
+    $this->assertFalse($this->config('ys_core.site')->get('environment_indicator.show'));
+    $this->assertConfigSchemaByName('ys_core.site');
+  }
+
+  /**
+   * Values already in the right shape are left alone, and a re-run is a no-op.
+   */
+  public function testAlreadyCorrectValuesAreUntouched(): void {
+    $this->config('ys_core.site')
+      ->set('custom_favicon', [9])
+      ->set('environment_indicator.show', TRUE)
+      ->save();
+    $this->config('ys_core.header_settings')->set('site_name_image', [])->save();
+
+    $this->assertSame([], ys_core_normalize_settings_shapes()['changes']);
+    $this->assertSame([9], $this->config('ys_core.site')->get('custom_favicon'));
+    $this->assertTrue($this->config('ys_core.site')->get('environment_indicator.show'));
+  }
+
+  /**
+   * A key this site never stored is not invented by the normalisation.
+   *
+   * The ys_core.header_settings object ships as a config/install default that
+   * is not in the profile's config/sync, so a site only gains it when its
+   * settings form is first saved. Writing into an object that does not exist
+   * yet would create it holding a single key and nothing else.
+   */
+  public function testAbsentKeysAreNotCreated(): void {
+    $this->assertSame([], ys_core_normalize_settings_shapes()['changes']);
+    $this->assertNull($this->config('ys_core.site')->get('custom_favicon'));
+    $this->assertNull($this->config('ys_core.header_settings')->get('site_name_image'));
+  }
+
+  /**
+   * A dry run reports what it would change without writing anything.
+   */
+  public function testDryRunReportsWithoutWriting(): void {
+    $this->storeLegacy('ys_core.site', ['custom_favicon' => '']);
+
+    $report = ys_core_normalize_settings_shapes(TRUE);
+
+    $this->assertCount(1, $report['changes']);
+    $this->assertSame('', $this->config('ys_core.site')->get('custom_favicon'));
+  }
+
+  /**
+   * Writes a pre-schema shape straight to storage, as a live site holds it.
+   *
+   * Going through the config factory would put the value past the schema
+   * checker, which is exactly what these shapes fail.
+   */
+  private function storeLegacy(string $name, array $data): void {
+    $this->container->get('config.storage')->write($name, $data);
+    // Drop the factory's cached copy so the next read sees the raw write.
+    $this->container->get('config.factory')->reset($name);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Traits/LegacyConfigFixtureTrait.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Traits/LegacyConfigFixtureTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Traits;
+
+/**
+ * Helpers for tests about config written before ys_core had a schema.
+ */
+trait LegacyConfigFixtureTrait {
+
+  /**
+   * Loads the deploy hooks so a test can call one directly.
+   *
+   * The ys_core.deploy.php file is loaded only by drush deploy:hook, not for a
+   * module that is merely enabled, so a test includes it itself. The path is
+   * resolved through the extension list rather than relative to this file, so
+   * moving a test class cannot silently break the include.
+   */
+  protected function requireDeployHooks(): void {
+    $path = \Drupal::service('extension.list.module')->getPath('ys_core');
+    require_once \Drupal::root() . '/' . $path . '/ys_core.deploy.php';
+  }
+
+  /**
+   * Writes a pre-schema shape straight to storage, as a live site holds it.
+   *
+   * Going through the config factory would put the value past the schema
+   * checker and the type casting, which is exactly what these shapes predate.
+   *
+   * @param string $name
+   *   The config object name.
+   * @param array $data
+   *   The raw data to store.
+   */
+  protected function storeLegacy(string $name, array $data): void {
+    $this->container->get('config.storage')->write($name, $data);
+    // Drop the factory's cached copy so the next read sees the raw write.
+    $this->container->get('config.factory')->reset($name);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.deploy.php
@@ -315,7 +315,7 @@ function ys_core_deploy_10007(&$sandbox) {
 /**
  * Normalises stored settings values that predate this module's config schema.
  *
- * Two kinds of value were being stored in a shape their own form never
+ * Three kinds of value were being stored in a shape their own form never
  * produces, which went unnoticed because these objects had no config schema to
  * validate them against:
  *
@@ -326,6 +326,11 @@ function ys_core_deploy_10007(&$sandbox) {
  * - `environment_indicator.show` ships boolean TRUE in config/install, but
  *   SiteSettingsForm used to store the checkbox's raw integer, so a site that
  *   saved the settings form before that cast landed stores 1 or 0.
+ * - `focus_header_image` names a single media item, but some sites store an
+ *   array of IDs - the shape ys_core_preprocess_region() has guarded against
+ *   since a production hotfix. Unlike the other two this one is not merely
+ *   untidy: it is the only legacy value the new schema makes unsaveable, so
+ *   repairing it is what lets a deploy finish at all on those sites.
  *
  * This runs as a deploy hook rather than a hook_update_N because it writes to
  * active config: drush deploy runs updatedb BEFORE config:import, so a config
@@ -341,8 +346,11 @@ function ys_core_deploy_10007(&$sandbox) {
  * ys_core_allow_secret_items() check, so a site_admin saving that form leaves
  * the stale value untouched.
  *
- * Every reader of all three keys only tests truthiness, and an empty list is
- * falsy exactly as the empty string was, so this changes no behaviour.
+ * Every reader of the two managed_file keys and the indicator flag only tests
+ * truthiness, and an empty list is falsy exactly as the empty string was, so
+ * this changes no behaviour for them. Clearing an array focus_header_image
+ * matches what the render path already did with that value: it named no single
+ * media item, so no image was ever shown for it.
  *
  * @param bool $dry_run
  *   When TRUE, report what would change without writing anything.
@@ -355,15 +363,16 @@ function ys_core_normalize_settings_shapes($dry_run = FALSE) {
   $changes = [];
   $config_factory = \Drupal::configFactory();
 
-  $describe = function ($name, $key, $from, $to) {
-    return sprintf(
-      '%s:%s %s => %s',
-      $name,
-      $key,
-      var_export($from, TRUE),
-      var_export($to, TRUE)
-    );
-  };
+  // var_export() spreads an array over several lines, which would break the
+  // one-line-per-change shape of the report.
+  $format = fn ($value) => is_array($value) ? json_encode($value) : var_export($value, TRUE);
+  $describe = fn ($name, $key, $from, $to) => sprintf(
+    '%s:%s %s => %s',
+    $name,
+    $key,
+    $format($from),
+    $format($to)
+  );
 
   // Every value is read before anything is written. Config::save() casts data
   // to the schema's types once a schema exists, so saving one key can silently
@@ -373,6 +382,18 @@ function ys_core_normalize_settings_shapes($dry_run = FALSE) {
     'ys_core.header_settings' => 'site_name_image',
   ];
   $planned = [];
+
+  // A focus_header_image holding an array of media IDs rather than one ID is a
+  // shape the render path already guards against (see
+  // ys_core_preprocess_region()), and it is the one legacy value the schema
+  // cannot tolerate: castValue() recurses into the array looking for
+  // focus_header_image.0 under a string element and throws. That aborts ANY
+  // save of ys_core.header_settings, this hook's own site_name_image write
+  // included, so it is planned first and so repaired first.
+  $focus_image = $config_factory->getEditable('ys_core.header_settings')->get('focus_header_image');
+  if ($focus_image !== NULL && !is_scalar($focus_image)) {
+    $planned[] = ['ys_core.header_settings', 'focus_header_image', $focus_image, NULL, TRUE];
+  }
 
   foreach ($file_settings as $name => $key) {
     $value = $config_factory->getEditable($name)->get($key);
@@ -384,17 +405,24 @@ function ys_core_normalize_settings_shapes($dry_run = FALSE) {
     // A numeric scalar is still a usable file ID, so keep it rather than
     // discarding a real upload. Anything else - notably the '' the install
     // default used to ship - names no file and becomes the empty list.
-    $planned[] = [$name, $key, $value, is_numeric($value) ? [(int) $value] : []];
+    $planned[] = [$name, $key, $value, is_numeric($value) ? [(int) $value] : [], FALSE];
   }
 
   $show = $config_factory->getEditable('ys_core.site')->get('environment_indicator.show');
   if ($show !== NULL && !is_bool($show)) {
-    $planned[] = ['ys_core.site', 'environment_indicator.show', $show, (bool) $show];
+    $planned[] = ['ys_core.site', 'environment_indicator.show', $show, (bool) $show, FALSE];
   }
 
-  foreach ($planned as [$name, $key, $from, $to]) {
+  foreach ($planned as [$name, $key, $from, $to, $clear]) {
     if (!$dry_run) {
-      $config_factory->getEditable($name)->set($key, $to)->save();
+      if ($clear) {
+        // Reuse the render path's clearing helper, silently: a deploy has no
+        // interactive user to show its message to.
+        _ys_core_clear_focus_header_image_config($name, FALSE);
+      }
+      else {
+        $config_factory->getEditable($name)->set($key, $to)->save();
+      }
     }
     $changes[] = $describe($name, $key, $from, $to);
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.deploy.php
@@ -311,3 +311,111 @@ function ys_core_deploy_10007(&$sandbox) {
 
   return t('Backfilled the default icon on @count In-Line Message block revision(s).', ['@count' => $sandbox['backfilled']]);
 }
+
+/**
+ * Normalises stored settings values that predate this module's config schema.
+ *
+ * Two kinds of value were being stored in a shape their own form never
+ * produces, which went unnoticed because these objects had no config schema to
+ * validate them against:
+ *
+ * - `custom_favicon` and `site_name_image` are managed_file values, so the
+ *   element only ever writes a list of file IDs. Both shipped an empty string
+ *   as their install default, so every site that never uploaded one still
+ *   stores that scalar.
+ * - `environment_indicator.show` ships boolean TRUE in config/install, but
+ *   SiteSettingsForm used to store the checkbox's raw integer, so a site that
+ *   saved the settings form before that cast landed stores 1 or 0.
+ *
+ * This runs as a deploy hook rather than a hook_update_N because it writes to
+ * active config: drush deploy runs updatedb BEFORE config:import, so a config
+ * edit made at that point can be overwritten by the import that follows.
+ * config_ignore does currently list `ys_core*`, which would spare these
+ * objects, but depending on that is fragile - deploy:hook runs after the
+ * import and is correct either way.
+ *
+ * The stale shapes would otherwise persist indefinitely. Saving
+ * one of the settings forms would fix the value in passing - Config::save()
+ * casts to the schema's types once a schema exists - but only partly: header
+ * settings write `site_name_image` solely inside a
+ * ys_core_allow_secret_items() check, so a site_admin saving that form leaves
+ * the stale value untouched.
+ *
+ * Every reader of all three keys only tests truthiness, and an empty list is
+ * falsy exactly as the empty string was, so this changes no behaviour.
+ *
+ * @param bool $dry_run
+ *   When TRUE, report what would change without writing anything.
+ *
+ * @return array
+ *   A report with a single 'changes' key holding one human-readable line per
+ *   value rewritten.
+ */
+function ys_core_normalize_settings_shapes($dry_run = FALSE) {
+  $changes = [];
+  $config_factory = \Drupal::configFactory();
+
+  $describe = function ($name, $key, $from, $to) {
+    return sprintf(
+      '%s:%s %s => %s',
+      $name,
+      $key,
+      var_export($from, TRUE),
+      var_export($to, TRUE)
+    );
+  };
+
+  // Every value is read before anything is written. Config::save() casts data
+  // to the schema's types once a schema exists, so saving one key can silently
+  // correct another - which would make a report built as we go under-count.
+  $file_settings = [
+    'ys_core.site' => 'custom_favicon',
+    'ys_core.header_settings' => 'site_name_image',
+  ];
+  $planned = [];
+
+  foreach ($file_settings as $name => $key) {
+    $value = $config_factory->getEditable($name)->get($key);
+    // NULL means the key is absent from this site's stored config, which the
+    // schema does not object to; an array is already the right shape.
+    if ($value === NULL || is_array($value)) {
+      continue;
+    }
+    // A numeric scalar is still a usable file ID, so keep it rather than
+    // discarding a real upload. Anything else - notably the '' the install
+    // default used to ship - names no file and becomes the empty list.
+    $planned[] = [$name, $key, $value, is_numeric($value) ? [(int) $value] : []];
+  }
+
+  $show = $config_factory->getEditable('ys_core.site')->get('environment_indicator.show');
+  if ($show !== NULL && !is_bool($show)) {
+    $planned[] = ['ys_core.site', 'environment_indicator.show', $show, (bool) $show];
+  }
+
+  foreach ($planned as [$name, $key, $from, $to]) {
+    if (!$dry_run) {
+      $config_factory->getEditable($name)->set($key, $to)->save();
+    }
+    $changes[] = $describe($name, $key, $from, $to);
+  }
+
+  return ['changes' => $changes];
+}
+
+/**
+ * Implements hook_deploy_NAME().
+ *
+ * Normalises ys_core settings values that predate the module's config schema.
+ */
+function ys_core_deploy_10008() {
+  $report = ys_core_normalize_settings_shapes();
+  $logger = \Drupal::logger('ys_core');
+
+  foreach ($report['changes'] as $change) {
+    $logger->notice('Normalised stored ys_core settings value: @change', ['@change' => $change]);
+  }
+
+  return t('Normalised @count stored ys_core settings value(s) to the shape the config schema now declares.', [
+    '@count' => count($report['changes']),
+  ]);
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -1136,10 +1136,18 @@ function ys_core_preprocess_html(&$variables) {
  *
  * @param string $configName
  *   The name of the config to clear the focus header on.
+ * @param bool $notify
+ *   Whether to tell the current user their focus header image is gone. Pass
+ *   FALSE from a non-interactive context such as a deploy hook, where there is
+ *   nobody to read the message and no page to link them to.
  */
-function _ys_core_clear_focus_header_image_config($configName) {
+function _ys_core_clear_focus_header_image_config($configName, $notify = TRUE) {
   $config = \Drupal::configFactory()->getEditable($configName);
   $config->clear('focus_header_image')->save();
+
+  if (!$notify) {
+    return;
+  }
 
   $headerSettingsPath = Url::fromRoute('ys_core.admin_header_settings')->toString();
   $message = t(


### PR DESCRIPTION
## [1563: Add config schema for ys_core.site, ys_core.header_settings, ys_core.footer_settings, and ys_core.social_links](https://github.com/yalesites-org/YaleSites-Internal/issues/1563)

### Description of work

- Adds `config_object` schema for `ys_core.site`, `ys_core.header_settings`, `ys_core.footer_settings`, and `ys_core.social_links` in `ys_core/config/schema/ys_core.schema.yml`, following the existing `ys_core.dashboard_settings` entry as the pattern. Until now those four sitewide settings objects were unvalidated, so a malformed value could be written and nothing caught it.
- The schema describes **what the forms actually write**, not the tidier shapes the install YAML declared. That means `custom_favicon` / `site_name_image` are sequences of file IDs (a `managed_file` value), the `search.*` flags are integers, `content.text` is a `{value, format}` mapping, and the footer's logo/link collections are sequences of mappings that may be sparsely indexed. Confirmed by reading every `submitForm()` and by inspecting a real pulled production database.
- Includes the nine keys that existed only in live active config and were declared nowhere: `taxonomy.custom_vocab_name`, `font_pairing`, `cas_app_name` (site); `site_wide_branding_name`, `site_wide_branding_link`, `cta_content`, `cta_url` (header); `bluesky` (social links). Also covers `ys_core.site:search.enable_search_form`, which `ys_core_update_9002` superseded but which is still exported in `config/sync`, so it has to validate on import.
- Corrects the two install defaults that declared a shape their field never produces: `custom_favicon: '' -> []` and `site_name_image: '' -> []`. Both consumers guard on truthiness (`YaleSitesMediaManager`, `CoreTwigExtension`) and `[]` is falsy exactly as `''` was, so this is behavior-preserving.
- Casts `environment_indicator.show` to `(bool)` in `SiteSettingsForm`, matching the cast pattern `DashboardSettingsForm` already uses. The install default already shipped boolean `true` while the checkbox was storing integer `1`. A comment at the call site explains why this one checkbox is normalized while the sibling `search.*` flags stay integers.
- **Adds `ys_core_deploy_10008()`** (plus a `ys_core_normalize_settings_shapes()` helper) to bring already-stored values into the shape the new schema declares: scalar `custom_favicon` / `site_name_image` -> list, integer `environment_indicator.show` -> boolean. It is a **deploy hook, not a `hook_update_N`**, because it writes to active config and `drush deploy` runs `updatedb` *before* `config:import` — a config edit made in the update phase can be undone by the import that follows. `config_ignore` does currently list `ys_core*`, which would spare these objects, but depending on that is fragile; `deploy:hook` runs after the import and is correct either way. See "Why a normalisation hook" below.
- Un-blocks and writes the custom-favicon branch of the favicon coverage as `ys_core/tests/src/Kernel/CustomFaviconTest.php`, using the real shipped favicon image styles and a real saved `custom_favicon` so each size is proven to resolve to its **own distinct** URL — which the existing unit test could not show, because it stubs one style for all four sizes. Saving that config is exactly what the missing schema used to prevent.
- Adds `ys_core/tests/src/Kernel/CoreSettingsSchemaTest.php` pinning that all four objects have a schema and validate both as shipped and in the shapes the forms write, and `ys_core/tests/src/Kernel/SettingsShapeNormalizationTest.php` covering the normalisation helper.
- Updates the "Known test coverage gaps" section of `ys_core/README.md` to drop the two entries this closes.

### Why a normalisation hook (the AC's "flag either case" branch)

The ticket asks to fix the schema to describe reality *or* write an update hook if a stored value is genuinely wrong, and to flag which. Both apply here, and here is the evidence.

The schema was written to describe reality wherever the stored value was defensible (integers for the search flags, `NULL` for cleared media references, sparse sequence keys). But two shapes are genuinely wrong rather than merely different: `custom_favicon` and `site_name_image` shipped `''` as their install default, while the `managed_file` element that owns them only ever writes a list of file IDs. So essentially every existing site stores a scalar where a list belongs, and `environment_indicator.show` stores integer `1` where its own install default ships boolean `true`.

Those stale values will not wash out on their own: `config_ignore.settings` lists **`ys_core*`**, so `config:import` never rewrites these objects. Verified on a pulled database — active `ys_core.site` carries `taxonomy`, `custom_favicon`, `font_pairing`, `cas_app_name` and `environment_indicator`, none of which appear in the profile's `config/sync/ys_core.site.yml`. Hence the normalisation hook.

### No existing site breaks

This was checked rather than assumed, because it is the kind of claim that deserves evidence. Two things are true at once:

1. A legacy scalar `''` **does not validate** against the new `sequence` element, but it also does not throw. `StorableConfigBase::castValue()` only casts a scalar when the matched schema element is a `PrimitiveInterface`; a `Sequence` element falls through and the value is returned untouched, so `Config::save()` on a legacy site does not blow up. Core's `SchemaCheckTrait`, run against the real pulled database, reports `variable type is string but applied schema class is Drupal\Core\Config\Schema\Sequence` (and likewise integer vs `BooleanData` for the environment indicator). Controls confirm the checker really bites, so those are real.
2. That still breaks nothing, because **strict schema checking is a test-only facility**. On the running production-like container there is no `ConfigSchemaChecker` service and no `config.save` listener for it, and saving the legacy `''` then reading it back returns `''` unchanged with no exception. Nothing validates config on save or on import in production.

There is also a self-healing effect worth knowing about: once a config object has a schema, `Config::save()` casts the whole data array to the declared types, so these values correct themselves on any site that saves one of these forms again. The hook exists for the sites that never do.

So the schema is safe to land as-is, and the hook is a tidy-up that makes every existing site's stored data actually match it — not a fix for a live breakage.

**Correction (follow-up commit).** That held for the two shapes above, but review found a third one where it does not: a `focus_header_image` storing an **array** of media IDs — the shape `ys_core_preprocess_region()` has guarded against since a production hotfix. Unlike a scalar meeting a `sequence`, an array meeting a scalar `string` element does not fall through: `castValue()` recurses into it looking for `focus_header_image.0`, finds no such element, and throws an uncaught `InvalidArgumentException`. That aborts *any* save of `ys_core.header_settings` on such a site, `ys_core_deploy_10008()`'s own write included — a release blocked on one site. `ys_core_normalize_settings_shapes()` now repairs that value **first**, so the hook clears the bad shape instead of tripping over it. So for that one key the hook is not a tidy-up; it is what lets the deploy finish.

### Verification

- All three kernel tests pass, and each was confirmed to fail first for the right reason. `CoreSettingsSchemaTest` before the schema: 7 errors, every one `SchemaIncompleteException: No schema for ys_core.<object>` raised by `ConfigSchemaChecker`. `CustomFaviconTest` with the schema temporarily reverted: the two tests that save a `custom_favicon` error with `SchemaIncompleteException: No schema for ys_core.site`, while the fallback-only test still passes — which is precisely the workaround the README documented.
- Validated against a **real pulled production database**, not a fresh install, per the AC. The three objects absent from that database were created by saving the real settings forms in a browser on local Lando (`/admin/yalesites/header`, `/admin/yalesites/footer`, `/admin/yalesites/settings`); all saved cleanly, and all four objects then report `VALID` under `SchemaCheckTrait`. The `(bool)` cast was confirmed end to end there — `environment_indicator.show` is stored as boolean `true` after a real form save — and `ys_core.social_links` gained `bluesky: ''` from the real form, which is exactly why a key present in no install default still needed a schema entry.
- `ys_core/tests/src/Unit/YaleSitesMediaManagerTest.php`, the closest existing coverage of the touched code, is unchanged at 16 tests / 52 assertions before and after. No other test in any custom module references `SiteSettingsForm` or `environment_indicator`.
- The hook was verified against the **real pulled database**, not just in a kernel test. The pre-schema state was recreated by writing the legacy shapes straight to `config.storage` (which is what an already-populated database looks like), then: the dry run reported 3 pending changes and wrote nothing; the real run reported the same 3 and left both objects `VALID`; a second run reported 0 changes (idempotent); and the pulled state restored cleanly afterwards.
- `lando composer code-sniff` (Drupal + DrupalPractice over the whole custom tree): exit 0. Worth noting for future changes that this script runs two standards and stops at the first failure, so a clean Drupal run does not by itself mean DrupalPractice is clean.

### Notes for the reviewer

- The AC says the favicon test "now lives in `ys_media` after yalesites-org/yalesites-project#1475". That PR is **still open**, so `ys_media` does not exist on `develop` and `YaleSitesMediaManagerTest` is still in `ys_core`. The new test is therefore written in `ys_core`, where the code lives today, rather than basing this PR on an unmerged branch. It travels with the module when #1475 lands.
- Deliberately **not** adding `bluesky: ''` to `config/install/ys_core.social_links.yml`. The AC asks only for the schema entry; adding the install default would change shipped defaults for new sites, which is a separate documented inconsistency. Same reasoning for the other live-only keys.
- `CoreSettingsSchemaTest` saves the four settings objects directly instead of calling `installConfig(['ys_core'])`, because installing the whole `config/install` directory also installs the `grand_hero` `field_display_mode` field and so drags in `block_content`, `field` and `options`. That is unrelated to this ticket and is now recorded in the README so it is not rediscovered.
- `ys_core.views_settings` is a fifth ys_core settings object that still has no schema. It is outside this ticket's stated scope, so it is left alone here — worth a follow-up if we want the module fully covered. The README wording this PR adds ("All four settings objects now have a schema") is accurate as written.
- One forward-looking note: modern core idiom would add `requiredKey: false` to optional mapping keys, because core's `mapping` base type now carries `ValidKeys: '<infer>'`. Nothing fails today, because kernel tests only pass `validateConstraints` for core tests, not for custom or contrib. If that ever changes, `ys_core.social_links` (no `bluesky` in install defaults) and `ys_core.footer_settings` (`content.text: []` against a `value`/`format` mapping) would be the two to revisit.
- Honest bound on the live check: that site's `footer_variation` is `basic`, which disables the logos/links/text accordions, so the live form save left `content.logos` and `links.links_col_*` empty. Their sequence-of-mapping shapes are covered by `CoreSettingsSchemaTest` rather than by the live save.

### Functional testing steps:

- [ ] On a site with existing settings, run `drush deploy` and confirm `ys_core_deploy_10008` runs in the `deploy:hook` phase and reports how many values it normalised.
- [ ] `drush cget ys_core.site custom_favicon` — confirm it is a list (`{  }` when empty), not `''`, and `drush cget ys_core.site environment_indicator.show` is `true`/`false`, not `1`/`0`.
- [ ] Go to `/admin/yalesites/settings`, upload a custom favicon, and save. Confirm the save succeeds with no validation error and the favicon appears in the browser tab at all four sizes.
- [ ] Remove the custom favicon and save again. Confirm the default Yale favicon returns.
- [ ] As a platform admin, toggle the environment indicator at `/admin/yalesites/settings` off and on. Confirm the banner hides and shows accordingly.
- [ ] Save `/admin/yalesites/header` (try the focus header variation and a site name image) and `/admin/yalesites/footer` (try the mega variation with logos, two link columns and footer text). Confirm each saves cleanly and renders as before.
- [ ] Save `/admin/yalesites/social-links`, including a Bluesky URL. Confirm it saves and the icon renders.
- [ ] **Array `focus_header_image` (the deploy blocker).** On a site with header settings saved, put the bad shape in place with `drush php:eval "\Drupal::service('config.storage')->write('ys_core.header_settings', ['focus_header_image' => ['12']] + \Drupal::service('config.storage')->read('ys_core.header_settings'));"`, then `drush cget ys_core.header_settings focus_header_image` to confirm it reads back as a list. Run `drush deploy` (or `drush deploy:hook`) and confirm it **completes** rather than aborting with `The configuration property focus_header_image.0 doesn't exist`, and that the hook's summary counts the cleared value.
- [ ] `drush cget ys_core.header_settings focus_header_image` again — confirm the key is now gone, and that `/admin/yalesites/header` still loads with the focus variation selectable and a new image savable.
- [ ] Re-run `drush deploy:hook`. Confirm `ys_core_deploy_10008` reports 0 changes the second time (idempotent) and that a scalar `focus_header_image` set through the form is left untouched.
- [ ] **Legacy `site_name_image` as a `site_admin`.** With `ys_core.header_settings:site_name_image` still holding the legacy `''`, log in as a plain `site_admin` (not a platform admin, so the sitewide-branding fields are hidden), save `/admin/yalesites/header`, and confirm the save succeeds — the form leaves the legacy scalar in place, and it must pass through the new `sequence` element un-cast rather than erroring.

References yalesites-org/YaleSites-Internal#1563

