### PR TITLE
1404: Gate Prettier formatting in CI

### DIFF
--- a/.ci/test/static/run
+++ b/.ci/test/static/run
@@ -14,6 +14,13 @@ composer install --no-ansi --no-interaction --optimize-autoloader --no-progress
 
 npm install
 
+# Fail fast if Prettier is not resolving .prettierrc.js. A misnamed config file
+# makes Prettier fall back to its own built-in defaults, which disagree with the
+# shared Yale config - so every formatting check below would silently be measuring
+# the wrong thing. --no-install keeps npx from fetching a different Prettier major
+# from the registry instead of failing.
+npx --no-install prettier --find-config-path package.json
+
 # Run unit tests
 composer -n unit-test
 
@@ -26,3 +33,8 @@ composer -n code-sniff
 # Lint styles and JS
 npm run lint:styles
 # npm run lint:js
+
+# Check formatting of our own tree. Without this gate, drift accumulates unnoticed
+# and then fails an unrelated commit's pre-commit hook, because Prettier checks the
+# whole staged file rather than just the diff.
+npm run prettier

--- a/README.md
+++ b/README.md
@@ -91,7 +91,15 @@ All commands are prefixed with `npm run`. For example: `npm run setup`
 - `lint:styles` - Stylelint for SCSS files
 - `fix:js` - Auto-fix JavaScript linting errors
 - `prettier` - Check code formatting (does not auto-fix)
+- `prettier:fix` - Auto-fix code formatting
 - `test` - Run complete test suite (prettier + all linting)
+
+`prettier` is part of the CI static-test gate, so formatting drift fails the build.
+Run `npm run prettier:fix` before pushing if `npm run prettier` reports any files.
+Formatting comes from `.prettierrc.js`, which re-exports the shared
+`@yalesites-org/eslint-config-and-other-formatting` config (single quotes, trailing
+commas) - keep the leading dot on that filename or Prettier silently falls back to
+its own defaults.
 
 ### Alternative Commands (via Lando)
 


### PR DESCRIPTION
## [1404: Gate Prettier formatting in CI](https://github.com/yalesites-org/YaleSites-Internal/issues/1404)

### Description of work

- Builds on yalesites-org/YaleSites-Internal#1404's first PR (see the "Builds on" note below) — this branch is stacked on it and its diff shows only the CI/documentation change.

`.ci/test/static/run` ran `composer unit-test`, `lint:php`, `code-sniff` and `npm run lint:styles`, but **never Prettier** — and nothing under `.github/workflows/` did either. That is how 55 files of formatting drift accumulated without anyone noticing, and it is why a one-time sweep on its own just resets the clock instead of fixing the problem. Two steps are added:

- **`npx --no-install prettier --find-config-path package.json`**, placed immediately after `npm install`. This fails the build if Prettier ever stops resolving `.prettierrc.js` — the exact regression that caused this ticket, where a misnamed config made Prettier fall back to its own defaults and every formatting check below silently measured the wrong style. Putting it before the slow steps means it fails in seconds instead of minutes. `--no-install` matters: without it, `npx` in non-interactive CI will quietly fetch a *different* Prettier major from the registry rather than failing, so the guard would pass while proving nothing about the Prettier that actually runs.
- **`npm run prettier`**, alongside the other lint steps, so formatting drift fails the build.

Plus the matching contributor note in `README.md`: the new `prettier:fix` script, the fact that formatting is now enforced in CI, where the style actually comes from, and the warning to keep the leading dot on `.prettierrc.js`.

**Both directions were verified rather than assumed** (the ticket asks for this explicitly):

| Condition | `npm run prettier` | Config guard |
| --- | --- | --- |
| Clean tree | exit 0 | exit 0 |
| Formatting-only edit introduced into a JS file | **exit 1**, naming that file | exit 0 |
| `.prettierrc.js` renamed back to the dotless form | — | **exit 1** |

**Why this is a separate PR:** the gate can only be added *after* the tree is clean, or it would fail on the very drift it is meant to prevent. Keeping it separate also keeps this diff small and reviewable next to the 55-file sweep, which is what the ticket asked for.

### Functional testing steps:

- [ ] CI (`Test` job / `.ci/test/static/run`) passes on this PR.
- [ ] Introduce a formatting-only change (e.g. add `var x = {a:1,   b:  "y"}` to any file under `web/profiles/custom`), push, and confirm CI **fails** on the `npm run prettier` step naming that file. Revert.
- [ ] Rename `.prettierrc.js` to `prettierrc.js`, push, and confirm CI fails fast on the `--find-config-path` step before reaching `code-sniff`. Revert.
- [ ] `README.md` renders correctly and the new note reads accurately.

### Builds on

- Builds on yalesites-org/YaleSites-Internal#1404 (PR yalesites-org/yalesites-project#1494) — this branch is stacked on that PR; please review/approve it first. GitHub will auto-retarget this PR to `develop` once it merges.

References yalesites-org/YaleSites-Internal#1404
