### PR TITLE
1589: Bug: Site Settings page loads scrolled down to the Fallback teaser image field

### DIFF
--- a/patches/contrib/media_library_form_element/core-3091297-port-focus-guard.patch
+++ b/patches/contrib/media_library_form_element/core-3091297-port-focus-guard.patch
@@ -1,0 +1,32 @@
+diff --git a/src/Element/MediaLibrary.php b/src/Element/MediaLibrary.php
+index d122a42..8aa169d 100644
+--- a/src/Element/MediaLibrary.php
++++ b/src/Element/MediaLibrary.php
+@@ -301,10 +301,24 @@ class MediaLibrary extends FormElementBase {
+     // items, the button needs to be disabled. Since we can't shift the focus to
+     // disabled elements, the focus is set back to the open button via
+     // JavaScript by adding the 'data-disabled-focus' attribute.
+-    // @see Drupal.behaviors.MediaLibraryWidgetDisableButton
++    // @see Drupal.behaviors.MediaLibraryFormElementDisableButton
+     if (!$cardinality_unlimited && $remaining === 0) {
+-      $element['media_library_open_button']['#attributes']['data-disabled-focus'] = 'true';
+-      $element['media_library_open_button']['#attributes']['class'][] = 'visually-hidden';
++      $triggering_element = $form_state->getTriggeringElement();
++      $trigger_parents = $triggering_element['#array_parents'] ?? [];
++      if ($trigger_parents && end($trigger_parents) === 'media_library_update_widget') {
++        // The element is being rebuilt from a selection change, so shift the
++        // focus back to the button the user left from before disabling it.
++        $element['media_library_open_button']['#attributes']['data-disabled-focus'] = 'true';
++        $element['media_library_open_button']['#attributes']['class'][] = 'visually-hidden';
++      }
++      else {
++        // The element is being built without a selection change, so it can be
++        // disabled right away and there is no need to set the focus first.
++        // Flagging it for focus here would make the browser scroll the
++        // visually-hidden button into view on a plain page load.
++        $element['media_library_open_button']['#disabled'] = TRUE;
++        $element['media_library_open_button']['#attributes']['class'][] = 'visually-hidden';
++      }
+     }
+ 
+     // This hidden field and button are used to add new items to the widget.

--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -165,7 +165,8 @@
         "Decode file URLs (link field) https://www.drupal.org/project/linkit/issues/3436733": "patches/contrib/linkit/3436733-5.patch"
       },
       "drupal/media_library_form_element": {
-        "Order Media items https://www.drupal.org/project/media_library_form_element/issues/3168027": "patches/contrib/media_library_form_element/3168027-8.patch"
+        "Order Media items https://www.drupal.org/project/media_library_form_element/issues/3168027": "patches/contrib/media_library_form_element/3168027-8.patch",
+        "Only shift focus to the open button on a selection change, so a page with a full media_library element does not load scrolled to it - ports the core fix from https://www.drupal.org/project/drupal/issues/3091297": "patches/contrib/media_library_form_element/core-3091297-port-focus-guard.patch"
       },
       "drupal/menu_item_limit": {
         "Can permissions be set for specific roles? https://www.drupal.org/project/menu_item_limit/issues/3458139": "patches/contrib/menu_item_limit/3458139-mr-12.patch"

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/modules/ys_core_test/config/schema/ys_core_test.schema.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/modules/ys_core_test/config/schema/ys_core_test.schema.yml
@@ -1,0 +1,16 @@
+ys_core_test.media_library.settings:
+  type: config_object
+  label: 'YS Core test media library settings'
+  mapping:
+    single:
+      type: string
+      label: 'Bare element, one item allowed'
+    multiple_partial:
+      type: string
+      label: 'Two items allowed, one selected'
+    multiple_full:
+      type: string
+      label: 'Two items allowed, both selected'
+    unlimited:
+      type: string
+      label: 'Unlimited items'

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/modules/ys_core_test/src/Form/MediaLibraryTestForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/modules/ys_core_test/src/Form/MediaLibraryTestForm.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\ys_core_test\Form;
+
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * A settings form carrying media_library elements at each cardinality.
+ *
+ * Stands in for the real ys_core settings forms, which all place
+ * '#type' => 'media_library' elements on plain config forms. Building those
+ * forms in a kernel test would drag in most of the platform; this carries the
+ * element under test at the cardinalities they use.
+ *
+ * Every one of those production elements is effectively cardinality 1: the
+ * Site Settings fallback teaser image, the Header Settings focus image, and
+ * both Footer Settings logos. Footer Settings does use '#cardinality' => 2,
+ * but on the multivalue wrapper around the element, not on the element itself.
+ * The higher cardinalities here therefore guard the element's own arithmetic
+ * rather than mirroring a specific form.
+ *
+ * @see \Drupal\ys_core\Form\SiteSettingsForm
+ * @see \Drupal\ys_core\Form\HeaderSettingsForm
+ * @see \Drupal\ys_core\Form\FooterSettingsForm
+ */
+class MediaLibraryTestForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'ys_core_test_media_library_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildForm($form, $form_state);
+    $config = $this->config('ys_core_test.media_library.settings');
+
+    // No explicit '#cardinality', so this defaults to 1 -- the shape every
+    // real ys_core media_library element has.
+    $form['single'] = [
+      '#type' => 'media_library',
+      '#allowed_bundles' => ['image'],
+      '#title' => $this->t('Single image'),
+      '#default_value' => $config->get('single') ?: NULL,
+    ];
+
+    $form['multiple_partial'] = [
+      '#type' => 'media_library',
+      '#allowed_bundles' => ['image'],
+      '#title' => $this->t('Two images, one selected'),
+      '#default_value' => $config->get('multiple_partial') ?: NULL,
+      '#cardinality' => 2,
+    ];
+
+    $form['multiple_full'] = [
+      '#type' => 'media_library',
+      '#allowed_bundles' => ['image'],
+      '#title' => $this->t('Two images, both selected'),
+      '#default_value' => $config->get('multiple_full') ?: NULL,
+      '#cardinality' => 2,
+    ];
+
+    $form['unlimited'] = [
+      '#type' => 'media_library',
+      '#allowed_bundles' => ['image'],
+      '#title' => $this->t('Unlimited images'),
+      '#default_value' => $config->get('unlimited') ?: NULL,
+      '#cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['ys_core_test.media_library.settings'];
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/modules/ys_core_test/ys_core_test.info.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/modules/ys_core_test/ys_core_test.info.yml
@@ -1,0 +1,7 @@
+name: 'YS Core Test'
+type: module
+description: 'Provides fixtures for ys_core kernel tests.'
+package: Testing
+core_version_requirement: ^10 || ^11
+dependencies:
+  - media_library_form_element:media_library_form_element

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/MediaLibraryOpenButtonFocusTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/MediaLibraryOpenButtonFocusTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\Core\Form\FormState;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\media\Traits\MediaTypeCreationTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\media\Entity\Media;
+
+/**
+ * Tests the media_library element does not steal focus on a plain page load.
+ *
+ * Site Settings (/admin/yalesites/settings) loaded scrolled ~1900px down,
+ * landing on the Fallback teaser image field, because the "Add media" button
+ * was rendered both visually-hidden and flagged data-disabled-focus="true" on
+ * every build once the element was at cardinality. The contrib JS focuses any
+ * .js-media-library-open-button[data-disabled-focus="true"] on behavior
+ * attach, and focusing an offscreen element makes the browser scroll it into
+ * view. Nothing scrolled the page; the focus did.
+ *
+ * Drupal core's own MediaLibraryWidget only sets that attribute when the
+ * widget is being rebuilt from a selection change, precisely so a fresh GET
+ * does not move focus. The contrib form element copied core's code without
+ * that guard. We patch the guard back in, so this asserts both halves of
+ * core's behaviour: no focus flag on a plain build, and the flag still present
+ * on a selection change so focus returns to the button for keyboard and screen
+ * reader users.
+ *
+ * This covers every ys_core form placing a '#type' => 'media_library'
+ * element -- SiteSettingsForm, HeaderSettingsForm and FooterSettingsForm --
+ * all of which use the element at its default cardinality of 1.
+ *
+ * @see \Drupal\media_library_form_element\Element\MediaLibrary
+ * @see https://github.com/yalesites-org/YaleSites-Internal/issues/1589
+ *
+ * @group ys_core
+ * @group yalesites
+ */
+class MediaLibraryOpenButtonFocusTest extends KernelTestBase {
+
+  use MediaTypeCreationTrait;
+  use UserCreationTrait;
+
+  /**
+   * The form element key core checks for, and the attribute it gates.
+   */
+  private const UPDATE_TRIGGER = 'media_library_update_widget';
+  private const FOCUS_ATTRIBUTE = 'data-disabled-focus';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'file',
+    'image',
+    'filter',
+    'views',
+    'media',
+    'media_library',
+    'media_library_form_element',
+    'ys_core_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('media');
+    $this->installSchema('file', ['file_usage']);
+    $this->installConfig(['field', 'system', 'image', 'media', 'media_library']);
+
+    $this->createMediaType('image', ['id' => 'image']);
+
+    // The form is only ever reached by a user who can already administer these
+    // settings; media previews are access checked as they render.
+    $this->setUpCurrentUser([], ['view media', 'access content'], TRUE);
+
+    $first = $this->createImage('Fallback teaser image');
+    $second = $this->createImage('Second image');
+
+    $this->config('ys_core_test.media_library.settings')
+      ->set('single', $first)
+      ->set('multiple_partial', $first)
+      ->set('multiple_full', "$first,$second")
+      ->set('unlimited', $first)
+      ->save();
+  }
+
+  /**
+   * A plain build must not flag the button for focus, even when full.
+   *
+   * This is the regression: 'single' holds one item at cardinality 1, so it is
+   * full, which is exactly when the unguarded contrib code set the flag. The
+   * button must end up disabled server-side and still hidden, so the fix is
+   * neither "focus it anyway" nor "just show it".
+   */
+  public function testPlainBuildDoesNotFlagOpenButtonForFocus(): void {
+    $button = $this->buildOpenButton('single');
+
+    $this->assertArrayNotHasKey(self::FOCUS_ATTRIBUTE, $button['#attributes'], 'A plain build of a full media_library element must not ask the browser to focus the hidden open button.');
+    $this->assertSame(TRUE, $button['#disabled'] ?? NULL, 'A full media_library element should disable its open button server-side instead of relying on JS to focus then disable it.');
+    $this->assertContains('visually-hidden', $button['#attributes']['class']);
+  }
+
+  /**
+   * A multi-value element that is full behaves the same as a single one.
+   *
+   * Guards the arithmetic as well as the guard: 'remaining' reaching zero is
+   * what matters, not the cardinality it counted down from.
+   */
+  public function testFullMultiValueElementIsDisabledNotFlagged(): void {
+    $button = $this->buildOpenButton('multiple_full');
+
+    $this->assertArrayNotHasKey(self::FOCUS_ATTRIBUTE, $button['#attributes']);
+    $this->assertSame(TRUE, $button['#disabled'] ?? NULL);
+    $this->assertContains('visually-hidden', $button['#attributes']['class']);
+  }
+
+  /**
+   * A partly filled element keeps its open button usable and unflagged.
+   */
+  public function testPartlyFilledElementLeavesOpenButtonEnabled(): void {
+    $button = $this->buildOpenButton('multiple_partial');
+
+    $this->assertArrayNotHasKey(self::FOCUS_ATTRIBUTE, $button['#attributes']);
+    $this->assertArrayNotHasKey('#disabled', $button, 'One of two items used, so more may still be added.');
+    $this->assertNotContains('visually-hidden', $button['#attributes']['class']);
+  }
+
+  /**
+   * An unlimited element is never full, so it is never flagged.
+   */
+  public function testUnlimitedElementNeverFlagsOpenButton(): void {
+    $button = $this->buildOpenButton('unlimited');
+
+    $this->assertArrayNotHasKey(self::FOCUS_ATTRIBUTE, $button['#attributes']);
+    $this->assertArrayNotHasKey('#disabled', $button);
+  }
+
+  /**
+   * A selection change must still return focus to the open button.
+   *
+   * The focus flag exists for a real accessibility reason: after the media
+   * library modal closes, keyboard and screen reader users need focus back on
+   * the control they left from. Suppressing it on a plain load must not
+   * suppress it here.
+   */
+  public function testSelectionChangeStillFlagsOpenButtonForFocus(): void {
+    $button = $this->buildOpenButton('single', ['single', self::UPDATE_TRIGGER]);
+
+    $this->assertSame('true', $button['#attributes'][self::FOCUS_ATTRIBUTE], 'After a selection change the button must still be flagged so focus returns to it.');
+    $this->assertContains('visually-hidden', $button['#attributes']['class']);
+  }
+
+  /**
+   * Recognising the trigger must not depend on how deeply it is nested.
+   *
+   * FooterSettingsForm nests media_library elements inside a multivalue
+   * wrapper, so the triggering element's '#array_parents' is several levels
+   * deeper than on Site Settings. The guard inspects only the last parent, and
+   * this pins that: swapping it for a fixed index would break the footer form
+   * while Site Settings kept working.
+   */
+  public function testDeeplyNestedSelectionChangeIsStillRecognised(): void {
+    $parents = ['footer_logos', 'logos', 0, 'logo', self::UPDATE_TRIGGER];
+    $button = $this->buildOpenButton('single', $parents);
+
+    $this->assertSame('true', $button['#attributes'][self::FOCUS_ATTRIBUTE]);
+  }
+
+  /**
+   * A removal is not a selection change, so it must not flag the button.
+   */
+  public function testUnrelatedTriggerDoesNotFlagOpenButton(): void {
+    $button = $this->buildOpenButton('single', ['single', 'selection', 0, 'preview', 'remove_button']);
+
+    $this->assertArrayNotHasKey(self::FOCUS_ATTRIBUTE, $button['#attributes']);
+  }
+
+  /**
+   * Creates a saved image media item and returns its ID.
+   *
+   * @param string $name
+   *   The media item name.
+   *
+   * @return string
+   *   The media ID, as the element takes its default value as a string.
+   */
+  protected function createImage(string $name): string {
+    $media = Media::create(['bundle' => 'image', 'name' => $name]);
+    $media->save();
+
+    return (string) $media->id();
+  }
+
+  /**
+   * Builds the test form and returns one element's open button.
+   *
+   * @param string $element
+   *   The media_library element key on the test form.
+   * @param array|null $trigger_parents
+   *   The '#array_parents' of the element to present as the triggering
+   *   element, or NULL for a plain build with no triggering element.
+   *
+   * @return array
+   *   The open button render array.
+   */
+  protected function buildOpenButton(string $element, ?array $trigger_parents = NULL): array {
+    $form_state = new FormState();
+    if ($trigger_parents !== NULL) {
+      $form_state->setTriggeringElement(['#array_parents' => $trigger_parents]);
+    }
+
+    $form = $this->container->get('form_builder')
+      ->buildForm('Drupal\ys_core_test\Form\MediaLibraryTestForm', $form_state);
+
+    $this->assertArrayHasKey('media_library_open_button', $form[$element], "The $element element should have been processed into a media_library widget.");
+
+    return $form[$element]['media_library_open_button'];
+  }
+
+}


### PR DESCRIPTION
## [1589: Bug: Site Settings page loads scrolled down to the Fallback teaser image field](https://github.com/yalesites-org/YaleSites-Internal/issues/1589)

### Description of work

- Site Settings (`/admin/yalesites/settings`) opened scrolled **1888px** down, landing on the Fallback teaser image field. Fixed at the source; the page now loads at `scrollY: 0` with Site name as the first visible field.
- **Root cause.** Nothing scrolled the page — a focus did. The "Add media" button was rendered both `visually-hidden` and flagged `data-disabled-focus="true"`, the contrib JS (`Drupal.behaviors.MediaLibraryFormElementDisableButton`) focuses any `.js-media-library-open-button[data-disabled-focus="true"]` on behavior attach, and focusing an offscreen element makes the browser scroll it into view. Confirmed by instrumenting `focus`, `scrollIntoView` and `scrollTo` in the browser: exactly one `focus()` call, on that button, at `scrollY` 0, immediately followed by the scroll. Nothing ever called `scrollTo`/`scrollIntoView` — which is why the ticket is right that a scroll-to-top script would be fighting the browser.
- The field is not core's media widget: `SiteSettingsForm` uses `'#type' => 'media_library'` from contrib **`media_library_form_element`**, which forked core's code and **dropped core's guard**. Core only sets that attribute when the widget is rebuilt from a selection change (core issue [#3091297](https://www.drupal.org/project/drupal/issues/3091297)); contrib set it on *every* build once the element was at cardinality, i.e. whenever an image was already selected.
- **Fix:** a composer patch on the profile porting core's guard verbatim — flag for focus only on a `media_library_update_widget` rebuild, otherwise set `#disabled` server-side. One patch instead of three form_alters, which is what makes the "fix it consistently rather than only on this one page" criterion hold: it also covers **Header Settings** (`/admin/yalesites/header`) and both **Footer Settings** logo fields (`/admin/yalesites/footer`), which had the same latent bug.
- **The accessibility behaviour the attribute exists for is preserved.** After a real media selection the flag is still set, so keyboard and screen reader users still get focus back on the control they left from. Verified in the browser and pinned by a test.
- Adds a `ys_core` kernel test (7 tests) and ys_core's first test-only module, `ys_core_test`.

### Reviewer notes

- **Patch application confirmed by the build** (was the one item I could not verify locally). The `Build frontend components` step of run [32543527729](https://github.com/yalesites-org/yalesites-project/actions/runs/32543527729) logs both patches applied to a freshly downloaded 2.1.4:
  ```
  - Applying patches for drupal/media_library_form_element
      patches/contrib/media_library_form_element/3168027-8.patch (Order Media items ...)
      patches/contrib/media_library_form_element/core-3091297-port-focus-guard.patch (Only shift focus ...)
  ```
  Worth knowing why local differs: in my checkout `PATCHES.txt` lists only the pre-existing patch, because that `composer.lock` is stale and every partial update aborts on drift unrelated to this PR (root `composer.json` asks core `10.6.15` / atomic `1.81.0`; the lock has `10.6.13` / `1.80.0`). `composer.lock` is untracked, so the build resolves fresh — which is what the log above shows. Anyone else seeing the bug persist locally after pulling this branch needs a full `composer update`, not just `composer install`.
- **This patch should go upstream.** It is a faithful port of a core fix and there is no matching issue in the `media_library_form_element` queue (the only focus-related one, #3509212, is a different concern), so today the patch has no path to ever being dropped. Filing that is outside what I did here.
- One deliberate deviation from core: `$triggering_element['#array_parents'] ?? []` instead of core's inline assignment-in-condition, which warns under PHP 8 if a triggering element ever lacks `#array_parents`. Equivalent across all four reachable input states.
- Pre-existing and untouched: `ys_core.libraries.yml.orig` is tracked in git and looks like a leftover merge artifact.

### Verification already run

- Kernel tests: **`OK (7 tests, 120 assertions)`**. Regression net measured rather than assumed — with the patch reverted the same file gives **`Tests: 7, Assertions: 116, Failures: 3`**, so 3 tests genuinely catch this bug and 4 are guard rails against over-correcting.
- CI lint gate: `composer lint:php` and `composer code-sniff` (Drupal + DrupalPractice) both **exit 0**. No SCSS touched.
- Accessibility gate: **PASS**. On load `activeElement` is `body` and `scrollY` is 0; the first 25 tab stops follow DOM order and never jump mid-form (2.4.3); no keyboard trap (2.1.2) — the now-disabled "Add media" button is correctly skipped while the field's **Remove** button stays reachable in both directions; text contrast in the region 4.5:1–21:1.
- Full interaction pass on the real form: initial load `scrollY` 0 → Remove (button re-enables, value clears) → open modal → Insert selected (flag correctly returns, value updates) → Save ("The configuration options have been saved.") → reload `scrollY` 0, value persisted. No JS errors at any step.

### Functional testing steps:

- [ ] With a fallback teaser image already set, open **YaleSites > Site Settings** (`/admin/yalesites/settings`). The page loads at the **top**, with **Site name** as the first visible field — it no longer jumps to Fallback teaser image.
- [ ] Same check on `/admin/yalesites/header` (focus header image set) and `/admin/yalesites/footer` (footer logos / school logo set) — both should also load at the top.
- [ ] On Site Settings, click **Remove** on the fallback teaser image. The **Add media** button becomes available again.
- [ ] Click **Add media**, pick an image, and **Insert selected**. The image appears and the Add media button goes away (the field only allows one).
- [ ] Press **Save configuration**, then reload the page. The image persisted, and the page still loads at the top.
- [ ] Keyboard check: from a fresh load press Tab repeatedly. Focus starts at the top of the document and moves in visual order; it never lands on the hidden "Add media" button, and the image's **Remove** button is still reachable by Tab and Shift+Tab.
- [x] ~~Confirm the Pantheon build log shows **both** `media_library_form_element` patches applied.~~ Done — see Reviewer notes.

References yalesites-org/YaleSites-Internal#1589
