### PR TITLE
Hotfix: upgrade drupal/core to 10.6.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
   "require": {
     "composer/installers": "^1.9",
     "cweagans/composer-patches": "^1.7",
-    "drupal/core-composer-scaffold": "10.6.13",
-    "drupal/core-project-message": "10.6.13",
-    "drupal/core-recommended": "10.6.13",
+    "drupal/core-composer-scaffold": "10.6.15",
+    "drupal/core-project-message": "10.6.15",
+    "drupal/core-recommended": "10.6.15",
     "drush/drush": "^13",
     "league/commonmark": "^2.0",
     "pantheon-systems/drupal-integrations": "^10",


### PR DESCRIPTION
## Hotfix: upgrade drupal/core to 10.6.15

### Description of work

**The problem**

Pantheon Integrated Composer runs `composer audit` during environment builds and
cancels the workflow when it fails. This is currently blocking creation of new test
environments. The failing dependency is `guzzlehttp/guzzle`, which resolves to
`7.12.x-dev` (branch commit `9aa17bc`) and is affected by six advisories, one rated
**high**:

| Severity | CVE | Advisory | Fixed in |
|---|---|---|---|
| High | CVE-2026-69246 | [Noncanonical host can bypass host-based checks](https://github.com/advisories/GHSA-v5mv-p594-2x33) | 7.15.2 |
| Medium | CVE-2026-69245 | [Noncanonical cookie domain keeps subdomain scope](https://github.com/advisories/GHSA-f7vp-7xgx-4w4r) | 7.15.2 |
| Medium | CVE-2026-67354 | [URI fragments disclosed in redirect Referer headers](https://github.com/advisories/GHSA-h95v-h523-3mw8) | 7.15.1 |
| Medium | CVE-2026-67355 | [Host-only cookie scope is not preserved](https://github.com/advisories/GHSA-wm3w-8rrp-j577) | 7.15.1 |
| Medium | CVE-2026-67353 | [Unbounded response cookies risk denial of service](https://github.com/advisories/GHSA-f283-ghqc-fg79) | 7.15.1 |
| Medium | CVE-2026-67339 | [Proxy-Authorization headers can be sent to origin servers](https://github.com/advisories/GHSA-94pj-82f3-465w) | 7.14.2 |

**Why updating Guzzle directly does not work**

Guzzle's version here is dictated by core, not by a root constraint:

- `drupal/core-recommended` **10.6.13** pins `guzzlehttp/guzzle` to `~7.12.1` → `>=7.12.1 <7.13.0`
- The advisories require **>= 7.15.2**

So no lock derived from core 10.6.13 can satisfy the audit, and updating the package
on its own is a no-op:

```
$ composer update guzzlehttp/guzzle --dry-run
Nothing to modify in lock file
  - Installing guzzlehttp/guzzle (7.12.x-dev 9aa17bc)
```

Core has to move first.
[10.6.14](https://www.drupal.org/project/drupal/releases/10.6.14) relaxed the pin to
`~7.15.1`, and [10.6.15](https://www.drupal.org/project/drupal/releases/10.6.15)
drops the Guzzle pin from `core-recommended` altogether, letting it resolve to the
latest stable release.

**The fix**

Bumps the three core pins in `composer.json` from `10.6.13` to `10.6.15`:

- `drupal/core-composer-scaffold`
- `drupal/core-project-message`
- `drupal/core-recommended`

This moves Guzzle off a dev-branch commit and onto
[7.15.3](https://github.com/guzzle/guzzle/releases/tag/7.15.3) — a tagged stable
release past the [7.15.2](https://github.com/guzzle/guzzle/releases/tag/7.15.2) fix
threshold — clearing all six advisories.

Resolution is tight: 11 packages change, all patch or minor.

```
drupal/core                      10.6.13    -> 10.6.15
drupal/core-composer-scaffold    10.6.13    -> 10.6.15
drupal/core-project-message      10.6.13    -> 10.6.15
drupal/core-recommended          10.6.13    -> 10.6.15
guzzlehttp/guzzle                7.12.x-dev -> 7.15.3
guzzlehttp/psr7                  2.12.5     -> 2.13.0
twig/twig                        v3.27.1    -> v3.28.0
symfony/polyfill-intl-grapheme   v1.37.0    -> v1.41.0
symfony/polyfill-intl-normalizer v1.37.0    -> v1.38.0
symfony/polyfill-mbstring        v1.37.0    -> v1.38.2
symfony/polyfill-php83           v1.37.0    -> v1.41.0
```

### Functional testing steps:
- [ ] `lando composer install` completes without resolution errors
- [ ] `composer show drupal/core` reports `10.6.15`; `composer show guzzlehttp/guzzle` reports `7.15.3`
- [ ] `composer audit --locked` reports no `guzzlehttp/guzzle` advisories
- [ ] `lando drush status` reports Drupal `10.6.15` with a clean bootstrap
- [ ] `lando drush deploy` runs cleanly (config import + `updatedb`)
- [ ] Smoke-test outbound-HTTP integrations, since Guzzle is the HTTP client: Localist events sync, CampusGroups sync, ServiceNow, CAS login
- [ ] Smoke-test core content editing: node create/edit, Layout Builder, media upload
- [ ] **A Pantheon test environment can be created without the workflow being cancelled**
