### PR TITLE
1581: Bug: Beacon index metadata is wrong for documents — migration metadata in AI Description, markdown escaping in embedded chunks

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/README.md
@@ -12,6 +12,28 @@ its `ai_engine_metadata` submodule, so the AI metadata tags editors already
 maintain (`ai_description`, `ai_tags`, `ai_disable_indexing`) keep working and
 flow into the vector index.
 
+One exception: sites imported from the legacy your.yale.edu platform carry the
+importer's own bookkeeping in `ai_description` rather than a description (for
+example `source_url: https://your.yale.edu/media/3359/download?inline`). Because
+that field is embedded as contextual content on every chunk of the item, a bare
+URL there is pure noise in the vector, so `AiMetadataManager` treats a value
+whose line begins with a `<word>_url:` key as if no description had been set.
+
+Scope of that suppression, so it is not mistaken for a general cleanup:
+
+- It applies to what Beacon *reads* - the vector index and the
+  `/api/content-feed` JSON, both of which go through `AiMetadataManager`. The
+  stored field is left untouched, so the raw value still renders in the page's
+  `<meta name="ai_description">` tag and any consumer scraping the page rather
+  than the index still sees it.
+- Nothing changes for editors. The check is anchored to the start of a line, so
+  prose that merely mentions or quotes a URL is kept; a description written in
+  the UI is used as-is, and writing one over a migrated value takes effect
+  immediately because the index has `index_directly` enabled.
+- Suppression only changes what is embedded the *next* time an item is indexed,
+  and nobody edits migrated media. `ys_beacon_deploy_10003()` therefore marks
+  the affected items for reindexing once, on deploy.
+
 ## Naming
 
 The chat widget originates from Microsoft's "Contoso Chat" sample (by way of

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/AiMetadataManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/AiMetadataManager.php
@@ -42,11 +42,50 @@ class AiMetadataManager {
     $aiTags = isset($tags['ai_tags']) ? strip_tags($this->token->replace($tags['ai_tags'], [$entity->getEntityTypeId() => $entity])) : "";
     $aiDisableIndex = isset($tags['ai_disable_indexing']);
 
+    // A migrated description is bookkeeping rather than meaning, so drop it and
+    // let the item take the same path as one that never had a description.
+    if ($this->isMigrationMetadata($aiDesc)) {
+      $aiDesc = "";
+    }
+
     return [
       'ai_description' => $aiDesc,
       'ai_tags' => $aiTags,
       'ai_disable_index' => $aiDisableIndex,
     ];
+  }
+
+  /**
+   * Checks whether a description is leftover migration metadata.
+   *
+   * Sites imported from the legacy your.yale.edu platform stored the importer's
+   * own key/value pairs in this metatag instead of a description, typically
+   * "source_url: https://your.yale.edu/media/3359/download?inline". The value
+   * is mapped as contextual_content in ai_search.index.ys_beacon.yml, so it is
+   * embedded into the vector for every chunk of the item, where a bare URL adds
+   * noise and can pull the chunk toward unrelated URL-shaped queries.
+   *
+   * Bookkeeping is recognised as a "<word>_url:" key at the start of any line,
+   * which covers every value counted by the audit published in
+   * YaleSites-Internal#1581 (15 of the 16 described media on the sampled site)
+   * as well as a key sitting on a later line of a multi-line blob
+   * ("title: ...\nfile_url: ...").
+   *
+   * The line anchor is the load-bearing part, in both directions. Without it a
+   * bare substring test would also discard genuine prose that happens to quote
+   * the key ("Set the source_url: parameter ..."), and because the value is
+   * dropped with no log and no admin signal that loss would be invisible. The
+   * great majority of the platform is not migrated, so keeping real
+   * descriptions intact matters more than catching an exotic bookkeeping shape.
+   *
+   * @param string $value
+   *   The resolved ai_description value.
+   *
+   * @return bool
+   *   TRUE when the value is importer bookkeeping rather than a description.
+   */
+  protected function isMigrationMetadata(string $value): bool {
+    return preg_match('/^\s*\w+_url\s*:/mi', $value) === 1;
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/AiMetadataManagerTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/AiMetadataManagerTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Utility\Token;
+use Drupal\metatag\MetatagManager;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\Service\AiMetadataManager;
+
+/**
+ * Tests the AI metadata read off an entity before it reaches the index.
+ *
+ * The ai_description value is mapped as contextual_content in
+ * ai_search.index.ys_beacon.yml, so whatever this service returns is embedded
+ * into the vector for every chunk of the item. Sites migrated from the legacy
+ * your.yale.edu platform carry raw importer bookkeeping in that metatag
+ * ("source_url: https://your.yale.edu/media/3359/download?inline") rather than
+ * a description, and a bare URL both adds noise to the vector and pulls the
+ * chunk toward unrelated URL-shaped queries. Those values must be treated as
+ * if no description had been provided at all.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Service\AiMetadataManager
+ */
+class AiMetadataManagerTest extends UnitTestCase {
+
+  /**
+   * The migration-metadata boundary, case by case.
+   *
+   * Both directions matter equally. Failing to suppress leaves the noise in the
+   * vector, which is the bug; suppressing too eagerly silently discards an
+   * editor's real description, and because the value is dropped without a log
+   * or any admin signal that failure would be invisible. The great majority of
+   * the platform is not migrated, so the preserved cases guard the common path.
+   *
+   * @return array
+   *   Test cases of [description, expected value after sanitisation].
+   */
+  public static function descriptionProvider(): array {
+    return [
+      'reported gatewayassist value' => [
+        'source_url: https://your.yale.edu/media/3359/download?inline',
+        '',
+      ],
+      'a different bookkeeping key' => [
+        'file_url: https://your.yale.edu/sites/default/files/2026-06/bank-statement-example.pdf',
+        '',
+      ],
+      'bookkeeping key in mixed case' => [
+        'Source_Url: https://your.yale.edu/media/3360/download?inline',
+        '',
+      ],
+      'bookkeeping key behind leading whitespace' => [
+        "  source_url: https://your.yale.edu/media/3359/download\n",
+        '',
+      ],
+      'bookkeeping key on a later line' => [
+        "title: Supplier Gateway\nsource_url: https://your.yale.edu/media/3359/download",
+        '',
+      ],
+      'other bookkeeping key on a later line' => [
+        "title: Supplier Gateway\nfile_url: https://your.yale.edu/media/3359/download",
+        '',
+      ],
+      'prose quoting the bookkeeping key is a real description' => [
+        'Set the source_url: parameter to the media path before importing.',
+        'Set the source_url: parameter to the media path before importing.',
+      ],
+      'prose mentioning a URL is a real description' => [
+        'Supplier onboarding steps; the full policy lives at https://your.yale.edu/policy/3359.',
+        'Supplier onboarding steps; the full policy lives at https://your.yale.edu/policy/3359.',
+      ],
+      'an ordinary description' => [
+        'Reference guide for suppliers using the gateway.',
+        'Reference guide for suppliers using the gateway.',
+      ],
+    ];
+  }
+
+  /**
+   * Migration bookkeeping is suppressed and real descriptions survive.
+   *
+   * @dataProvider descriptionProvider
+   *
+   * @covers ::getAiMetadata
+   * @covers ::isMigrationMetadata
+   */
+  public function testDescriptionBoundary(string $description, string $expected): void {
+    $this->assertSame($expected, $this->getMetadata(['ai_description' => $description])['ai_description']);
+  }
+
+  /**
+   * Markup is still stripped from both AI values.
+   *
+   * Stripping runs before the migration check, so bookkeeping wrapped in markup
+   * by a WYSIWYG is still detected.
+   *
+   * @covers ::getAiMetadata
+   */
+  public function testMarkupIsStrippedFromBothValues(): void {
+    $metadata = $this->getMetadata([
+      'ai_description' => '<p>Reference <strong>guide</strong>.</p>',
+      'ai_tags' => '<em>supplier</em>, gateway',
+    ]);
+
+    $this->assertSame('Reference guide.', $metadata['ai_description']);
+    $this->assertSame('supplier, gateway', $metadata['ai_tags']);
+
+    $wrapped = $this->getMetadata([
+      'ai_description' => '<p>source_url: https://your.yale.edu/media/3359/download</p>',
+    ]);
+
+    $this->assertSame('', $wrapped['ai_description']);
+  }
+
+  /**
+   * Tags and the indexing flag are untouched by the description guard.
+   *
+   * @covers ::getAiMetadata
+   */
+  public function testTagsAndDisableFlagAreIndependent(): void {
+    $metadata = $this->getMetadata([
+      'ai_description' => 'source_url: https://your.yale.edu/media/3359/download',
+      'ai_tags' => 'supplier, gateway',
+      'ai_disable_indexing' => '1',
+    ]);
+
+    $this->assertSame('', $metadata['ai_description']);
+    $this->assertSame('supplier, gateway', $metadata['ai_tags']);
+    $this->assertTrue($metadata['ai_disable_index']);
+  }
+
+  /**
+   * A media item with no AI metatags at all yields empty values.
+   *
+   * This is the shape a suppressed description has to match: the search_api
+   * processor skips empty values, so a migrated item ends up on exactly the
+   * same path as an item that never had a description. That contract is pinned
+   * in AiMetadataPropertiesTest.
+   *
+   * @covers ::getAiMetadata
+   */
+  public function testMissingTagsYieldEmptyValues(): void {
+    $metadata = $this->getMetadata([]);
+
+    $this->assertSame('', $metadata['ai_description']);
+    $this->assertSame('', $metadata['ai_tags']);
+    $this->assertFalse($metadata['ai_disable_index']);
+  }
+
+  /**
+   * Runs the service over a set of metatag values from a media entity.
+   *
+   * @param array $tags
+   *   The metatag values as MetatagManager::tagsFromEntity() would return them.
+   *
+   * @return array
+   *   The metadata array returned by the service.
+   */
+  private function getMetadata(array $tags): array {
+    $entity = $this->createMock(ContentEntityInterface::class);
+    $entity->method('getEntityTypeId')->willReturn('media');
+
+    $metatagManager = $this->createMock(MetatagManager::class);
+    $metatagManager->method('tagsFromEntity')->with($entity)->willReturn($tags);
+
+    $token = $this->createMock(Token::class);
+    $token->method('replace')->willReturnArgument(0);
+
+    return (new AiMetadataManager($metatagManager, $token))->getAiMetadata($entity);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/AiMetadataPropertiesTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/AiMetadataPropertiesTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Drupal\Tests\ys_beacon\Unit;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\TypedData\ComplexDataInterface;
+use Drupal\search_api\Item\FieldInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\Utility\FieldsHelperInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_beacon\Plugin\search_api\processor\AiMetadataProperties;
+use Drupal\ys_beacon\Service\AiMetadataManager;
+
+/**
+ * Tests that the processor only indexes AI metadata it actually has.
+ *
+ * This pins the contract the ai_description sanitisation in AiMetadataManager
+ * relies on: an empty value must add no field value at all, so a media item
+ * whose migrated description was suppressed takes exactly the same path as one
+ * that never had a description. If this guard were ever relaxed to a NULL check
+ * the suppressed empty string would start being indexed again, and every test
+ * in AiMetadataManagerTest would still pass.
+ *
+ * @group ys_beacon
+ * @coversDefaultClass \Drupal\ys_beacon\Plugin\search_api\processor\AiMetadataProperties
+ */
+class AiMetadataPropertiesTest extends UnitTestCase {
+
+  /**
+   * An empty description contributes no value to the index field.
+   *
+   * @covers ::addFieldValues
+   * @covers ::addMetadataValue
+   */
+  public function testEmptyDescriptionAddsNoFieldValue(): void {
+    $description = $this->createMock(FieldInterface::class);
+    $description->method('getPropertyPath')->willReturn('ys_beacon_ai_description');
+    $description->expects($this->never())->method('addValue');
+
+    $tags = $this->createMock(FieldInterface::class);
+    $tags->method('getPropertyPath')->willReturn('ys_beacon_ai_tags');
+    $tags->expects($this->once())->method('addValue')->with('supplier, gateway');
+
+    $this->runProcessor(['ai_description' => '', 'ai_tags' => 'supplier, gateway'], [$description, $tags]);
+  }
+
+  /**
+   * A real description is added to the index field.
+   *
+   * @covers ::addFieldValues
+   * @covers ::addMetadataValue
+   */
+  public function testRealDescriptionIsAddedToTheField(): void {
+    $description = $this->createMock(FieldInterface::class);
+    $description->method('getPropertyPath')->willReturn('ys_beacon_ai_description');
+    $description->expects($this->once())->method('addValue')->with('Reference guide for suppliers.');
+
+    $tags = $this->createMock(FieldInterface::class);
+    $tags->method('getPropertyPath')->willReturn('ys_beacon_ai_tags');
+    $tags->expects($this->never())->method('addValue');
+
+    $this->runProcessor(['ai_description' => 'Reference guide for suppliers.', 'ai_tags' => ''], [$description, $tags]);
+  }
+
+  /**
+   * Runs addFieldValues() with a stubbed metadata manager and index fields.
+   *
+   * @param array $metadata
+   *   The values AiMetadataManager::getAiMetadata() should return.
+   * @param \Drupal\search_api\Item\FieldInterface[] $fields
+   *   The index fields present on the item.
+   */
+  private function runProcessor(array $metadata, array $fields): void {
+    $entity = $this->createMock(ContentEntityInterface::class);
+
+    $original = $this->createMock(ComplexDataInterface::class);
+    $original->method('getValue')->willReturn($entity);
+
+    $item = $this->createMock(ItemInterface::class);
+    $item->method('getOriginalObject')->willReturn($original);
+    $item->method('getFields')->with(FALSE)->willReturn($fields);
+
+    $manager = $this->createMock(AiMetadataManager::class);
+    $manager->method('getAiMetadata')->with($entity)->willReturn($metadata);
+
+    $fieldsHelper = $this->createMock(FieldsHelperInterface::class);
+    $fieldsHelper->method('filterForPropertyPath')
+      ->willReturnCallback(fn (array $candidates, $datasource_id, $property_path) => array_filter(
+        $candidates,
+        fn (FieldInterface $field) => $field->getPropertyPath() === $property_path
+      ));
+
+    $processor = new AiMetadataProperties([], 'ys_beacon_ai_metadata', []);
+    $processor->setFieldsHelper($fieldsHelper);
+
+    $injected = new \ReflectionProperty($processor, 'aiMetadataManager');
+    $injected->setAccessible(TRUE);
+    $injected->setValue($processor, $manager);
+
+    $processor->addFieldValues($item);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/RagRetrieverTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/tests/src/Unit/RagRetrieverTest.php
@@ -232,6 +232,12 @@ class RagRetrieverTest extends UnitTestCase {
    * read path must undo that so the citation URL is not corrupted (a stored
    * "annual\_report" would otherwise 404).
    *
+   * This is also the regression cover YaleSites-Internal#1581 asks for on the
+   * citation half of that issue: the document reported there
+   * ("Supplier\_Gateway-Reference\_Guide\_for\_Suppliers.pdf") reaches the
+   * user through this exact path, and the multi-underscore filename asserted
+   * below is the same shape. Keep it passing.
+   *
    * @covers ::buildStoredCitations
    * @covers ::decodeStoredValue
    */

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.deploy.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/ys_beacon.deploy.php
@@ -130,3 +130,77 @@ function ys_beacon_deploy_10002(array &$sandbox) {
     '@count' => $sandbox['queued'],
   ]);
 }
+
+/**
+ * Reindexes migrated media whose AI Description was importer bookkeeping.
+ *
+ * AiMetadataManager now treats a migration-metadata-shaped ai_description as
+ * if no description had been set, but that only changes what gets embedded the
+ * next time an item is indexed. The affected items are migrated media that no
+ * editor is ever going to open, and Search API's cron only revisits items it
+ * has been told changed, so without this sweep the noisy vectors measured in
+ * issue #1581 (15 of the 16 described media on the sampled site) would sit in
+ * Azure indefinitely and the fix would be inert on exactly the content it was
+ * written for.
+ *
+ * Affected items are identified by asking AiMetadataManager itself: a non-empty
+ * stored tag that comes back empty is one it suppressed. That deliberately
+ * avoids restating the detection rule here, so this hook cannot drift from the
+ * indexing path it is meant to refresh.
+ *
+ * Only media are scanned, matching the scope of the audit in #1581 - the
+ * ai_description metatag field is only editable on media:document. Sites where
+ * Beacon is unauthorized or unconfigured are skipped before the library is
+ * enumerated. Marking an item updated re-embeds it, which costs an embedding
+ * call per item, so the count is kept to the items that actually carry the bad
+ * data rather than reindexing the whole index.
+ */
+function ys_beacon_deploy_10003(array &$sandbox) {
+  // Decide once, up front: Beacon is authorized per site by a platform
+  // administrator and a site can be left without an index name, so most sites
+  // receiving this deploy have it switched off and the enumeration below would
+  // cost real deploy time to achieve nothing.
+  if (!\Drupal::service('ys_beacon.authorization')->isAuthorized()
+    || !\Drupal::config('ys_beacon.settings')->get('azure_index_name')) {
+    $sandbox['#finished'] = 1;
+    return t('Beacon is not enabled on this site; no media were marked for reindexing.');
+  }
+
+  if (!isset($sandbox['ids'])) {
+    $sandbox['ids'] = array_values(\Drupal::entityQuery('media')->accessCheck(FALSE)->execute());
+    $sandbox['total'] = count($sandbox['ids']);
+    $sandbox['marked'] = 0;
+  }
+  if (!$sandbox['total']) {
+    $sandbox['#finished'] = 1;
+    return t('The media library is empty; nothing was marked for reindexing.');
+  }
+
+  $metatag_manager = \Drupal::service('metatag.manager');
+  $ai_metadata_manager = \Drupal::service('ys_beacon.ai_metadata_manager');
+  $tracking_manager = \Drupal::service('search_api.entity_datasource.tracking_manager');
+  $storage = \Drupal::entityTypeManager()->getStorage('media');
+
+  // Paging matters: loading a large media library in one go would not survive
+  // the deploy window.
+  foreach ($storage->loadMultiple(array_splice($sandbox['ids'], 0, 50)) as $media) {
+    $tags = $metatag_manager->tagsFromEntity($media);
+    if (trim((string) ($tags['ai_description'] ?? '')) === '') {
+      continue;
+    }
+    if ($ai_metadata_manager->getAiMetadata($media)['ai_description'] !== '') {
+      continue;
+    }
+    $tracking_manager->trackEntityChange($media);
+    $sandbox['marked']++;
+  }
+
+  if ($sandbox['ids']) {
+    $sandbox['#finished'] = 1 - (count($sandbox['ids']) / $sandbox['total']);
+    return NULL;
+  }
+  $sandbox['#finished'] = 1;
+  return t('Marked @count media item(s) carrying migration metadata in their AI Description for reindexing.', [
+    '@count' => $sandbox['marked'],
+  ]);
+}


### PR DESCRIPTION
## [1581: Bug: Beacon index metadata is wrong for documents — migration metadata in AI Description, markdown escaping in embedded chunks](https://github.com/yalesites-org/YaleSites-Internal/issues/1581)

### Description of work

**Issue 1 — migration metadata in AI Description (fixed).**

- `AiMetadataManager::getAiMetadata()` now treats a migration-metadata-shaped `ai_description` as if no description had been set, so importer bookkeeping like `source_url: https://your.yale.edu/media/3359/download?inline` is no longer embedded into the vector as `contextual_content`. Bookkeeping is recognised as a `<word>_url:` key at the **start of any line**.
- The fix is read-side rather than a data rewrite. An update hook that nulled the field would destructively rewrite an editor-facing field platform-wide on a regex match; this is non-destructive, idempotent, and self-heals the moment an editor writes a real description.
- **No config change was needed.** `AiMetadataProperties::addMetadataValue()` already skips empty values, so a suppressed description takes the *identical* path as a media item that never had one. That contract is now pinned by a test, because the whole design rests on it.
- One read-side fix serves both consumers of the value: the Beacon vector index and the `/api/content-feed` JSON (`ContentFeedBuilder::buildItem()`).
- `ys_beacon_deploy_10003()` marks the affected media for reindexing once, on deploy. Without it this fix would be **inert on exactly the content it was written for** — suppression only changes what is embedded the next time an item is indexed, and nobody is ever going to open a migrated media item. It guards on authorization + `azure_index_name` before enumerating anything, pages the library 50 at a time, and identifies affected items by asking `AiMetadataManager` itself (a non-empty stored tag that comes back empty), so it cannot drift from the detection rule. Modelled on `ys_beacon_deploy_10002()`, the equivalent sweep added by yalesites-org/YaleSites-Internal#1580.

**Answer to the AC "is the migration still writing `source_url:`?" — No.**

This is purely historical data; the data fix will **not** regress on a future run. Evidence: `ai_description` appears in exactly 8 files in this repo (2 config YAML, README, 4 `ys_beacon` PHP, 1 Kernel test) and **zero** migration files. `source_url` appears only in an unrelated `ys_campus_groups` unit test. Every migration YAML was inventoried (`ys_pages`, `ys_posts`, `ys_terms`, `ys_menu_links`, `ys_images_files`, `ys_images_media`, `ys_migrate_onha`, `ys_migrate_sustainability_news`, `ys_migrate_whc`) — none map metatags, and `ys_sn_news` carries an explicit `# metatags -> skip`. `git log --all -S"ai_description" -- ys_migrate` is empty. The bad values came from an out-of-repo your.yale.edu import.

**Issue 2 — markdown escaping in embedded `content` (regression test added; the strip is deliberately deferred).**

The AC is conditional — *"Determine whether backslash-escaped punctuation in the embedded `content` measurably affects retrieval quality, **and strip it before embedding if so**."* My determination is that it should **not** be stripped here, for three reasons:

1. **The measurement is not possible.** It needs a live Azure index with two corpora to compare. `ys_beacon` is not enabled on the local instance and there is no Beacon index in the local DB.
2. **"Before embedding" would require patching contrib.** `league/html-to-markdown` 5.1.1 has no option to disable escaping, and `new HtmlConverter()` is hard-coded in `EmbeddingStrategyPluginBase::create()` rather than being a swappable service.
3. **It would actively collide with yalesites-org/YaleSites-Internal#1584.** That issue removes `html_filter` so `content` becomes *real Markdown*. Today `content` is flat plain text and the backslashes in it are pure noise; **after #1584 they are load-bearing** — `ParagraphConverter` emits leading `\-`, `\>`, `\--` precisely to stop literal text being parsed as list or quote structure. A blanket unescape (which is what `decodeStoredValue()` does — it strips a backslash before *any* ASCII punctuation) would inject phantom list items and blockquotes into #1584's Markdown.

So the content-escaping decision belongs to #1584, where the Markdown premise is actually settled. **Flagging this for the reviewer to accept or reject rather than leaving it silent.**

The other half of that AC — *"Regression test that citation URLs containing underscores are delivered unescaped and resolvable... This currently works — the test is to keep it working"* — is already covered by the existing `RagRetrieverTest::testReadOnlyStoredCitationDecodesEscapedFields`, which drives the identical path (`isReadOnly()` -> `buildStoredCitations()` -> `storedCitation()` -> `decodeStoredValue()`) and already asserts multi-underscore filename unescaping. I initially added a second test for the verbatim gatewayassist URL and then removed it as duplicate coverage that pinned no new behaviour; the existing test's docblock is annotated instead to record that it is this issue's regression cover.

### Verification — please read, confidence is reduced

- **Unit: `OK (342 tests, 788 assertions)`** across the whole `ys_beacon` Unit suite. Test-first: with the tests in place and the fix held back the run was `Tests: 336, Assertions: 779, Failures: 3`, and all 3 failed for the right reason (the metadata arriving verbatim). Baseline on `develop` was **0** pre-existing failures.
- **Lint: `composer code-sniff` exit 0 and `composer lint:php` exit 0** (the actual CI gate — both Drupal and DrupalPractice over all three custom dirs).
- The new line-anchored predicate was **verified empirically over 11 cases** before it was adopted. It strictly dominates a leading-key-plus-substring test: it fixes 2 false negatives (a bookkeeping key on a later line of a multi-line blob) *and* 2 false positives (developer prose quoting `source_url:`, which a bare substring test silently discarded), with 0 mismatches against intent.
- **What was NOT verified, and why:** there is **no end-to-end verification against a real Beacon index.** `ys_beacon` is not enabled on the local instance, the local `search_api` indexes are only `node_index` and `secure_index`, and no local media carries a `source_url:` value — running the issue's own audit script locally returned `media scanned: 61 / with a non-empty ai_description: 0`. I deliberately did **not** enable the module or import Beacon/Azure config, because that would have leaked into a shared local checkout other work was using. So `ys_beacon_deploy_10003()` has **not been executed against real migrated data** — that is the main thing worth exercising in review, ideally against a gatewayassist DB pull.
- **Kernel: `OK (3 tests, 35 assertions)`** for `ContentFeedBuilderTest`, the Kernel test covering the second consumer of this value. Run individually because the full `ys_beacon` Kernel suite does not complete here — it timed out after 10 minutes having run 4 tests, and this single file alone took 7m39s. So the *whole* Kernel suite is not a green run and is not being reported as one; the one file that exercises the changed code path is.

### Functional testing steps:

- [ ] On a **migrated** site (e.g. a gatewayassist DB pull) with Beacon enabled, run the audit script from yalesites-org/YaleSites-Internal#1581 and record the counts before deploying.
- [ ] Run `drush deploy` and confirm `ys_beacon_deploy_10003()` reports a non-zero count of media marked for reindexing.
- [ ] After reindexing, read the raw index record for an affected document (e.g. media/48) and confirm `content` no longer contains `AI Description: source_url: ...`. The label line remains with an empty value, exactly as `AI Tags:` already does.
- [ ] Confirm on a **non-migrated** site that the same deploy reports `0` and that media with a genuine AI Description still have it embedded.
- [ ] Edit a migrated document's AI Description to real text and confirm it appears in the index (the index has `index_directly` enabled, so saving is enough).
- [ ] Confirm a description containing prose such as `Set the source_url: parameter to the media path.` is **kept**, not discarded.
- [ ] Ask Beacon a question that retrieves a document whose filename contains underscores and confirm the citation URL resolves with real underscores.
- [ ] Confirm a site with Beacon unauthorized or without an index name is skipped by the deploy hook with no media enumeration.

References yalesites-org/YaleSites-Internal#1581
