### PR TITLE
1590: Site Settings: group settings into task-based sections instead of one flat list

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/SiteSettingsForm.php
@@ -162,14 +162,37 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
     $siteConfig = $this->config('system.site');
     $yaleConfig = $this->config('ys_core.site');
 
-    $form['site_name'] = [
+    // Group the settings by the task a user came here to do, rather than
+    // leaving them in one flat run. Each setting is nested inside its details
+    // group, the same way ViewsSettingsForm already does it: '#tree' is never
+    // set, so nesting rearranges only the render tree and every value still
+    // arrives flat in the form state. submitForm() therefore keeps reading
+    // 'site_name' and friends exactly as before.
+    //
+    // Nesting rather than tagging each setting with '#group' is deliberate.
+    // '#group' is only honoured by element types that wire preRenderGroup —
+    // textfield, textarea, checkbox, container, details, fieldset — so radios
+    // (font pairing), managed_file (favicon), media_library (teaser fallback)
+    // and item (the Tag Manager link) would silently render outside the tabs.
+    $form['vertical_tabs'] = [
+      '#type' => 'vertical_tabs',
+    ];
+
+    $form['site_basics'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Site basics'),
+      '#description' => $this->t('What this site is called and who automated email comes from.'),
+      '#group' => 'vertical_tabs',
+    ];
+
+    $form['site_basics']['site_name'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Site name'),
       '#default_value' => $siteConfig->get('name'),
       '#required' => TRUE,
     ];
 
-    $form['site_mail'] = [
+    $form['site_basics']['site_mail'] = [
       '#type' => 'textfield',
       '#description' => $this->t("The From address in automated emails sent during registration and new password requests, and other notifications. (Use an address ending in your site's domain to help prevent this email being flagged as spam.)"),
       '#title' => $this->t('Site email'),
@@ -177,16 +200,23 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       '#required' => TRUE,
     ];
 
-    $form['site_page_front'] = [
+    $form['key_pages'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Key pages'),
+      '#description' => $this->t('Which page the site should use for each of these purposes.'),
+      '#group' => 'vertical_tabs',
+    ];
+
+    $form['key_pages']['site_page_front'] = [
       '#type' => 'entity_autocomplete',
-      '#title' => $this->t('Front page'),
-      '#description' => $this->t("Specify a relative URL to display as the front page. Typically this points to a page in Drupal and is referenced by a node id. Use this autocomplete field to select the correct node."),
+      '#title' => $this->t('Homepage'),
+      '#description' => $this->t("Start typing to find the page you want visitors to land on first, then pick it from the list."),
       '#default_value' => $this->pathToNode($siteConfig->get('page')['front']),
       '#required' => TRUE,
       '#target_type' => 'node',
     ];
 
-    $form['site_page_posts'] = [
+    $form['key_pages']['site_page_posts'] = [
       '#type' => 'textfield',
       '#description' => $this->t("Specify a relative URL to display as the post landing page. This can be set to an existing page URL or use the default value '/post'."),
       '#title' => $this->t('Post landing page'),
@@ -194,7 +224,7 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       '#required' => FALSE,
     ];
 
-    $form['site_page_events'] = [
+    $form['key_pages']['site_page_events'] = [
       '#type' => 'textfield',
       '#description' => $this->t("Specify a relative URL to display as the events calendar page. This can be set to an existing page URL or use the default value '/events'."),
       '#title' => $this->t('Events calendar page'),
@@ -202,46 +232,28 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       '#required' => FALSE,
     ];
 
-    $form['site_page_403'] = [
+    $form['key_pages']['site_page_403'] = [
       '#type' => 'textfield',
       '#description' => $this->t('This page is displayed when the requested document is denied to the current user. Leave blank to display a generic "access denied" page.'),
-      '#title' => $this->t('403 page'),
+      '#title' => $this->t('Access denied page (403)'),
       '#default_value' => $siteConfig->get('page')['403'],
     ];
 
-    $form['site_page_404'] = [
+    $form['key_pages']['site_page_404'] = [
       '#type' => 'textfield',
       '#description' => $this->t('This page is displayed when no other content matches the requested document. Leave blank to display a generic "page not found" page.'),
-      '#title' => $this->t('404 page'),
+      '#title' => $this->t('Page not found (404)'),
       '#default_value' => $siteConfig->get('page')['404'],
     ];
 
-    $form['google_site_verification'] = [
-      '#type' => 'textfield',
-      '#description' => $this->t('Get a verification key from Google Search Console Tools using the "URL Prefix" tool, clicking on the the alternate methods tab, and selecting the HTML Tag option. Use the "content" attribute from the Google tag within this field. Example: <code>&#60;meta name="google-site-verification" content="USE-THIS-CODE" /></code>'),
-      '#title' => $this->t('Google Site Verification'),
-      '#default_value' => $yaleConfig->get('seo')['google_site_verification'],
+    $form['look_and_feel'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Look and feel'),
+      '#description' => $this->t('Settings that change what visitors see.'),
+      '#group' => 'vertical_tabs',
     ];
 
-    $form['google_analytics_migration'] = [
-      '#type' => 'item',
-      '#title' => $this->t('Google Analytics/Tag Manager'),
-      '#description' => $this->t('YaleSites is transitioning from Google Analytics to Google Tag Manager. Configure Google Tag Manager below to maintain your website analytics tracking.'),
-      '#markup' => Link::fromTextAndUrl(
-        $this->t('Configure Google Tag Manager'),
-        Url::fromRoute('entity.google_tag_container.single_form')
-          ->setOptions(['attributes' => ['class' => ['button'], 'style' => 'margin-top: 0; margin-bottom: 0;']])
-      )->toString(),
-    ];
-
-    $form['custom_vocab_name'] = [
-      '#type' => 'textfield',
-      '#description' => $this->t('This field will update the name of the custom vocabulary for the site. By default, the name is "Custom Vocab".'),
-      '#title' => $this->t('Custom Vocabulary Name'),
-      '#default_value' => $yaleConfig->get('taxonomy')['custom_vocab_name'] ?? 'Custom Vocab',
-    ];
-
-    $form['font_pairing'] = [
+    $form['look_and_feel']['font_pairing'] = [
       '#type' => 'radios',
       '#options' => [
         'yalenew' => $this->t('Yale New (Old-Style Numerals) / Mallory (YaleNew with old-style numerals for headings and other numeric text; Mallory for paragraph text)'),
@@ -255,8 +267,16 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       '#suffix' => '</div>',
     ];
 
-    // Add font preview section.
-    $form['font_preview'] = [
+    // The preview stays directly under the font pairing radios: font-preview.js
+    // toggles the active preview on change and the two read as one control.
+    //
+    // Only the sample digits are hidden from assistive technology, not the
+    // whole preview. They are marked up as h2 purely for size, so they would
+    // otherwise be the only headings in this tab's outline and read as
+    // "1234567890" with nothing to convey. The paragraphs beside them do carry
+    // real information the radio labels omit (which digits descend below the
+    // baseline), so those stay exposed.
+    $form['look_and_feel']['font_preview'] = [
       '#type' => 'container',
       '#attributes' => [
         'class' => ['font-preview-container'],
@@ -274,7 +294,7 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
           '#type' => 'html_tag',
           '#tag' => 'h2',
           '#value' => $this->t('1234567890'),
-          '#attributes' => ['class' => ['preview-heading']],
+          '#attributes' => ['class' => ['preview-heading'], 'aria-hidden' => 'true'],
         ],
         'text' => [
           '#type' => 'html_tag',
@@ -293,7 +313,7 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
           '#type' => 'html_tag',
           '#tag' => 'h2',
           '#value' => $this->t('Mallory Heading Sample'),
-          '#attributes' => ['class' => ['preview-heading']],
+          '#attributes' => ['class' => ['preview-heading'], 'aria-hidden' => 'true'],
         ],
         'text' => [
           '#type' => 'html_tag',
@@ -312,7 +332,7 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
           '#type' => 'html_tag',
           '#tag' => 'h2',
           '#value' => $this->t('1234567890'),
-          '#attributes' => ['class' => ['preview-heading']],
+          '#attributes' => ['class' => ['preview-heading'], 'aria-hidden' => 'true'],
         ],
         'text' => [
           '#type' => 'html_tag',
@@ -323,16 +343,7 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       ],
     ];
 
-    $form['teaser_image_fallback'] = [
-      '#type' => 'media_library',
-      '#allowed_bundles' => ['image'],
-      '#title' => $this->t('Fallback teaser image'),
-      '#required' => FALSE,
-      '#default_value' => ($yaleConfig->get('image_fallback')) ? $yaleConfig->get('image_fallback')['teaser'] : NULL,
-      '#description' => $this->t('This image will be used for event and post card displays when no teaser image is selected.'),
-    ];
-
-    $form['favicon'] = [
+    $form['look_and_feel']['favicon'] = [
       '#type' => 'managed_file',
       '#upload_location' => 'public://favicons',
       '#multiple' => FALSE,
@@ -350,8 +361,74 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       '#use_favicon_preview' => TRUE,
     ];
 
+    // "Teaser" is jargon, but it is used consistently across the platform —
+    // including three node field descriptions that point back at this setting —
+    // so the label stays and the description does the explaining instead.
+    $form['look_and_feel']['teaser_image_fallback'] = [
+      '#type' => 'media_library',
+      '#allowed_bundles' => ['image'],
+      '#title' => $this->t('Fallback teaser image'),
+      '#required' => FALSE,
+      '#default_value' => ($yaleConfig->get('image_fallback')) ? $yaleConfig->get('image_fallback')['teaser'] : NULL,
+      '#description' => $this->t('Used on event and post cards whenever that piece of content has no teaser image of its own, so a card never appears blank.'),
+    ];
+
+    $form['search_and_analytics'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Search and analytics'),
+      '#description' => $this->t('How search engines verify the site and how visits are measured.'),
+      '#group' => 'vertical_tabs',
+    ];
+
+    $form['search_and_analytics']['google_site_verification'] = [
+      '#type' => 'textfield',
+      '#description' => $this->t('Get a verification key from Google Search Console Tools using the "URL Prefix" tool, clicking on the the alternate methods tab, and selecting the HTML Tag option. Use the "content" attribute from the Google tag within this field. Example: <code>&#60;meta name="google-site-verification" content="USE-THIS-CODE" /></code>'),
+      '#title' => $this->t('Google Site Verification'),
+      '#default_value' => $yaleConfig->get('seo')['google_site_verification'],
+    ];
+
+    $form['search_and_analytics']['google_analytics_migration'] = [
+      '#type' => 'item',
+      '#title' => $this->t('Google Analytics/Tag Manager'),
+      '#description' => $this->t('YaleSites is transitioning from Google Analytics to Google Tag Manager. Configure Google Tag Manager below to maintain your website analytics tracking.'),
+      '#markup' => Link::fromTextAndUrl(
+        $this->t('Configure Google Tag Manager'),
+        Url::fromRoute('entity.google_tag_container.single_form')
+          ->setOptions(['attributes' => ['class' => ['button'], 'style' => 'margin-top: 0; margin-bottom: 0;']])
+      )->toString(),
+    ];
+
+    $form['content_and_tagging'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Content and tagging'),
+      '#description' => $this->t('Sitewide defaults for how content is organized and labeled.'),
+      '#group' => 'vertical_tabs',
+    ];
+
+    $form['content_and_tagging']['custom_vocab_name'] = [
+      '#type' => 'textfield',
+      '#description' => $this->t('This field will update the name of the custom vocabulary for the site. By default, the name is "Custom Vocab".'),
+      '#title' => $this->t('Custom Vocabulary Name'),
+      '#default_value' => $yaleConfig->get('taxonomy')['custom_vocab_name'] ?? 'Custom Vocab',
+    ];
+
+    // Both settings in this group are already restricted, so gate the group
+    // itself too — an Advanced tab a user cannot open anything inside is worse
+    // than no tab at all. ys_core_allow_secret_items() already covers user 1,
+    // so it is the whole condition; the narrower $is_user_1 still gates the CAS
+    // field on its own below.
     $is_user_1 = ($this->currentUser->id() == 1);
-    $form['cas_app_name'] = [
+    $allow_secret_items = ys_core_allow_secret_items($this->currentUserSession);
+
+    $form['advanced'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Advanced'),
+      '#description' => $this->t('Platform-level settings. Most sites never need to change these.'),
+      '#group' => 'vertical_tabs',
+      '#access' => $allow_secret_items,
+    ];
+
+    $form['advanced']['cas_app_name'] = [
       '#type' => 'textfield',
       '#title' => $this->t('CAS Application Name'),
       '#description' => $this->t('The name of the application to be used in CAS login.'),
@@ -359,8 +436,8 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
       '#access' => $is_user_1,
     ];
 
-    if (ys_core_allow_secret_items($this->currentUserSession)) {
-      $form['environment_indicator_show'] = [
+    if ($allow_secret_items) {
+      $form['advanced']['environment_indicator_show'] = [
         '#type' => 'checkbox',
         '#title' => $this->t('Show environment indicator'),
         '#description' => $this->t('Display the environment indicator banner at the top of the site. This setting overrides all environment-specific configurations.'),
@@ -378,34 +455,88 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
     // Validate front, post, and event page paths.
     $this->validateIsNode($form_state, 'site_page_front');
 
+    // These four fields share the same three path messages, so each message has
+    // to name the field it came from. That mattered less when every setting was
+    // visible in one list; now the offending field can be in a tab the user is
+    // not looking at, "The path has to start with a slash" alone does not say
+    // which of the four is wrong.
     if (!$form_state->isValueEmpty('site_page_posts')) {
-      $this->validateStartWithSlash($form_state, 'site_page_posts');
-      $this->validateIsNotRootPath($form_state, 'site_page_posts');
-      $this->validatePath($form_state, 'site_page_posts');
+      $label = $this->keyPageLabel($form, 'site_page_posts');
+      $this->validateStartWithSlash($form_state, 'site_page_posts', $label);
+      $this->validateIsNotRootPath($form_state, 'site_page_posts', $label);
+      $this->validatePath($form_state, 'site_page_posts', $label);
     }
 
     if (!$form_state->isValueEmpty('site_page_events')) {
-      $this->validateStartWithSlash($form_state, 'site_page_events');
-      $this->validateIsNotRootPath($form_state, 'site_page_events');
-      $this->validatePath($form_state, 'site_page_events');
+      $label = $this->keyPageLabel($form, 'site_page_events');
+      $this->validateStartWithSlash($form_state, 'site_page_events', $label);
+      $this->validateIsNotRootPath($form_state, 'site_page_events', $label);
+      $this->validatePath($form_state, 'site_page_events', $label);
     }
 
     // Get the normal paths of error pages.
     if (!$form_state->isValueEmpty('site_page_403')) {
-      $form_state->setValueForElement($form['site_page_403'], $this->aliasManager->getPathByAlias($form_state->getValue('site_page_403')));
-      $this->validateStartWithSlash($form_state, 'site_page_403');
-      $this->validatePath($form_state, 'site_page_403');
+      $label = $this->keyPageLabel($form, 'site_page_403');
+      $form_state->setValueForElement($form['key_pages']['site_page_403'], $this->aliasManager->getPathByAlias($form_state->getValue('site_page_403')));
+      $this->validateStartWithSlash($form_state, 'site_page_403', $label);
+      $this->validatePath($form_state, 'site_page_403', $label);
     }
     if (!$form_state->isValueEmpty('site_page_404')) {
-      $form_state->setValueForElement($form['site_page_404'], $this->aliasManager->getPathByAlias($form_state->getValue('site_page_404')));
-      $this->validateStartWithSlash($form_state, 'site_page_404');
-      $this->validatePath($form_state, 'site_page_404');
+      $label = $this->keyPageLabel($form, 'site_page_404');
+      $form_state->setValueForElement($form['key_pages']['site_page_404'], $this->aliasManager->getPathByAlias($form_state->getValue('site_page_404')));
+      $this->validateStartWithSlash($form_state, 'site_page_404', $label);
+      $this->validatePath($form_state, 'site_page_404', $label);
     }
 
     // Email validations.
     $this->validateEmail($form_state, 'site_mail');
 
     parent::validateForm($form, $form_state);
+
+    // Reveal the group holding anything that just failed, so the user is never
+    // told there is a problem with no field in sight. Runs last so it also sees
+    // errors the parent added.
+    $this->openGroupsWithErrors($form, $form_state);
+  }
+
+  /**
+   * Returns the visible label of a Key pages field, for error messages.
+   *
+   * @param array $form
+   *   The form array.
+   * @param string $fieldId
+   *   The id of a field in the Key pages group.
+   *
+   * @return string
+   *   The field's title, or its id if it somehow has none.
+   */
+  protected function keyPageLabel(array $form, string $fieldId): string {
+    return (string) ($form['key_pages'][$fieldId]['#title'] ?? $fieldId);
+  }
+
+  /**
+   * Opens each tab group holding a field that failed validation.
+   *
+   * A user must never be told there is a problem with no field in sight. Core's
+   * vertical-tabs.js does open the tab containing a '.error' field, but only
+   * once JS has attached, so doing it server-side as well means the reveal
+   * holds with JS off and there is no flash of the wrong tab before it does.
+   *
+   * @param array $form
+   *   The form array, by reference so the owning group can be opened.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state holding the errors collected so far.
+   */
+  protected function openGroupsWithErrors(array &$form, FormStateInterface $form_state) {
+    foreach (array_keys($form_state->getErrors()) as $name) {
+      // Error keys are '][' separated; the first segment is the element key.
+      $element = explode('][', $name)[0];
+      foreach ($form as $key => $group) {
+        if (is_array($group) && ($group['#type'] ?? NULL) === 'details' && isset($group[$element])) {
+          $form[$key]['#open'] = TRUE;
+        }
+      }
+    }
   }
 
   /**
@@ -473,14 +604,17 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
    *   The form state of the parent form.
    * @param string $fieldId
    *   The id of a field on the connfig form.
+   * @param string $label
+   *   The field's visible label, named in the message so the user can tell
+   *   which of the four path fields is being complained about.
    */
-  protected function validateStartWithSlash(FormStateInterface &$form_state, string $fieldId) {
+  protected function validateStartWithSlash(FormStateInterface &$form_state, string $fieldId, string $label) {
     if (($value = $form_state->getValue($fieldId)) && $value[0] !== '/') {
       $form_state->setErrorByName(
         $fieldId,
         $this->t(
-          "The path '%path' has to start with a slash.",
-         ['%path' => $form_state->getValue($fieldId)]
+          "@label: the path '%path' has to start with a slash.",
+         ['@label' => $label, '%path' => $form_state->getValue($fieldId)]
         )
       );
     }
@@ -493,14 +627,16 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
    *   The form state passed by reference.
    * @param string $fieldId
    *   The id of a field on the connfig form.
+   * @param string $label
+   *   The field's visible label, named in the message.
    */
-  protected function validateIsNotRootPath(FormStateInterface &$form_state, string $fieldId) {
+  protected function validateIsNotRootPath(FormStateInterface &$form_state, string $fieldId, string $label) {
     if (($value = $form_state->getValue($fieldId)) && $value == '/') {
       $form_state->setErrorByName(
         $fieldId,
         $this->t(
-          "The path '%path' can not be the site root.",
-         ['%path' => $form_state->getValue($fieldId)]
+          "@label: the path '%path' can not be the site root.",
+         ['@label' => $label, '%path' => $form_state->getValue($fieldId)]
         )
       );
     }
@@ -513,14 +649,16 @@ class SiteSettingsForm extends ConfigFormBase implements ContainerInjectionInter
    *   The form state passed by reference.
    * @param string $fieldId
    *   The id of a field on the connfig form.
+   * @param string $label
+   *   The field's visible label, named in the message.
    */
-  protected function validatePath(FormStateInterface &$form_state, string $fieldId) {
+  protected function validatePath(FormStateInterface &$form_state, string $fieldId, string $label) {
     if (!$this->pathValidator->isValid($form_state->getValue($fieldId))) {
       $form_state->setErrorByName(
         $fieldId,
         $this->t(
-          "Either the path '%path' is invalid or you do not have access to it.",
-          ['%path' => $form_state->getValue($fieldId)]
+          "@label: either the path '%path' is invalid or you do not have access to it.",
+          ['@label' => $label, '%path' => $form_state->getValue($fieldId)]
         )
       );
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/SiteSettingsFormGroupingTest.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/tests/src/Kernel/SiteSettingsFormGroupingTest.php
@@ -1,0 +1,411 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Kernel;
+
+use Drupal\Component\Serialization\Yaml;
+use Drupal\Core\Form\FormState;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\ys_core\Form\SiteSettingsForm;
+
+/**
+ * Tests that the Site Settings form is grouped into task-based vertical tabs.
+ *
+ * The form used to be a single flat run of fifteen unrelated settings with no
+ * headings: site name a few fields above the 404 page, which sat above a Google
+ * Search Console key, which sat above the font picker. Nothing told a user
+ * which settings belonged together, which is the "users know what to change
+ * but not where" discoverability problem the 2026 UX research names as the
+ * platform's second most-cited pain point.
+ *
+ * The restructure is presentation-only, and that is exactly the part worth
+ * pinning down. Each setting is nested inside its details group and '#tree' is
+ * never set, so nesting rearranges only the render tree while every value still
+ * arrives flat in the form state — submitForm() keeps reading 'site_name' and
+ * friends unchanged.
+ *
+ * The first attempt tagged each setting with '#group' instead and left them at
+ * the top level, which looked right and passed a test asserting '#group' was
+ * set — but rendered the font pairing radios, the favicon, the teaser fallback
+ * and the Tag Manager link *outside* the tabs. '#group' is only honoured by
+ * element types that wire preRenderGroup (textfield, textarea, checkbox,
+ * container, details, fieldset). That is why these assertions check where an
+ * element actually lives rather than what it asked for, and why
+ * testSettingsAreNestedRatherThanGroupTagged() exists at all.
+ *
+ * @group ys_core
+ */
+class SiteSettingsFormGroupingTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'node',
+    'field',
+    'text',
+    'filter',
+    'path_alias',
+    'file',
+    'image',
+    'taxonomy',
+    'google_tag',
+    // KernelTestBase does not resolve module dependencies, and the form injects
+    // ys_media.media_manager, so ys_media has to be listed explicitly. Its own
+    // imagemagick dependency is deliberately left out: the media manager
+    // service needs only core services, and imagemagick cannot boot here
+    // without sophron.
+    'ys_media',
+    'ys_core',
+  ];
+
+  /**
+   * The expected group keys, in the order they should be displayed.
+   *
+   * Ordered by how often a user is likely to need them, not by the field order
+   * the flat form happened to have.
+   */
+  const EXPECTED_GROUPS = [
+    'site_basics',
+    'key_pages',
+    'look_and_feel',
+    'search_and_analytics',
+    'content_and_tagging',
+    'advanced',
+  ];
+
+  /**
+   * The expected group for each setting, in expected display order.
+   */
+  const EXPECTED_MEMBERSHIP = [
+    'site_name' => 'site_basics',
+    'site_mail' => 'site_basics',
+    'site_page_front' => 'key_pages',
+    'site_page_posts' => 'key_pages',
+    'site_page_events' => 'key_pages',
+    'site_page_403' => 'key_pages',
+    'site_page_404' => 'key_pages',
+    'font_pairing' => 'look_and_feel',
+    'font_preview' => 'look_and_feel',
+    'favicon' => 'look_and_feel',
+    'teaser_image_fallback' => 'look_and_feel',
+    'google_site_verification' => 'search_and_analytics',
+    'google_analytics_migration' => 'search_and_analytics',
+    'custom_vocab_name' => 'content_and_tagging',
+    'cas_app_name' => 'advanced',
+    'environment_indicator_show' => 'advanced',
+  ];
+
+  /**
+   * {@inheritdoc}
+   *
+   * Strict schema checking is off because ys_core.site ships no config schema.
+   * Writing that schema is explicitly not test-only work and is tracked in
+   * yalesites-org/YaleSites-Internal#579: as this module's README records, no
+   * schema type validates both the install defaults and the real saved values
+   * without first correcting them (environment_indicator.show ships boolean
+   * true but is saved as integer 1, custom_favicon is declared '' but holds an
+   * array of file ids). Suppressed the same way the six sibling settings-form
+   * kernel tests in this profile do, rather than pre-empting that ticket.
+   */
+  // phpcs:ignore DrupalPractice.Objects.StrictSchemaDisabled.StrictConfigSchema
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('path_alias');
+    $this->installEntitySchema('taxonomy_vocabulary');
+    $this->installConfig(['system']);
+
+    // ys_core's config/install cannot be imported wholesale here: its Grand
+    // Hero list_string field storage still carries pre-D10 allowed_values
+    // ("text: {text: Text}" rather than "text: Text"), which core's list field
+    // type rejects with "Undefined array key label". That is a real but
+    // separate problem. Loading just the settings object this form reads, from
+    // the same shipped file, keeps the defaults under test the genuine ones.
+    $this->config('ys_core.site')->setData(Yaml::decode(
+      file_get_contents(
+        DRUPAL_ROOT . '/' . $this->container->get('extension.list.module')->getPath('ys_core')
+        . '/config/install/ys_core.site.yml'
+      )
+    ))->save();
+  }
+
+  /**
+   * Builds the Site Settings form array as the given user.
+   */
+  protected function buildFormAs(int $uid): array {
+    $this->setUpCurrentUser(['uid' => $uid]);
+    return $this->formObject()->buildForm([], new FormState());
+  }
+
+  /**
+   * Instantiates the form object from the container.
+   */
+  protected function formObject(): SiteSettingsForm {
+    return SiteSettingsForm::create($this->container);
+  }
+
+  /**
+   * The settings found nested under the groups, in display order.
+   */
+  protected function nestedSettingKeys(array $form): array {
+    $keys = [];
+    foreach (self::EXPECTED_GROUPS as $group) {
+      foreach (array_keys($form[$group] ?? []) as $key) {
+        if (!str_starts_with((string) $key, '#')) {
+          $keys[] = $key;
+        }
+      }
+    }
+    return $keys;
+  }
+
+  /**
+   * Top-level keys that are form scaffolding rather than a site setting.
+   */
+  protected function scaffoldingKeys(): array {
+    return array_merge(['vertical_tabs', 'actions'], self::EXPECTED_GROUPS);
+  }
+
+  /**
+   * Every group is a details element inside the one tab container.
+   */
+  public function testGroupsRenderAsVerticalTabs(): void {
+    $form = $this->buildFormAs(1);
+
+    $this->assertSame('vertical_tabs', $form['vertical_tabs']['#type']);
+
+    foreach (self::EXPECTED_GROUPS as $group) {
+      $this->assertArrayHasKey($group, $form, "Group $group is missing.");
+      $this->assertSame('details', $form[$group]['#type'], "Group $group is not a details element.");
+      $this->assertSame('vertical_tabs', $form[$group]['#group'], "Group $group is not inside the tab container.");
+      $this->assertNotEmpty((string) $form[$group]['#title'], "Group $group has no title.");
+    }
+
+    $group_keys = array_values(array_intersect(array_keys($form), self::EXPECTED_GROUPS));
+    $this->assertSame(self::EXPECTED_GROUPS, $group_keys, 'Groups are not in the intended reading order.');
+  }
+
+  /**
+   * Nothing was dropped in the move and nothing was left outside the tabs.
+   *
+   * An ungrouped setting renders orphaned above the first tab, so this doubles
+   * as a guard for the next setting somebody appends to this form.
+   */
+  public function testEverySettingBelongsToItsIntendedGroup(): void {
+    $form = $this->buildFormAs(1);
+
+    $this->assertSame(
+      array_keys(self::EXPECTED_MEMBERSHIP),
+      $this->nestedSettingKeys($form),
+      'The set or order of settings on the form changed.'
+    );
+
+    foreach (self::EXPECTED_MEMBERSHIP as $key => $group) {
+      $this->assertArrayHasKey($key, $form[$group], "Setting $key is not inside $group.");
+    }
+
+    // Nothing may be left stranded at the top level, where it would render
+    // above the first tab instead of inside one.
+    $stranded = array_diff(
+      array_filter(array_keys($form), fn($k) => !str_starts_with((string) $k, '#')),
+      $this->scaffoldingKeys()
+    );
+    $this->assertSame([], array_values($stranded), 'Settings were left outside the tabs.');
+  }
+
+  /**
+   * Nesting must not repoint a single config write.
+   *
+   * This is the assertion the whole change rests on. Nesting is only safe
+   * because '#tree' is never set: with it set, a nested element's '#parents'
+   * would become ['group', 'key'] and submitForm()'s flat getValue() calls
+   * would every one of them read NULL, silently blanking the site's settings.
+   *
+   * Asserting the absence of '#tree' would pass vacuously — the code never
+   * mentions it — and would keep passing if a child element declared '#tree'
+   * itself or a wrapper's getInfo() set it. So this submits the form for real
+   * and checks where each value landed.
+   */
+  public function testSubmittingStillWritesEveryValueToItsOwnConfigKey(): void {
+    $form = $this->buildFormAs(1);
+
+    $form_state = new FormState();
+    $form_state->setValues([
+      'site_name' => 'Grouped Settings Site',
+      'site_mail' => 'someone@yale.edu',
+      // submitForm() only concatenates this into '/node/<id>'; it never loads
+      // the node, so a bare id is enough and no bundle setup is needed.
+      'site_page_front' => 42,
+      'site_page_posts' => '/news',
+      'site_page_events' => '/happenings',
+      'site_page_403' => '/no-entry',
+      'site_page_404' => '/gone',
+      'google_site_verification' => 'verification-key',
+      'custom_vocab_name' => 'Custom Vocab',
+      'font_pairing' => 'mallory',
+      'teaser_image_fallback' => '',
+      // handleMediaFilesystem() only dereferences this when it is truthy.
+      'favicon' => [],
+      'cas_app_name' => 'yalesites',
+      'environment_indicator_show' => TRUE,
+    ]);
+    $this->formObject()->submitForm($form, $form_state);
+
+    $site = $this->config('system.site');
+    $this->assertSame('Grouped Settings Site', $site->get('name'));
+    $this->assertSame('someone@yale.edu', $site->get('mail'));
+    $this->assertSame('/node/42', $site->get('page.front'));
+    $this->assertSame('/no-entry', $site->get('page.403'));
+    $this->assertSame('/gone', $site->get('page.404'));
+
+    $yale = $this->config('ys_core.site');
+    $this->assertSame('/news', $yale->get('page.posts'));
+    $this->assertSame('/happenings', $yale->get('page.events'));
+    $this->assertSame(
+      'verification-key',
+      $yale->get('seo.google_site_verification')
+    );
+    $this->assertSame('Custom Vocab', $yale->get('taxonomy.custom_vocab_name'));
+    $this->assertSame('mallory', $yale->get('font_pairing'));
+    $this->assertSame('yalesites', $yale->get('cas_app_name'));
+  }
+
+  /**
+   * Settings must be nested, not merely tagged with '#group'.
+   *
+   * Tagging is the trap this form already fell into once: '#group' is silently
+   * ignored by radios, managed_file, media_library and item, so the font
+   * pairing, favicon, teaser fallback and Tag Manager link rendered outside the
+   * tabs while every '#group' assertion still passed.
+   */
+  public function testSettingsAreNestedRatherThanGroupTagged(): void {
+    $form = $this->buildFormAs(1);
+
+    foreach (self::EXPECTED_MEMBERSHIP as $key => $group) {
+      $this->assertArrayNotHasKey(
+        '#group',
+        $form[$group][$key],
+        "Setting $key relies on #group, which its element type may ignore."
+      );
+    }
+  }
+
+  /**
+   * The form id is contract with the admin theme and must not drift.
+   *
+   * FormBuilder turns it into the form's ys-admin-settings class, which
+   * ys_admin_theme's gin-custom.scss targets to constrain input widths.
+   */
+  public function testFormIdIsUnchanged(): void {
+    $this->assertSame('ys_admin_settings', $this->formObject()->getFormId());
+  }
+
+  /**
+   * Labels drop Drupal's jargon for words an untrained user recognises.
+   */
+  public function testPlainLanguageLabels(): void {
+    $form = $this->buildFormAs(1);
+
+    $this->assertSame('Homepage', (string) $form['key_pages']['site_page_front']['#title']);
+    $this->assertSame('Access denied page (403)', (string) $form['key_pages']['site_page_403']['#title']);
+    // The description was reworded with the label: it used to say "front page".
+    $this->assertStringNotContainsString(
+      'front page',
+      (string) $form['key_pages']['site_page_front']['#description']
+    );
+    $this->assertSame('Page not found (404)', (string) $form['key_pages']['site_page_404']['#title']);
+
+    // "Teaser" is confusing but used consistently platform-wide — three node
+    // field descriptions in config/sync name it — so renaming it here alone
+    // would make things worse. The description carries the explanation instead.
+    $this->assertSame('Fallback teaser image', (string) $form['look_and_feel']['teaser_image_fallback']['#title']);
+    $this->assertStringContainsString(
+      'no teaser image',
+      (string) $form['look_and_feel']['teaser_image_fallback']['#description']
+    );
+  }
+
+  /**
+   * An Advanced tab with nothing openable inside is worse than no tab.
+   */
+  public function testAdvancedGroupIsHiddenWhenItWouldBeEmpty(): void {
+    $form = $this->buildFormAs(2);
+
+    $this->assertFalse($form['advanced']['#access']);
+    $this->assertFalse($form['advanced']['cas_app_name']['#access']);
+    $this->assertArrayNotHasKey('environment_indicator_show', $form['advanced']);
+  }
+
+  /**
+   * User 1 still sees the Advanced group and both restricted settings.
+   */
+  public function testAdvancedGroupIsVisibleToUser1(): void {
+    $form = $this->buildFormAs(1);
+
+    $this->assertTrue($form['advanced']['#access']);
+    $this->assertTrue($form['advanced']['cas_app_name']['#access']);
+    $this->assertArrayHasKey('environment_indicator_show', $form['advanced']);
+  }
+
+  /**
+   * A user must never be told there is a problem with no field in sight.
+   *
+   * Core's vertical-tabs.js opens the tab holding a '.error' field, but only
+   * once JS has run. Opening the group server-side means the reveal also holds
+   * without JS and before behaviours attach, and it is what makes the behaviour
+   * assertable here rather than only in a browser.
+   */
+  public function testValidationErrorOpensItsOwnGroup(): void {
+    $form = $this->buildFormAs(1);
+
+    // Calling buildForm() directly skips form processing, so supply the
+    // '#parents' FormBuilder would have added: validateForm() hands
+    // $form['site_page_404'] to setValueForElement(), which reads it.
+    foreach (self::EXPECTED_MEMBERSHIP as $key => $group) {
+      if (isset($form[$group][$key])) {
+        $form[$group][$key]['#parents'] = [$key];
+      }
+    }
+
+    $form_state = new FormState();
+    // A path with no leading slash is rejected by validateStartWithSlash().
+    $form_state->setValues([
+      'site_page_404' => 'not-a-path',
+      'site_mail' => 'someone@yale.edu',
+    ]);
+    $this->formObject()->validateForm($form, $form_state);
+
+    $errors = $form_state->getErrors();
+    $this->assertArrayHasKey('site_page_404', $errors);
+
+    // Four fields in this group share the same three path messages, so the
+    // message has to say which one it means — revealing the tab is not enough
+    // if the text could be about any of them.
+    $this->assertStringContainsString(
+      'Page not found (404)',
+      (string) $errors['site_page_404'],
+      'The path error does not name the field it belongs to.'
+    );
+
+    $this->assertTrue(
+      $form['key_pages']['#open'] ?? FALSE,
+      'The group holding the invalid field was left collapsed.'
+    );
+    $this->assertNotTrue(
+      $form['look_and_feel']['#open'] ?? FALSE,
+      'An unrelated group was opened.'
+    );
+  }
+
+}


### PR DESCRIPTION
## [1590: Site Settings: group settings into task-based sections instead of one flat list](https://github.com/yalesites-org/YaleSites-Internal/issues/1590)

### Description of work

Restructures `/admin/yalesites/settings` from one flat run of fifteen unrelated settings into six task-based vertical tabs. **No capability change:** every setting still exists, still saves to the same config key, the route is still `/admin/yalesites/settings`, and the permission is still `yalesites manage settings`.

- Groups, in the order a user is likely to need them:
  - **Site basics** — Site name, Site email
  - **Key pages** — Homepage, Post landing page, Events calendar page, Access denied page (403), Page not found (404)
  - **Look and feel** — Font Pairing (+ its live preview), Custom Favicon, Fallback teaser image
  - **Search and analytics** — Google Site Verification, Google Analytics/Tag Manager
  - **Content and tagging** — Custom Vocabulary Name
  - **Advanced** — CAS Application Name, Show environment indicator
- Follows the existing house pattern in `ViewsSettingsForm`: one `#type: vertical_tabs` container plus `details` children carrying `#group`.
- **Grouped with `#group`, not by nesting.** `#group` relocates an element at render time and leaves `#parents` alone, so all sixteen values stay flat in the form state. `submitForm()` is therefore untouched, and so are the two `setValueForElement($form['site_page_403'|'site_page_404'], ...)` calls in `validateForm()` that reach for those elements by their top-level key — nesting would have silently repointed every config write and broken those two.
- **Label improvements** from the ticket: `Front page` → `Homepage`, `403 page` → `Access denied page (403)`, `404 page` → `Page not found (404)`. `Fallback teaser image` keeps its label (the word is used consistently platform-wide, including three node field descriptions in `config/sync` that point back at this setting) and gets a clearer description instead.
- **The Advanced group is `#access`-gated** on (user 1 OR `platform_admin`), so it never renders as an empty tab for a user who cannot see either field inside it.
- **Validation errors reveal their own group.** New `openGroupsWithErrors()` sets `#open` on the group holding any errored field. Core's `vertical-tabs.js` already opens the tab containing a `.error` field, but only once JS attaches — doing it server-side too means the reveal holds with JS off, avoids a flash of the wrong tab, and makes the behaviour assertable in a Kernel test rather than only in a browser.
- **Deep links work natively.** `core/misc/vertical-tabs.js` resolves `window.location.hash` to a tab, so documentation can point at `/admin/yalesites/settings#edit-key-pages` instead of "scroll down". Anchors: `#edit-site-basics`, `#edit-key-pages`, `#edit-look-and-feel`, `#edit-search-and-analytics`, `#edit-content-and-tagging`, `#edit-advanced`.
- `getFormId()` is deliberately unchanged (`ys_admin_settings`) — FormBuilder turns it into the `.ys-admin-settings` class that `ys_admin_theme/scss/gin-custom.scss` targets to constrain input widths. Pinned by a test so it cannot drift. No new CSS was needed.
- **Accessibility fixes that came out of reviewing this change** (both in the categories the ticket's a11y AC names):
  - The three path validation messages now name their field: "Page not found (404): the path 'not-a-path' has to start with a slash." Four Key pages fields share those three messages, and `inline_form_errors` is not enabled anywhere on this platform, so the messages region is the *only* error text on the page — with tabs, an unnamed message could be about any of four fields in a pane you are not looking at (3.3.1). Done by threading a `$label` argument into `validateStartWithSlash()`, `validateIsNotRootPath()` and `validatePath()`; every call site is in this class.
  - The three font-preview *sample headings* are now `aria-hidden`. They are `<h2>` purely for size, so they were the only headings in the Look and feel pane's outline and read as "1234567890" with nothing to convey (1.3.1). Deliberately scoped to the headings only, not the whole preview: the paragraphs next to them carry information the radio labels do not ("some digits (3, 4, 5, 7, 9) descend below the text baseline"), so those stay exposed. Retagging the `<h2>` to a `div` was the other option and was rejected — `font-preview.css` sets font-family, font-size and margin-bottom on `.preview-heading` but not font-weight or margin-top, so it would have changed the visuals.
  - `openGroupsWithErrors()` runs after `parent::validateForm()` so it also sees errors the parent adds.
- **First test coverage this form has ever had:** `SiteSettingsFormGroupingTest` (Kernel, 9 tests, 178 assertions) covers the tab structure and group order; that every setting lands in its intended group (a drop guard, plus an orphan guard for whoever appends the next setting); that settings are nested rather than `#group`-tagged; the form id; the relabels; Advanced hidden/visible per role; and that a validation error both opens its own group and names its field.

  The important one is `testSubmittingStillWritesEveryValueToItsOwnConfigKey()`, which submits the form for real and asserts all eleven config keys landed where they should. An earlier version of this test just asserted `#tree` was absent — which passed *vacuously*, since the code never mentions `#tree`, and would have kept passing under the regressions that actually matter (a child element declaring `#tree` itself, an explicit `#parents`, or a wrapper whose `getInfo()` sets it). This is the test that would catch a repointed config key, and nothing covered that before.

- Uses `phpcs:ignore` + `$strictConfigSchema = FALSE` for the test, matching the six sibling settings-form Kernel tests in this profile. `ys_core.site` still has no config schema; per this module's README that is deliberately **not** test-only work and is tracked in yalesites-org/YaleSites-Internal#579, so this PR does not pre-empt it.

### One thing worth knowing about how this was built

The first attempt tagged each setting with `#group` and left them at the top level. The Kernel suite went green — and the page was wrong: Font Pairing, Custom Favicon, the fallback teaser image and the Tag Manager link all rendered *outside* the tab widget. `#group` is only honoured by element types that wire `preRenderGroup` (textfield, textarea, checkbox, container, details, fieldset), so `radios`, `managed_file`, `media_library` and `item` silently ignored it. The tests had asserted intent (`#group` is set) rather than outcome (the element is actually inside the group). Caught by driving the real page, then fixed by nesting. The tests were rewritten to assert placement, and `testSettingsAreNestedRatherThanGroupTagged()` exists specifically so nobody re-introduces the tagging approach.

### Decisions that need a human, please confirm on review

1. **The open decision on group 5 (Content and tagging) was made without the team, because this was implemented autonomously.** The ticket says to get a decision rather than choose silently, and offers (a) fold Custom Vocabulary Name into Site basics and ship five groups, or (b) keep Content and tagging as a real group on the grounds that sitewide content settings are coming. I took the ticket's own recommendation — **(b)**, since yalesites-org/YaleSites-Internal#1061 (sitewide default event meta layout setting) is open and is exactly the named future occupant. If the team prefers (a), it is a one-line change. **A tab with one field in it does look thin, so this is the thing to push back on if you're going to push back on anything.**
2. **`Custom Vocabulary Name` was NOT renamed**, per the ticket's instruction to flag rather than rename unilaterally — "vocabulary" is jargon, but the label appears in help documentation and training.

### Acceptance criteria this PR does NOT cover

These are on the ticket and genuinely need a person; none of them are code:

- [ ] The two-person untrained-user findability test ("find the page shown when a link is broken" / "the image used when a post has no picture" in under two groups), including noting what they tried first.
- [ ] Accessibility engineer's WCAG 2.1 AA sign-off on the tab pattern. This PR uses core's standard vertical tabs unmodified rather than a custom widget, so the keyboard/focus/ARIA behaviour is core's — but that is an argument for why it should pass, not evidence that it did.
- [ ] Screen reader confirmation that group names are announced.
- [ ] `yalesites.yale.edu` Site Settings help page: new screenshots and instructions rewritten to reference groups instead of scroll position, plus the other help pages that say "scroll down to". The relabels need to land in docs in the same release.
- [ ] Release notes callout — users who know this page well will notice it moved.
- [ ] Coordination check with yalesites-org/YaleSites-Internal#1238 and yalesites-org/YaleSites-Internal#1368, both of which change the font controls on this exact form.
- [ ] yalesites-org/yalesites-project#1499 (issue yalesites-org/YaleSites-Internal#1589, the scroll-jump bug on this same page) is open and in review. It does **not** touch `SiteSettingsForm` — it patches a contrib media-library focus guard — so there is no file conflict, but whichever merges second should have the other retested, as that ticket's AC asks.

### Verification already done locally

Driven with Playwright against the local Lando site, not just asserted in tests:

- Every field checked for **actual DOM containment** inside its own `<details>` — 11 of 11 testable fields `ok`, the fallback-teaser fieldset and the font-preview container included. Nothing outside the tabs except core's own `visually-hidden` active-tab input.
- Font preview live-updates on radio change (`yalenew` -> `yalenew-oldstyle`).
- Deep links verified on fresh page loads: `#edit-search-and-analytics`, `#edit-content-and-tagging`, `#edit-key-pages` each open the right tab.
- Bad 404 path -> error message shown, **Key pages** becomes the active tab, errored field visible.
- **`system.site` and `ys_core.site` are byte-identical after two full form saves** (diff clean) — nothing dropped or repointed.
- Keyboard: Tab walks all six tabs in order, Enter activates the focused one, focus ring visible (confirmed on a screenshot).
- 390px viewport: no horizontal overflow; tabs degrade to six stacked collapsed `details`, which is core's behaviour.
- No console errors. `composer code-sniff` exit 0 (both standards, whole custom tree); `composer lint:php` clean. Full `ys_core` Kernel suite green against a captured pre-change baseline of 52 tests / 580 assertions.

### Functional testing steps:

- [ ] Go to `/admin/yalesites/settings` as a site admin. The page shows vertical tabs — Site basics, Key pages, Look and feel, Search and analytics, Content and tagging — instead of one long list, and **no** Advanced tab.
- [ ] Every setting that was on the page before is still present, in the group listed above. Nothing is stranded above the tabs.
- [ ] Open **Look and feel** and change Font Pairing. The live preview underneath updates immediately.
- [ ] Change something in two different tabs, save, and confirm both saved correctly and the page still saves everything else unchanged.
- [ ] In **Key pages**, put `not-a-path` (no leading slash) in Page not found (404) and save. The error appears with the Key pages tab open and the invalid field visible — not a message with no field in sight.
- [ ] Visit `/admin/yalesites/settings#edit-look-and-feel` directly. The Look and feel tab is the one open on arrival.
- [ ] As user 1, the **Advanced** tab appears and contains CAS Application Name and Show environment indicator. As a `platform_admin` who is not user 1, Advanced appears with Show environment indicator only.
- [ ] Save as a non-user-1 admin, then check `ys_core.site:cas_app_name` is unchanged (not blanked).
- [ ] Keyboard only: Tab through the six tab links and press Enter to switch panes (core's vertical tabs are a list of links, not an ARIA tablist, so there is no arrow-key navigation — worth an opinion from the accessibility engineer). Confirm focus stays visible, and note that core moves focus into the newly revealed pane's first field on Enter.
- [ ] Narrow the viewport to phone width and confirm the tabs collapse to stacked sections sensibly rather than breaking.

References yalesites-org/YaleSites-Internal#1590
