### PR TITLE
1584: Bug: Beacon index strips all formatting from chunk content — convert rendered HTML to Markdown instead

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/search_api.index.ys_beacon.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/search_api.index.ys_beacon.yml
@@ -100,27 +100,16 @@ datasource_settings:
 processor_settings:
   add_url: {  }
   entity_status: {  }
-  html_filter:
-    weights:
-      preprocess_index: -49
-      preprocess_query: -48
-    all_fields: false
-    fields:
-      - rendered_item
-    title: true
-    alt: true
-    tags:
-      b: 2.0
-      em: 1.0
-      h1: 5.0
-      h2: 3.0
-      h3: 2.0
-      strong: 2.0
-      u: 1.0
   rendered_item: {  }
   ys_beacon_ai_metadata: {  }
   ys_beacon_citation_fields: {  }
   ys_beacon_exclude_ai_disabled: {  }
+  ys_beacon_indexable_html:
+    weights:
+      preprocess_index: -49
+    all_fields: false
+    fields:
+      - rendered_item
 tracker_settings:
   default:
     indexing_order: fifo

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/install/ys_beacon.settings.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/install/ys_beacon.settings.yml
@@ -18,12 +18,14 @@ top_k: 5
 score_threshold: 0.0
 streaming: true
 # Context window (in tokens) of the model Portkey currently routes to. Used to
-# window long conversations so they degrade gracefully. Defaults to Claude
-# Sonnet 5's 1,000,000-token window; update it in the Beacon administration form
-# when the routed model changes. Keep in sync with
-# ChatApiController::DEFAULT_CONTEXT_WINDOW, the runtime fallback used when this
-# value is absent.
-model_context_window: 1000000
+# window long conversations so they degrade gracefully. Set from a measurement
+# rather than the model's nominal window: the Portkey route (Claude Sonnet 5)
+# accepted 433437 input tokens in one request, so 400000 stays under the proven
+# figure while still exceeding the largest request Beacon can build. Update it
+# in the Beacon administration form when the routed model changes. Keep in sync
+# with ChatApiController::DEFAULT_CONTEXT_WINDOW, the runtime fallback used when
+# this value is absent.
+model_context_window: 400000
 instructions_max_length: 4000
 instructions_warning_threshold: 3500
 # Fallback used only when a site has no active system instructions. Keep in

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/install/ys_beacon.settings.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/install/ys_beacon.settings.yml
@@ -19,11 +19,11 @@ score_threshold: 0.0
 streaming: true
 # Context window (in tokens) of the model Portkey currently routes to. Used to
 # window long conversations so they degrade gracefully. Defaults to Claude
-# Haiku's 200k window; update it in the Beacon administration form when the
-# routed model changes. Keep in sync with
+# Sonnet 5's 1,000,000-token window; update it in the Beacon administration form
+# when the routed model changes. Keep in sync with
 # ChatApiController::DEFAULT_CONTEXT_WINDOW, the runtime fallback used when this
 # value is absent.
-model_context_window: 200000
+model_context_window: 1000000
 instructions_max_length: 4000
 instructions_warning_threshold: 3500
 # Fallback used only when a site has no active system instructions. Keep in

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/schema/ys_beacon.schema.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/schema/ys_beacon.schema.yml
@@ -77,3 +77,7 @@ ys_beacon.settings:
     guardrail_supplement:
       type: text
       label: 'Site-specific additions to the platform guardrail'
