### PR TITLE
1576: Prune the unused MathJax payload from the Pantheon artifact

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -171,10 +171,12 @@
     ],
     "lint:php": "./.ci/test/static/lint_php",
     "post-install-cmd": [
-      "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+      "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+      "DrupalProject\\composer\\ScriptHandler::pruneMathJaxLibrary"
     ],
     "post-update-cmd": [
-      "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+      "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+      "DrupalProject\\composer\\ScriptHandler::pruneMathJaxLibrary"
     ],
     "post-create-project-cmd": [
       "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -47,6 +47,65 @@ class ScriptHandler
     }
   }
 
+  // Trims the self-hosted MathJax package down to what pages actually request.
+  // web/libraries is gitignored, but CI force-adds it into the Pantheon
+  // artifact, so whatever composer leaves here gets committed - the whole
+  // 66 MB, when a math-heavy page only ever pulls about 448 KB. unpacked/ is
+  // an unminified mirror of the packed tree that MathJax.js never loads, and
+  // on its own is roughly a third of the payload;
+  // test/ is the upstream sample suite, otherwise publicly reachable at
+  // /libraries/MathJax/test/. Composer cannot filter paths inside a package,
+  // so this has to run after it places them.
+  //
+  // Registered on both post-install-cmd and post-update-cmd because composer
+  // fires exactly one of the two per command: the deploy build uses
+  // `composer update` (.ci/build/build_frontend) while the test job and local
+  // installs use `composer install`. Re-running against an already-pruned
+  // tree is the normal local case, so it has to be a no-op.
+  //
+  // The package is required by the profile's composer.json; only its
+  // repository definition and this hook sit at root, because composer runs
+  // root-package scripts only.
+  public static function pruneMathJaxLibrary(Event $event)
+  {
+    $fs = new Filesystem();
+    $library = static::getDrupalRoot(getcwd()) . '/libraries/MathJax';
+
+    // Nothing to do when the library was never installed in this checkout,
+    // and a safe stop if the pin ever moved to MathJax 3.x, which ships no
+    // root MathJax.js and none of the directories below.
+    if (!$fs->exists($library . '/MathJax.js')) {
+      return;
+    }
+
+    // docs/ only exists in some upstream builds, not in the pinned 2.7.9 dist.
+    // Filesystem::remove() is already a no-op on a missing path, so the
+    // exists() check is here only to keep the log line to what was removed.
+    foreach (['unpacked', 'test', 'docs'] as $dir) {
+      $path = $library . '/' . $dir;
+      if (!$fs->exists($path)) {
+        continue;
+      }
+      try {
+        $fs->remove($path);
+        $event->getIO()->write("Pruned unused MathJax directory: $dir");
+      }
+      catch (\Throwable $e) {
+        // Deliberately broad. Failing to prune only costs artifact size, so
+        // this must never fail a build - and IOException alone is not a wide
+        // enough net: Filesystem::remove() renames the target aside and then
+        // builds a \FilesystemIterator over it, which throws
+        // \UnexpectedValueException (not an IOException) if a directory in
+        // the tree cannot be opened. Note that path leaves the renamed
+        // `.!XXXX` sibling behind, hence naming the directory here.
+        $event->getIO()->writeError(
+          "<warning>Could not prune MathJax $dir; check $library for a "
+          . "leftover .! directory: " . $e->getMessage() . "</warning>"
+        );
+      }
+    }
+  }
+
   // This is called by the QuickSilver deploy hook to convert from
   // a 'lean' repository to a 'fat' repository. This should only be
   // called when using this repository as a custom upstream, and

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -47,23 +47,38 @@ class ScriptHandler
     }
   }
 
