### PR TITLE
1587: Bug: AI Tester marks long runs as failed when a single question hits a transient upstream error

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/install/ys_beacon.settings.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/install/ys_beacon.settings.yml
@@ -80,3 +80,20 @@ fallback_system_prompt: |-
   - Support accessibility through clear communication
   - Prioritize helping users accomplish their goals efficiently
 guardrail_supplement: ''
+# Milliseconds the AI Tester pauses between questions. The tester is the only
+# path that issues a long burst of upstream requests - the chat widget answers
+# one question per visitor - so pacing lives here rather than in the shared
+# provider. Small by default because each question already costs seconds of
+# model latency; raise it if an upstream per-minute ceiling is suspected. Clamped
+# to 0-10000 by AiTesterRetry::questionDelayMs(); 0 disables pacing.
+#
+# Read and written only by the ys_ai_tester submodule, which is a deliberate
+# exception to keeping a module's settings in its own config object. It lives
+# here because this object is covered by the 'ys_beacon*' config_ignore pattern
+# and is therefore absent from the profile's config/sync: a value an operator
+# tunes during an incident survives the next `drush deploy` config import. A
+# ys_ai_tester.settings object would be exported and re-imported instead,
+# resetting the knob on every deploy unless a second ignore pattern were added
+# to chase it. Being here also means _ys_beacon_seed_settings() backfills this
+# default on existing sites for free, since it unions the whole shipped file.
+ai_tester_question_delay_ms: 500

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/schema/ys_beacon.schema.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/config/schema/ys_beacon.schema.yml
@@ -77,3 +77,6 @@ ys_beacon.settings:
     guardrail_supplement:
       type: text
       label: 'Site-specific additions to the platform guardrail'