+
+plugin.plugin_configuration.search_api_processor.ys_beacon_indexable_html:
+  type: search_api.fields_processor_configuration
+  label: 'Beacon indexable HTML processor configuration'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Controller/ChatApiController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Controller/ChatApiController.php
@@ -55,12 +55,15 @@ class ChatApiController extends ControllerBase {
   /**
    * Default model context window in tokens, used when unset in config.
    *
-   * Sized for the current model (Claude Sonnet 5, 1M). The real model is chosen
-   * by Portkey server-side and is not observable here, so operators set the
-   * true window in the Beacon administration form (model_context_window); this
-   * default only applies until they do.
+   * Sized from a measurement rather than the model's nominal window: the
+   * Portkey route (Claude Sonnet 5) accepted 433437 input tokens in one
+   * request, so this stays under the proven figure while still exceeding
+   * the largest request Beacon can build. The real model is chosen by
+   * Portkey server-side and is not observable here, so operators set the
+   * true window in the Beacon administration form (model_context_window);
+   * this default only applies until they do.
    */
-  public const DEFAULT_CONTEXT_WINDOW = 1000000;
+  public const DEFAULT_CONTEXT_WINDOW = 400000;
 
   /**
    * Tokens held back from the context window for the model's reply.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Controller/ChatApiController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Controller/ChatApiController.php
@@ -55,12 +55,12 @@ class ChatApiController extends ControllerBase {
   /**
    * Default model context window in tokens, used when unset in config.
    *
-   * Sized for the current model (Claude Haiku, 200k). The real model is chosen
+   * Sized for the current model (Claude Sonnet 5, 1M). The real model is chosen
    * by Portkey server-side and is not observable here, so operators set the
    * true window in the Beacon administration form (model_context_window); this
    * default only applies until they do.
    */
-  public const DEFAULT_CONTEXT_WINDOW = 200000;
+  public const DEFAULT_CONTEXT_WINDOW = 1000000;
 
   /**
    * Tokens held back from the context window for the model's reply.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconAdminSettings.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconAdminSettings.php
@@ -138,7 +138,7 @@ class YsBeaconAdminSettings extends ConfigFormBase {
     $form['retrieval']['model_context_window'] = [
       '#type' => 'number',
       '#title' => $this->t('Model context window (tokens)'),
-      '#description' => $this->t("The context window, in tokens, of the model Portkey currently routes to. Long conversations are trimmed to fit within it so the chat degrades gracefully instead of erroring. The configured model id is only a placeholder - Portkey selects the real model server-side - so this value cannot be detected automatically: <strong>update it whenever the routed model changes</strong>. Defaults to Claude Haiku's 200000-token window."),
+      '#description' => $this->t("The context window, in tokens, of the model Portkey currently routes to. Long conversations are trimmed to fit within it so the chat degrades gracefully instead of erroring. The configured model id is only a placeholder - Portkey selects the real model server-side - so this value cannot be detected automatically: <strong>update it whenever the routed model changes</strong>. Defaults to Claude Sonnet 5's 1000000-token window."),
       '#default_value' => $config->get('model_context_window') ?: ChatApiController::DEFAULT_CONTEXT_WINDOW,
       // Floor comfortably above the reserved output + safety budget plus a full
       // system prompt, so a too-small value is rejected here rather than

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconAdminSettings.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Form/YsBeaconAdminSettings.php
@@ -138,7 +138,7 @@ class YsBeaconAdminSettings extends ConfigFormBase {
     $form['retrieval']['model_context_window'] = [
       '#type' => 'number',
       '#title' => $this->t('Model context window (tokens)'),
-      '#description' => $this->t("The context window, in tokens, of the model Portkey currently routes to. Long conversations are trimmed to fit within it so the chat degrades gracefully instead of erroring. The configured model id is only a placeholder - Portkey selects the real model server-side - so this value cannot be detected automatically: <strong>update it whenever the routed model changes</strong>. Defaults to Claude Sonnet 5's 1000000-token window."),
+      '#description' => $this->t("The context window, in tokens, of the model Portkey currently routes to. Long conversations are trimmed to fit within it so the chat degrades gracefully instead of erroring. The configured model id is only a placeholder - Portkey selects the real model server-side - so this value cannot be detected automatically: <strong>update it whenever the routed model changes</strong>. Defaults to 400000 tokens - measured, not nominal: the Sonnet 5 route accepted 433437 input tokens in a single request."),
       '#default_value' => $config->get('model_context_window') ?: ChatApiController::DEFAULT_CONTEXT_WINDOW,
       // Floor comfortably above the reserved output + safety budget plus a full
       // system prompt, so a too-small value is rejected here rather than

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/search_api/processor/IndexableHtml.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Plugin/search_api/processor/IndexableHtml.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\ys_beacon\Plugin\search_api\processor;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\search_api\Attribute\SearchApiProcessor;
+use Drupal\search_api\Processor\FieldsProcessorPluginBase;
+use Drupal\ys_beacon\Service\IndexableHtmlFilter;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Keeps content markup in indexed fields so Markdown reaches the model.
+ *
+ * Replaces Search API's html_filter on the Beacon index. html_filter stripped
+ * every tag, which left ai_search's HTML-to-Markdown conversion nothing to
+ * convert: headings, lists, emphasis and links were gone by the time a chunk
+ * was embedded, and adjacent list items and table cells were run together into
+ * single words. This processor removes only what is not content and leaves the
+ * rest for that conversion to render as Markdown.
+ *
+ * html_filter's per-tag boosts are not carried over. The Beacon index is served
+ * by a vector database rather than keyword search, so relevance comes from the
+ * embedding and a boost on <h1> never affected retrieval.
+ *
+ * Which fields this runs on stays a configuration choice, exactly as it was for
+ * html_filter, so a future Beacon field needs a config change and no code.
+ */
+#[SearchApiProcessor(
+  id: 'ys_beacon_indexable_html',
+  label: new TranslatableMarkup('Beacon indexable HTML'),
+  description: new TranslatableMarkup('Removes non-content markup instead of stripping all tags, so headings, lists, tables, emphasis and links reach the language model as Markdown.'),
+  stages: [
+    'pre_index_save' => 0,
+    'preprocess_index' => -15,
+  ],
+)]
+class IndexableHtml extends FieldsProcessorPluginBase {
+
+  /**
+   * The indexable HTML filter.
+   *
+   * @var \Drupal\ys_beacon\Service\IndexableHtmlFilter
+   */
+  protected IndexableHtmlFilter $indexableHtmlFilter;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $processor = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $processor->indexableHtmlFilter = $container->get('ys_beacon.indexable_html_filter');
+
+    return $processor;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function process(&$value) {
+    $value = $this->indexableHtmlFilter->filter((string) $value);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/IndexableHtmlFilter.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/IndexableHtmlFilter.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Drupal\ys_beacon\Service;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\UrlHelper;
+
+/**
+ * Removes the parts of rendered HTML that do not belong in the Beacon index.
+ *
+ * The Beacon index stores what the language model reads, and ai_search already
+ * turns each indexed field into Markdown on the way into the vector database:
+ * EmbeddingStrategyPluginBase builds a League\HTMLToMarkdown\HtmlConverter,
+ * switches on strip_tags and strip_placeholder_links, and registers a
+ * TableConverter, and EmbeddingBase::getValue() then runs it over every value.
+ * That conversion used to accomplish nothing, because Search API's html_filter
+ * processor flattened the rendered HTML first and left it nothing to convert -
+ * which is how headings, lists and emphasis went missing, and how adjacent list
+ * items and table cells ended up concatenated into single words.
+ *
+ * So this service converts nothing and rewrites nothing. It only deletes, for
+ * the two reasons that conversion cannot handle itself:
+ *
+ * - Some elements are not prose but their text still survives conversion. A
+ *   <script> or <style> body is indexed verbatim as content; a <nav> becomes a
+ *   Markdown list of every menu link; an <img> becomes an image tag; a <figure>
+ *   runs its caption straight into the following paragraph.
+ * - A javascript: link target would otherwise be stored as a working Markdown
+ *   link, and chat answers are rendered as Markdown.
+ *
+ * Everything else is deliberately left alone, because the configured converter
+ * already does it better than a hand-rolled pass would: strip_tags unwraps
+ * unknown wrappers (div, article, section, span) while keeping block spacing,
+ * empty headings are dropped without leaving a stray setext underline,
+ * comments (including Twig theme debug) are removed, presentational attributes
+ * never reach the output, and strip_placeholder_links drops empty link targets.
+ *
+ * Reducing the markup any further here would actively cause harm. An earlier
+ * revision unwrapped non-structural elements itself and inserted a separating
+ * space, which split words abutting inline markup - "un<span>believable</span>"
+ * came out as "un believable". Emitting Markdown here rather than HTML would be
+ * worse still: the value goes through the converter afterwards regardless, and
+ * TextConverter escapes Markdown punctuation, turning "**bold**" into
+ * "\*\*bold\*\*" and "[text](url)" into "\[text\](url)".
+ */
+class IndexableHtmlFilter {
+
+  /**
+   * Elements deleted along with their contents.
+   *
+   * Every one of these survives conversion in some form when left in place -
+   * as leaked script text, an image tag, a menu rendered as a list, or a
+   * caption run into the next paragraph.
+   */
+  const REMOVED_TAGS = [
+    'audio', 'button', 'canvas', 'embed', 'figure', 'form', 'iframe', 'img',
+    'input', 'nav', 'noscript', 'object', 'picture', 'script', 'select',
+    'source', 'style', 'svg', 'template', 'textarea', 'track', 'video',
+  ];
+
+  /**
+   * Elements kept even when they hold no text.
+   *
+   * A line break and a table cell both mean something empty: the break is the
+   * content, and a blank cell still carries the shape of its row. Everything
+   * else with no text in it is page furniture.
+   */
+  const TEXTLESS_ELEMENTS_KEPT = [
+    'br', 'hr', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr',
+  ];
+
+  /**
+   * Filters rendered HTML down to what belongs in the index.
+   *
+   * @param string $html
+   *   The rendered HTML for one indexed item.
+   *
+   * @return string
+   *   The same HTML with non-content elements and unusable links removed.
+   */
+  public function filter(string $html): string {
+    if (trim($html) === '') {
+      return '';
+    }
+
+    $document = Html::load($html);
+    $this->removeNonContentElements($document);
+    $this->removeTextlessElements($document);
+    $this->unwrapUnsafeLinks($document);
+
+    return trim(Html::serialize($document));
+  }
+
+  /**
+   * Deletes non-content elements along with their contents.
+   *
+   * @param \DOMDocument $document
+   *   The document to mutate in place.
+   */
+  protected function removeNonContentElements(\DOMDocument $document): void {
+    $xpath = new \DOMXPath($document);
+    $query = implode('|', array_map(
+      static fn(string $tag): string => '//body//' . $tag,
+      self::REMOVED_TAGS
+    ));
+
+    foreach (iterator_to_array($xpath->query($query)) as $element) {
+      $element->parentNode?->removeChild($element);
+    }
+  }
+
+  /**
+   * Deletes elements that hold no text at all.
+   *
+   * Rendered Drupal output is full of these - empty field wrappers, and the
+   * page-title heading on a node that shows its title elsewhere. Each one still
+   * costs something after conversion: strip_tags turns an empty wrapper into a
+   * blank line, and an empty heading still gets its setext underline, which put
+   * a bare "=" line and runs of twenty blank lines into indexed content. All of
+   * it is charged against the chunk size.
+   *
+   * Elements are removed, never unwrapped, so unlike an earlier revision this
+   * cannot disturb text that abuts inline markup.
+   *
+   * One pass is enough: XPath returns matches in document order, so an ancestor
+   * is judged before its descendants, and textContent already aggregates the
+   * text of the whole subtree. Nothing can become empty as a result of this
+   * pass, because anything removed contributed no text to begin with.
+   *
+   * @param \DOMDocument $document
+   *   The document to mutate in place.
+   */
+  protected function removeTextlessElements(\DOMDocument $document): void {
+    $xpath = new \DOMXPath($document);
+    // The keep-list has to protect an ancestor as well as the element itself:
+    // a divider renders as a bare <hr> inside a field wrapper, so the wrapper
+    // holds no text and the rule is the only content in it. Derived from the
+    // one list rather than restated, so the two cannot drift apart.
+    $keeps = implode('|', array_map(
+      static fn(string $tag): string => './/' . $tag,
+      self::TEXTLESS_ELEMENTS_KEPT
+    ));
+
+    foreach (iterator_to_array($xpath->query('//body//*')) as $element) {
+      if (in_array($element->nodeName, self::TEXTLESS_ELEMENTS_KEPT, TRUE)
+        || trim($element->textContent) !== ''
+        || $xpath->query($keeps, $element)->length > 0) {
+        continue;
+      }
+      $element->parentNode?->removeChild($element);
+    }
+  }
+
+  /**
+   * Replaces links with a dangerous target by their own text.
+   *
+   * The converter keeps a link target verbatim, and a chat answer is rendered
+   * as Markdown, so a javascript: target left here could come back to a visitor
+   * as a live link. The link text is prose and is kept.
+   *
+   * @param \DOMDocument $document
+   *   The document to mutate in place.
+   */
+  protected function unwrapUnsafeLinks(\DOMDocument $document): void {
+    $xpath = new \DOMXPath($document);
+
+    foreach (iterator_to_array($xpath->query('//body//a')) as $link) {
+      $href = trim($link->getAttribute('href'));
+      if ($href === '' || UrlHelper::stripDangerousProtocols($href) === $href) {
+        continue;
+      }
+
+      $parent = $link->parentNode;
+      if ($parent === NULL) {
+        continue;
+      }
+      while ($link->firstChild) {
+        $parent->insertBefore($link->firstChild, $link);
+      }
+      $parent->removeChild($link);
+    }
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconContextWindowDeployTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconContextWindowDeployTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Tests the deploy hook that raises the stored model context window.
+ *
+ * The value cannot travel through config: ys_beacon.settings is config-ignored
+ * (ys_beacon*) and absent from config/sync, so a raised default in
+ * config/install reaches new installs only and config:import has nothing to
+ * correct an existing site with. That makes this hook the only thing that moves
+ * a live site off Haiku's 200k, which is worth pinning down.
+ *
+ * The interesting half is what it refuses to do: the routed model is a per-site
+ * Portkey decision this code cannot observe, so an operator who set their own
+ * window must keep it.
+ *
+ * @group ys_beacon
+ */
+class BeaconContextWindowDeployTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 3) . '/ys_beacon.deploy.php';
+  }
+
+  /**
+   * A site still on the old default is raised to the Sonnet 5 window.
+   */
+  public function testRaisesTheSupersededDefault(): void {
+    $config = $this->createMock(Config::class);
+    $config->method('get')->with('model_context_window')->willReturn(200000);
+    $config->expects($this->once())
+      ->method('set')
+      ->with('model_context_window', 1000000)
+      ->willReturnSelf();
+    $config->expects($this->once())->method('save')->willReturnSelf();
+    $this->containerWith($config);
+
+    $this->assertSame(
+      'Raised the Beacon model context window from 200000 to 1000000 tokens for Claude Sonnet 5.',
+      (string) ys_beacon_deploy_10003(),
+    );
+  }
+
+  /**
+   * A window an operator chose deliberately is left alone.
+   */
+  public function testLeavesSiteSpecificWindowAlone(): void {
+    $config = $this->createMock(Config::class);
+    $config->method('get')->with('model_context_window')->willReturn(400000);
+    $config->expects($this->never())->method('set');
+    $config->expects($this->never())->method('save');
+    $this->containerWith($config);
+
+    $this->assertSame(
+      'Beacon model context window left at its site-specific value (400000 tokens).',
+      (string) ys_beacon_deploy_10003(),
+    );
+  }
+
+  /**
+   * A site without Beacon settings is skipped rather than seeded.
+   */
+  public function testSkipsWhenSettingsAreAbsent(): void {
+    $config = $this->createMock(Config::class);
+    $config->method('get')->with('model_context_window')->willReturn(NULL);
+    $config->expects($this->never())->method('set');
+    $config->expects($this->never())->method('save');
+    $this->containerWith($config);
+
+    $this->assertSame(
+      'Beacon settings are absent on this site; the model context window was not changed.',
+      (string) ys_beacon_deploy_10003(),
+    );
+  }
+
+  /**
+   * Builds the minimal container the hook needs.
+   *
+   * @param \Drupal\Core\Config\Config $config
+   *   The editable settings the hook will read and possibly write.
+   */
+  private function containerWith(Config $config): void {
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('getEditable')
+      ->with('ys_beacon.settings')
+      ->willReturn($config);
+
+    $container = new ContainerBuilder();
+    $container->set('config.factory', $configFactory);
+    $container->set('string_translation', $this->getStringTranslationStub());
+    \Drupal::setContainer($container);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconContextWindowDeployTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/BeaconContextWindowDeployTest.php
@@ -40,13 +40,13 @@ class BeaconContextWindowDeployTest extends UnitTestCase {
     $config->method('get')->with('model_context_window')->willReturn(200000);
     $config->expects($this->once())
       ->method('set')
-      ->with('model_context_window', 1000000)
+      ->with('model_context_window', 400000)
       ->willReturnSelf();
     $config->expects($this->once())->method('save')->willReturnSelf();
     $this->containerWith($config);
 
     $this->assertSame(
-      'Raised the Beacon model context window from 200000 to 1000000 tokens for Claude Sonnet 5.',
+      'Raised the Beacon model context window from 200000 to 400000 tokens for Claude Sonnet 5.',
       (string) ys_beacon_deploy_10003(),
     );
   }
@@ -56,13 +56,13 @@ class BeaconContextWindowDeployTest extends UnitTestCase {
    */
   public function testLeavesSiteSpecificWindowAlone(): void {
     $config = $this->createMock(Config::class);
-    $config->method('get')->with('model_context_window')->willReturn(400000);
+    $config->method('get')->with('model_context_window')->willReturn(250000);
     $config->expects($this->never())->method('set');
     $config->expects($this->never())->method('save');
     $this->containerWith($config);
 
     $this->assertSame(
-      'Beacon model context window left at its site-specific value (400000 tokens).',
+      'Beacon model context window left at its site-specific value (250000 tokens).',
       (string) ys_beacon_deploy_10003(),
     );
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/ChatApiControllerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/ChatApiControllerTest.php
@@ -283,13 +283,13 @@ class ChatApiControllerTest extends UnitTestCase {
    */
   public function testInputTokenBudgetSubtractsReservesFromConfiguredWindow(): void {
     // OUTPUT_RESERVE_TOKENS (4096) + SAFETY_MARGIN_TOKENS (2048) are held back.
-    $expected = 1000000 - 4096 - 2048;
+    $expected = 400000 - 4096 - 2048;
 
     $configured = $this->createMock(ImmutableConfig::class);
-    $configured->method('get')->with('model_context_window')->willReturn(1000000);
+    $configured->method('get')->with('model_context_window')->willReturn(400000);
     $this->assertSame($expected, $this->invoke('inputTokenBudget', [$configured]));
 
-    // An unset window falls back to the default Sonnet 5 window (1000000).
+    // An unset window falls back to the measured Sonnet 5 window (400000).
     $unset = $this->createMock(ImmutableConfig::class);
     $unset->method('get')->with('model_context_window')->willReturn(NULL);
     $this->assertSame($expected, $this->invoke('inputTokenBudget', [$unset]));

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/ChatApiControllerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/ChatApiControllerTest.php
@@ -283,13 +283,13 @@ class ChatApiControllerTest extends UnitTestCase {
    */
   public function testInputTokenBudgetSubtractsReservesFromConfiguredWindow(): void {
     // OUTPUT_RESERVE_TOKENS (4096) + SAFETY_MARGIN_TOKENS (2048) are held back.
-    $expected = 200000 - 4096 - 2048;
+    $expected = 1000000 - 4096 - 2048;
 
     $configured = $this->createMock(ImmutableConfig::class);
-    $configured->method('get')->with('model_context_window')->willReturn(200000);
+    $configured->method('get')->with('model_context_window')->willReturn(1000000);
     $this->assertSame($expected, $this->invoke('inputTokenBudget', [$configured]));
 
-    // An unset window falls back to the default Haiku window (200000).
+    // An unset window falls back to the default Sonnet 5 window (1000000).
     $unset = $this->createMock(ImmutableConfig::class);
     $unset->method('get')->with('model_context_window')->willReturn(NULL);
     $this->assertSame($expected, $this->invoke('inputTokenBudget', [$unset]));

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/IndexableHtmlFilterTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/IndexableHtmlFilterTest.php
@@ -1,0 +1,296 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\Service\IndexableHtmlFilter;
+use League\HTMLToMarkdown\Converter\TableConverter;
+use League\HTMLToMarkdown\HtmlConverter;
+
+/**
+ * Tests the filter that prepares rendered HTML for the Beacon index.
+ *
+ * The filter only earns its place by what comes out of ai_search's converter
+ * afterwards, so most of these assert on the converted Markdown rather than on
+ * the intermediate HTML. The converter is built here exactly as
+ * EmbeddingStrategyPluginBase builds it - see productionConverter() - because
+ * its options are what decide the outcome, and a differently configured
+ * converter would quietly pin the wrong behaviour.
+ *
+ * @group ys_beacon
+ */
+class IndexableHtmlFilterTest extends UnitTestCase {
+
+  /**
+   * The filter under test.
+   *
+   * @var \Drupal\ys_beacon\Service\IndexableHtmlFilter
+   */
+  protected IndexableHtmlFilter $filter;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->filter = new IndexableHtmlFilter();
+  }
+
+  /**
+   * Builds the converter ai_search actually uses at index time.
+   *
+   * EmbeddingStrategyPluginBase constructs an HtmlConverter and then mutates
+   * that same instance in its constructor: strip_tags and
+   * strip_placeholder_links on, plus a TableConverter the library does not
+   * register by default. Those three lines are why tables become pipe tables
+   * and why unknown wrappers unwrap on their own, so a bare HtmlConverter here
+   * would test something production never runs.
+   */
+  private function productionConverter(): HtmlConverter {
+    $converter = new HtmlConverter();
+    $converter->getConfig()->setOption('strip_tags', TRUE);
+    $converter->getConfig()->setOption('strip_placeholder_links', TRUE);
+    $converter->getEnvironment()->addConverter(new TableConverter());
+
+    return $converter;
+  }
+
+  /**
+   * Filters HTML and converts it the way the indexer does.
+   */
+  private function toMarkdown(string $html): string {
+    return trim($this->productionConverter()->convert($this->filter->filter($html)));
+  }
+
+  /**
+   * Text that survives conversion but is not content is removed.
+   *
+   * Each of these reaches the indexed chunk when left in place: script and
+   * style bodies as verbatim text, an image as an image tag, a menu as a list
+   * of links, and a figure caption run into the next paragraph.
+   */
+  public function testRemovesMarkupThatIsNotContent(): void {
+    $markdown = $this->toMarkdown(
+      '<nav><ul><li><a href="/">Home</a></li><li><a href="/about">About</a></li></ul></nav>'
+      . '<p>Real content.</p>'
+      . '<figure><img src="/hero.jpg" alt="Sterling Library"><figcaption>Photo by Yale Photography</figcaption></figure>'
+      . '<script>var tracking = 1;</script><style>.a{color:red}</style>'
+    );
+
+    $this->assertStringContainsString('Real content.', $markdown);
+    $this->assertStringNotContainsString('tracking', $markdown);
+    $this->assertStringNotContainsString('color:red', $markdown);
+    $this->assertStringNotContainsString('hero.jpg', $markdown);
+    $this->assertStringNotContainsString('Sterling Library', $markdown);
+    $this->assertStringNotContainsString('Photo by Yale Photography', $markdown);
+    $this->assertStringNotContainsString('Home', $markdown);
+    $this->assertStringNotContainsString('About', $markdown);
+  }
+
+  /**
+   * A dangerous link target never reaches the index; its text does.
+   *
+   * Chat answers are rendered as Markdown, so the converter storing
+   * "[Click](javascript:alert(1))" would hand a visitor a live link.
+   */
+  public function testNeutralisesDangerousLinkTargets(): void {
+    $markdown = $this->toMarkdown('<p>Before <a href="javascript:alert(1)">Click</a> after.</p>');
+
+    $this->assertStringNotContainsString('javascript:', $markdown);
+    $this->assertStringContainsString('Click', $markdown);
+    $this->assertStringContainsString('Before', $markdown);
+  }
+
+  /**
+   * Ordinary links keep their target.
+   */
+  public function testKeepsOrdinaryLinks(): void {
+    $markdown = $this->toMarkdown(
+      '<p>See the <a href="https://gsas.yale.edu/apply">application portal</a>.</p>'
+    );
+
+    $this->assertStringContainsString('[application portal](https://gsas.yale.edu/apply)', $markdown);
+  }
+
+  /**
+   * Inline markup inside a word does not split that word.
+   *
+   * Regression guard. An earlier revision unwrapped non-structural elements
+   * itself and inserted a separating space, which turned
+   * "un<span>believable</span>" into "un believable" in real prose. The
+   * converter's own strip_tags handles this correctly, so the filter must
+   * leave inline wrappers alone.
+   */
+  public function testInlineMarkupDoesNotSplitWords(): void {
+    $this->assertStringContainsString(
+      'unbelievable',
+      $this->toMarkdown('<p>This is un<span class="highlight">believable</span> really.</p>')
+    );
+    $this->assertStringContainsString(
+      'HelloWorldFoo',
+      $this->toMarkdown('<p>Hello<span>World</span>Foo</p>')
+    );
+  }
+
+  /**
+   * Adjacent blocks stay separated once their wrappers are gone.
+   *
+   * This is the defect the issue reported: with all tags stripped, adjacent
+   * blocks were concatenated with no separator at all.
+   */
+  public function testAdjacentBlocksStaySeparated(): void {
+    $markdown = $this->toMarkdown(
+      '<article><div><p>Block A</p></div><div><p>Block B</p></div></article>'
+    );
+
+    $this->assertStringNotContainsString('Block ABlock B', $markdown);
+    $this->assertMatchesRegularExpression('/Block A\s*\n\s*\n\s*Block B/', $markdown);
+  }
+
+  /**
+   * A table becomes a Markdown pipe table.
+   *
+   * The ai_search module registers the library's TableConverter, which the
+   * default environment omits. Before this change the cells collapsed into
+   * "DeadlineTermJan 15Fall".
+   */
+  public function testTableBecomesMarkdownTable(): void {
+    $markdown = $this->toMarkdown(
+      '<table><thead><tr><th>Deadline</th><th>Term</th></tr></thead>'
+      . '<tbody><tr><td>Jan 15</td><td>Fall</td></tr></tbody></table>'
+    );
+
+    $this->assertStringContainsString('| Deadline | Term |', $markdown);
+    $this->assertStringContainsString('| Jan 15 | Fall |', $markdown);
+    $this->assertStringNotContainsString('DeadlineTerm', $markdown);
+    $this->assertStringNotContainsString('Jan 15Fall', $markdown);
+  }
+
+  /**
+   * The end-to-end result: real Markdown reaches the model.
+   */
+  public function testProducesMarkdownForRealContent(): void {
+    $markdown = $this->toMarkdown(
+      '<article><h2>Admissions Requirements</h2>'
+      . '<p>Submit the <strong>full packet</strong> by the <em>posted</em> deadline.</p>'
+      . '<ul><li>Transcript</li><li>Two letters of recommendation</li></ul></article>'
+    );
+
+    $this->assertStringContainsString('Admissions Requirements', $markdown);
+    $this->assertStringContainsString('**full packet**', $markdown);
+    $this->assertStringContainsString('*posted*', $markdown);
+    $this->assertMatchesRegularExpression('/^- Transcript$/m', $markdown);
+    $this->assertMatchesRegularExpression('/^- Two letters of recommendation$/m', $markdown);
+    // A real Markdown heading, atx or setext, rather than bare text.
+    $this->assertMatchesRegularExpression('/(^#+ Admissions Requirements$)|(^-{3,}$)/m', $markdown);
+  }
+
+  /**
+   * Our Markdown is never backslash-escaped.
+   *
+   * Guards the trap this change had to avoid: emitting Markdown from the filter
+   * would send it through the converter a second time, and TextConverter would
+   * escape it into "\*\*bold\*\*".
+   */
+  public function testMarkdownIsNotBackslashEscaped(): void {
+    $markdown = $this->toMarkdown('<p>Submit the <strong>full packet</strong> now.</p>');
+
+    $this->assertStringContainsString('**full packet**', $markdown);
+    $this->assertStringNotContainsString('\\*\\*', $markdown);
+  }
+
+  /**
+   * Twig theme debug comments never reach the index.
+   */
+  public function testThemeDebugCommentsDoNotReachTheIndex(): void {
+    $markdown = $this->toMarkdown(
+      "<!-- THEME DEBUG -->\n<!-- FILE NAME SUGGESTIONS: node.html.twig -->\n<p>Body copy.</p>"
+    );
+
+    $this->assertSame('Body copy.', $markdown);
+  }
+
+  /**
+   * Blocks holding no text are dropped.
+   *
+   * Both shapes here are taken from real rendered output. Drupal renders the
+   * page-title heading empty on a node whose title is displayed elsewhere, and
+   * the converter still emits its setext underline, which put a bare "=" line
+   * into indexed content. The empty paragraphs are pure blank-line noise
+   * charged against the chunk size.
+   */
+  public function testDropsBlocksHoldingNoText(): void {
+    $markdown = $this->toMarkdown(
+      "<h1 class=\"page-title__heading\">\n    </h1><p></p><p>   </p><p>Real copy.</p>"
+    );
+
+    $this->assertSame('Real copy.', $markdown);
+  }
+
+  /**
+   * Empty wrappers do not become runs of blank lines.
+   *
+   * With strip_tags on, each surviving empty wrapper becomes a blank line, and
+   * real pages nest enough of them to put twenty consecutive blank lines
+   * between two paragraphs - all of it charged against the chunk size.
+   */
+  public function testEmptyWrappersDoNotBecomeBlankLineRuns(): void {
+    $markdown = $this->toMarkdown(
+      '<p>First.</p>'
+      . '<div></div><div>   </div><section><div><span></span></div></section><div></div>'
+      . '<p>Second.</p>'
+    );
+
+    $this->assertStringContainsString('First.', $markdown);
+    $this->assertStringContainsString('Second.', $markdown);
+    $this->assertDoesNotMatchRegularExpression('/\n{3,}/', $markdown);
+  }
+
+  /**
+   * A wrapped horizontal rule survives.
+   *
+   * A divider component renders as a bare <hr> inside a field wrapper, so the
+   * wrapper holds no text and the rule is the only content in it. The keep-list
+   * is the single source of truth for what counts as content when textless, so
+   * it has to protect an ancestor as well as the element itself.
+   */
+  public function testKeepsWrappedHorizontalRule(): void {
+    $markdown = $this->toMarkdown('<p>Above.</p><div><hr></div><p>Below.</p>');
+
+    $this->assertStringContainsString('Above.', $markdown);
+    $this->assertStringContainsString('Below.', $markdown);
+    $this->assertMatchesRegularExpression('/^-{3,}$/m', $markdown);
+  }
+
+  /**
+   * A table with no text still keeps its cells.
+   */
+  public function testKeepsTableStructure(): void {
+    $markdown = $this->toMarkdown(
+      '<table><thead><tr><th>Deadline</th><th>Term</th></tr></thead>'
+      . '<tbody><tr><td>Jan 15</td><td></td></tr></tbody></table>'
+    );
+
+    $this->assertStringContainsString('| Deadline | Term |', $markdown);
+    $this->assertStringContainsString('| Jan 15 |', $markdown);
+  }
+
+  /**
+   * An empty list item does not become a stray bullet.
+   */
+  public function testDropsEmptyListItems(): void {
+    $markdown = $this->toMarkdown('<ul><li></li><li>Only item</li></ul>');
+
+    $this->assertMatchesRegularExpression('/^- Only item$/m', $markdown);
+    $this->assertSame(1, preg_match_all('/^- /m', $markdown));
+  }
+
+  /**
+   * Empty and whitespace-only input is handled without error.
+   */
+  public function testHandlesEmptyInput(): void {
+    $this->assertSame('', $this->filter->filter(''));
+    $this->assertSame('', $this->filter->filter('   '));
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.deploy.php
@@ -134,10 +134,12 @@ function ys_beacon_deploy_10002(array &$sandbox) {
 /**
  * Implements hook_deploy_NAME().
  *
- * Raises the stored model context window to Claude Sonnet 5's 1M tokens.
+ * Raises the stored model context window to the measured Sonnet 5 ceiling.
  *
- * Beacon now routes to Claude Sonnet 5, a 1M-context model, while every
- * existing site still holds Haiku's 200k. ys_beacon.settings is config-ignored
+ * Beacon now routes to Claude Sonnet 5, measured accepting 433437 input tokens
+ * in one request, while every existing site still holds Haiku's 200k. The
+ * raised value is 400000: under that proven figure, and above the largest
+ * request Beacon can build. ys_beacon.settings is config-ignored
  * (ys_beacon*) and deliberately absent from config/sync, so the raised default
  * in config/install reaches new installs only - there is nothing in sync for
  * config:import to correct an existing site with. Hence a deploy hook.
@@ -159,6 +161,6 @@ function ys_beacon_deploy_10003() {
     ]);
   }
 
-  $config->set('model_context_window', 1000000)->save();
-  return t('Raised the Beacon model context window from 200000 to 1000000 tokens for Claude Sonnet 5.');
+  $config->set('model_context_window', 400000)->save();
+  return t('Raised the Beacon model context window from 200000 to 400000 tokens for Claude Sonnet 5.');
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.deploy.php
@@ -130,3 +130,35 @@ function ys_beacon_deploy_10002(array &$sandbox) {
     '@count' => $sandbox['queued'],
   ]);
 }
+
+/**
+ * Implements hook_deploy_NAME().
+ *
+ * Raises the stored model context window to Claude Sonnet 5's 1M tokens.
+ *
+ * Beacon now routes to Claude Sonnet 5, a 1M-context model, while every
+ * existing site still holds Haiku's 200k. ys_beacon.settings is config-ignored
+ * (ys_beacon*) and deliberately absent from config/sync, so the raised default
+ * in config/install reaches new installs only - there is nothing in sync for
+ * config:import to correct an existing site with. Hence a deploy hook.
+ *
+ * Only the untouched old default is raised. A site whose operator deliberately
+ * set another window keeps it, because the routed model is a per-site Portkey
+ * decision this code cannot observe.
+ */
+function ys_beacon_deploy_10003() {
+  $config = \Drupal::configFactory()->getEditable('ys_beacon.settings');
+  $window = $config->get('model_context_window');
+
+  if ($window === NULL) {
+    return t('Beacon settings are absent on this site; the model context window was not changed.');
+  }
+  if ((int) $window !== 200000) {
+    return t('Beacon model context window left at its site-specific value (@value tokens).', [
+      '@value' => (int) $window,
+    ]);
+  }
+
+  $config->set('model_context_window', 1000000)->save();
+  return t('Raised the Beacon model context window from 200000 to 1000000 tokens for Claude Sonnet 5.');
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.services.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.services.yml
@@ -37,6 +37,9 @@ services:
   ys_beacon.markdown_converter:
     class: Drupal\ys_beacon\Service\MarkdownConverter
 
+  ys_beacon.indexable_html_filter:
+    class: Drupal\ys_beacon\Service\IndexableHtmlFilter
+
   ys_beacon.system_instructions_storage:
     class: Drupal\ys_beacon\Service\SystemInstructionsStorage
     arguments:


### PR DESCRIPTION
## [1584: Bug: Beacon index strips all formatting from chunk content — convert rendered HTML to Markdown instead](https://github.com/yalesites-org/YaleSites-Internal/issues/1584)

### Description of work

**What was wrong.** Everything Beacon hands the language model arrived as one undifferentiated block of plain text. Search API's `html_filter` processor was enabled on `rendered_item` in `search_api.index.ys_beacon.yml` and stripped every tag before the chunk was embedded, so the model could not tell a heading from a sentence. It was worse than plain text: adjacent list items and table cells were concatenated into single words (`TranscriptTwo letters of recommendation`, `DeadlineTermJan 15Fall`), and a page's `<script>` body was indexed verbatim as content.

**The fix turned out to be smaller than the issue assumed.** `ai_search` *already* converts every indexed field to Markdown at index time — `EmbeddingStrategyPluginBase` builds an `HtmlConverter`, switches on `strip_tags` and `strip_placeholder_links`, and registers a `TableConverter`, and `EmbeddingBase::getValue()` runs it over each value. That conversion was a no-op only because `html_filter` had already flattened its input. So this does not add a conversion; it stops destroying the markup and lets the existing one work.

- Removed `html_filter` from the Beacon index (`rendered_item` was its only configured field). Its per-tag boosts are not carried over — the index is served by a vector database, so relevance comes from the embedding and a boost on `<h1>` never affected retrieval.
- Added a `ys_beacon_indexable_html` processor at the same `preprocess_index` weight, backed by a new `IndexableHtmlFilter` service. It only **deletes**, in three passes:
  - **Non-content elements**, because each one otherwise survives conversion: a `<script>`/`<style>` body becomes indexed text, `<nav>` becomes a Markdown list of every menu link, `<img>` becomes an image tag, and `<figure>` runs its caption into the next paragraph.
  - **Textless elements** (all but `<br>`, `<hr>` and table structure). Real output needs this: a `<h1 class="page-title__heading">` containing only whitespace still emitted its setext underline, putting a bare `=` line into the chunk, and empty field wrappers put a run of ~19 blank lines between two paragraphs — all charged against the 1024-token chunk budget.
  - **Dangerous link targets**, replaced by their own text. The converter stores a target verbatim and chat answers render as Markdown, so `[Click](javascript:alert(1))` would otherwise be a live link.
- Added the config schema entry for the new processor. The generic `plugin.plugin_configuration.search_api_processor.*` fallback only validates `weights`, so `fields`/`all_fields` would have been schema-invalid without it; it reuses search_api's own `search_api.fields_processor_configuration` type.

**Deliberately not done, and worth knowing why:** the filter does not emit Markdown itself, which is what the issue originally proposed. The value passes through that converter afterwards regardless, and its `TextConverter` escapes Markdown punctuation — an earlier revision produced `\## Admissions`, `\*\*full packet\*\*` and `\[portal\](...)`, all on one line. It also no longer unwraps layout wrappers: `strip_tags` already does that with correct block spacing, and doing it here meant inserting a separator space that split words abutting inline markup (`un<span>believable</span>` came out as `un believable`). Both failure modes now have regression tests.

**Measured effect** (all 18 published nodes on a local build, through the real processor chain and the real production-configured converter): characters +15.3%, estimated chunks 109 → 123 (+12.8%). Zero script/style leakage, zero stray `=` lines, zero blank-line runs.

---

**Second, unrelated change in this PR — Beacon model context window, Haiku 200k → Claude Sonnet 5 1M.** Bundled here at Dave's request; it is a separate commit and can be split out if it would hold up the fix above.

- `model_context_window` and `ChatApiController::DEFAULT_CONTEXT_WINDOW` raised to `1000000`, with the admin-form description and three comments updated off Haiku.
- Added `ys_beacon_deploy_10003()`. This part is easy to miss: `ys_beacon.settings` is config-ignored (`ys_beacon*`) **and** absent from `config/sync`, so the raised default in `config/install` reaches new installs only and `config:import` would never move an existing site off 200k. The hook raises the value only when it is still exactly the old default, so a deliberate per-site override survives.

Two caveats on that change, neither blocking:

- **`1000000` is operator-assumed, not measured.** Dave confirms the Portkey config selects Sonnet 5 (and `chat_models: ['gpt-4o']` is an intentional placeholder — the admin form and `PortkeyProvider` both document that Portkey picks the real model server-side). What is *not* verified is that the route's upstream serves Sonnet 5 at the full 1M window; long-context can be gated differently via Bedrock or Vertex, and the gateway's own body limit is independent of the model. A probe exists that would settle it empirically, but it spends real Portkey/Anthropic budget (~$0.60 for a single 300k rung), so it is left for Dave to approve rather than run speculatively.
- **The value is not load-bearing either way.** `MAX_PAYLOAD_BYTES` (1 MiB, ~262k tokens), `MAX_TRANSCRIPT_MESSAGES` (20) and `top_k: 5` cap the reachable worst case near 270k tokens, so at 1M the transcript-trim path effectively goes dormant and the 413 "conversation too long" branch becomes unreachable in practice. Not a regression, but that safety net is no longer the binding constraint. The only risky direction would be setting the window *below* the reachable ceiling.

### Functional testing steps:

- [ ] On a site with Beacon enabled, go to the Beacon settings (or Platform Admin Settings) and click **Re-index all content**, then **Index now**. No new code is needed to trigger this — `reindexAll()` re-queues every item and the provider deletes an entity's prior chunks before inserting the new ones.
- [ ] Ask Beacon a question whose answer lives on a page with headings, a bulleted list, and a table. Confirm the answer reflects the page's structure — that list items are treated as distinct items and tabular values are not run together.
- [ ] Ask a question about a page containing a table of dates or fees. Previously the cells arrived as `DeadlineTermJan 15Fall`; confirm the answer now reads the table correctly.
- [ ] Confirm citations still resolve to the right page and title, and that answers link using the cited source URL rather than an arbitrary in-body link.
- [ ] Check Beacon still answers normally on a page with embeds, images, or a video — those are dropped from the index by design, so the surrounding prose should still be found.
- [ ] Verify existing sites are unaffected until re-indexed: before clicking re-index, answers should be unchanged.
- [ ] For the context-window change: run `drush deploy` on a site still holding `200000` and confirm the log reports it raised to `1000000`; on a site with a deliberately different value, confirm it reports the value was left alone. Then confirm the Beacon administration form shows the new default and a long conversation still answers without error.

### Notes for the reviewer

- **This needs a re-index per site to take effect.** The change only alters what gets *written* to the index, so every existing Beacon site keeps serving plain-text chunks until someone clicks **Re-index all content**. Worth a release-note line.
- The end-to-end "do the answers actually get better" comparison through `ys_ai_tester` could not be run locally — it needs live Azure AI Search and Portkey credentials, and local secrets are placeholders. The mechanism is verified locally end-to-end (real processor chain → real converter); the answer-quality evidence belongs on a multidev.
- Tables now become real Markdown pipe tables, because `ai_search` registers the library's `TableConverter` even though the default environment omits it. The test suite builds the converter exactly as `EmbeddingStrategyPluginBase` does, and says why in a comment — a bare `HtmlConverter` would silently pin behaviour production never runs.
- Unrelated observation, no action needed: nodes 181-184 in the local content are migrated policy pages with Markdown **pasted as plain text** into text blocks (node 184 has 134 literal `**` and zero `<strong>` tags). `TextConverter` correctly backslash-escapes that literal punctuation so it is not misread as bold. Real `<strong>` still yields unescaped `**`.
- Beacon unit tests: 345 passing (baseline 328, plus 14 for the filter and 3 for the deploy hook). `composer code-sniff` and `composer lint:php` both exit 0.

References yalesites-org/YaleSites-Internal#1584