-  // Trims the self-hosted MathJax package down to what pages actually request.
-  // web/libraries is gitignored, but CI force-adds it into the Pantheon
-  // artifact, so whatever composer leaves here gets committed - the whole
-  // 66 MB, when a math-heavy page only ever pulls about 448 KB. unpacked/ is
-  // an unminified mirror of the packed tree that MathJax.js never loads, and
-  // on its own is roughly a third of the payload;
-  // test/ is the upstream sample suite, otherwise publicly reachable at
-  // /libraries/MathJax/test/. Composer cannot filter paths inside a package,
-  // so this has to run after it places them.
+  // Removes the parts of the self-hosted MathJax package that the runtime
+  // never loads. web/libraries is gitignored, but the deploy job force-adds
+  // all of web into the Pantheon artifact
+  // (.github/workflows/build_deploy_and_test.yml), so whatever composer
+  // leaves on disk gets committed - all 66 MB of MathJax 2.7.9, across 3,147
+  // files.
+  //
+  // What goes: unpacked/ is an unminified mirror of the packed tree that
+  // MathJax.js never loads, and on its own is a third of the package;
+  // test/ is the upstream sample suite, which would otherwise be publicly
+  // reachable at /libraries/MathJax/test/ - a surface-area reason rather than
+  // a size one, since it is only 104 KB.
+  //
+  // What stays, and why this is not a "trim to what a page requests": the
+  // remaining ~44 MB is mostly fonts/, jax/, config/ and localization/, which
+  // MathJax fetches lazily per formula. Very little of it is requested by any
+  // one page, but it all has to be there. Do not "finish the job" by pruning
+  // those.
+  //
+  // Composer has no way to exclude paths from a package it installs, so this
+  // has to run after composer has extracted it.
   //
   // Registered on both post-install-cmd and post-update-cmd because composer
-  // fires exactly one of the two per command: the deploy build uses
-  // `composer update` (.ci/build/build_frontend) while the test job and local
-  // installs use `composer install`. Re-running against an already-pruned
-  // tree is the normal local case, so it has to be a no-op.
+  // dispatches exactly one of the two per command (Installer.php picks on
+  // $this->update): the deploy build uses `composer update`
+  // (.ci/build/build_frontend), while .ci/test/static/run uses
+  // `composer install`. Note a first `composer install` with no composer.lock
+  // - the normal case here, since the root lock is untracked - is promoted to
+  // an update internally and so fires post-update-cmd. Re-running against an
+  // already-pruned tree is the everyday local case, so this must be a no-op.
   //
-  // The package is required by the profile's composer.json; only its
+  // The version pin lives in the profile's composer.json; only the package's
   // repository definition and this hook sit at root, because composer runs
   // root-package scripts only.
   public static function pruneMathJaxLibrary(Event $event)
@@ -71,14 +86,19 @@ class ScriptHandler
     $fs = new Filesystem();
     $library = static::getDrupalRoot(getcwd()) . '/libraries/MathJax';
 
-    // Nothing to do when the library was never installed in this checkout,
-    // and a safe stop if the pin ever moved to MathJax 3.x, which ships no
-    // root MathJax.js and none of the directories below.
+    // Nothing to do when the library was never installed in this checkout.
+    // Also a safe stop if the pin ever moved to MathJax 3.x, which ships no
+    // root MathJax.js and none of the directories below - belt-and-braces,
+    // since the README's pin rule already forbids 3.x outright.
     if (!$fs->exists($library . '/MathJax.js')) {
       return;
     }
 
