### PR TITLE
1579: AI Tester: run comparison reports zero citation overlap when the two runs are on different hostnames

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/Controller/AiTesterController.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/Controller/AiTesterController.php
@@ -521,14 +521,16 @@ class AiTesterController extends ControllerBase {
    * @param string|\Drupal\Component\Render\MarkupInterface $label
    *   The run label (e.g. a t() "Run A").
    * @param array $meta
-   *   The run meta: id, created, source_filename, status.
+   *   The run meta: id, created, source_filename, status, backend, host.
    *
    * @return array
    *   A #markup render element.
    */
   protected function runMetaBlock(string|MarkupInterface $label, array $meta): array {
+    $host = (string) ($meta['host'] ?? '');
+
     return $this->wrap('ys-compare-meta__run', $this->t(
-      '<strong>@label — Run #@id</strong><br>@date<br>File: @file<br>Assistant: @backend<br>Status: @status',
+      '<strong>@label — Run #@id</strong><br>@date<br>File: @file<br>Assistant: @backend<br>Status: @status<br>Host: @host',
       [
         '@label' => $label,
         '@id' => $meta['id'],
@@ -536,6 +538,10 @@ class AiTesterController extends ControllerBase {
         '@file' => $meta['source_filename'],
         '@backend' => $this->backendRegistry->labelFor($meta['backend']),
         '@status' => $meta['status'],
+        // Stated on every comparison, not only the cross-host ones: citation
+        // matching ignores this host, so a reader has to be able to see whether
+        // the two sides were answered on the same site at all.
+        '@host' => $host !== '' ? $host : $this->t('unknown (no citation named one)'),
       ]
     ));
   }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/RunComparator.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/RunComparator.php
@@ -82,6 +82,11 @@ class RunComparator {
     ];
     $b_pointers = [];
 
+    // Each side's own host, resolved once: it is what citation matching treats
+    // as noise, and what the run meta reports.
+    $host_a = $this->citationHost($results_a);
+    $host_b = $this->citationHost($results_b);
+
     // Walk A in order, pairing each question with the next unused B match.
     foreach ($results_a as $a) {
       $key = trim((string) $a['question']);
@@ -93,12 +98,12 @@ class RunComparator {
         $status = trim((string) $a['answer']) === trim((string) $b['answer'])
           ? 'identical'
           : 'differs';
-        $pairs[] = $this->buildPair($key, $a, $b, $status);
+        $pairs[] = $this->buildPair($key, $a, $b, $status, $host_a, $host_b);
         $summary['total_compared']++;
         $summary[$status === 'identical' ? 'identical' : 'differ']++;
       }
       else {
-        $pairs[] = $this->buildPair($key, $a, NULL, 'only_a');
+        $pairs[] = $this->buildPair($key, $a, NULL, 'only_a', $host_a, $host_b);
         $summary['only_a']++;
       }
     }
@@ -107,14 +112,14 @@ class RunComparator {
     // order; array_slice drops the prefix already consumed by matched pairs.
     foreach ($b_by_question as $key => $queue) {
       foreach (array_slice($queue, $b_pointers[$key] ?? 0) as $b) {
-        $pairs[] = $this->buildPair($key, NULL, $b, 'only_b');
+        $pairs[] = $this->buildPair($key, NULL, $b, 'only_b', $host_a, $host_b);
         $summary['only_b']++;
       }
     }
 
     return [
-      'run_a' => $this->metaArray($meta_a),
-      'run_b' => $this->metaArray($meta_b),
+      'run_a' => $this->metaArray($meta_a, $host_a),
+      'run_b' => $this->metaArray($meta_b, $host_b),
       'pairs' => $pairs,
       'summary' => $summary,
     ];
@@ -122,8 +127,24 @@ class RunComparator {
 
   /**
    * Builds one comparison pair for a question.
+   *
+   * @param string $question
+   *   The question text.
+   * @param array|null $a
+   *   Run A's result, or NULL when A did not ask this question.
+   * @param array|null $b
+   *   Run B's result, or NULL when B did not ask it.
+   * @param string $status
+   *   One of identical, differs, only_a, only_b.
+   * @param string $host_a
+   *   Run A's own host, the one its citation URLs are matched independently of.
+   * @param string $host_b
+   *   Run B's own host, likewise.
+   *
+   * @return array
+   *   The comparison pair.
    */
-  protected function buildPair(string $question, ?array $a, ?array $b, string $status): array {
+  protected function buildPair(string $question, ?array $a, ?array $b, string $status, string $host_a, string $host_b): array {
     $side_a = $a !== NULL ? $this->side($a) : NULL;
     $side_b = $b !== NULL ? $this->side($b) : NULL;
 
@@ -138,6 +159,8 @@ class RunComparator {
       'citation_overlap' => $this->overlap(
         $a['citations'] ?? [],
         $b['citations'] ?? [],
+        $host_a,
+        $host_b,
       ),
     ];
   }
@@ -170,25 +193,36 @@ class RunComparator {
   }
 
   /**
-   * Partitions two citation lists into shared and run-unique sources by URL.
+   * Partitions two citation lists into shared and run-unique sources.
+   *
+   * @param array $citations_a
+   *   Run A's citations for one question.
+   * @param array $citations_b
+   *   Run B's citations for the same question.
+   * @param string $host_a
+   *   Run A's own host, matched independently of.
+   * @param string $host_b
+   *   Run B's own host, likewise.
+   *
+   * @return array
+   *   The both, only_a and only_b partitions.
    */
-  protected function overlap(array $citations_a, array $citations_b): array {
-    $a_by_url = $this->indexByUrl($citations_a);
-    $b_by_url = $this->indexByUrl($citations_b);
+  protected function overlap(array $citations_a, array $citations_b, string $host_a, string $host_b): array {
+    $a_by_key = $this->indexByMatchKey($citations_a, $host_a);
+    $b_by_key = $this->indexByMatchKey($citations_b, $host_b);
 
     $both = $only_a = $only_b = [];
-    foreach ($a_by_url as $url => $citation) {
-      $entry = ['url' => $url, 'title' => (string) ($citation['title'] ?? '')];
-      if (isset($b_by_url[$url])) {
-        $both[] = $entry;
+    foreach ($a_by_key as $key => $citation) {
+      if (isset($b_by_key[$key])) {
+        $both[] = $this->overlapEntry($citation);
       }
       else {
-        $only_a[] = $entry;
+        $only_a[] = $this->overlapEntry($citation);
       }
     }
-    foreach ($b_by_url as $url => $citation) {
-      if (!isset($a_by_url[$url])) {
-        $only_b[] = ['url' => $url, 'title' => (string) ($citation['title'] ?? '')];
+    foreach ($b_by_key as $key => $citation) {
+      if (!isset($a_by_key[$key])) {
+        $only_b[] = $this->overlapEntry($citation);
       }
     }
 
@@ -196,27 +230,170 @@ class RunComparator {
   }
 
   /**
-   * Indexes citations by URL, keeping the first per URL and skipping empties.
+   * Reduces a citation to what the overlap partitions expose.
+   *
+   * The URL shown is the run's own, not the match key: a reader following a
+   * shared source needs a link that resolves, and the key has the run's own
+   * host stripped out.
    */
-  protected function indexByUrl(array $citations): array {
-    $by_url = [];
+  protected function overlapEntry(array $citation): array {
+    return [
+      'url' => (string) ($citation['url'] ?? ''),
+      'title' => (string) ($citation['title'] ?? ''),
+    ];
+  }
+
+  /**
+   * Indexes citations by match key, keeping the first per key.
+   *
+   * Two spellings of one source therefore fold to a single overlap entry, while
+   * the side's own 'retrieved' count still counts both.
+   *
+   * @param array $citations
+   *   One side's citations for a question.
+   * @param string $own_host
+   *   The run's own host, stripped from its citations' match keys.
+   *
+   * @return array
+   *   Citations keyed by match key.
+   */
+  protected function indexByMatchKey(array $citations, string $own_host): array {
+    $by_key = [];
     foreach ($citations as $citation) {
       // Sources without a URL are dropped from overlap: they cannot be matched
       // across runs. This intentionally diverges from CitationFormatter, which
       // keeps URL-less sources distinct for display.
-      $url = $citation['url'] ?? '';
+      // Trimmed because a stored citation_url reaches us through ai_search's
+      // HTML-to-Markdown conversion and RagRetriever::decodeStoredValue(),
+      // neither of which trims; padding would otherwise defeat every match and
+      // hide the host.
+      $url = trim((string) ($citation['url'] ?? ''));
       if ($url === '') {
         continue;
       }
-      $by_url[$url] ??= $citation;
+      $by_key[$this->citationMatchKey($url, $own_host)] ??= $citation;
     }
-    return $by_url;
+    return $by_key;
+  }
+
+  /**
+   * Reduces a citation URL to the identity two runs are matched on.
+   *
+   * The whole point of a run comparison is to hold the question set constant
+   * and vary the assistant, so the normal case is comparing a multidev or
+   * staging build against production -- two hosts serving the same content.
+   * Keying overlap on the full URL made every source differ by host, so no
+   * question ever reported a shared source.
+   *
+   * Only the run's **own** host is dropped, not every host. A run is not always
+   * confined to one site: a read-only borrowed index cites other sites'
+   * documents from their stored URLs, and a site querying the whole collection
+   * gets a deliberate mix of its own pages and foreign ones (see
+   * RagRetriever::buildStoredCitations() and buildMixedCitations()). Only the
+   * own host changes between a multidev and production, so it is the only noise
+   * here; dropping foreign hosts too would report siteA.yale.edu/about and
+   * siteB.yale.edu/about as one shared source, and "/about" is among the most
+   * common paths on the platform. A false shared source would corrupt exactly
+   * the number this fix exists to make trustworthy.
+   *
+   * Deliberately ignored: scheme, the own host (with any port or credentials),
+   * a trailing slash, percent-encoding, and the fragment -- a fragment
+   * addresses a place inside a source, not a different source. Deliberately
+   * kept: the query string, because it selects the resource on real Beacon
+   * citations such as /media/3359/download?inline.
+   *
+   * @param string $url
+   *   The citation URL as the run recorded it. May be relative.
+   * @param string $own_host
+   *   The host of the site this run was answered on. Empty when unknown, in
+   *   which case every host is treated as foreign and kept.
+   *
+   * @return string
+   *   The key two runs' citations are matched on.
+   */
+  protected function citationMatchKey(string $url, string $own_host): string {
+    $parts = parse_url($url);
+    if ($parts === FALSE) {
+      return $url;
+    }
+
+    // A foreign host stays in the key so it cannot be confused with the same
+    // path on the run's own site. Compared case-insensitively: hosts are.
+    $host = (string) ($parts['host'] ?? '');
+    $prefix = ($host === '' || ($own_host !== '' && strcasecmp($host, $own_host) === 0))
+      ? ''
+      : $host;
+
+    // Decoded so the percent-encoded and literal spellings of one path agree.
+    // This also decodes encoded delimiters, so /a%2Fb keys as /a/b and
+    // ?q=x%26y=z keys as ?q=x&y=z. Accepted rather than worked around: our
+    // citations come from Drupal routes and file URLs, which do not carry
+    // encoded delimiters, so no real citation reaches those collisions.
+    $path = rawurldecode($parts['path'] ?? '');
+    if ($path !== '/') {
+      $path = rtrim($path, '/');
+    }
+    $query = isset($parts['query']) ? '?' . rawurldecode($parts['query']) : '';
+    $key = $prefix . $path . $query;
+
+    // Nothing left to key on -- the run's own bare host, or something parse_url
+    // could not make sense of. Such a URL stays whole rather than being
+    // normalized: every one of them would otherwise collapse onto the same
+    // empty key and be reported as one shared source, and a false shared source
+    // misleads a reader worse than a missed one does. The cost is that a bare
+    // https://own-host does not match https://other-host/ even though both name
+    // a front page; real citations are page and file URLs that always carry a
+    // path, so that asymmetry is unreachable from actual run data.
+    return $key === '' ? $url : $key;
+  }
+
+  /**
+   * Finds the host a run was answered on.
+   *
+   * Runs do not record the site they ran against, so the host is read back off
+   * the citations. The most frequent one wins rather than the first: a run
+   * whose index is read-only or queried whole cites foreign sites alongside its
+   * own, so the first citation can name a site the run was not answered on, and
+   * that value both labels the run in the UI and decides which host citation
+   * matching treats as noise. Ties go to whichever host was seen first.
+   *
+   * @param array $results
+   *   The run's results, each with a 'citations' list.
+   *
+   * @return string
+   *   The host, or an empty string when no citation names one.
+   */
+  protected function citationHost(array $results): string {
+    $counts = [];
+    foreach ($results as $result) {
+      foreach ($result['citations'] ?? [] as $citation) {
+        $host = parse_url(trim((string) ($citation['url'] ?? '')), PHP_URL_HOST);
+        if (is_string($host) && $host !== '') {
+          $counts[$host] = ($counts[$host] ?? 0) + 1;
+        }
+      }
+    }
+    if ($counts === []) {
+      return '';
+    }
+    // PHP sorts are stable, so equal counts keep insertion order and a tie
+    // resolves to the host seen first.
+    arsort($counts, SORT_NUMERIC);
+    return (string) array_key_first($counts);
   }
 
   /**
    * Normalizes a run meta row to the keys the comparison exposes.
+   *
+   * @param array $meta
+   *   The run row loaded from storage.
+   * @param string $host
+   *   The host this run's citations point at, empty when none name one.
+   *
+   * @return array
+   *   The run meta the comparison exposes.
    */
-  protected function metaArray(array $meta): array {
+  protected function metaArray(array $meta, string $host): array {
     return [
       'id' => (int) $meta['id'],
       'created' => (int) $meta['created'],
@@ -225,6 +402,9 @@ class RunComparator {
       // Which assistant answered this side. Runs recorded before the tester
       // supported more than one read back as Beacon.
       'backend' => (string) ($meta['backend'] ?? AnswerBackendInterface::DEFAULT_ID),
+      // Citation overlap ignores this host when matching, so it has to be
+      // stated for the overlap figures to be interpretable.
+      'host' => $host,
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/templates/ys-ai-tester-ai-export.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/templates/ys-ai-tester-ai-export.html.twig
@@ -48,7 +48,7 @@ Attached is a JSON export of one comparison covering {{ question_count }} questi
 
 How the file is structured:
 
-- `run_a` and `run_b`: metadata for each run — `id`, `created` (Unix timestamp), `source_filename`, `status`, and `backend` (which assistant answered it).
+- `run_a` and `run_b`: metadata for each run — `id`, `created` (Unix timestamp), `source_filename`, `status`, `backend` (which assistant answered it), and `host` (the site its citations point at, empty when no citation named one).
 - `summary`: counts across the whole comparison — `total_compared`, `differ`, `identical`, `only_a`, `only_b`.
 - `pairs`: one entry per question, each containing:
   - `question`: the question text, the same on both sides.
@@ -56,7 +56,7 @@ How the file is structured:
   - `a` and `b`: that question's result for Run A and Run B, or `null` when the question was not asked in that run. Each side has `answer` (the answer text), `citations`, `len` (answer length in characters), `cited` (how many sources the answer referenced), `retrieved` (how many sources were retrieved), `empty`, and `error` (non-empty only when that side failed to answer).
     - `citations`: one entry per retrieved source, nested inside each side rather than on the question — `number`, `title`, `url`, `excerpt`, and `cited`.
   - `len_delta`: Run B's answer length minus Run A's, and `0` when the question was asked in only one run.
-  - `citation_overlap`: `both`, `only_a` and `only_b`, each a list of `{url, title}`, partitioning the two sides' sources by URL.
+  - `citation_overlap`: `both`, `only_a` and `only_b`, each a list of `{url, title}`, partitioning the two sides' sources. Sources are matched on path plus query string, ignoring the scheme, trailing slash, percent-encoding, fragment, and the run's own host (`run_a.host` / `run_b.host`) — so the same page counts as shared even when the two runs were answered on different hosts. A citation pointing at a *different* site keeps its host in the comparison, so one site's `/about` is never treated as another site's `/about`. The `url` shown is the citing run's own, so a `both` entry carries Run A's host.
 
 Three things to keep in mind while reading it:
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterCompareRenderTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterCompareRenderTest.php
@@ -50,13 +50,14 @@ class AiTesterCompareRenderTest extends UnitTestCase {
   /**
    * A run meta entry as produced by RunComparator::metaArray().
    */
-  protected function runMeta(int $id, string $file, string $backend = 'beacon'): array {
+  protected function runMeta(int $id, string $file, string $backend = 'beacon', string $host = 'example.yale.edu'): array {
     return [
       'id' => $id,
       'created' => $id * 1000,
       'source_filename' => $file,
       'status' => 'complete',
       'backend' => $backend,
+      'host' => $host,
     ];
   }
 
@@ -560,6 +561,69 @@ class AiTesterCompareRenderTest extends UnitTestCase {
 
     $this->assertStringContainsString('Operation timed out', $meta);
     $this->assertStringNotContainsString('Empty answer', $meta);
+  }
+
+  /**
+   * Builds the comparison header for two runs answered on the given hosts.
+   */
+  protected function metaBlocksFor(string $host_a, string $host_b): array {
+    $data = $this->comparisonOf('beacon', 'beacon', $this->side('B answer.', 1, 1, FALSE));
+    $data['run_a'] = $this->runMeta(2, 'a.txt', 'beacon', $host_a);
+    $data['run_b'] = $this->runMeta(3, 'a.txt', 'beacon', $host_b);
+
+    $build = $this->controllerReturning($data)->compare(2, 3);
+
+    return [
+      (string) $build['meta']['a']['#markup'],
+      (string) $build['meta']['b']['#markup'],
+    ];
+  }
+
+  /**
+   * Each run's header states the host it was answered on.
+   *
+   * Citation overlap is matched independently of the run's own host, so the
+   * overlap figures are only interpretable if the reader can see whether the
+   * two sides ran against the same site.
+   *
+   * @covers ::runMetaBlock
+   */
+  public function testRunMetaBlockShowsEachRunsHost(): void {
+    [$meta_a, $meta_b] = $this->metaBlocksFor(
+      'v2260-sitea-yale-edu.pantheonsite.io',
+      'sitea.yale.edu',
+    );
+
+    $this->assertStringContainsString('Host: v2260-sitea-yale-edu.pantheonsite.io', $meta_a);
+    $this->assertStringContainsString('Host: sitea.yale.edu', $meta_b);
+  }
+
+  /**
+   * A run whose citations name no host says so rather than showing a blank.
+   *
+   * @covers ::runMetaBlock
+   */
+  public function testRunMetaBlockReportsAnUnknownHost(): void {
+    [$meta_a] = $this->metaBlocksFor('', 'sitea.yale.edu');
+
+    $this->assertStringContainsString('unknown (no citation named one)', $meta_a);
+  }
+
+  /**
+   * The host is escaped on the way into the header.
+   *
+   * It is derived from a citation URL, which on a borrowed index came from
+   * another site's stored field, so it is not ours to trust. parse_url really
+   * does return a host containing markup for a URL shaped like this one, so
+   * this is a reachable input rather than a contrived one.
+   *
+   * @covers ::runMetaBlock
+   */
+  public function testRunMetaBlockEscapesTheHost(): void {
+    [$meta_a] = $this->metaBlocksFor('<script>alert(1)</script>', 'sitea.yale.edu');
+
+    $this->assertStringNotContainsString('<script>', $meta_a);
+    $this->assertStringContainsString('&lt;script&gt;', $meta_a);
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/RunComparatorTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/RunComparatorTest.php
@@ -307,4 +307,434 @@ class RunComparatorTest extends UnitTestCase {
     $this->assertSame('beacon', $out['run_b']['backend']);
   }
 
+  /**
+   * Returns the overlap partition for a one-question, two-sided comparison.
+   *
+   * Every host-normalization case below asks the same question of the same
+   * shape of input, so the setup lives here rather than in each test.
+   */
+  protected function overlapOf(array $urls_a, array $urls_b): array {
+    $cite = fn (array $urls): array => array_map(
+      fn (string $url): array => $this->citation($url, 'T', TRUE),
+      $urls,
+    );
+
+    $out = $this->comparator->compareResults(
+      $this->meta(1),
+      $this->meta(2),
+      [$this->result('Q1', 'a', $cite($urls_a))],
+      [$this->result('Q1', 'b', $cite($urls_b))],
+    );
+
+    return $out['pairs'][0]['citation_overlap'];
+  }
+
+  /**
+   * The reported bug: the same source on two hosts counted as no overlap.
+   *
+   * Comparing a multidev against production is the normal case for this tool,
+   * and before normalization every URL differed by host, so `both` was empty on
+   * every question. The URLs here are the ones from the report.
+   *
+   * @covers ::compareResults
+   */
+  public function testCitationOverlapMatchesTheSameSourceAcrossHostnames(): void {
+    $overlap = $this->overlapOf(
+      ['https://v2260-ys-gatewayassist-yale-edu.pantheonsite.io/sites/default/files/2026-06/guide.pdf'],
+      ['https://gatewayassist.yale.edu/sites/default/files/2026-06/guide.pdf'],
+    );
+
+    $this->assertCount(1, $overlap['both']);
+    $this->assertSame([], $overlap['only_a']);
+    $this->assertSame([], $overlap['only_b']);
+  }
+
+  /**
+   * A shared source is displayed with a real URL, not the internal match key.
+   *
+   * @covers ::compareResults
+   */
+  public function testSharedSourceIsDisplayedWithItsOriginalUrl(): void {
+    $overlap = $this->overlapOf(
+      ['https://staging.example.edu/about'],
+      ['https://www.example.edu/about'],
+    );
+
+    $this->assertSame(
+      ['https://staging.example.edu/about'],
+      array_column($overlap['both'], 'url'),
+    );
+    $this->assertSame(['T'], array_column($overlap['both'], 'title'));
+  }
+
+  /**
+   * A scheme change alone is not a different source.
+   *
+   * @covers ::compareResults
+   */
+  public function testCitationOverlapIgnoresTheScheme(): void {
+    $overlap = $this->overlapOf(
+      ['http://example.edu/about'],
+      ['https://example.edu/about'],
+    );
+
+    $this->assertCount(1, $overlap['both']);
+  }
+
+  /**
+   * A trailing slash is not part of a source's identity.
+   *
+   * @covers ::compareResults
+   */
+  public function testCitationOverlapIgnoresTrailingSlashes(): void {
+    $overlap = $this->overlapOf(
+      ['https://a.example.edu/about/'],
+      ['https://b.example.edu/about'],
+    );
+
+    $this->assertCount(1, $overlap['both']);
+  }
+
+  /**
+   * Percent-encoded and literal spellings of one path are the same source.
+   *
+   * @covers ::compareResults
+   */
+  public function testCitationOverlapNormalisesPercentEncoding(): void {
+    $overlap = $this->overlapOf(
+      ['https://a.example.edu/files/Supplier%20Guide.pdf'],
+      ['https://b.example.edu/files/Supplier Guide.pdf'],
+    );
+
+    $this->assertCount(1, $overlap['both']);
+  }
+
+  /**
+   * A fragment addresses a place inside a source, not a different source.
+   *
+   * @covers ::compareResults
+   */
+  public function testCitationOverlapIgnoresTheFragment(): void {
+    $overlap = $this->overlapOf(
+      ['https://a.example.edu/policies#section-3'],
+      ['https://b.example.edu/policies'],
+    );
+
+    $this->assertCount(1, $overlap['both']);
+  }
+
+  /**
+   * A relative citation matches the absolute form of the same path.
+   *
+   * @covers ::compareResults
+   */
+  public function testCitationOverlapMatchesRelativeAndAbsoluteForms(): void {
+    $overlap = $this->overlapOf(
+      ['/about/leadership'],
+      ['https://example.edu/about/leadership'],
+    );
+
+    $this->assertCount(1, $overlap['both']);
+  }
+
+  /**
+   * The query string stays significant: it can select a different resource.
+   *
+   * `/media/3359/download?inline` is a real Beacon citation shape, so dropping
+   * the query would merge genuinely distinct sources.
+   *
+   * @covers ::compareResults
+   */
+  public function testCitationOverlapKeepsTheQueryStringSignificant(): void {
+    $overlap = $this->overlapOf(
+      ['https://a.example.edu/media/3359/download?inline'],
+      ['https://b.example.edu/media/3359/download?attachment'],
+    );
+
+    $this->assertSame([], $overlap['both']);
+    $this->assertCount(1, $overlap['only_a']);
+    $this->assertCount(1, $overlap['only_b']);
+  }
+
+  /**
+   * Two different paths on one host stay distinct — no over-matching.
+   *
+   * @covers ::compareResults
+   */
+  public function testCitationOverlapKeepsDifferentPathsDistinct(): void {
+    $overlap = $this->overlapOf(
+      ['https://example.edu/about', 'https://example.edu/contact'],
+      ['https://example.edu/about'],
+    );
+
+    $this->assertSame(
+      ['https://example.edu/about'],
+      array_column($overlap['both'], 'url'),
+    );
+    $this->assertSame(
+      ['https://example.edu/contact'],
+      array_column($overlap['only_a'], 'url'),
+    );
+  }
+
+  /**
+   * A URL with no path keeps its full value rather than matching every other.
+   *
+   * This is the guard against the worst failure mode: without it every
+   * path-less URL would normalize to the same empty key and a whole run's
+   * worth of unrelated sources would be reported as shared. It is also what
+   * keeps the pre-existing partition test's bare-host sources distinct.
+   *
+   * @covers ::compareResults
+   */
+  public function testCitationOverlapDoesNotMatchTwoBareHosts(): void {
+    $overlap = $this->overlapOf(
+      ['https://a.example.edu'],
+      ['https://b.example.edu'],
+    );
+
+    $this->assertSame([], $overlap['both']);
+    $this->assertCount(1, $overlap['only_a']);
+    $this->assertCount(1, $overlap['only_b']);
+  }
+
+  /**
+   * Several path-less URLs in one run stay distinct from each other.
+   *
+   * The dangerous shape is not two runs but one: three sources collapsing onto
+   * a single key would silently drop two of them from the partition.
+   *
+   * @covers ::compareResults
+   */
+  public function testCitationOverlapKeepsSeveralPathlessUrlsDistinct(): void {
+    $overlap = $this->overlapOf(
+      ['http://x', 'http://y'],
+      ['http://x', 'http://z'],
+    );
+
+    $this->assertSame(['http://x'], array_column($overlap['both'], 'url'));
+    $this->assertSame(['http://y'], array_column($overlap['only_a'], 'url'));
+    $this->assertSame(['http://z'], array_column($overlap['only_b'], 'url'));
+  }
+
+  /**
+   * Each run reports the host its citations came from.
+   *
+   * A cross-host comparison is only readable if the reader can see that is
+   * what they are looking at.
+   *
+   * @covers ::compareResults
+   */
+  public function testRunMetaExposesEachRunsCitationHost(): void {
+    $out = $this->comparator->compareResults(
+      $this->meta(1),
+      $this->meta(2),
+      [
+        $this->result('Q1', 'a', [
+          // A source without a URL cannot name a host; the next one can.
+          $this->citation('', 'NoUrl', TRUE),
+          $this->citation('https://v2260-ys-gatewayassist-yale-edu.pantheonsite.io/x', 'X', TRUE),
+        ]),
+      ],
+      [
+        $this->result('Q1', 'b', [
+          $this->citation('https://gatewayassist.yale.edu/x', 'X', TRUE),
+        ]),
+      ],
+    );
+
+    $this->assertSame('v2260-ys-gatewayassist-yale-edu.pantheonsite.io', $out['run_a']['host']);
+    $this->assertSame('gatewayassist.yale.edu', $out['run_b']['host']);
+  }
+
+  /**
+   * A foreign site's page is never confused with the run's own same-named page.
+   *
+   * A read-only or whole-collection index cites other sites alongside this one,
+   * so one run legitimately holds both. Only the run's own host is noise; a
+   * foreign host stays in the key. '/about' is among the most common paths on
+   * the platform, so collapsing the two would be a high-rate false match.
+   *
+   * @covers ::compareResults
+   */
+  public function testCitationOverlapKeepsForeignSitesDistinctFromTheOwnSite(): void {
+    $overlap = $this->overlapOf(
+      [
+        // Two own-site citations, so the run's own host is unambiguous.
+        'https://sitea.yale.edu/about',
+        'https://sitea.yale.edu/directory',
+        // A borrowed chunk from a different site that shares a path.
+        'https://siteb.yale.edu/about',
+      ],
+      ['https://sitea.yale.edu/directory'],
+    );
+
+    $this->assertSame(
+      ['https://sitea.yale.edu/directory'],
+      array_column($overlap['both'], 'url'),
+    );
+    // The own /about and the foreign /about are both unmatched, and crucially
+    // they are two entries rather than one collapsed one.
+    $this->assertSame(
+      ['https://sitea.yale.edu/about', 'https://siteb.yale.edu/about'],
+      array_column($overlap['only_a'], 'url'),
+    );
+  }
+
+  /**
+   * A cross-host comparison still matches its foreign sources.
+   *
+   * The multidev-vs-production case with a borrowed source in the mix: the own
+   * host differs between the runs and is dropped on each side, while the
+   * foreign host is identical on both sides and matches as it stands.
+   *
+   * @covers ::compareResults
+   */
+  public function testCitationOverlapMatchesOwnAndForeignSourcesAcrossHosts(): void {
+    $overlap = $this->overlapOf(
+      [
+        'https://v2260-sitea-yale-edu.pantheonsite.io/about',
+        'https://v2260-sitea-yale-edu.pantheonsite.io/directory',
+        'https://siteb.yale.edu/policies',
+      ],
+      [
+        'https://sitea.yale.edu/about',
+        'https://sitea.yale.edu/directory',
+        'https://siteb.yale.edu/policies',
+      ],
+    );
+
+    $this->assertCount(3, $overlap['both']);
+    $this->assertSame([], $overlap['only_a']);
+    $this->assertSame([], $overlap['only_b']);
+  }
+
+  /**
+   * Surrounding whitespace does not defeat a match.
+   *
+   * A stored citation_url arrives through ai_search's HTML-to-Markdown
+   * conversion and RagRetriever::decodeStoredValue(), neither of which trims,
+   * so padding is reachable from real data. Untrimmed, a leading space also
+   * stops parse_url finding a host at all.
+   *
+   * @covers ::compareResults
+   */
+  public function testCitationOverlapIgnoresSurroundingWhitespace(): void {
+    $overlap = $this->overlapOf(
+      ["  https://a.example.edu/about\n"],
+      ['https://b.example.edu/about'],
+    );
+
+    $this->assertCount(1, $overlap['both']);
+  }
+
+  /**
+   * Two spellings of one source in a single run fold to one overlap entry.
+   *
+   * Pinned deliberately rather than left implicit: the side's own 'retrieved'
+   * count still counts both, so a reader comparing the two numbers on screen
+   * should be able to rely on this difference being intended.
+   *
+   * @covers ::compareResults
+   */
+  public function testCitationOverlapFoldsTwoSpellingsWithinOneRun(): void {
+    $out = $this->comparator->compareResults(
+      $this->meta(1),
+      $this->meta(2),
+      [
+        $this->result('Q1', 'a', [
+          $this->citation('https://a.example.edu/about', 'T', TRUE),
+          $this->citation('https://a.example.edu/about/', 'T', TRUE),
+        ]),
+      ],
+      [
+        $this->result('Q1', 'b', [
+          $this->citation('https://b.example.edu/about', 'T', TRUE),
+        ]),
+      ],
+    );
+
+    $this->assertCount(1, $out['pairs'][0]['citation_overlap']['both']);
+    $this->assertSame(2, $out['pairs'][0]['a']['retrieved']);
+  }
+
+  /**
+   * An encoded delimiter decodes, which is an accepted collision.
+   *
+   * Documented in citationMatchKey() as a tradeoff rather than a defect: our
+   * citations come from Drupal routes and file URLs, which never carry one.
+   * This test exists so that changing the tradeoff has to be deliberate.
+   *
+   * @covers ::compareResults
+   */
+  public function testCitationOverlapTreatsAnEncodedSlashAsLiteral(): void {
+    $overlap = $this->overlapOf(
+      ['https://a.example.edu/files/a%2Fb'],
+      ['https://b.example.edu/files/a/b'],
+    );
+
+    $this->assertCount(1, $overlap['both']);
+  }
+
+  /**
+   * A run with no absolute citation URLs reports no host rather than guessing.
+   *
+   * @covers ::compareResults
+   */
+  public function testRunMetaHostIsEmptyWhenNoCitationNamesOne(): void {
+    $out = $this->comparator->compareResults(
+      $this->meta(1),
+      $this->meta(2),
+      [$this->result('Q1', 'a', [$this->citation('/relative/only', 'R', TRUE)])],
+      [$this->result('Q1', 'b')],
+    );
+
+    $this->assertSame('', $out['run_a']['host']);
+    $this->assertSame('', $out['run_b']['host']);
+  }
+
+  /**
+   * The run's host is the one it cites most, not the one it cites first.
+   *
+   * On a borrowed or whole-collection index a foreign site can rank first, and
+   * this value both labels the run in the UI and decides which host citation
+   * matching treats as noise -- so a confidently wrong host is worse than none.
+   *
+   * @covers ::compareResults
+   */
+  public function testRunMetaHostIsTheMostFrequentlyCitedHost(): void {
+    $out = $this->comparator->compareResults(
+      $this->meta(1),
+      $this->meta(2),
+      [
+        $this->result('Q1', 'a', [
+          // A borrowed source ranks first, but the run is not answered on it.
+          $this->citation('https://borrowed.yale.edu/policies', 'B', TRUE),
+          $this->citation('https://own.yale.edu/about', 'O', TRUE),
+          $this->citation('https://own.yale.edu/directory', 'O', TRUE),
+        ]),
+      ],
+      [$this->result('Q1', 'b')],
+    );
+
+    $this->assertSame('own.yale.edu', $out['run_a']['host']);
+  }
+
+  /**
+   * A source only Run B retrieved is reported with Run B's own URL.
+   *
+   * @covers ::compareResults
+   */
+  public function testSourceOnlyInSecondRunKeepsItsOwnUrl(): void {
+    $overlap = $this->overlapOf(
+      ['https://staging.example.edu/about'],
+      ['https://www.example.edu/about', 'https://www.example.edu/news'],
+    );
+
+    $this->assertSame(
+      ['https://www.example.edu/news'],
+      array_column($overlap['only_b'], 'url'),
+    );
+  }
+
 }


### PR DESCRIPTION
## [1579: AI Tester: run comparison reports zero citation overlap when the two runs are on different hostnames](https://github.com/yalesites-org/YaleSites-Internal/issues/1579)

### Description of work

- Citation overlap in the run comparison was keyed on the **full citation URL**, so comparing a multidev against production — the normal case for this tool — made every source differ by host and `citation_overlap.both` came back empty on **every** question. The 149-question Beacon vs legacy comparison read as `"differ": 149, "identical": 0` with no shared sources, when the two systems actually share sources on ~141 of those questions.
- Citations are now matched on **path plus query string**. Ignored: the scheme, a trailing slash, percent-encoding, and the fragment (a fragment addresses a place *inside* a source, not a different source). **Kept: the query string**, because real Beacon citations use it to select the resource — `/media/3359/download?inline` is a live example — so dropping it would merge genuinely distinct sources.
- **Only the run's own host is dropped, not every host.** This is the part worth reviewing closely. A run is *not* always confined to one site: `RagRetriever::buildStoredCitations()` cites other sites' documents from their stored URLs when the index is read-only, and `buildMixedCitations()` returns a deliberate mix of this site's pages and foreign ones when `query_entire_index` is set. Only the *own* host changes between a multidev and production, so it is the only noise here — dropping foreign hosts too would report `siteA.yale.edu/about` and `siteB.yale.edu/about` as one shared source, and `/about` is among the most common paths on the platform. That would corrupt the very number this PR exists to make trustworthy.
- The run's own host is resolved as the **most frequently cited** host rather than the first one seen, so a borrowed source that happens to rank first cannot mislabel the run (and cannot cause the wrong host to be stripped).
- Each run's host is now surfaced in the comparison header and in the JSON/AI export's `run_a.host` / `run_b.host`, because the overlap figures are only interpretable next to it. It is shown on every comparison, not just cross-host ones, so a reader can tell whether the two sides ran against the same site at all.
- Citation URLs are trimmed before matching: a stored `citation_url` reaches us through ai_search's HTML-to-Markdown conversion and `RagRetriever::decodeStoredValue()`, neither of which trims, and untrimmed padding both defeats the match and hides the host from `parse_url()`.
- Tests: **+23** unit tests (`ys_ai_tester` Unit suite 114 → 137, all green). These include the exact gatewayassist URL pair from the issue, and deliberate negative controls against over-matching — a foreign site's `/about` staying distinct from the own site's `/about`, several path-less URLs staying distinct, and the query string staying significant. The `Host:` line has render coverage including an escaping assertion.

**Two decisions the issue explicitly left open, both answered in code comments with rationale:**

1. *Should query strings and fragments participate in the match?* Fragment no, query yes (see above). Query parameters are deliberately **not** sorted, so `?a=1&b=2` still differs from `?b=2&a=1` — not worth the machinery for a case that has not come up.
2. *Is matching on path alone too loose?* Yes, it would have been — hence own-host-only stripping rather than dropping the host entirely.

**Known, documented trade-off:** decoding the path also decodes encoded delimiters, so `/a%2Fb` matches `/a/b`. Our citations come from Drupal routes and file URLs, which never carry one, so it is unreachable from real data. There is a test pinning it so any future change to that behaviour has to be deliberate.

### Reviewer notes — what could not be verified locally

- **No live-site verification was possible.** Lando serves only the main checkout, which is on `develop`, so the running site never contained this change. The behaviour is covered by unit tests only. `ys_ai_tester` is also not installed in the local integration DB (`ys_ai_tester_run` does not exist there), so the comparison page has no runs to render locally.
- **The issue's "re-run the comparison of runs #4 and #5 and confirm 141 of 149" criterion is UNVERIFIED** and is the one acceptance criterion left open. Those runs live in the database of the environment they were executed against, not in the integration DB, so nothing local can reproduce that figure. It needs a check on the environment that holds runs #4 and #5 — see the first functional testing step.
- `ys_beacon`'s Kernel suite was not completed: no Kernel test references `RunComparator` or `ys_ai_tester` (verified by grep), so it cannot be affected, and a concurrent run of the same suite by another process made it unreliable to gate on. Full `phpcs` `Drupal` **and** `DrupalPractice` over the whole custom tree exit 0, and `.ci/test/static/lint_php` exits 0.

### Functional testing steps:

- [ ] On the environment that holds AI Tester runs **#4 and #5**, open their comparison. `citation_overlap.both` should now be populated instead of empty on every question, with shared sources on roughly **141 of the 149** questions (previously 0).
- [ ] Confirm each run's panel in the comparison header shows a **`Host:`** line, and that the two hosts differ for a multidev-vs-production comparison.
- [ ] Compare two runs answered on the **same** host and confirm the overlap figures are unchanged from before this PR — no regression to the same-host case.
- [ ] Download the JSON export and confirm `run_a.host` and `run_b.host` are present, and that `citation_overlap.both` entries still carry a **resolvable** URL (the citing run's own, so a `both` entry carries Run A's host).
- [ ] If a site with a read-only or whole-collection Beacon index is available, confirm a borrowed citation from a different site is **not** reported as shared with a same-path page on the site under test.

References yalesites-org/YaleSites-Internal#1579