+    ai_tester_question_delay_ms:
+      type: integer
+      label: 'Milliseconds the AI Tester pauses between questions'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/AiTesterBatch.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/AiTesterBatch.php
@@ -36,13 +36,15 @@ class AiTesterBatch {
     $citations = [];
     $error = '';
 
+    self::pace($delta);
+
     try {
       $backend = \Drupal::service('ys_ai_tester.answer_backend_registry')
         ->getAvailable($backend_id);
       if ($backend === NULL) {
         throw new \RuntimeException(sprintf('The "%s" assistant is not available on this site.', $backend_id));
       }
-      $result = $backend->answer($question);
+      $result = self::answerWithRetry($backend, $question, $run_id, $delta, $backend_id);
       $answer = $result['answer'];
       // Normalizing here rather than in each backend is what makes the stored
       // shape uniform: the formatter owns marker parsing, de-duplication, and
@@ -53,17 +55,24 @@ class AiTesterBatch {
         ->format($answer, $result['citations']);
     }
     catch (\Throwable $e) {
+      // The row stores the plain message, which is what the run view shows in
+      // its per-question error cell. The log gets the full detail instead:
+      // status code, correlation headers, and the response body these clients
+      // otherwise discard.
       $error = $e->getMessage();
       \Drupal::logger('ys_ai_tester')->error(
-        'AI tester error on run @run question @delta (@backend): @msg',
+        'AI tester error on run @run question @delta (@backend): @detail',
         [
           '@run' => $run_id,
           '@delta' => $delta,
           '@backend' => $backend_id,
-          '@msg' => $error,
+          '@detail' => AiTesterFailure::describe($e),
         ]
       );
-      $context['results']['errors'][] = "Question {$delta}: " . $error;
+      // Keyed by delta so a question whose answer and whose DB write both fail
+      // is still one failed question, not two — an inflated count would push a
+      // partial run over into 'failed'.
+      $context['results']['failed_deltas'][$delta] = $delta;
     }
 
     try {
@@ -83,11 +92,147 @@ class AiTesterBatch {
         'AI tester DB write failed on run @run question @delta: @msg',
         ['@run' => $run_id, '@delta' => $delta, '@msg' => $e->getMessage()]
       );
-      $context['results']['errors'][] = "Question {$delta}: DB write failed.";
+      $context['results']['failed_deltas'][$delta] = $delta;
     }
 
     $context['results']['run_id'] = $run_id;
+    // Counted here rather than derived from the run's question_count, so the
+    // status a partly-processed batch reports describes what actually ran.
+    $context['results']['processed'] = ($context['results']['processed'] ?? 0) + 1;
     $context['message'] = t('Processing question @num...', ['@num' => $delta + 1]);
+  }
+
+  /**
+   * Asks one question, retrying only failures that a retry could clear.
+   *
+   * A run against both assistants makes roughly 200 back-to-back calls to
+   * outside services. At that volume a transient fault somewhere is more likely
+   * than not, and without this every one of them permanently failed a question
+   * and marked the whole run failed.
+   *
+   * @param \Drupal\ys_ai_tester\AnswerBackendInterface $backend
+   *   The assistant answering.
+   * @param string $question
+   *   The question text.
+   * @param int $run_id
+   *   The run ID, for logging.
+   * @param int $delta
+   *   Position of this question within the run, for logging.
+   * @param string $backend_id
+   *   The assistant id, for logging.
+   *
+   * @return array
+   *   The backend's ['answer', 'citations'] result.
+   *
+   * @throws \Throwable
+   *   The last failure, when attempts are exhausted or the failure is one that
+   *   retrying cannot clear.
+   */
+  protected static function answerWithRetry(AnswerBackendInterface $backend, string $question, int $run_id, int $delta, string $backend_id): array {
+    $waited_ms = 0;
+
+    for ($attempt = 1;; $attempt++) {
+      try {
+        return $backend->answer($question);
+      }
+      catch (\Throwable $e) {
+        // A deterministic failure — a filtered completion, a malformed request,
+        // a missing assistant — fails identically however many times it is
+        // sent, so it is surfaced on the first attempt rather than the third.
+        if ($attempt >= AiTesterRetry::MAX_ATTEMPTS || !AiTesterFailure::isTransient($e)) {
+          throw $e;
+        }
+
+        $wait_ms = AiTesterRetry::backoffMs(
+          $attempt,
+          AiTesterFailure::retryAfterMs($e),
+          AiTesterRetry::jitter()
+        );
+
+        // A gateway can ask to be retried later than this question can afford
+        // to wait. Giving up on the question is the smaller loss: sleeping past
+        // the platform's request ceiling would have the whole batch request
+        // killed, losing every question still queued behind this one.
+        if (!AiTesterRetry::withinWaitBudget($waited_ms, $wait_ms)) {
+          throw $e;
+        }
+        $waited_ms += $wait_ms;
+
+        // Logged even though the retry may succeed: a run that only passes on
+        // its second attempt is a warning that an upstream ceiling is close,
+        // and that is worth seeing before it starts failing outright.
+        \Drupal::logger('ys_ai_tester')->warning(
+          'AI tester retrying run @run question @delta (@backend) after a transient failure — attempt @attempt of @max, waiting @wait ms: @detail',
+          [
+            '@run' => $run_id,
+            '@delta' => $delta,
+            '@backend' => $backend_id,
+            '@attempt' => $attempt,
+            '@max' => AiTesterRetry::MAX_ATTEMPTS,
+            '@wait' => $wait_ms,
+            '@detail' => AiTesterFailure::describe($e),
+          ]
+        );
+
+        usleep($wait_ms * 1000);
+      }
+    }
+  }
+
+  /**
+   * Pauses before a question so a long run does not burst the upstream APIs.
+   *
+   * Skipped for the first question of a run, where there is nothing to pace
+   * against.
+   *
+   * @param int $delta
+   *   Position of this question within the run (0-based).
+   */
+  protected static function pace(int $delta): void {
+    if ($delta < 1) {
+      return;
+    }
+
+    $delay_ms = AiTesterRetry::questionDelayMs(
+      \Drupal::config('ys_beacon.settings')->get('ai_tester_question_delay_ms')
+    );
+    if ($delay_ms > 0) {
+      usleep($delay_ms * 1000);
+    }
+  }
+
+  /**
+   * Derives the status a finished run is recorded with.
+   *
+   * The distinction 'partial' draws is the point of it: before it existed, one
+   * transient failure out of a hundred questions recorded the same 'failed' as
+   * a run where nothing was answered at all, so a 99-percent-successful run
+   * read as broken and its results got thrown away.
+   *
+   * @param bool $success
+   *   TRUE when the batch itself completed, as Drupal reports it.
+   * @param int $error_count
+   *   How many questions were recorded with an error.
+   * @param int $processed
+   *   How many questions the batch actually processed.
+   *
+   * @return string
+   *   'complete', 'partial', or 'failed'. All three fit the varchar(32) status
+   *   column, so no schema change is involved.
+   */
+  public static function runStatus(bool $success, int $error_count, int $processed): string {
+    // An aborted batch did not finish, whatever the per-question tally says.
+    // Nothing processed is likewise not a success.
+    if (!$success || $processed < 1) {
+      return 'failed';
+    }
+    if ($error_count < 1) {
+      return 'complete';
+    }
+
+    // Reserved for a genuine collapse: a bad credential, an assistant that is
+    // gone, an upstream down for the whole run.
+    return $error_count >= $processed ? 'failed' : 'partial';
   }
 
   /**
@@ -102,8 +247,9 @@ class AiTesterBatch {
    */
   public static function finished(bool $success, array $results, array $operations): void {
     $run_id = $results['run_id'] ?? NULL;
-    $has_errors = !empty($results['errors']);
-    $status = ($success && !$has_errors) ? 'complete' : 'failed';
+    $failed_deltas = $results['failed_deltas'] ?? [];
+    $processed = (int) ($results['processed'] ?? 0);
+    $status = self::runStatus($success, count($failed_deltas), $processed);
 
     if ($run_id) {
       \Drupal::database()->update('ys_ai_tester_run')
@@ -117,12 +263,28 @@ class AiTesterBatch {
       );
     }
 
-    if ($success && !$has_errors) {
+    if ($status === 'complete') {
       \Drupal::messenger()->addStatus(t('All questions processed successfully.'));
+      return;
     }
-    else {
-      \Drupal::messenger()->addWarning(t('Some questions encountered errors. Check the Drupal logs for details.'));
+
+    if ($status === 'partial') {
+      // Naming the questions is what makes a partial run actionable: they can
+      // be re-asked individually instead of re-running all hundred.
+      \Drupal::messenger()->addWarning(t(
+        '@failed of @total questions could not be answered (question numbers: @list). The rest of the run completed and its answers are saved. Check the Drupal logs for the cause.',
+        [
+          '@failed' => count($failed_deltas),
+          '@total' => $processed,
+          // Deltas are 0-based; the progress message and the run view both
+          // number questions from 1, so the label matches what a user saw.
+          '@list' => implode(', ', array_map(static fn($delta) => $delta + 1, $failed_deltas)),
+        ]
+      ));
+      return;
     }
+
+    \Drupal::messenger()->addWarning(t('This run failed — no questions were answered. Check the Drupal logs for details.'));
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/AiTesterFailure.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/AiTesterFailure.php
@@ -1,0 +1,392 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_ai_tester;
+
+use Drupal\ai\Exception\AiQuotaException;
+use Drupal\ai\Exception\AiRateLimitException;
+use Drupal\ys_beacon\Exception\BeaconStageException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Utils;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Reads everything knowable about a failed question from its exception.
+ *
+ * Two separate problems live here, and both come from the same root cause -
+ * the exception classes these APIs throw put almost nothing in their message:
+ *
+ * - **Classification.** Whether a retry could plausibly succeed. Decided from
+ *   HTTP status codes and the AI module's typed exceptions, never from message
+ *   wording, for the reason already documented in
+ *   \Drupal\ys_beacon_portkey\Plugin\AiProvider\PortkeyProvider: Portkey fronts
+ *   several upstream providers, so the wording varies by provider and by
+ *   openai-php version while the status code stays stable.
+ * - **Description.** A log line with enough in it to diagnose the failure once.
+ *   openai-php's ServerException message is literally "Server error (HTTP 500)
+ *   occurred." and discards the response body it is holding; Guzzle truncates
+ *   response bodies to 120 characters when building an exception message, which
+ *   is how a production 400 was recorded as cut off mid-word with its cause
+ *   lost.
+ *
+ * Everything is static and dependency-free so it can be unit tested directly,
+ * matching how the rest of this module keeps its decisions testable.
+ */
+class AiTesterFailure {
+
+  /**
+   * Maximum response-body characters to include in a log line.
+   *
+   * Generously above Guzzle's 120-character summary, but still bounded: this
+   * lands in watchdog, once per failed question.
+   */
+  const MAX_BODY_LENGTH = 2000;
+
+  /**
+   * How deep to follow ::getPrevious() before giving up.
+   *
+   * These chains are two or three links in practice; the cap only exists so a
+   * pathological cycle cannot hang a logging call.
+   */
+  const MAX_CHAIN_DEPTH = 10;
+
+  /**
+   * Gateway correlation headers, in the order they are reported.
+   *
+   * Without one of these there is no way to find a failed request in Portkey's
+   * own logs, which is what made "no errors in Portkey" impossible to confirm
+   * or refute.
+   */
+  const TRACE_HEADERS = ['x-portkey-trace-id', 'x-portkey-request-id'];
+
+  /**
+   * Returns whether retrying this failure could plausibly succeed.
+   *
+   * The exception chain is walked rather than just the outermost exception,
+   * which is essential rather than defensive: LegacyConversationClient::ask()
+   * rethrows every Guzzle failure wrapped in a \RuntimeException, and
+   * BeaconAnswerService wraps its own in a BeaconStageException. Reading only
+   * the top of either chain would classify every one of those failures as
+   * permanent and retry none of them.
+   *
+   * @param \Throwable $e
+   *   The failure.
+   *
+   * @return bool
+   *   TRUE when the same request might succeed on a later attempt.
+   */
+  public static function isTransient(\Throwable $e): bool {
+    foreach (self::chain($e) as $link) {
+      // The AI module's typed exceptions are unambiguous, so they settle it
+      // without looking at any status code. A rate limit clears on its own; an
+      // exhausted quota does not, and retrying it only burns time.
+      if ($link instanceof AiRateLimitException) {
+        return TRUE;
+      }
+      if ($link instanceof AiQuotaException) {
+        return FALSE;
+      }
+
+      $code = self::statusCode($link);
+      // Only an error status settles it. statusCode() reports whatever the
+      // response carried, and a success status can reach here: openai-php
+      // raises UnserializableResponse on an unparseable body, and its own
+      // ErrorException docblock warns a streamed request "might be 200 even in
+      // case of an error". Treating 200 as decisive would both answer "not
+      // transient" on no evidence and abort the walk before the wrapped cause
+      // and the transport checks below were ever consulted.
+      if ($code !== NULL && $code >= 400) {
+        // 5xx is the far end breaking on a well-formed request. 429 is
+        // throttling. 408 is the server giving up on a slow request. Every
+        // other 4xx - a filtered completion, a malformed request, a bad key -
+        // will fail identically however many times it is sent.
+        return $code >= 500 || $code === 429 || $code === 408;
+      }
+
+      // No status code means no HTTP response came back at all, so the request
+      // never completed: a connection failure or a read timeout. Both are worth
+      // one more attempt.
+      if ($link instanceof ConnectException || $link instanceof RequestException) {
+        return TRUE;
+      }
+    }
+
+    // Nothing in the chain looks like a transport failure. This is the path a
+    // configuration error takes - "the assistant is not available on this site"
+    // is a bare \RuntimeException - and it must fail on the first attempt
+    // rather than being retried three times per question.
+    return FALSE;
+  }
+
+  /**
+   * Returns the HTTP status carried by an exception, if any.
+   *
+   * @param \Throwable $e
+   *   The failure. Not walked - callers that want the chain use ::chain().
+   *
+   * @return int|null
+   *   The status code, or NULL when this exception carries no HTTP response.
+   */
+  public static function statusCode(\Throwable $e): ?int {
+    // A backend that parsed its status out of a streamed body reports it
+    // directly: there is no HTTP response to read it off, because the response
+    // itself was a 200.
+    if ($e instanceof UpstreamStatusInterface) {
+      return $e->getUpstreamStatusCode();
+    }
+
+    return self::responseOf($e)?->getStatusCode();
+  }
+
+  /**
+   * Returns the milliseconds a Retry-After header asks the caller to wait.
+   *
+   * Only the delta-seconds form is honored. The HTTP-date form is legal but
+   * rare from these APIs, and misreading a date as a number of seconds would
+   * produce an absurd wait, so anything unparseable defers to normal backoff.
+   *
+   * @param \Throwable $e
+   *   The failure.
+   *
+   * @return int|null
+   *   Milliseconds to wait, or NULL when the response gave no usable hint.
+   */
+  public static function retryAfterMs(\Throwable $e): ?int {
+    foreach (self::chain($e) as $link) {
+      $response = self::responseOf($link);
+      if ($response === NULL) {
+        continue;
+      }
+      $header = trim($response->getHeaderLine('Retry-After'));
+      if ($header !== '' && ctype_digit($header)) {
+        return (int) $header * 1000;
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Returns which upstream call failed, when the chain says so.
+   *
+   * @param \Throwable $e
+   *   The failure.
+   *
+   * @return string|null
+   *   A BeaconStageException stage name, or NULL for a backend that does not
+   *   label its stages (the legacy assistant is a single request, so there is
+   *   nothing to disambiguate).
+   */
+  public static function stageOf(\Throwable $e): ?string {
+    foreach (self::chain($e) as $link) {
+      if ($link instanceof BeaconStageException) {
+        return $link->getStage();
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Builds a diagnosable one-line description of a failure.
+   *
+   * @param \Throwable $e
+   *   The failure.
+   *
+   * @return string
+   *   The exception class and message, the failing stage where known, and the
+   *   HTTP status, correlation headers, and response body of the first response
+   *   found in the chain.
+   */
+  public static function describe(\Throwable $e): string {
+    $parts = [self::shortClass($e) . ': ' . $e->getMessage()];
+
+    $stage = self::stageOf($e);
+    if ($stage !== NULL) {
+      $parts[] = 'stage: ' . self::stageHint($stage);
+    }
+
+    $response = NULL;
+    foreach (self::chain($e) as $link) {
+      $response = self::responseOf($link);
+      if ($response !== NULL) {
+        break;
+      }
+    }
+
+    if ($response !== NULL) {
+      $parts[] = 'HTTP ' . $response->getStatusCode();
+      foreach (self::TRACE_HEADERS as $header) {
+        $value = trim($response->getHeaderLine($header));
+        if ($value !== '') {
+          $parts[] = $header . ': ' . $value;
+        }
+      }
+      $parts[] = 'body: ' . self::bodyOf($response);
+    }
+
+    return implode(' | ', $parts);
+  }
+
+  /**
+   * Explains a stage, and which credential to check for it.
+   *
+   * The two Portkey calls authenticate with different keys
+   * (ys_beacon_portkey.settings: api_key for chat, embeddings_api_key for
+   * embeddings), so they can sit in different gateway workspaces. Naming the
+   * key in the log is the difference between checking the right log and
+   * concluding the gateway saw nothing.
+   *
+   * @param string $stage
+   *   A BeaconStageException stage name.
+   *
+   * @return string
+   *   The stage with its credential hint.
+   */
+  protected static function stageHint(string $stage): string {
+    return match ($stage) {
+      // No credential hint here on purpose. RagRetriever swallows a failed
+      // query and degrades to an empty citation list, so an embeddings or
+      // Azure AI Search outage never reaches this stage - it is logged
+      // separately as 'Beacon retrieval failed'. This firing at all means
+      // something escaped that handling, which is worth saying plainly rather
+      // than pointing at a credential the failure probably has nothing to do
+      // with.
+      BeaconStageException::STAGE_RETRIEVAL => $stage . ' (unexpected: a failed retrieval normally degrades to an empty citation list instead of raising)',
+      BeaconStageException::STAGE_CHAT => $stage . ' (Portkey api_key)',
+      BeaconStageException::STAGE_CHAT_FOLLOW_UP => $stage . ' (Portkey api_key, tool follow-up turn)',
+      default => $stage,
+    };
+  }
+
+  /**
+   * Returns the response body, bounded, without ever throwing.
+   *
+   * This runs only on a path that is already handling a failure, so it must not
+   * become the thing that fails. Reading consumes the stream, which is safe
+   * here: nothing downstream reads the response of a failed request.
+   *
+   * @param \Psr\Http\Message\ResponseInterface $response
+   *   The response to read.
+   *
+   * @return string
+   *   The body, truncated on a byte boundary with an explicit marker when
+   *   oversized, or a stated reason it could not be read - never a silent
+   *   empty string.
+   */
+  protected static function bodyOf(ResponseInterface $response): string {
+    try {
+      $stream = $response->getBody();
+      if ($stream->isSeekable()) {
+        $stream->rewind();
+      }
+      // Bound the read itself, not just the reported length: a gateway or
+      // WAF answering with a large HTML error page would otherwise be pulled
+      // into memory in full - once per attempt - only to be cut down
+      // afterwards. One byte past the limit is all it takes to know the body
+      // was longer than the limit.
+      //
+      // Everything here is measured in BYTES, deliberately and consistently:
+      // Utils::copyToString() bounds on strlen(), so mixing in a character
+      // count below would compare two different units and let a body that is
+      // over the byte limit but under the character limit through as though it
+      // were complete - silently truncated with no marker, which is the exact
+      // failure this class exists to stop.
+      $body = trim(Utils::copyToString($stream, self::MAX_BODY_LENGTH + 1));
+    }
+    catch (\Throwable $unreadable) {
+      return '(unreadable: ' . $unreadable->getMessage() . ')';
+    }
+
+    if ($body === '') {
+      return '(empty)';
+    }
+    if (strlen($body) > self::MAX_BODY_LENGTH) {
+      // mb_strcut(), not mb_substr(): it cuts on a byte count without ever
+      // splitting a multi-byte character. A partial sequence here would be
+      // worse than a long line - Drupal escapes log placeholders through
+      // htmlspecialchars(), which returns an empty string for invalid UTF-8,
+      // so a torn character would blank the whole message.
+      return mb_strcut($body, 0, self::MAX_BODY_LENGTH)
+        . ' (truncated at ' . self::MAX_BODY_LENGTH . ' bytes)';
+    }
+
+    return $body;
+  }
+
+  /**
+   * Returns the HTTP response an exception carries, if it carries one.
+   *
+   * Covers both client libraries in play. openai-php exposes the response as a
+   * public property - ServerException::$response and ErrorException::$response,
+   * the latter readonly - while Guzzle exposes it through
+   * BadResponseException::getResponse(). Both accesses are visibility-aware on
+   * purpose: get_object_vars() returns only public properties when called from
+   * outside the class, and is_callable() resolves a method against this scope,
+   * so neither a private property nor a protected method of the same name can
+   * turn a logging call into a second failure.
+   *
+   * @param \Throwable $e
+   *   The failure.
+   *
+   * @return \Psr\Http\Message\ResponseInterface|null
+   *   The response, or NULL when there is none.
+   */
+  protected static function responseOf(\Throwable $e): ?ResponseInterface {
+    $public = get_object_vars($e);
+    if (($public['response'] ?? NULL) instanceof ResponseInterface) {
+      return $public['response'];
+    }
+
+    // is_callable(), not method_exists(): method_exists() answers TRUE for a
+    // protected or private method too, so calling it would raise an Error from
+    // inside a catch block - making this the thing that fails. is_callable()
+    // resolves visibility from here, the same reason get_object_vars() is used
+    // for the property above.
+    if (is_callable([$e, 'getResponse'])) {
+      $response = $e->getResponse();
+      if ($response instanceof ResponseInterface) {
+        return $response;
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Returns an exception's class name without its namespace.
+   *
+   * @param \Throwable $e
+   *   The failure.
+   *
+   * @return string
+   *   The short class name.
+   */
+  protected static function shortClass(\Throwable $e): string {
+    $parts = explode('\\', get_class($e));
+    return end($parts);
+  }
+
+  /**
+   * Returns an exception and its causes, outermost first.
+   *
+   * @param \Throwable $e
+   *   The failure.
+   *
+   * @return \Throwable[]
+   *   The chain, capped at ::MAX_CHAIN_DEPTH.
+   */
+  protected static function chain(\Throwable $e): array {
+    $chain = [];
+    $link = $e;
+    while ($link !== NULL && count($chain) < self::MAX_CHAIN_DEPTH) {
+      $chain[] = $link;
+      $link = $link->getPrevious();
+    }
+
+    return $chain;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/AiTesterRetry.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/AiTesterRetry.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_ai_tester;
+
+/**
+ * Timing policy for retrying and pacing the tester's upstream requests.
+ *
+ * Deliberately knows nothing about exceptions - AiTesterFailure decides whether
+ * a failure is worth retrying, this decides only how long to wait. Keeping the
+ * two apart is what lets both be unit tested without constructing a request.
+ *
+ * Every value here is bounded, for one reason: these waits happen inside a
+ * batch request, alongside the question's own LLM latency, and the hosting
+ * platform terminates a web request at 120 seconds. An unbounded backoff would
+ * trade one failed question for a whole killed batch.
+ *
+ * This is the tester's policy and only the tester's. The live chat widget
+ * answers one question per visitor and cannot burst, already rate limits it
+ * per IP, and its provider documents a deliberate no-sleep contract so that a
+ * request never holds a PHP-FPM worker while waiting. Pacing belongs here,
+ * where the burst actually is.
+ */
+class AiTesterRetry {
+
+  /**
+   * Attempts allowed per question, including the first.
+   *
+   * Three means one initial call plus two retries.
+   */
+  const MAX_ATTEMPTS = 3;
+
+  /**
+   * First retry's wait, in milliseconds. Doubles per attempt.
+   */
+  const BASE_DELAY_MS = 1000;
+
+  /**
+   * Ceiling on the computed exponential wait, in milliseconds.
+   */
+  const MAX_BACKOFF_MS = 8000;
+
+  /**
+   * Ceiling on an honored Retry-After, in milliseconds.
+   *
+   * A gateway asking for five minutes gets waited on for ten seconds instead:
+   * obeying it literally would stall the batch request until the platform
+   * killed it, losing the whole run rather than one question.
+   */
+  const MAX_RETRY_AFTER_MS = 10000;
+
+  /**
+   * Maximum random spread added to a computed wait, in milliseconds.
+   *
+   * Keeps a run that tripped a per-minute ceiling from retrying every question
+   * in lockstep and tripping it again together.
+   */
+  const JITTER_MS = 250;
+
+  /**
+   * Default pause between questions, in milliseconds.
+   *
+   * Small on purpose. Each question already costs seconds of model latency, so
+   * this is a rounding error against a run's total time (about 50 seconds
+   * across a hundred questions) while still giving a real knob to slow a run
+   * down when an upstream ceiling is suspected.
+   */
+  const DEFAULT_QUESTION_DELAY_MS = 500;
+
+  /**
+   * Ceiling on the configured pause between questions, in milliseconds.
+   */
+  const MAX_QUESTION_DELAY_MS = 10000;
+
+  /**
+   * Ceiling on the total time one question may spend waiting to retry, in ms.
+   *
+   * The per-attempt caps above are not enough on their own. Two retries each
+   * honouring a Retry-After capped at ::MAX_RETRY_AFTER_MS would sleep for 20
+   * seconds, and with the pause between questions also set to its maximum that
+   * is 30 seconds of a 120-second request budget spent not working - before the
+   * three real upstream calls have had any of it. Past this budget the question
+   * gives up instead, because failing one question is the smaller loss than
+   * having the platform kill the request and take the rest of the batch with
+   * it.
+   */
+  const MAX_TOTAL_RETRY_WAIT_MS = 12000;
+
+  /**
+   * Returns how long to wait before the next attempt at a question.
+   *
+   * @param int $attempt
+   *   The attempt that just failed, 1-based.
+   * @param int|null $retry_after_ms
+   *   What the response's Retry-After header asked for, or NULL when it gave no
+   *   usable hint.
+   * @param float $jitter
+   *   A 0-1 fraction of ::JITTER_MS to add. Passed in rather than generated
+   *   here so the calculation stays deterministic under test.
+   *
+   * @return int
+   *   Milliseconds to wait.
+   */
+  public static function backoffMs(int $attempt, ?int $retry_after_ms, float $jitter): int {
+    // A server that said how long to wait knows better than a guess - within
+    // the bound above.
+    if ($retry_after_ms !== NULL) {
+      return max(0, min($retry_after_ms, self::MAX_RETRY_AFTER_MS));
+    }
+
+    $base = min(
+      self::BASE_DELAY_MS * (2 ** max(0, $attempt - 1)),
+      self::MAX_BACKOFF_MS
+    );
+
+    return (int) $base + (int) round($jitter * self::JITTER_MS);
+  }
+
+  /**
+   * Returns a random jitter fraction for ::backoffMs().
+   *
+   * @return float
+   *   A fraction between 0 and 1.
+   */
+  public static function jitter(): float {
+    return mt_rand(0, 100) / 100;
+  }
+
+  /**
+   * Returns whether one more wait of this length fits the question's budget.
+   *
+   * @param int $waited_ms
+   *   How long this question has already spent waiting to retry.
+   * @param int $next_wait_ms
+   *   How long the next wait would be.
+   *
+   * @return bool
+   *   TRUE when the wait fits within ::MAX_TOTAL_RETRY_WAIT_MS.
+   */
+  public static function withinWaitBudget(int $waited_ms, int $next_wait_ms): bool {
+    return ($waited_ms + $next_wait_ms) <= self::MAX_TOTAL_RETRY_WAIT_MS;
+  }
+
+  /**
+   * Resolves the configured pause between questions.
+   *
+   * Config can hold anything - an unset key on a site that predates the
+   * setting, a numeric string from a form, a value hand-edited into YAML - so
+   * the value is clamped rather than trusted. A fat-fingered number cannot
+   * stall every run on the site.
+   *
+   * @param mixed $configured
+   *   The raw config value.
+   *
+   * @return int
+   *   Milliseconds to pause, between 0 and ::MAX_QUESTION_DELAY_MS.
+   */
+  public static function questionDelayMs(mixed $configured): int {
+    if ($configured === NULL || !is_numeric($configured)) {
+      return self::DEFAULT_QUESTION_DELAY_MS;
+    }
+
+    return max(0, min((int) $configured, self::MAX_QUESTION_DELAY_MS));
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/UpstreamStatusInterface.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/src/UpstreamStatusInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_ai_tester;
+
+/**
+ * Implemented by exceptions that carry an upstream status code of their own.
+ *
+ * Most failures arrive as an HTTP exception the response can be read off, but
+ * not all of them: a streamed endpoint can answer 200 and put the error in the
+ * body, which is exactly what the legacy assistant does and what openai-php
+ * warns about for its own streamed requests. An exception raised from a parsed
+ * body has no HTTP response attached, so without this the tester would have to
+ * guess at the failure from its message text - the one signal
+ * \Drupal\ys_beacon_portkey\Plugin\AiProvider\PortkeyProvider already documents
+ * as unreliable, because the wording varies by provider and by library version.
+ *
+ * A backend submodule implements this on its own exception to report the code
+ * it found in the body, and AiTesterFailure treats it exactly like a status
+ * read off a response. The interface lives here, in the tester, so backend
+ * submodules depend on the tester rather than the other way round.
+ */
+interface UpstreamStatusInterface {
+
+  /**
+   * Returns the status code the upstream service reported.
+   *
+   * @return int|null
+   *   An HTTP-style status code, or NULL when the payload carried none.
+   */
+  public function getUpstreamStatusCode(): ?int;
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterFailureTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterFailureTest.php
@@ -1,0 +1,387 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ys_ai_tester\Unit;
+
+use Drupal\ai\Exception\AiQuotaException;
+use Drupal\ai\Exception\AiRateLimitException;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai_tester\AiTesterFailure;
+use Drupal\ys_ai_tester\UpstreamStatusInterface;
+use Drupal\ys_beacon\Exception\BeaconStageException;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ServerException as GuzzleServerException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use OpenAI\Exceptions\ErrorException as OpenAiErrorException;
+use OpenAI\Exceptions\ServerException as OpenAiServerException;
+
+/**
+ * Tests what the tester can learn about a failed question from its exception.
+ *
+ * @coversDefaultClass \Drupal\ys_ai_tester\AiTesterFailure
+ *
+ * @group ys_beacon
+ */
+class AiTesterFailureTest extends UnitTestCase {
+
+  /**
+   * Builds a stand-in for a backend exception carrying its own status code.
+   *
+   * A local double rather than ys_ai_tester_legacy's LegacyStreamException: a
+   * backend submodule depends on this module, so this module's tests must not
+   * depend back on one. What is under test is the interface contract, not any
+   * particular backend's implementation of it.
+   *
+   * @param string $message
+   *   The exception message.
+   * @param int|null $status
+   *   The status code the payload reported.
+   *
+   * @return \Throwable
+   *   The stand-in exception.
+   */
+  protected static function streamedFailure(string $message, ?int $status = NULL): \Throwable {
+    return new class($message, $status) extends \RuntimeException implements UpstreamStatusInterface {
+
+      /**
+       * Constructs the stand-in.
+       *
+       * @param string $message
+       *   The exception message.
+       * @param int|null $statusCode
+       *   The reported status code.
+       */
+      public function __construct(string $message, protected ?int $statusCode) {
+        parent::__construct($message);
+      }
+
+      /**
+       * {@inheritdoc}
+       */
+      public function getUpstreamStatusCode(): ?int {
+        return $this->statusCode;
+      }
+
+    };
+  }
+
+  /**
+   * @covers ::isTransient
+   * @dataProvider provideTransienceCases
+   */
+  public function testIsTransient(\Throwable $e, bool $expected): void {
+    $this->assertSame($expected, AiTesterFailure::isTransient($e));
+  }
+
+  /**
+   * Exception, and whether retrying it could plausibly succeed.
+   *
+   * The wrapped cases are the ones that matter most in practice:
+   * LegacyConversationClient::ask() rethrows every Guzzle failure inside a
+   * \RuntimeException, so a classifier that only looked at the top-level
+   * exception would treat every legacy failure as permanent and never retry
+   * the transient ones.
+   */
+  public static function provideTransienceCases(): array {
+    $request = new Request('POST', 'https://example.test/conversation');
+
+    return [
+      // Server-side faults: the request was well-formed, the far end broke.
+      'openai 500' => [new OpenAiServerException(new Response(500)), TRUE],
+      'openai 503' => [new OpenAiServerException(new Response(503)), TRUE],
+      'guzzle 502' => [new GuzzleServerException('bad gateway', $request, new Response(502)), TRUE],
+
+      // Throttling and timeouts clear on their own.
+      'openai 429' => [new OpenAiErrorException(['message' => 'slow down'], new Response(429)), TRUE],
+      'request timeout 408' => [new OpenAiErrorException(['message' => 'timeout'], new Response(408)), TRUE],
+      'ai rate limit' => [new AiRateLimitException('rate limited'), TRUE],
+      'connect failure' => [new ConnectException('cURL error 28: timed out', $request), TRUE],
+      // No response at all means the request never completed - a network-level
+      // failure, which is the shape a read timeout arrives in.
+      'request exception with no response' => [new RequestException('cURL error 28', $request), TRUE],
+
+      // Deterministic failures: the same request will fail the same way, so a
+      // retry only burns time and quota.
+      'openai 400' => [new OpenAiErrorException(['message' => 'content filtered'], new Response(400)), FALSE],
+      'guzzle 400' => [new ClientException('bad request', $request, new Response(400)), FALSE],
+      'openai 401' => [new OpenAiErrorException(['message' => 'bad key'], new Response(401)), FALSE],
+      'openai 404' => [new OpenAiErrorException(['message' => 'no model'], new Response(404)), FALSE],
+      // An exhausted quota is not a rate limit: waiting does not refill it.
+      'ai quota' => [new AiQuotaException('out of credits'), FALSE],
+      // The tester's own "assistant is not available on this site" guard. A
+      // misconfiguration must fail on the first attempt, not three.
+      'bare runtime exception' => [
+        new \RuntimeException('The "beacon" assistant is not available on this site.'),
+        FALSE,
+      ],
+
+      // Reported by a backend that read its status out of a streamed body,
+      // where the HTTP status was 200 and carries no information at all.
+      'in-stream 429' => [self::streamedFailure('Rate limit exceeded', 429), TRUE],
+      'in-stream 500' => [self::streamedFailure('Upstream failed', 500), TRUE],
+      'in-stream 400' => [self::streamedFailure('Bad request', 400), FALSE],
+      // A stream error with no usable code stays permanent rather than being
+      // retried on a guess.
+      'in-stream with no code' => [self::streamedFailure('Something went wrong'), FALSE],
+
+      // Wrapped, as the legacy client and the staged Beacon path rethrow.
+      'runtime wrapping a 500' => [
+        new \RuntimeException('The legacy ai_engine request failed: ...', 0, new GuzzleServerException('boom', $request, new Response(500))),
+        TRUE,
+      ],
+      'runtime wrapping a 400' => [
+        new \RuntimeException('The legacy ai_engine request failed: ...', 0, new ClientException('boom', $request, new Response(400))),
+        FALSE,
+      ],
+      'stage exception wrapping a 500' => [
+        new BeaconStageException('retrieval', 'boom', new OpenAiServerException(new Response(500))),
+        TRUE,
+      ],
+      'stage exception wrapping a 400' => [
+        new BeaconStageException('chat', 'boom', new OpenAiErrorException(['message' => 'filtered'], new Response(400))),
+        FALSE,
+      ],
+    ];
+  }
+
+  /**
+   * @covers ::statusCode
+   */
+  public function testStatusCodeReadsEveryClientShape(): void {
+    $request = new Request('POST', 'https://example.test/x');
+
+    // openai-php exposes the response as a public property on ServerException
+    // and both a property and a getter on ErrorException; Guzzle exposes it via
+    // getResponse(). All three have to be readable or the classification above
+    // silently degrades to "not transient".
+    $this->assertSame(500, AiTesterFailure::statusCode(new OpenAiServerException(new Response(500))));
+    $this->assertSame(429, AiTesterFailure::statusCode(new OpenAiErrorException(['message' => 'x'], new Response(429))));
+    $this->assertSame(404, AiTesterFailure::statusCode(new ClientException('x', $request, new Response(404))));
+    $this->assertNull(AiTesterFailure::statusCode(new \RuntimeException('no http here')));
+    $this->assertNull(AiTesterFailure::statusCode(new ConnectException('x', $request)));
+    // Reported by the exception itself rather than read off a response.
+    $this->assertSame(429, AiTesterFailure::statusCode(self::streamedFailure('throttled', 429)));
+    $this->assertNull(AiTesterFailure::statusCode(self::streamedFailure('no code')));
+  }
+
+  /**
+   * @covers ::retryAfterMs
+   * @dataProvider provideRetryAfterCases
+   */
+  public function testRetryAfterMs(?string $header, ?int $expected): void {
+    $headers = $header === NULL ? [] : ['Retry-After' => $header];
+    $e = new OpenAiErrorException(['message' => 'slow down'], new Response(429, $headers));
+
+    $this->assertSame($expected, AiTesterFailure::retryAfterMs($e));
+  }
+
+  /**
+   * Retry-After header value, and the milliseconds it should mean.
+   *
+   * Only the delta-seconds form is honored. The HTTP-date form is legal but
+   * rare from these APIs, and misreading one as seconds would produce an
+   * absurd wait, so an unparseable value defers to the normal backoff instead.
+   */
+  public static function provideRetryAfterCases(): array {
+    return [
+      'absent' => [NULL, NULL],
+      'seconds' => ['3', 3000],
+      'zero' => ['0', 0],
+      'empty' => ['', NULL],
+      'http date' => ['Wed, 21 Oct 2015 07:28:00 GMT', NULL],
+      'not a number' => ['soon', NULL],
+      'negative' => ['-5', NULL],
+    ];
+  }
+
+  /**
+   * A success status neither settles the verdict nor hides the real cause.
+   *
+   * The status code reported is whatever the response carried, and a 200 can
+   * arrive on an exception - openai-php raises on an unparseable body, and
+   * warns that a streamed request may report 200 even in the error case. A 2xx
+   * must therefore not be read as evidence of a permanent failure, and must
+   * not stop the walk before the wrapped cause is examined.
+   *
+   * @covers ::isTransient
+   */
+  public function testSuccessStatusDoesNotMaskTheWrappedCause(): void {
+    $carrying200 = new OpenAiServerException(new Response(200));
+
+    // On its own: no evidence either way, so not retried.
+    $this->assertFalse(AiTesterFailure::isTransient($carrying200));
+
+    // Wrapping a real server fault: the 200 must not shadow the 503 beneath it.
+    $this->assertTrue(AiTesterFailure::isTransient(
+      new \RuntimeException('wrapper', 0, new OpenAiServerException(new Response(503)))
+    ));
+    $this->assertTrue(AiTesterFailure::isTransient(
+      new BeaconStageException('chat', 'wrapper', new OpenAiServerException(new Response(502)))
+    ));
+  }
+
+  /**
+   * @covers ::stageOf
+   */
+  public function testStageOfNamesTheFailingUpstreamCall(): void {
+    $this->assertSame(
+      'retrieval',
+      AiTesterFailure::stageOf(new BeaconStageException('retrieval', 'boom', new \RuntimeException('inner')))
+    );
+    // Wrapped one level deeper, as it would be if the backend rethrew.
+    $this->assertSame(
+      'chat',
+      AiTesterFailure::stageOf(new \RuntimeException('outer', 0, new BeaconStageException('chat', 'boom', NULL)))
+    );
+    $this->assertNull(AiTesterFailure::stageOf(new \RuntimeException('no stage')));
+  }
+
+  /**
+   * @covers ::describe
+   */
+  public function testDescribeCarriesTheDetailTheOldLogDiscarded(): void {
+    $body = '{"error":{"code":"upstream_failure","message":"the gateway could not reach the model"}}';
+    $response = new Response(500, [
+      'x-portkey-trace-id' => 'trace-abc-123',
+      'x-portkey-request-id' => 'req-def-456',
+    ], $body);
+
+    $detail = AiTesterFailure::describe(new OpenAiServerException($response));
+
+    // The status code is all the old log ever carried.
+    $this->assertStringContainsString('500', $detail);
+    $this->assertStringContainsString('ServerException', $detail);
+    // The body is the part that was thrown away entirely.
+    $this->assertStringContainsString('the gateway could not reach the model', $detail);
+    // Without a trace id there is no way to find the request in Portkey's logs,
+    // which is why "no errors in Portkey" was unfalsifiable.
+    $this->assertStringContainsString('trace-abc-123', $detail);
+    $this->assertStringContainsString('req-def-456', $detail);
+  }
+
+  /**
+   * @covers ::describe
+   */
+  public function testDescribeBoundsAnEnormousBody(): void {
+    $response = new Response(500, [], str_repeat('x', 50000));
+
+    $detail = AiTesterFailure::describe(new OpenAiServerException($response));
+
+    // Bounded, but far above Guzzle's 120-character summary, which cut the
+    // legacy error off mid-word at "'Ser" and lost the cause.
+    $this->assertLessThan(4000, strlen($detail));
+    $this->assertGreaterThan(2000, strlen($detail));
+    $this->assertStringContainsString('truncated', $detail);
+  }
+
+  /**
+   * A multi-byte body is still marked as truncated, and stays valid UTF-8.
+   *
+   * This is the case a pure-ASCII fixture cannot reach. The read is bounded in
+   * bytes, so a body over the byte limit but under the character limit is
+   * exactly where comparing the two units would let a silently cut-off body
+   * through with no marker - and where a cut could land mid-character, which
+   * matters because Drupal escapes log placeholders through htmlspecialchars()
+   * and that returns an empty string for invalid UTF-8, blanking the message.
+   *
+   * @covers ::describe
+   */
+  public function testDescribeBoundsMultibyteBodyWithoutLosingTheMarker(): void {
+    // Three bytes per character: 900 characters is 2700 bytes - over the byte
+    // limit, comfortably under the same number of characters.
+    $response = new Response(500, [], str_repeat("\u{4e2d}", 900));
+
+    $detail = AiTesterFailure::describe(new OpenAiServerException($response));
+
+    $this->assertStringContainsString('truncated', $detail);
+    $this->assertTrue(mb_check_encoding($detail, 'UTF-8'), 'The log line must stay valid UTF-8.');
+  }
+
+  /**
+   * @covers ::describe
+   */
+  public function testDescribeReadsThroughWrappedExceptions(): void {
+    $inner = new ClientException(
+      'Client error',
+      new Request('POST', 'https://askyaleyalesites.azurewebsites.net/conversation'),
+      new Response(400, [], '{"error":"Error code: 400 - the part Guzzle used to cut off"}')
+    );
+    $outer = new \RuntimeException('The legacy ai_engine request failed: truncated junk', 0, $inner);
+
+    $detail = AiTesterFailure::describe($outer);
+
+    $this->assertStringContainsString('400', $detail);
+    $this->assertStringContainsString('the part Guzzle used to cut off', $detail);
+  }
+
+  /**
+   * An inaccessible getResponse() must not turn logging into a second failure.
+   *
+   * A method_exists() check answers TRUE for a protected or private method, and
+   * calling one raises an Error - from inside the catch block that is trying to
+   * report the original failure, so the whole batch operation would die
+   * reporting an error rather than recording it.
+   *
+   * @covers ::statusCode
+   * @covers ::describe
+   */
+  public function testNonPublicGetResponseIsIgnoredRatherThanCalled(): void {
+    $hostile = new class('boom') extends \RuntimeException {
+
+      /**
+       * Deliberately not public, as some libraries declare it.
+       *
+       * Throws rather than returning, so a regression that calls it fails
+       * loudly instead of quietly handing back a plausible value.
+       */
+      protected function getResponse() {
+        throw new \LogicException('This must never be called.');
+      }
+
+    };
+
+    $this->assertNull(AiTesterFailure::statusCode($hostile));
+    $this->assertStringContainsString('boom', AiTesterFailure::describe($hostile));
+  }
+
+  /**
+   * @covers ::describe
+   */
+  public function testDescribeSurvivesAnExceptionWithNoResponse(): void {
+    // A logging path must never be the thing that throws.
+    $detail = AiTesterFailure::describe(new \RuntimeException('The "beacon" assistant is not available on this site.'));
+
+    $this->assertStringContainsString('not available on this site', $detail);
+    $this->assertStringContainsString('RuntimeException', $detail);
+  }
+
+  /**
+   * @covers ::describe
+   */
+  public function testDescribeNamesTheStageAndTheCredentialToCheck(): void {
+    // Chat is the reachable case, and naming its key is the diagnostic win:
+    // chat and embeddings authenticate with different Portkey keys and can sit
+    // in different workspaces, so "no errors in Portkey" is unfalsifiable
+    // without knowing which one to look in.
+    $chat = AiTesterFailure::describe(
+      new BeaconStageException('chat', 'boom', new OpenAiServerException(new Response(500)))
+    );
+    $this->assertStringContainsString('chat', $chat);
+    $this->assertStringContainsString('api_key', $chat);
+
+    // Retrieval must NOT claim an embeddings failure. RagRetriever swallows a
+    // failed query and degrades to an empty citation list, so an embeddings or
+    // Azure AI Search outage never surfaces here - pointing at the embeddings
+    // credential would send someone to the wrong log.
+    $retrieval = AiTesterFailure::describe(
+      new BeaconStageException('retrieval', 'boom', new OpenAiServerException(new Response(500)))
+    );
+    $this->assertStringContainsString('retrieval', $retrieval);
+    $this->assertStringNotContainsString('embedding', strtolower($retrieval));
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterPacingFormAlterTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterPacingFormAlterTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ys_ai_tester\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai_tester\AiTesterRetry;
+
+/**
+ * Tests the pacing field the tester adds to the Beacon administration form.
+ *
+ * The field is contributed from this submodule rather than declared in the
+ * Beacon form so the dependency runs the same direction the module dependency
+ * does, and so the field disappears with the submodule rather than needing a
+ * module-exists guard on the Beacon side.
+ *
+ * @group ys_beacon
+ */
+class AiTesterPacingFormAlterTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 3) . '/ys_ai_tester.module';
+  }
+
+  /**
+   * Puts a config factory returning one stored delay value on the container.
+   *
+   * @param mixed $stored
+   *   The value ys_beacon.settings:ai_tester_question_delay_ms holds.
+   */
+  protected function setUpConfig(mixed $stored): void {
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')
+      ->with('ai_tester_question_delay_ms')
+      ->willReturn($stored);
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('get')->with('ys_beacon.settings')->willReturn($config);
+
+    $container = new ContainerBuilder();
+    $container->set('config.factory', $factory);
+    $container->set('string_translation', $this->getStringTranslationStub());
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Runs the alter against a minimal stand-in for the Beacon settings form.
+   *
+   * The '::submitForm' entry is what FormBuilder::prepareForm() has already put
+   * in '#submit' by the time alter hooks run, so the fixture carries it.
+   */
+  protected function alterForm(): array {
+    $form = ['#submit' => ['::submitForm']];
+    $form_state = $this->createMock(FormStateInterface::class);
+    ys_ai_tester_form_ys_beacon_admin_settings_alter($form, $form_state);
+
+    return $form;
+  }
+
+  /**
+   * The field is added, bounded, and cannot be saved outside its clamp.
+   */
+  public function testAlterAddsBoundedPacingField(): void {
+    $this->setUpConfig(750);
+    $form = $this->alterForm();
+
+    $field = $form['tester']['ai_tester_question_delay_ms'];
+    $this->assertSame('number', $field['#type']);
+    $this->assertSame(750, $field['#default_value']);
+    $this->assertSame(0, $field['#min']);
+    $this->assertSame(AiTesterRetry::MAX_QUESTION_DELAY_MS, $field['#max']);
+    // An unlabelled or undescribed number field would be a WCAG 2.1 AA failure
+    // (1.3.1 / 3.3.2) on a form only reachable by a platform operator, but a
+    // failure all the same.
+    $this->assertNotEmpty((string) $field['#title']);
+    $this->assertNotEmpty((string) $field['#description']);
+    // Required so an emptied field is rejected rather than silently reverting
+    // to the default while appearing to have saved.
+    $this->assertTrue($field['#required']);
+  }
+
+  /**
+   * A site predating the setting shows the default, not an empty field.
+   */
+  public function testAlterFallsBackToTheDefaultWhenUnset(): void {
+    // ys_beacon.settings is not exported to the profile's config/sync, so an
+    // existing site genuinely will not have this key until it is saved once.
+    $this->setUpConfig(NULL);
+
+    $this->assertSame(
+      AiTesterRetry::DEFAULT_QUESTION_DELAY_MS,
+      $this->alterForm()['tester']['ai_tester_question_delay_ms']['#default_value']
+    );
+  }
+
+  /**
+   * The tester's submit handler is appended, not substituted for the form's.
+   */
+  public function testAlterAppendsItsSubmitHandler(): void {
+    $this->setUpConfig(500);
+    $submit = $this->alterForm()['#submit'];
+
+    // Replacing '::submitForm' rather than appending would stop every other
+    // Beacon setting on the form from saving at all.
+    $this->assertSame(['::submitForm', 'ys_ai_tester_admin_settings_submit'], $submit);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterRetryTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterRetryTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ys_ai_tester\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai_tester\AiTesterRetry;
+
+/**
+ * Tests the tester's retry timing and inter-question pacing policy.
+ *
+ * @coversDefaultClass \Drupal\ys_ai_tester\AiTesterRetry
+ *
+ * @group ys_beacon
+ */
+class AiTesterRetryTest extends UnitTestCase {
+
+  /**
+   * @covers ::backoffMs
+   * @dataProvider provideBackoffCases
+   */
+  public function testBackoffMs(int $attempt, ?int $retry_after_ms, float $jitter, int $expected): void {
+    $this->assertSame($expected, AiTesterRetry::backoffMs($attempt, $retry_after_ms, $jitter));
+  }
+
+  /**
+   * Attempt number, Retry-After hint, jitter fraction, milliseconds to wait.
+   *
+   * Every value here has to stay small: this sleep happens inside a batch
+   * request, and Pantheon terminates a web request at 120 seconds. A retry
+   * policy that could outlast that ceiling would trade one failed question for
+   * a whole killed batch.
+   */
+  public static function provideBackoffCases(): array {
+    return [
+      'first retry, no jitter' => [1, NULL, 0.0, 1000],
+      'second retry doubles' => [2, NULL, 0.0, 2000],
+      'full jitter adds a bounded spread' => [1, NULL, 1.0, 1250],
+      'half jitter' => [2, NULL, 0.5, 2125],
+      // A server-supplied hint wins over the computed backoff.
+      'retry-after honored' => [1, 2000, 0.0, 2000],
+      'retry-after of zero is honored' => [1, 0, 0.0, 0],
+      // ... but never unboundedly: a gateway asking for five minutes would
+      // otherwise stall the batch request until the platform killed it.
+      'absurd retry-after is capped' => [1, 300000, 0.0, 10000],
+      // Growth is capped even if MAX_ATTEMPTS is ever raised.
+      'exponential growth is capped' => [9, NULL, 0.0, 8000],
+    ];
+  }
+
+  /**
+   * @covers ::backoffMs
+   */
+  public function testTotalRetryWaitStaysWellInsideTheRequestCeiling(): void {
+    $worst = 0;
+    for ($attempt = 1; $attempt < AiTesterRetry::MAX_ATTEMPTS; $attempt++) {
+      $worst += AiTesterRetry::backoffMs($attempt, NULL, 1.0);
+    }
+
+    // The whole retry budget for one question, worst case, plus the capped
+    // pacing delay - comfortably short of the 120s platform ceiling that the
+    // question's own LLM latency also has to fit inside.
+    $this->assertLessThan(10000, $worst);
+  }
+
+  /**
+   * @covers ::withinWaitBudget
+   * @covers ::backoffMs
+   */
+  public function testWaitIsBoundedEvenWhenEveryResponseAsksForFiveMinutes(): void {
+    // The per-attempt cap alone does not bound this: two retries each honouring
+    // a Retry-After clamped to MAX_RETRY_AFTER_MS would sleep 20 seconds.
+    $waited = 0;
+    for ($attempt = 1; $attempt < AiTesterRetry::MAX_ATTEMPTS; $attempt++) {
+      $wait = AiTesterRetry::backoffMs($attempt, 300000, 1.0);
+      if (!AiTesterRetry::withinWaitBudget($waited, $wait)) {
+        break;
+      }
+      $waited += $wait;
+    }
+
+    $this->assertLessThanOrEqual(AiTesterRetry::MAX_TOTAL_RETRY_WAIT_MS, $waited);
+    // Worst case overall: this budget plus the largest configurable pause,
+    // still leaving the great majority of a 120s request for real work.
+    $this->assertLessThan(30000, $waited + AiTesterRetry::MAX_QUESTION_DELAY_MS);
+  }
+
+  /**
+   * @covers ::withinWaitBudget
+   * @dataProvider provideBudgetCases
+   */
+  public function testWithinWaitBudget(int $waited, int $next, bool $expected): void {
+    $this->assertSame($expected, AiTesterRetry::withinWaitBudget($waited, $next));
+  }
+
+  /**
+   * Already waited, the next wait, and whether it is allowed.
+   */
+  public static function provideBudgetCases(): array {
+    $budget = AiTesterRetry::MAX_TOTAL_RETRY_WAIT_MS;
+
+    return [
+      'first wait of a normal run' => [0, 1250, TRUE],
+      'exactly on the budget is allowed' => [0, $budget, TRUE],
+      'one millisecond over is refused' => [0, $budget + 1, FALSE],
+      'second large wait tips it over' => [10000, 10000, FALSE],
+      'budget already spent' => [$budget, 1, FALSE],
+    ];
+  }
+
+  /**
+   * @covers ::questionDelayMs
+   * @dataProvider provideDelayCases
+   */
+  public function testQuestionDelayMs(mixed $configured, int $expected): void {
+    $this->assertSame($expected, AiTesterRetry::questionDelayMs($configured));
+  }
+
+  /**
+   * Configured value, and the delay actually applied.
+   *
+   * Config can hold anything - an unset key, a string from a form, a value
+   * hand-edited into a YAML file - so the clamp is what keeps a fat-fingered
+   * number from stalling every run on the site.
+   */
+  public static function provideDelayCases(): array {
+    return [
+      'unset falls back to the default' => [NULL, AiTesterRetry::DEFAULT_QUESTION_DELAY_MS],
+      'zero disables pacing' => [0, 0],
+      'a normal value passes through' => [250, 250],
+      'numeric string from a form' => ['750', 750],
+      'negative clamps to zero' => [-5, 0],
+      'absurd value clamps to the ceiling' => [999999, AiTesterRetry::MAX_QUESTION_DELAY_MS],
+      'non-numeric falls back to the default' => ['soon', AiTesterRetry::DEFAULT_QUESTION_DELAY_MS],
+    ];
+  }
+
+  /**
+   * @covers ::questionDelayMs
+   */
+  public function testDefaultPacingDoesNotMeaningfullySlowLongRuns(): void {
+    // A hundred-question run is the case in the bug report. The default delay
+    // must be a rounding error next to the LLM latency it sits beside, or the
+    // cure is worse than the disease.
+    $added_seconds = (AiTesterRetry::questionDelayMs(NULL) * 100) / 1000;
+
+    $this->assertLessThanOrEqual(60, $added_seconds);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterRunStatusTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/tests/src/Unit/AiTesterRunStatusTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ys_ai_tester\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai_tester\AiTesterBatch;
+
+/**
+ * Tests the run status a finished batch records.
+ *
+ * The bug this covers: a hundred-question run where one question hit a
+ * transient upstream error was recorded as 'failed', identically to a run where
+ * every single question failed. There was no way to tell a run that was 99
+ * percent successful from a collapsed one, so large runs read as broken and
+ * their results got discarded.
+ *
+ * @coversDefaultClass \Drupal\ys_ai_tester\AiTesterBatch
+ *
+ * @group ys_beacon
+ */
+class AiTesterRunStatusTest extends UnitTestCase {
+
+  /**
+   * @covers ::runStatus
+   * @dataProvider provideStatusCases
+   */
+  public function testRunStatus(bool $success, int $error_count, int $processed, string $expected): void {
+    $this->assertSame($expected, AiTesterBatch::runStatus($success, $error_count, $processed));
+  }
+
+  /**
+   * Batch success flag, errored questions, processed questions, run status.
+   */
+  public static function provideStatusCases(): array {
+    return [
+      'every question answered' => [TRUE, 0, 100, 'complete'],
+      // The reported case: one transient 500 out of a hundred.
+      'one question of a hundred failed' => [TRUE, 1, 100, 'partial'],
+      'most questions failed but not all' => [TRUE, 99, 100, 'partial'],
+      // The boundary either side of 'failed': one survivor is still partial.
+      'boundary, one short of every question failing' => [TRUE, 9, 10, 'partial'],
+      // Reserved for a genuine collapse - a bad key, a missing assistant, an
+      // upstream that is down for the whole run.
+      'every question failed' => [TRUE, 100, 100, 'failed'],
+      'single question run that failed' => [TRUE, 1, 1, 'failed'],
+      'single question run that passed' => [TRUE, 0, 1, 'complete'],
+      // The batch itself aborted: whatever the per-question tally says, the run
+      // did not finish, so it must not read as complete or partial.
+      'batch aborted with no errors recorded' => [FALSE, 0, 50, 'failed'],
+      'batch aborted with errors recorded' => [FALSE, 2, 50, 'failed'],
+      // Defensive: finished() with nothing processed is not a success.
+      'nothing processed' => [TRUE, 0, 0, 'failed'],
+    ];
+  }
+
+  /**
+   * Every status the method can return fits the storage column.
+   *
+   * The ys_ai_tester_run.status column is varchar(32), which is why this change
+   * needs no update hook. Asserted over what ::runStatus() actually returns
+   * rather than over a hardcoded list, so a future status too long for the
+   * column fails here instead of being silently truncated on write.
+   *
+   * @covers ::runStatus
+   */
+  public function testEveryStatusFitsTheStorageColumn(): void {
+    foreach ([[TRUE, 0, 10], [TRUE, 1, 10], [TRUE, 10, 10], [FALSE, 0, 10], [TRUE, 0, 0]] as $case) {
+      $status = AiTesterBatch::runStatus(...$case);
+      $this->assertLessThanOrEqual(32, strlen($status), "Status '{$status}' does not fit varchar(32).");
+    }
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/ys_ai_tester.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester/ys_ai_tester.module
@@ -5,6 +5,83 @@
  * Contains ys_ai_tester.module functions.
  */
 
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\ys_ai_tester\AiTesterRetry;
+
+/**
+ * Implements hook_form_FORM_ID_alter() for ys_beacon_admin_settings.
+ *
+ * Adds the tester's pacing knob to the Beacon administration form, which is
+ * where the platform team already tunes assistant behaviour, and which is
+ * restricted to platform operators.
+ *
+ * The field is added from here rather than declared in the Beacon form so the
+ * dependency runs the way the module dependency does - the tester depends on
+ * Beacon, never the reverse. It also means the field simply is not there when
+ * this submodule is uninstalled, with no module-exists guard on either side,
+ * and nothing can write NULL over the stored value on a site that lacks the
+ * tester.
+ */
+function ys_ai_tester_form_ys_beacon_admin_settings_alter(array &$form, FormStateInterface $form_state): void {
+  $form['tester'] = [
+    '#type' => 'details',
+    '#title' => t('AI Tester'),
+    '#open' => FALSE,
+  ];
+  $form['tester']['ai_tester_question_delay_ms'] = [
+    '#type' => 'number',
+    '#title' => t('Pause between questions (milliseconds)'),
+    '#description' => t('How long the AI Tester waits before each question after the first. A tester run is the only thing on this site that sends a long burst of requests to the assistants - the chat widget answers one question per visitor - so this is where a run is slowed down if an upstream rate limit is suspected. Raise it if long runs report questions that fail here but answer fine when asked on their own. Defaults to @default ms, which is negligible against the time a question already takes; 0 turns the pause off. This does not affect the chat widget.', [
+      '@default' => AiTesterRetry::DEFAULT_QUESTION_DELAY_MS,
+    ]),
+    // Clamped rather than read raw, so a site that predates this setting shows
+    // the real default instead of an empty field.
+    '#default_value' => AiTesterRetry::questionDelayMs(
+      \Drupal::config('ys_beacon.settings')->get('ai_tester_question_delay_ms')
+    ),
+    '#min' => 0,
+    '#max' => AiTesterRetry::MAX_QUESTION_DELAY_MS,
+    '#step' => 50,
+    // Required so clearing the field is rejected rather than quietly falling
+    // back to the default: an operator who empties it means zero, and would
+    // otherwise be shown 500 again on the next load as though it had saved.
+    // Zero has to be typed.
+    '#required' => TRUE,
+  ];
+
+  // Appended to the form-level handlers, which already hold the config form's
+  // own '::submitForm' by the time alters run.
+  $form['#submit'][] = 'ys_ai_tester_admin_settings_submit';
+}
+
+/**
+ * Saves the AI Tester pacing setting added by the form alter above.
+ *
+ * Writes through its own editable config object: the Beacon form has already
+ * saved by the time this runs, so keeping the two writes separate keeps each
+ * module responsible for its own setting.
+ *
+ * The key deliberately lives in ys_beacon.settings rather than a
+ * ys_ai_tester.settings of its own, even though only this module reads it. That
+ * object is covered by the 'ys_beacon*' config_ignore pattern and so is absent
+ * from the profile's config/sync, which is what lets an operator's tuned value
+ * survive the next `drush deploy` config import. See the comment on the key in
+ * ys_beacon/config/install/ys_beacon.settings.yml.
+ *
+ * @param array $form
+ *   The form structure.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ */
+function ys_ai_tester_admin_settings_submit(array &$form, FormStateInterface $form_state): void {
+  \Drupal::configFactory()->getEditable('ys_beacon.settings')
+    ->set(
+      'ai_tester_question_delay_ms',
+      AiTesterRetry::questionDelayMs($form_state->getValue('ai_tester_question_delay_ms'))
+    )
+    ->save();
+}
+
 /**
  * Implements hook_theme().
  */

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/src/LegacyStreamException.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/src/LegacyStreamException.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_ai_tester_legacy;
+
+use Drupal\ys_ai_tester\UpstreamStatusInterface;
+
+/**
+ * An error the legacy assistant reported inside an otherwise-successful stream.
+ *
+ * The legacy endpoint streams its reply, and a streamed response can carry a
+ * failure in its body while the HTTP status stays 200 - openai-php documents
+ * the same hazard for its own streamed requests. Those failures arrive with no
+ * HTTP response to read a status off, so before this they were
+ * indistinguishable from a permanent error and never retried, even when the
+ * body plainly said 429.
+ *
+ * Carrying the code the body reported lets the tester classify the failure the
+ * same way it classifies every other one: on a status code, never on the
+ * wording of a message.
+ */
+class LegacyStreamException extends \RuntimeException implements UpstreamStatusInterface {
+
+  /**
+   * Constructs a legacy stream exception.
+   *
+   * @param string $message
+   *   The message to record against the question.
+   * @param int|null $statusCode
+   *   The status code the stream's error payload reported, when it carried one.
+   */
+  public function __construct(string $message, protected ?int $statusCode = NULL) {
+    parent::__construct($message);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getUpstreamStatusCode(): ?int {
+    return $this->statusCode;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/src/LegacyStreamParser.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/src/LegacyStreamParser.php
@@ -70,7 +70,10 @@ final class LegacyStreamParser {
       $parsed++;
 
       if (isset($envelope['error'])) {
-        throw new \RuntimeException(self::errorMessage($envelope['error']));
+        throw new LegacyStreamException(
+          self::errorMessage($envelope['error']),
+          self::errorStatusCode($envelope['error'])
+        );
       }
 
       foreach ($envelope['choices'][0]['messages'] ?? [] as $message) {
@@ -118,6 +121,31 @@ final class LegacyStreamParser {
       return (string) $error['message'];
     }
     return (string) json_encode($error);
+  }
+
+  /**
+   * Reads the status code out of an envelope's error payload.
+   *
+   * The structured Azure OpenAI shape reports it as `code`, sometimes as a
+   * string. It is what lets a throttled or broken-upstream stream be retried:
+   * the response itself was a 200, so there is no HTTP status to read instead.
+   *
+   * @param mixed $error
+   *   The envelope's error value.
+   *
+   * @return int|null
+   *   The reported status code, or NULL when the payload carried none.
+   */
+  private static function errorStatusCode(mixed $error): ?int {
+    if (!is_array($error) || !isset($error['code'])) {
+      return NULL;
+    }
+    $code = $error['code'];
+
+    // Only a plain integer-valued code is usable. Some upstreams report a
+    // symbolic code here instead ("content_filter"), which is not a status and
+    // must not be coerced into one.
+    return is_numeric($code) ? (int) $code : NULL;
   }
 
   /**

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/tests/src/Unit/LegacyStreamExceptionTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/modules/ys_ai_tester_legacy/tests/src/Unit/LegacyStreamExceptionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ys_ai_tester_legacy\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\ys_ai_tester\AiTesterFailure;
+use Drupal\ys_ai_tester_legacy\LegacyStreamException;
+use Drupal\ys_ai_tester_legacy\LegacyStreamParser;
+
+/**
+ * Tests that an error inside a 200 stream still reports its status code.
+ *
+ * The legacy endpoint streams its reply, so it can report a failure in the body
+ * while the HTTP status stays 200. Those failures carry no response to read a
+ * status off, so without the code travelling on the exception the tester would
+ * treat a plainly retryable 429 as permanent and never retry it.
+ *
+ * @coversDefaultClass \Drupal\ys_ai_tester_legacy\LegacyStreamParser
+ *
+ * @group ys_beacon
+ */
+class LegacyStreamExceptionTest extends UnitTestCase {
+
+  /**
+   * Builds a one-envelope stream body carrying an error payload.
+   *
+   * @param array $error
+   *   The envelope's error value.
+   *
+   * @return string
+   *   The stream body.
+   */
+  protected function errorStream(array $error): string {
+    return json_encode(['error' => $error]) . "\n";
+  }
+
+  /**
+   * @covers ::parse
+   * @covers ::errorStatusCode
+   * @dataProvider provideErrorPayloads
+   */
+  public function testParseCarriesTheReportedStatusCode(array $error, ?int $expected_code, bool $transient): void {
+    try {
+      LegacyStreamParser::parse($this->errorStream($error));
+      $this->fail('Expected the stream error to throw.');
+    }
+    catch (LegacyStreamException $e) {
+      $this->assertSame($expected_code, $e->getUpstreamStatusCode());
+      // The whole point of carrying the code: the tester's classification.
+      $this->assertSame($transient, AiTesterFailure::isTransient($e));
+    }
+  }
+
+  /**
+   * Error payload, the status code it should yield, and whether to retry it.
+   */
+  public static function provideErrorPayloads(): array {
+    return [
+      'throttled' => [['code' => 429, 'message' => 'Rate limit exceeded'], 429, TRUE],
+      // Azure reports the code as a string in this shape.
+      'throttled as a string' => [['code' => '429', 'message' => 'Rate limit exceeded'], 429, TRUE],
+      'upstream broke' => [['code' => '500', 'message' => 'Server error'], 500, TRUE],
+      'bad request' => [['code' => '400', 'message' => 'Bad request'], 400, FALSE],
+      // A symbolic code is not a status and must not be coerced into one, or
+      // "content_filter" would cast to 0 and be compared against 500.
+      'symbolic code' => [['code' => 'content_filter', 'message' => 'Filtered'], NULL, FALSE],
+      'no code at all' => [['message' => 'Something went wrong'], NULL, FALSE],
+    ];
+  }
+
+  /**
+   * The message recorded against the question is unchanged by this.
+   *
+   * @covers ::parse
+   */
+  public function testTheRecordedMessageIsStillTheUpstreamMessage(): void {
+    $this->expectException(LegacyStreamException::class);
+    $this->expectExceptionMessage('Rate limit exceeded');
+
+    LegacyStreamParser::parse($this->errorStream([
+      'code' => '429',
+      'message' => 'Rate limit exceeded',
+    ]));
+  }
+
+  /**
+   * The new exception is still a \RuntimeException to every existing caller.
+   *
+   * @covers ::parse
+   */
+  public function testItRemainsRuntimeExceptionForExistingCallers(): void {
+    $this->expectException(\RuntimeException::class);
+
+    LegacyStreamParser::parse($this->errorStream(['message' => 'boom']));
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Exception/BeaconStageException.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Exception/BeaconStageException.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ys_beacon\Exception;
+
+/**
+ * Names which upstream call failed while answering one question.
+ *
+ * Answering a single question makes several calls to different outside
+ * services, and the exceptions they throw are indistinguishable once they reach
+ * the caller: a 500 from the embeddings request and a 500 from the chat request
+ * arrive as the same openai-php ServerException carrying the same message. That
+ * ambiguity is what made a production failure impossible to correlate against
+ * the gateway's own logs - the two calls authenticate with different Portkey
+ * API keys, so "no errors in Portkey" may simply have been the wrong workspace.
+ *
+ * This wraps the original exception rather than replacing it. The cause stays
+ * reachable through ::getPrevious(), which is what lets the AI Tester still
+ * decide whether the failure is worth retrying.
+ *
+ * It lives in ys_beacon, not ys_ai_tester, because the dependency runs in that
+ * direction: the tester submodule depends on Beacon, never the reverse.
+ */
+class BeaconStageException extends \RuntimeException {
+
+  /**
+   * Retrieval: embedding the question, then querying the vector index.
+   */
+  const STAGE_RETRIEVAL = 'retrieval';
+
+  /**
+   * The chat completion that produces the answer.
+   */
+  const STAGE_CHAT = 'chat';
+
+  /**
+   * The second chat turn, taken only when the first returned a tool call.
+   */
+  const STAGE_CHAT_FOLLOW_UP = 'chat_follow_up';
+
+  /**
+   * Constructs a staged Beacon exception.
+   *
+   * @param string $stage
+   *   Which upstream call failed - one of the STAGE_* constants.
+   * @param string $message
+   *   The original exception's message, kept verbatim so anything already
+   *   displaying it (the tester's per-question error cell) is unaffected.
+   * @param \Throwable|null $previous
+   *   The exception this wraps.
+   */
+  public function __construct(
+    protected string $stage,
+    string $message = '',
+    ?\Throwable $previous = NULL,
+  ) {
+    parent::__construct($message, 0, $previous);
+  }
+
+  /**
+   * Returns which upstream call failed.
+   *
+   * @return string
+   *   One of the STAGE_* constants.
+   */
+  public function getStage(): string {
+    return $this->stage;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/BeaconAnswerService.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_beacon/src/Service/BeaconAnswerService.php
@@ -5,6 +5,7 @@ namespace Drupal\ys_beacon\Service;
 use Drupal\ai\AiProviderPluginManager;
 use Drupal\ai\OperationType\Chat\ChatInput;
 use Drupal\ai\OperationType\Chat\ChatMessage;
+use Drupal\ys_beacon\Exception\BeaconStageException;
 
 /**
  * Answers a question through the Beacon assistant, non-streamed.
@@ -44,7 +45,10 @@ class BeaconAnswerService {
       throw new \RuntimeException('No default chat provider is configured.');
     }
 
-    $citations = $this->ragRetriever->retrieve($question);
+    $citations = $this->runStage(
+      BeaconStageException::STAGE_RETRIEVAL,
+      fn() => $this->ragRetriever->retrieve($question)
+    );
     $messages = [
       new ChatMessage('system', $this->promptBuilder->build($citations)),
       new ChatMessage('user', $question),
@@ -54,12 +58,18 @@ class BeaconAnswerService {
     $chat_input = new ChatInput($messages);
     $this->toolCallHandler->attachTools($chat_input);
 
-    $output = $provider->chat($chat_input, $defaults['model_id'], ['ys_beacon']);
+    $output = $this->runStage(
+      BeaconStageException::STAGE_CHAT,
+      fn() => $provider->chat($chat_input, $defaults['model_id'], ['ys_beacon'])
+    );
     $normalized = $output->getNormalized();
 
     $follow_up_input = $this->toolCallHandler->followUpInput($normalized, $messages);
     if ($follow_up_input) {
-      $output = $provider->chat($follow_up_input, $defaults['model_id'], ['ys_beacon']);
+      $output = $this->runStage(
+        BeaconStageException::STAGE_CHAT_FOLLOW_UP,
+        fn() => $provider->chat($follow_up_input, $defaults['model_id'], ['ys_beacon'])
+      );
       $normalized = $output->getNormalized();
     }
 
@@ -67,6 +77,44 @@ class BeaconAnswerService {
       'answer' => (string) $normalized->getText(),
       'citations' => $citations,
     ];
+  }
+
+  /**
+   * Runs one upstream call, labeling any failure with the stage it came from.
+   *
+   * Answering a question makes several calls to different outside services, and
+   * their exceptions are indistinguishable once they reach the caller: a 500
+   * from the embeddings request and a 500 from the chat request arrive as the
+   * same openai-php ServerException with the same message. Labeling the stage
+   * is what lets a failure be traced to the right service - and, for the two
+   * Portkey calls, to the right API key, since chat and embeddings authenticate
+   * with different ones and can sit in different gateway workspaces.
+   *
+   * The cause is preserved as the wrapped exception, so a caller can still
+   * classify the failure. This service answers only the AI Tester (the chat
+   * widget uses the streamed ChatApiController path), so the wrapping cannot
+   * change what a site visitor sees.
+   *
+   * @param string $stage
+   *   A BeaconStageException::STAGE_* constant.
+   * @param callable $operation
+   *   The call to make.
+   *
+   * @return mixed
+   *   Whatever the call returned.
+   *
+   * @throws \Drupal\ys_beacon\Exception\BeaconStageException
+   *   When the call failed, wrapping the original exception.
+   */
+  protected function runStage(string $stage, callable $operation): mixed {
+    try {
+      return $operation();
+    }
+    catch (\Throwable $e) {
+      // The message is carried over verbatim so anything already displaying it
+      // - the tester's per-question error cell - reads exactly as before.
+      throw new BeaconStageException($stage, $e->getMessage(), $e);
+    }
   }
 
   /**


### PR DESCRIPTION
## [1587: Bug: AI Tester marks long runs as failed when a single question hits a transient upstream error](https://github.com/yalesites-org/YaleSites-Internal/issues/1587)

### Description of work

- **A run where some questions failed is now recorded `partial`.** `failed` is reserved for a run where nothing was answered. Previously one transient error out of a hundred questions recorded the same `failed` as a total collapse, so a 99-percent-successful run read as broken. No schema change or update hook: the status column is already `varchar(32)`.
- **Transient failures are retried, deterministic ones are not.** Up to two retries with jittered exponential backoff, honouring `Retry-After`. Retryable means 5xx, 429, 408, a connect or read timeout, or `AiRateLimitException`. A filtered completion, a malformed request, a bad key, an exhausted quota, or "the assistant is not available on this site" fails on the first attempt rather than the third. Classification reads HTTP status codes and the AI module's typed exceptions, never message wording, for the reason already documented in `PortkeyProvider::handleApiException()`: the wording varies by upstream provider and by library version while the codes stay stable.
- **Classification walks the `getPrevious()` chain**, which is required rather than defensive. `LegacyConversationClient::ask()` rethrows every Guzzle failure wrapped in a `RuntimeException`, so reading only the outermost exception would classify every legacy failure as permanent and retry none of them.
- **Every wait is bounded**, because these sleeps happen inside a batch request that the platform terminates at 120 seconds. Per-attempt caps plus a total per-question budget, so a gateway asking to be retried in five minutes cannot get the whole request killed and take the queued questions with it.
- **A configurable pause between questions**, on the Beacon administration form. The tester is the only path on the platform that bursts these APIs; the chat widget answers one question per visitor, already rate limits per IP, and its provider documents a deliberate no-sleep contract so a request never holds a PHP-FPM worker. The widget is untouched, and the field is contributed by the tester's own `hook_form_FORM_ID_alter()` so it disappears with the submodule.
- **Failures now log enough to diagnose.** openai-php's `ServerException` message is only `Server error (HTTP 500) occurred.` and discards the response body it is holding; Guzzle truncates response bodies to 120 characters when building an exception message, which is how the 400 in the issue was recorded cut off mid-word with its cause lost. Failures now log the status code, the response body bounded to 2000 bytes, and Portkey's `x-portkey-trace-id` / `x-portkey-request-id`, without which a failure cannot be matched against the gateway's own logs at all.
- **The log names which upstream call failed.** Chat and embeddings authenticate with different Portkey keys and can sit in different workspaces, so naming the stage is the difference between checking the right log and concluding the gateway saw nothing.
- **Closes a gap in the same mechanism for the legacy assistant.** It streams its reply, so it can report a failure inside an HTTP 200 body; those arrived as a bare `RuntimeException` with no status, meaning retry would have worked for Beacon and silently not for legacy even when the body said 429. `UpstreamStatusInterface` lets a backend report a status it parsed itself. Symbolic codes such as `content_filter` are deliberately not coerced into a status.

### Two things for the reviewer

**1. A deliberate exception to config ownership, flagged for you to overrule.** `ai_tester_question_delay_ms` is read and written only by `ys_ai_tester`, so it would normally belong in a `ys_ai_tester.settings` object. It is in `ys_beacon.settings` on purpose: that object is covered by the `ys_beacon*` pattern in `config_ignore.settings.yml` and so is absent from `config/sync`, which is what lets a value tuned during an incident survive the next `drush deploy` config import. A `ys_ai_tester.settings` object would be exported and re-imported, resetting the knob on every deploy unless a second ignore pattern were added to chase it. Being in that file also means `_ys_beacon_seed_settings()` backfills the new default onto existing sites for free. Reasoning is recorded at both the key and the submit handler.

**2. A separate blind spot this uncovered, not fixed here.** `RagRetriever::retrieve()` catches `Throwable` and degrades to an empty citation list, logging separately as "Beacon retrieval failed". So an embeddings or Azure AI Search outage during a tester run produces answers with **no sources** rather than errors — a run conducted during such an outage reads as "Beacon gives poor, uncited answers" instead of "retrieval was down", which is actively misleading for the evaluation work the tester exists to support. Not changed here because `RagRetriever` is shared with the live chat widget, where quiet degradation is deliberate and documented. Worth its own ticket to surface citation-free answers on the run view.

This also narrows the original diagnosis: because retrieval failures are swallowed, the `Server error (HTTP 500) occurred.` recorded against run 9 question 89 cannot have come from the embeddings call. It came from the chat call or the tool follow-up, both on `portkey_llm_api_key`.

### Functional testing steps:

- [ ] As user 1, visit `/admin/config/yalesites/ys-beacon/admin`. Confirm an **AI Tester** section with a **Pause between questions (milliseconds)** field, defaulting to 500, with a description explaining what it does.
- [ ] Change the pause to 1000 and save. Confirm it persists on reload, and confirm the other Beacon settings on that form (sources per answer, relevance score, streaming) still save correctly.
- [ ] Try to save the pause field empty. Confirm it is rejected rather than silently reverting to 500.
- [ ] Run the AI Tester with a short question list against Beacon. Confirm it still completes normally and the run history shows status `complete`.
- [ ] Run a list that includes one question you expect the assistant to refuse or filter, alongside questions that answer normally. Confirm the run is recorded **`partial`** rather than `failed`, that the successful answers are all saved and viewable, and that the completion message names which question numbers failed.
- [ ] Open the failed question's entry at `/admin/reports/dblog`. Confirm the log line now carries an HTTP status, a response body (not cut off at 120 characters), and, for a Beacon failure, which stage failed. Confirm no API key or credential appears in it.
- [ ] Confirm a `partial` run can still be re-run from the run history.
- [ ] Regression: confirm the Beacon chat widget on a page still answers normally and streams as before. It should be entirely unaffected by this change.

### Notes on verification

- Unit tests: `ys_ai_tester` 114 -> 190, `ys_ai_tester_legacy` 29 -> 37, `ys_beacon` 328 unchanged. All pass, no pre-existing failures in the baseline and none introduced.
- `composer lint:php` and `composer code-sniff` both exit 0 over the whole custom tree.
- The transient upstream failure in the issue cannot be induced locally, so the retry and classification paths are covered by unit tests over real `openai-php`, Guzzle, and AI-module exception objects rather than by a live reproduction. The form alter, its field bounds, its label association, and the preservation of the config form's own submit handler were each verified against the rendered form and the built form, not only in tests.

References yalesites-org/YaleSites-Internal#1587