-    // docs/ only exists in some upstream builds, not in the pinned 2.7.9 dist.
+    // docs/ cannot appear under the current pin: the repository definition
+    // points dist.url at the npm tarball, which has no docs/. It is listed
+    // for the case where that is ever repointed at the upstream git tree,
+    // which at tag 2.7.9 does ship one. Kept deliberately, not left over.
+    //
     // Filesystem::remove() is already a no-op on a missing path, so the
     // exists() check is here only to keep the log line to what was removed.
     foreach (['unpacked', 'test', 'docs'] as $dir) {
@@ -91,13 +111,17 @@ class ScriptHandler
         $event->getIO()->write("Pruned unused MathJax directory: $dir");
       }
       catch (\Throwable $e) {
-        // Deliberately broad. Failing to prune only costs artifact size, so
-        // this must never fail a build - and IOException alone is not a wide
-        // enough net: Filesystem::remove() renames the target aside and then
-        // builds a \FilesystemIterator over it, which throws
-        // \UnexpectedValueException (not an IOException) if a directory in
-        // the tree cannot be opened. Note that path leaves the renamed
-        // `.!XXXX` sibling behind, hence naming the directory here.
+        // Deliberately broad, \Error included: nothing in a size
+        // optimization is worth failing a deploy over. IOException alone is
+        // not a wide enough net either - Filesystem::remove() renames the
+        // target to a `.!` sibling and then builds a \FilesystemIterator
+        // over it, and that constructor throws \UnexpectedValueException,
+        // not an IOException, if a directory in the tree cannot be opened.
+        //
+        // That code path also skips the rename-back that the IOException path
+        // does, so the `.!` sibling is left holding the full unpacked tree -
+        // and `git add -f ... web` would commit it, making a failed prune
+        // ship more than no prune at all. Hence naming the directory to check.
         $event->getIO()->writeError(
           "<warning>Could not prune MathJax $dir; check $library for a "
           . "leftover .! directory: " . $e->getMessage() . "</warning>"

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/README.md
@@ -77,9 +77,13 @@ page loads.
   survives — but note it does not run in CI (`composer unit-test` is a stub),
   so it is a local guard rather than a gate. One consequence worth knowing:
   `MathJax.js` tells developers to load `unpacked/MathJax.js` when debugging a
-  rendering problem, and the prune removes it. To get it back temporarily, run
-  `composer install --no-scripts` or extract the upstream tarball by hand — a
-  plain `composer install` will just prune it again.
+  rendering problem, and the prune removes it. To get it back temporarily use
+  `composer reinstall mathjax/mathjax --no-scripts`, which re-extracts the
+  package without re-running the prune. A plain `composer install` will not
+  restore it: composer decides what to install from the lock and
+  `vendor/composer/installed.php`, so with the package still recorded as
+  installed it reports "Nothing to install, update or remove" and leaves the
+  pruned tree alone.
 - **The pin must stay on MathJax 2.7.1 or later.** Contrib `mathjax` 4.x still
   targets the MathJax 2.x API, so this is deliberately not a 3.x/4.x library.
   Within 2.x, 2.7.0 and earlier fetch the accessibility menu from `[Contrib]`,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/README.md
@@ -59,6 +59,27 @@ page loads.
   rendering and the status report shows the contrib module's "local library
   files could not be found" error; run `composer install` rather than
   re-enabling the CDN.
+- The install is **pruned after composer places it**. The upstream package is
+  66 MB across 3,147 files, and CI force-adds the gitignored `web/libraries`
+  into the Pantheon artifact on every deploy, so all of it would be committed
+  even though a math-heavy page only ever requests about 448 KB.
+  `ScriptHandler::pruneMathJaxLibrary()` (registered on the root
+  `post-install-cmd` and `post-update-cmd`) removes `unpacked/` — an unminified
+  mirror of the packed tree that `MathJax.js` never loads — plus `test/`, the
+  upstream sample suite, and `docs/` on the builds that ship one (the pinned
+  2.7.9 npm dist has no `docs/`; the upstream git tree at that tag does). A
+  fresh `composer install` should therefore leave **about 44 MB across 1,863
+  files**, with no `unpacked/`, `test/` or `docs/` directory. The prune is a
+  no-op when those are already gone, and only warns rather than failing the
+  build if a removal cannot be completed, since the only thing at stake is
+  artifact size. `MathjaxLibraryInstallTest` asserts
+  both halves — that the directories are gone and that the runtime tree
+  survives — but note it does not run in CI (`composer unit-test` is a stub),
+  so it is a local guard rather than a gate. One consequence worth knowing:
+  `MathJax.js` tells developers to load `unpacked/MathJax.js` when debugging a
+  rendering problem, and the prune removes it. To get it back temporarily, run
+  `composer install --no-scripts` or extract the upstream tarball by hand — a
+  plain `composer install` will just prune it again.
 - **The pin must stay on MathJax 2.7.1 or later.** Contrib `mathjax` 4.x still
   targets the MathJax 2.x API, so this is deliberately not a 3.x/4.x library.
   Within 2.x, 2.7.0 and earlier fetch the accessibility menu from `[Contrib]`,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/README.md
@@ -53,16 +53,20 @@ page loads.
   (`config_type: 0`, single-dollar inline math disabled, and `use_cdn: 0` so the
   library is self-hosted rather than loaded from a CDN).
 - The library itself comes from the `mathjax` package repository in the **root**
-  `composer.json` and is installed by `composer install` into
-  `web/libraries/MathJax` — capital M, capital J, which the contrib module
-  hardcodes. If a checkout has no `web/libraries/MathJax`, math silently stops
-  rendering and the status report shows the contrib module's "local library
+  `composer.json` (the version pin itself lives in the profile's
+  `composer.json`, alongside `drupal/mathjax`) and is installed by
+  `composer install` into `web/libraries/MathJax` — capital M, capital J, which
+  the contrib module hardcodes. If a checkout has no `web/libraries/MathJax`,
+  math silently stops rendering and the status report shows the "local library
   files could not be found" error; run `composer install` rather than
   re-enabling the CDN.
 - The install is **pruned after composer places it**. The upstream package is
   66 MB across 3,147 files, and CI force-adds the gitignored `web/libraries`
   into the Pantheon artifact on every deploy, so all of it would be committed
-  even though a math-heavy page only ever requests about 448 KB.
+  even though a page with math requests only a few hundred KB of it. (Not a
+  fixed figure: MathJax fetches jax, fonts and config lazily per formula, and
+  turning on the accessibility explorer pulls several MB more from
+  `extensions/a11y/` — which is why that directory is not pruned.)
   `ScriptHandler::pruneMathJaxLibrary()` (registered on the root
   `post-install-cmd` and `post-update-cmd`) removes `unpacked/` — an unminified
   mirror of the packed tree that `MathJax.js` never loads — plus `test/`, the
@@ -79,11 +83,12 @@ page loads.
   `MathJax.js` tells developers to load `unpacked/MathJax.js` when debugging a
   rendering problem, and the prune removes it. To get it back temporarily use
   `composer reinstall mathjax/mathjax --no-scripts`, which re-extracts the
-  package without re-running the prune. A plain `composer install` will not
-  restore it: composer decides what to install from the lock and
-  `vendor/composer/installed.php`, so with the package still recorded as
-  installed it reports "Nothing to install, update or remove" and leaves the
-  pruned tree alone.
+  package without re-running the prune. A plain `composer install` will *not*
+  restore it, and the reason reconciles this with the bullet above:
+  `LibraryInstaller::isInstalled()` treats a package as present when it is
+  recorded in the lock **and** its install directory exists — it never looks
+  inside. So a missing `web/libraries/MathJax` is reinstalled, while a missing
+  `unpacked/` inside it goes unnoticed and the pruned tree is left alone.
 - **The pin must stay on MathJax 2.7.1 or later.** Contrib `mathjax` 4.x still
   targets the MathJax 2.x API, so this is deliberately not a 3.x/4.x library.
   Within 2.x, 2.7.0 and earlier fetch the accessibility menu from `[Contrib]`,

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/tests/src/Unit/MathjaxLibraryInstallTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/tests/src/Unit/MathjaxLibraryInstallTest.php
@@ -35,9 +35,7 @@ class MathjaxLibraryInstallTest extends UnitTestCase {
   protected const LIBRARY_DIR = 'libraries/MathJax';
 
   /**
-   * Upstream directories `ScriptHandler::pruneMathJaxLibrary()` removes.
-   *
-   * `docs/` only exists in some upstream builds, not in the pinned 2.7.9 dist.
+   * Upstream directories the composer prune removes.
    */
   protected const PRUNED_DIRS = [
     'unpacked',
@@ -46,7 +44,10 @@ class MathjaxLibraryInstallTest extends UnitTestCase {
   ];
 
   /**
-   * Directories MathJax loads at runtime, which the prune must leave alone.
+   * Directories MathJax may load at runtime, which the prune must leave alone.
+   *
+   * `localization/` only loads when a non-English locale is configured, but it
+   * is listed for the same reason as the rest: the prune must not touch it.
    */
   protected const RUNTIME_DIRS = [
     'config',
@@ -92,8 +93,9 @@ class MathjaxLibraryInstallTest extends UnitTestCase {
    *
    * CI force-adds `web/libraries` into the Pantheon artifact, so anything
    * composer leaves in the package ships whether or not a page requests it.
-   * `ScriptHandler::pruneMathJaxLibrary()` removes these after install, and
-   * that comment carries the per-directory reasoning.
+   * The per-directory reasoning, and why the rest of the tree stays, lives in
+   * the comment above `pruneMathJaxLibrary()` in
+   * `scripts/composer/ScriptHandler.php`.
    */
   public function testUnusedUpstreamDirectoriesArePruned(): void {
     foreach (self::PRUNED_DIRS as $dir) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/tests/src/Unit/MathjaxLibraryInstallTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/tests/src/Unit/MathjaxLibraryInstallTest.php
@@ -12,7 +12,9 @@ use Drupal\Tests\UnitTestCase;
  * config, output jax, font data and extensions at runtime through its own
  * loader, and none of those follow-up requests carry an integrity hash. The
  * platform therefore installs the library itself, and these assertions cover
- * the two ways that install can be subtly wrong while still looking fine.
+ * the ways that install can be subtly wrong while still looking fine: the path
+ * it lands at, the build it resolves its a11y extensions from, and the prune
+ * that keeps the committed artifact from carrying the parts nothing loads.
  *
  * These assert build state rather than code: they read the composer-installed
  * tree under `web/libraries/`, which is gitignored. A failure here means the
@@ -31,6 +33,28 @@ class MathjaxLibraryInstallTest extends UnitTestCase {
    * so a package installed under any other casing silently fails to load.
    */
   protected const LIBRARY_DIR = 'libraries/MathJax';
+
+  /**
+   * Upstream directories `ScriptHandler::pruneMathJaxLibrary()` removes.
+   *
+   * `docs/` only exists in some upstream builds, not in the pinned 2.7.9 dist.
+   */
+  protected const PRUNED_DIRS = [
+    'unpacked',
+    'test',
+    'docs',
+  ];
+
+  /**
+   * Directories MathJax loads at runtime, which the prune must leave alone.
+   */
+  protected const RUNTIME_DIRS = [
+    'config',
+    'extensions',
+    'fonts',
+    'jax',
+    'localization',
+  ];
 
   /**
    * The library is installed on disk at the casing the module expects.
@@ -61,6 +85,34 @@ class MathjaxLibraryInstallTest extends UnitTestCase {
     $config = $this->libraryPath('config/TeX-AMS-MML_HTMLorMML.js');
     $this->assertFileExists($config);
     $this->assertStringContainsString('[MathJax]/extensions/a11y/accessibility-menu.js', file_get_contents($config), 'The combined MathJax config must load the accessibility menu from the local [MathJax] path, not from [Contrib] (cdn.mathjax.org).');
+  }
+
+  /**
+   * The unused upstream directories are pruned from the installed tree.
+   *
+   * CI force-adds `web/libraries` into the Pantheon artifact, so anything
+   * composer leaves in the package ships whether or not a page requests it.
+   * `ScriptHandler::pruneMathJaxLibrary()` removes these after install, and
+   * that comment carries the per-directory reasoning.
+   */
+  public function testUnusedUpstreamDirectoriesArePruned(): void {
+    foreach (self::PRUNED_DIRS as $dir) {
+      $this->assertDirectoryDoesNotExist($this->libraryPath($dir), sprintf('The composer prune must remove %s/ from the installed MathJax tree, because web/libraries is committed into the Pantheon artifact.', $dir));
+    }
+  }
+
+  /**
+   * The prune leaves every directory MathJax loads at runtime in place.
+   *
+   * Over-reach is the failure worth guarding: losing `jax/`, `fonts/` or
+   * `config/` stops math rendering everywhere, and the only symptom is LaTeX
+   * sitting on the page unrendered. Kept as its own test so that a failure
+   * here cannot be masked by the removal assertions above.
+   */
+  public function testThePruneKeepsTheRuntimeTree(): void {
+    foreach (self::RUNTIME_DIRS as $dir) {
+      $this->assertDirectoryExists($this->libraryPath($dir), sprintf('The composer prune must not remove %s/ - MathJax loads it at runtime.', $dir));
+    }
   }
 
   /**


### PR DESCRIPTION
## [1576: Prune the unused MathJax payload from the Pantheon artifact](https://github.com/yalesites-org/YaleSites-Internal/issues/1576)

### Description of work

- Adds `ScriptHandler::pruneMathJaxLibrary()` and registers it on the root `composer.json`
  `post-install-cmd` and `post-update-cmd`. After composer places the self-hosted MathJax
  package it removes `unpacked/`, `test/` and `docs/`, which nothing loads at runtime.
- **Measured effect: `web/libraries/MathJax` goes from 66 MB / 3,147 files to 44 MB / 1,863
  files.** `unpacked/` alone is 22 MB / 1,264 files — an unminified mirror of the packed tree
  that `MathJax.js` never loads. What a page actually requests is unchanged, because these
  directories were never requested in the first place.
- **To be clear about what is *not* being claimed:** the remaining 44 MB is mostly `fonts/`,
  `jax/`, `config/` and `localization/`, which MathJax fetches lazily per formula. Very little
  of it is requested by any single page, but it all has to be present — so this is not a
  "trim to what a page requests", and the comments say so explicitly to stop someone
  "finishing the job" later. `extensions/a11y/` in particular stays: turning on the
  accessibility explorer pulls several MB from it.
- `web/libraries` is gitignored but force-added into the Pantheon artifact by the deploy job
  (`git add -f pantheon.upstream.yml vendor web`), so all 66 MB was being committed on every
  deploy. Composer has no way to filter paths inside a package, which is why this is a script
  rather than a composer config change — as the ticket anticipated.
- **Verified from a clean state, which is what CI actually does.** Deleting
  `web/libraries/MathJax` entirely and re-running `lando composer install` made composer
  re-download and re-extract the full package, and the hook pruned it back to 44 MB / 1,863
  files in the same run (exit 0). So the fresh-runner path — no pre-existing `web/libraries` —
  is confirmed end to end, not just the already-installed path.
- **`docs/` does not exist in the pinned 2.7.9 npm distribution.** The ticket listed it, so it
  is still handled, but that means the "directory already absent" path is hit on the very
  first clean install rather than only on a re-run — the idempotency requirement is real, not
  hypothetical.
- Registered on **both** composer events on purpose. Composer fires exactly one of the two per
  command (`$eventName = $this->update ? POST_UPDATE_CMD : POST_INSTALL_CMD`), and the deploy
  path builds the artifact with `composer update` (`.ci/build/build_frontend`) while the CI
  test job and local installs use `composer install`. Both are needed for coverage.
- Fails soft: a failed removal is reported as a warning and the build continues, since the only
  thing at stake is artifact size. It is reported, not swallowed. A guard also makes the whole
  hook a no-op unless `web/libraries/MathJax/MathJax.js` is actually present.
- The `catch` is deliberately `\Throwable` rather than `IOException`, which review showed was
  too narrow to honour that intent. `Filesystem::remove()` renames the target to a `.!XXXX`
  sibling and then builds a `\FilesystemIterator` over it unguarded
  (`vendor/symfony/filesystem/Filesystem.php:192`); that constructor throws
  `\UnexpectedValueException`, which is not an `IOException`. With the narrow catch it would
  have escaped, and `set -eo pipefail` in `.ci/build/build_frontend` would have failed the
  deploy — over a size optimization. Worse, Symfony renames the directory back on the
  `IOException` path but not that one, so a mangled `.!XXXX` directory would have been
  force-added into the artifact on top of an unpruned tree. The warning now names the library
  path so a leftover is findable.
- Extends the existing `MathjaxLibraryInstallTest` with both halves of the contract: the three
  directories are gone, **and** the runtime tree (`config/`, `extensions/`, `fonts/`, `jax/`,
  `localization/`) survives. The second test is the one that would catch an over-reaching
  prune, whose only symptom would be LaTeX sitting unrendered on the page.
- Updates the `ys_mathjax` README developer note to say the install is pruned and what a fresh
  `composer install` should produce.

### What I could not verify, and want a second pair of eyes on

- **That the Pantheon artifact actually shrinks.** I cannot run a Pantheon build locally, so
  this is a traced argument rather than an observed artifact. What I did confirm: the hook
  fires on `composer install` locally (with output); the artifact's `web/libraries` comes from
  the root-level `composer update --prefer-dist` inside `.ci/build/build_frontend`, which
  fires `post-update-cmd`; that happens *before* the `git add -f ... web` step that commits it;
  and the later `composer remove` runs from the profile directory, whose `composer.json` has no
  `scripts` block, so it cannot un-prune. Worth a glance at the first multidev build to confirm.
- **These tests are not a CI gate.** Root `composer unit-test` is `echo 'No unit test step
  defined.'`, so `MathjaxLibraryInstallTest` — new assertions included — does not run in CI at
  all. It is a local guard. Pre-existing, out of scope here, but I would rather say it than let
  the new tests read as protection they do not provide.

### Independently checked during review

A reviewer re-derived the numbers from the pinned upstream tarball rather than trusting mine —
it fetched `mathjax-2.7.9.tgz`, confirmed its shasum matches the `dist.shasum` pinned in the
root `composer.json`, and measured: whole package 3,147 files, `unpacked/` 1,264 files (34% of
the payload, so "roughly a third" holds), remainder **1,863 files / ~44 MB**. Those match what
the prune actually produces here. It also confirmed nothing in custom code or contrib
references the pruned directories — contrib `mathjax.module:65` only ever wants
`/libraries/MathJax/MathJax.js` — and that both phpcs standards pass on the test file with
`--no-cache`, ruling out the stale-cache trap that can make a per-file run disagree with CI.

One correction that came out of it: `unpacked/` mirrors the whole packed tree, not just `jax/`,
`extensions/` and `config/` as I first wrote (it also carries `localization/`, `MathJax.js` and
`latest.js`). Comment and README both corrected.

### Notes for the reviewer

- A reasonable alternative would be an `rm -rf` line in the deploy workflow next to the
  existing `.git`-stripping step, right before `git add -f`. I went with the composer hook
  because any composer call added after such a step would silently re-fatten the artifact, it
  also slims local checkouts, and it is what lets the new assertions be checkable at all.
  Happy to move it if you would rather keep artifact concerns in the artifact-only place.
- `ScriptHandler.php` lives in `scripts/`, which `composer code-sniff` does not scan, so the
  new method deliberately follows that file's existing style (Allman braces, `//` comments
  rather than docblocks) rather than Drupal standard. Please don't "fix" it to match Drupal.
- Heads-up for anyone debugging math later: `MathJax.js` tells developers to load
  `unpacked/MathJax.js` when a rendering problem needs an unminified trace, and the prune
  removes it. `composer reinstall mathjax/mathjax --no-scripts` brings it back without
  re-running the prune; a plain `composer install` will **not**. The reason is worth knowing
  because it also explains why the README's other advice ("no `web/libraries/MathJax`? run
  `composer install`") is still correct: `LibraryInstaller::isInstalled()` treats a package as
  present when it is recorded in the lock **and** its install directory is readable, and never
  looks inside. So a missing package directory is reinstalled, while a missing `unpacked/`
  inside it goes unnoticed. Verified both directions locally (reinstall -> 66 MB / 3,147 files
  with `unpacked/` back; `composer install` -> pruned to 44 MB / 1,863).
- Commits two and three on this branch are self-corrections from review: I first documented that
  recovery recipe wrongly, then explained the mechanism behind it wrongly in a way that
  contradicted a neighbouring bullet. Both are fixed; flagging them so the commit history reads
  as intended rather than as churn.
- Side benefit: `test/` was 20 upstream sample HTML/JS files that were force-added into the
  artifact and therefore publicly reachable at `/libraries/MathJax/test/` on every deployed
  site. Pruning it is a small reduction in public attack surface, as is dropping `unpacked/`
  (an unminified mirror of the runtime code) out of the docroot.

### Functional testing steps:

- [ ] Run `lando composer install` on a checkout that has `web/libraries/MathJax`. Confirm the
      output includes `Pruned unused MathJax directory: unpacked` and `... test`, and that
      `du -sh web/libraries/MathJax` reports ~44 MB rather than ~66 MB.
- [ ] Run `lando composer install` a second time. Confirm it exits 0, prints no prune lines
      (nothing left to remove), and leaves the tree unchanged — the step must be idempotent.
- [ ] Visit `/admin/reports/status` and confirm there is **no** MathJax "local library files
      could not be found" error. (Sanity check that this is a real assertion: temporarily
      renaming `web/libraries/MathJax` makes that error appear.)
- [ ] Add a Text block containing inline `\(a^2 + b^2 = c^2\)`, display `$$\sum_{i=1}^{n} i$$`,
      a `$$\begin{pmatrix} a & b \\ c & d \end{pmatrix}$$` matrix, and
      `$$\int_0^1 x^2 \, dx = \tfrac{1}{3}$$`. Confirm all four typeset correctly and none are
      left as raw LaTeX.
- [ ] With that page open, confirm each rendered expression contains an `.MJX_Assistive_MathML`
      element (inspect the DOM), and that the browser network tab shows no 404s under
      `/libraries/MathJax/`.
- [ ] Confirm `https://<site>/libraries/MathJax/extensions/a11y/accessibility-menu.js` returns
      200 — the a11y extensions are what the 2.7.1+ pin exists for. (MathJax loads it lazily on
      first context-menu use, so it will not show in the initial network log.)
- [ ] Confirm `/libraries/MathJax/unpacked/MathJax.js` and `/libraries/MathJax/test/index.html`
      now return 404.
- [ ] Run `lando ssh -c "php /app/vendor/bin/phpunit -c /app/phpunit.xml /app/web/profiles/custom/yalesites_profile/modules/custom/ys_mathjax/tests/src/Unit/"`
      and confirm it is green, including `testUnusedUpstreamDirectoriesArePruned` and
      `testThePruneKeepsTheRuntimeTree`.
- [ ] On the multidev build for this branch, spot-check that the deployed
      `web/libraries/MathJax` has no `unpacked/` or `test/` directory.

References yalesites-org/YaleSites-Internal#1576
